### PR TITLE
ci: add ESLint linting step to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: bun install
       - name: Type check
         run: bun run typecheck
+      - name: Lint
+        run: bun run lint
       - name: Run tests with coverage
         run: bun run test:coverage
 


### PR DESCRIPTION
## Summary
Adds ESLint linting to the CI pipeline, running before tests.

## Changes
- Added `Lint` step to the test job in CI workflow
- Linting runs after dependency install, before tests

## Testing
- Verified `bun run lint` runs successfully locally
- Currently shows warnings only (will become errors after #39)

Contributes to #37