### PR TITLE
fix: improve email validation to accept valid addresses

### DIFF
--- a/src/server/lib/users.ts
+++ b/src/server/lib/users.ts
@@ -103,7 +103,12 @@ export const createToken = async (
 export const isValidEmail = (email: string) => {
   const values = email.split("@");
   if (values.length !== 2) return false;
-  return !values.find((v) => !/^[a-z0-9.-]+$/.test(v));
+  const [local, domain] = values;
+  // Local part: allow letters, digits, dots, underscores, hyphens, plus (case insensitive)
+  const localValid = /^[a-zA-Z0-9._%+-]+$/.test(local);
+  // Domain: allow letters, digits, dots, hyphens (case insensitive), must have at least one dot
+  const domainValid = /^[a-zA-Z0-9.-]+$/.test(domain) && domain.includes(".");
+  return localValid && domainValid;
 };
 
 export const startTimer = (userId: string) => {


### PR DESCRIPTION
## Summary
Fix the `isValidEmail` function to correctly validate email addresses per RFC 5321.

## Problem
The previous validation regex was too restrictive, rejecting many valid email addresses:
| Email | RFC Valid | Previous Result |
|-------|-----------|-----------------|
| `Test@Example.com` | ✓ | ✗ rejected |
| `test+alias@gmail.com` | ✓ | ✗ rejected |
| `test_user@example.com` | ✓ | ✗ rejected |
| `user.name@Example.COM` | ✓ | ✗ rejected |

## Changes
Updated `isValidEmail` in `src/server/lib/users.ts`:
- Allow uppercase letters in both local and domain parts
- Allow `+` and `_` characters in local part (plus-addressing support)
- Require domain to contain at least one dot

## Testing
Manual verification:
```typescript
isValidEmail('test@example.com')       // true
isValidEmail('Test@Example.COM')       // true  
isValidEmail('test+alias@gmail.com')   // true
isValidEmail('test_user@example.com')  // true
isValidEmail('invalid')                // false
isValidEmail('no@domain')              // false (no dot in domain)
```

Contributes to #42