### PR TITLE
ci: remove Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,6 @@ jobs:
         run: bun install
       - name: Run tests with coverage
         run: bun run test:coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: ./coverage/lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          # Don't fail CI for fork PRs (secrets not available)
-          fail_ci_if_error: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-          verbose: true
 
   build:
     needs: test


### PR DESCRIPTION
Remove Codecov integration from CI.

Coverage is still collected via `bun run test:coverage` and visible in CI logs. External reporting will be replaced with threshold enforcement after #18 improves test coverage.

## Why
- Codecov requires CI to run on both push and PR to compare base/head
- With squash merges, the base commit never gets coverage uploaded
- Simpler alternative: enforce coverage threshold directly in test config

## What's next
Coverage threshold enforcement will be configured after #18 (test coverage improvement) — tracked in a follow-up issue.