### PR TITLE
docs: add MAILGUN_KEY to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ ADMIN_PASSWORD=inbox
 
 OPENAI_KEY=
 
+# Mailgun API key for email sending
+MAILGUN_KEY=
+
 # PostgreSQL Configuration
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432


### PR DESCRIPTION
## Summary
Add missing `MAILGUN_KEY` environment variable to `.env.example`.

## Problem
The `.env.example` file was missing the `MAILGUN_KEY` variable, which is required for email sending via Mailgun API. This led to:
- Developers not knowing MAILGUN_KEY is required
- Cryptic Mailgun errors when email sending failed
- Incomplete setup documentation

## Changes
- Added `MAILGUN_KEY=` with a descriptive comment to `.env.example`

## Testing
Verified the file includes all required environment variables.

Contributes to #45