### PR TITLE
feat: add input validation for mail sending API endpoint

### DIFF
--- a/src/server/lib/http/routes/mails/post-send.ts
+++ b/src/server/lib/http/routes/mails/post-send.ts
@@ -1,10 +1,24 @@
 import { MailDataToSend, MailDataToSendType } from "common";
-import { sendMail, AUTH_ERROR_MESSAGE } from "server";
+import { sendMail, AUTH_ERROR_MESSAGE, isValidEmail } from "server";
 import { Route } from "../route";
 
 export type SendMailPostResponse = undefined;
 
 export type SendMailPostBody = MailDataToSendType;
+
+const MAX_SUBJECT_LENGTH = 998; // RFC 5322 line length limit
+const MAX_BODY_LENGTH = 10 * 1024 * 1024; // 10MB limit for HTML body
+
+const validateEmailList = (emails: string | undefined): string | null => {
+  if (!emails) return null;
+  const list = emails.split(",").map((e) => e.trim()).filter((e) => e);
+  for (const email of list) {
+    if (!isValidEmail(email.toLowerCase())) {
+      return `Invalid email address: ${email}`;
+    }
+  }
+  return null;
+};
 
 export const postSendMailRoute = new Route<SendMailPostResponse>(
   "POST",
@@ -15,6 +29,32 @@ export const postSendMailRoute = new Route<SendMailPostResponse>(
 
     const body: SendMailPostBody = req.body;
     const attachments = req.files?.attachments;
+
+    // Validate recipient (required)
+    if (!body.to || typeof body.to !== "string" || body.to.trim() === "") {
+      return { status: "failed", message: "Recipient email address is required" };
+    }
+
+    const toError = validateEmailList(body.to);
+    if (toError) return { status: "failed", message: toError };
+
+    // Validate cc (optional)
+    const ccError = validateEmailList(body.cc);
+    if (ccError) return { status: "failed", message: ccError };
+
+    // Validate bcc (optional)
+    const bccError = validateEmailList(body.bcc);
+    if (bccError) return { status: "failed", message: bccError };
+
+    // Validate subject length
+    if (body.subject && body.subject.length > MAX_SUBJECT_LENGTH) {
+      return { status: "failed", message: `Subject exceeds maximum length of ${MAX_SUBJECT_LENGTH} characters` };
+    }
+
+    // Validate body length
+    if (body.html && body.html.length > MAX_BODY_LENGTH) {
+      return { status: "failed", message: "Email body is too large" };
+    }
 
     await sendMail(user, new MailDataToSend({ ...body }), attachments);
 


### PR DESCRIPTION
## Summary

Adds validation to the `POST /send` endpoint before calling `sendMail()`.

## Changes

- **Required recipient**: Validates `to` field is present and non-empty
- **Email format validation**: Uses existing `isValidEmail` for `to`, `cc`, and `bcc` fields
- **Subject length limit**: 998 characters (per RFC 5322 line length)
- **Body size limit**: 10MB for HTML body

Returns clear error messages on validation failure rather than failing downstream at Mailgun.

## Testing

- Verified TypeScript compiles without new errors
- Validation logic uses existing `isValidEmail` function that's already battle-tested

Fixes #27