### PR TITLE
fix: warn when session secret falls back to default

### DIFF
--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -6,6 +6,16 @@ import path from "path";
 import { getDomain, PostgresSessionStore } from "server";
 import apiRouter from "./routes";
 
+// Validate session secret at module load
+if (!process.env.SECRET) {
+  if (process.env.NODE_ENV === "production") {
+    console.error("❌ FATAL: SECRET env var must be set in production!");
+    process.exit(1);
+  }
+  console.warn("⚠️  WARNING: SECRET env var not set. Using insecure default.");
+}
+const sessionSecret = process.env.SECRET || "secret";
+
 export const initializeHttp = async () => {
   const app = express();
 
@@ -13,7 +23,7 @@ export const initializeHttp = async () => {
   app.use(fileupload());
   app.use(
     session({
-      secret: process.env.SECRET || "secret",
+      secret: sessionSecret,
       resave: true,
       saveUninitialized: false,
       rolling: true,


### PR DESCRIPTION
## Summary
Addresses #15

In development: logs a warning when SECRET env var is not set.
In production: exits immediately with an error (fail fast, same as budget PR #12).

## Changes
- Validate SECRET at module load (before any requests)
- Development: console.warn with emoji for visibility
- Production: console.error + process.exit(1)

## Testing
- Compiled cleanly
- Without SECRET: warning appears
- With SECRET: no warning

## Self-Review Notes
Matches the approach used in budget repo (PR #12). Simple, non-breaking for development, strict for production.