### PR TITLE
feat: add test coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev-server": "bun --watch ./src/server/start.ts",
     "migrate": "bun scripts/migrate-es-to-pg.ts",
     "test": "bun test",
+    "test:coverage": "bun test --coverage",
     "preview": "bun vite preview"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
Adds `test:coverage` npm script using Bun's built-in coverage support.

## Changes
- Added `"test:coverage": "bun test --coverage"` to package.json scripts

## Usage
```bash
bun run test:coverage
```

Output shows per-file function/line coverage with uncovered line numbers.

## Current coverage
- **48.52% functions**
- **34.66% lines**

Partial progress on #12 (CI integration step remains for future PR).