### PR TITLE
fix: filter accounts by user domain

### DIFF
--- a/src/server/lib/mails/accounts.ts
+++ b/src/server/lib/mails/accounts.ts
@@ -13,32 +13,27 @@ export const getAccounts = async (
   const userDomain = getUserDomain(user.username);
 
   const [receivedStats, sentStats] = await Promise.all([
-    getAccountStats(user.id, false),
-    getAccountStats(user.id, true),
+    getAccountStats(user.id, false, userDomain),
+    getAccountStats(user.id, true, userDomain),
   ]);
 
-  // Filter to only show accounts under the user's domain
-  const received = receivedStats
-    .filter((stat) => stat.address?.endsWith(`@${userDomain}`))
-    .map((stat) => {
-      return new Account({
-        key: stat.address,
-        doc_count: stat.count,
-        unread_doc_count: stat.unread,
-        saved_doc_count: stat.saved,
-        updated: stat.latest,
-      });
+  const received = receivedStats.map((stat) => {
+    return new Account({
+      key: stat.address,
+      doc_count: stat.count,
+      unread_doc_count: stat.unread,
+      saved_doc_count: stat.saved,
+      updated: stat.latest,
     });
+  });
 
-  const sent = sentStats
-    .filter((stat) => stat.address?.endsWith(`@${userDomain}`))
-    .map((stat) => {
-      return new Account({
-        key: stat.address,
-        doc_count: stat.count,
-        updated: stat.latest,
-      });
+  const sent = sentStats.map((stat) => {
+    return new Account({
+      key: stat.address,
+      doc_count: stat.count,
+      updated: stat.latest,
     });
+  });
 
   return { received, sent };
 };


### PR DESCRIPTION
Only show accounts that match the user's domain (e.g., `@hoie.hoie.kim`).

External email addresses from received/sent mails are no longer shown in the accounts tab.

This fix was developed alongside PR #1 but wasn't included in the merged squash commit.