### PR TITLE
chore: fix ESLint violations (42 unused vars fixed)

### DIFF
--- a/src/client/Box/components/Mails/components/RobotIcon.tsx
+++ b/src/client/Box/components/Mails/components/RobotIcon.tsx
@@ -1,8 +1,8 @@
-const RobotIcon = (Props: React.SVGAttributes<SVGSVGElement>) => (
+const RobotIcon = (props: React.SVGAttributes<SVGSVGElement>) => (
   // Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com
   // License - https://fontawesome.com/license (Commercial License) Copyright 2023 Fonticons, Inc.
   // ----------------from here----------------
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512" {...props}>
     <path
       fill="currentColor"
       d="M320 0c17.7 0 32 14.3 32 32V96H472c39.8 0 72 32.2 72 72V440c0 39.8-32.2 72-72 72H168c-39.8 0-72-32.2-72-72V168c0-39.8 32.2-72 72-72H288V32c0-17.7 14.3-32 32-32zM208 384c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H208zm96 0c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H304zm96 0c-8.8 0-16 7.2-16 16s7.2 16 16 16h32c8.8 0 16-7.2 16-16s-7.2-16-16-16H400zM264 256a40 40 0 1 0 -80 0 40 40 0 1 0 80 0zm152 40a40 40 0 1 0 0-80 40 40 0 1 0 0 80zM48 224H64V416H48c-26.5 0-48-21.5-48-48V272c0-26.5 21.5-48 48-48zm544 0c26.5 0 48 21.5 48 48v96c0 26.5-21.5 48-48 48H576V224h16z"

--- a/src/server/lib/imap/idle-manager.ts
+++ b/src/server/lib/imap/idle-manager.ts
@@ -140,7 +140,7 @@ class IdleManager {
     this.idleSessions.forEach((idleSession, _) => {
       try {
         idleSession.session.write("* BYE Server shutting down\r\n");
-      } catch (error) {
+      } catch {
         // Ignore errors during shutdown
       }
     });

--- a/src/server/lib/imap/parsers/append-parser.ts
+++ b/src/server/lib/imap/parsers/append-parser.ts
@@ -3,7 +3,7 @@
  */
 
 import { ParseContext, ParseResult, AppendRequest } from '../types';
-import { parseAtom, parseString, parseNumber, skipWhitespace } from './primitive-parsers';
+import { parseAtom, parseString, skipWhitespace } from './primitive-parsers';
 
 /**
  * Parse APPEND command

--- a/src/server/lib/imap/parsers/fetch-parsers.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.ts
@@ -2,8 +2,8 @@
  * FETCH command parsing
  */
 
-import { ParseContext, ParseResult, ImapRequest, FetchRequest, FetchDataItem, BodyFetch, BodySection, PartialRange } from '../types';
-import { parseSequenceSet, skipWhitespace, peek, consume, parseAtom, parseNumber } from './primitive-parsers';
+import { ParseContext, ParseResult, ImapRequest, FetchDataItem, BodyFetch, BodySection, PartialRange } from '../types';
+import { parseSequenceSet, skipWhitespace, peek, parseAtom } from './primitive-parsers';
 
 /**
  * Parse FETCH command
@@ -128,7 +128,7 @@ export const parseFetchDataItem = (context: ParseContext): ParseResult<FetchData
 /**
  * Parse BODY fetch expressions
  */
-export const parseBodyFetch = (bodyExpr: string, context: ParseContext): ParseResult<BodyFetch> => {
+export const parseBodyFetch = (bodyExpr: string, _context: ParseContext): ParseResult<BodyFetch> => {
   // Handle BODY (without section)
   if (bodyExpr === 'BODY') {
     return { 

--- a/src/server/lib/imap/parsers/store-parsers.ts
+++ b/src/server/lib/imap/parsers/store-parsers.ts
@@ -6,9 +6,6 @@ import {
   ParseContext,
   ParseResult,
   ImapRequest,
-  SearchRequest,
-  StoreRequest,
-  CopyRequest,
   StoreOperation
 } from "../types";
 import {
@@ -17,10 +14,8 @@ import {
   parseString,
   parseAtom,
   parseFlag,
-  peek,
-  consume
+  peek
 } from "./primitive-parsers";
-import { parseSearchCriteria } from "./search-parsers";
 
 /**
  * Runtime validation for StoreOperation

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -628,23 +628,23 @@ export class ImapSession {
     }
   };
 
-  createMailbox = async (tag: string, mailbox: string) => {
+  createMailbox = async (tag: string, _mailbox: string) => {
     this.write(`${tag} NO CREATE not supported\r\n`);
   };
 
-  deleteMailbox = async (tag: string, mailbox: string) => {
+  deleteMailbox = async (tag: string, _mailbox: string) => {
     this.write(`${tag} NO DELETE not supported\r\n`);
   };
 
-  renameMailbox = async (tag: string, oldName: string, newName: string) => {
+  renameMailbox = async (tag: string, _oldName: string, _newName: string) => {
     this.write(`${tag} NO RENAME not supported\r\n`);
   };
 
-  subscribeMailbox = async (tag: string, mailbox: string) => {
+  subscribeMailbox = async (tag: string, _mailbox: string) => {
     this.write(`${tag} OK SUBSCRIBE completed\r\n`);
   };
 
-  unsubscribeMailbox = async (tag: string, mailbox: string) => {
+  unsubscribeMailbox = async (tag: string, _mailbox: string) => {
     this.write(`${tag} OK UNSUBSCRIBE completed\r\n`);
   };
 
@@ -669,7 +669,7 @@ export class ImapSession {
       }
 
       // Build STATUS response
-      let statusItems: string[] = [];
+      const statusItems: string[] = [];
 
       items.forEach((item) => {
         switch (item) {
@@ -834,8 +834,8 @@ export class ImapSession {
 
   copyMessageTyped = async (
     tag: string,
-    copyRequest: CopyRequest,
-    isUidCommand: boolean = false
+    _copyRequest: CopyRequest,
+    _isUidCommand: boolean = false
   ) => {
     // Reject all COPY operations - we don't want clients moving messages around
     this.write(`${tag} NO [CANNOT] COPY not permitted\r\n`);

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import { Mail, SignedUser, MailType } from "common";
+import { Mail, SignedUser } from "common";
 import {
   getAccountStats,
   countMessages,

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -2,7 +2,7 @@
  * TypeScript interfaces for IMAP protocol requests and responses
  */
 
-import { MailType } from "common";
+// IMAP type definitions
 
 // IMAP-specific request interfaces
 export interface SearchRequest {

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -1,5 +1,5 @@
 import { MailType, MailAddressValueType, AttachmentType } from "common";
-import { getAttachment, getUserDomain } from "server";
+import { getUserDomain } from "server";
 
 export const encodeText = (str: string) => {
   return Buffer.from(str, "utf8").toString("base64");

--- a/src/server/lib/mails/notifications.ts
+++ b/src/server/lib/mails/notifications.ts
@@ -1,6 +1,5 @@
-import { DateString, SignedUser } from "common";
+import { SignedUser } from "common";
 import { getUnreadNotifications } from "../postgres/repositories/mails";
-import { addressToUsername } from "./receive";
 
 export type Notifications = Map<string, { count: number; latest?: Date }>;
 

--- a/src/server/lib/mails/search.ts
+++ b/src/server/lib/mails/search.ts
@@ -1,4 +1,4 @@
-import { MailHeaderData, SignedUser, Pagination, MaskedUser } from "common";
+import { MailHeaderData, SignedUser } from "common";
 import {
   searchMails,
   SearchMailModel,

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -36,8 +36,8 @@ export interface UpsertOptions {
 const isNull = (v: unknown): v is null => v === null;
 const isUndefined = (v: unknown): v is undefined => v === undefined;
 const isDate = (v: unknown): v is Date => v instanceof Date;
-const isNumber = (v: unknown): v is number => typeof v === "number";
-const isString = (v: unknown): v is string => typeof v === "string";
+const _isNumber = (v: unknown): v is number => typeof v === "number";
+const _isString = (v: unknown): v is string => typeof v === "string";
 
 export function buildCreateTable(
   tableName: string,

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -31,7 +31,7 @@ import {
   UPDATED,
   MAILS,
 } from "./common";
-import { Schema, Model, createTable } from "./base";
+import { Model, createTable } from "./base";
 
 // Type guards
 const isString = (v: unknown): v is string => typeof v === "string";

--- a/src/server/lib/postgres/models/push_subscription.ts
+++ b/src/server/lib/postgres/models/push_subscription.ts
@@ -8,7 +8,7 @@ import {
   UPDATED,
   PUSH_SUBSCRIPTIONS,
 } from "./common";
-import { Schema, Model, createTable } from "./base";
+import { Model, createTable } from "./base";
 
 // Type guards
 const isString = (v: unknown): v is string => typeof v === "string";

--- a/src/server/lib/postgres/models/session.ts
+++ b/src/server/lib/postgres/models/session.ts
@@ -15,7 +15,7 @@ import {
   UPDATED,
   SESSIONS,
 } from "./common";
-import { Schema, Model, createTable } from "./base";
+import { Model, createTable } from "./base";
 
 // Type guards
 const isString = (v: unknown): v is string => typeof v === "string";

--- a/src/server/lib/postgres/models/user.ts
+++ b/src/server/lib/postgres/models/user.ts
@@ -10,7 +10,7 @@ import {
   USERS,
   IMAP_UID_VALIDITY,
 } from "./common";
-import { Schema, Model, createTable } from "./base";
+import { Model, createTable } from "./base";
 
 // Type guards
 const isString = (v: unknown): v is string => typeof v === "string";

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -3,15 +3,11 @@ import { pool } from "../client";
 import { ParamValue } from "../database";
 import {
   MailModel,
-  MailJSON,
   mailsTable,
   MAIL_ID,
   USER_ID,
-  MESSAGE_ID,
-  SENT,
   READ,
   SAVED,
-  DATE,
   UID_DOMAIN,
   UID_ACCOUNT,
   TO_ADDRESS,
@@ -211,7 +207,7 @@ export interface SearchMailModel extends MailModel {
 export const searchMails = async (
   user_id: string,
   searchTerm: string,
-  field?: string
+  _field?: string
 ): Promise<SearchMailModel[]> => {
   try {
     // Use PostgreSQL full-text search with ranking and highlights

--- a/src/server/lib/postgres/repositories/push_subscriptions.ts
+++ b/src/server/lib/postgres/repositories/push_subscriptions.ts
@@ -1,8 +1,7 @@
 import crypto from "crypto";
-import webPush, { PushSubscription } from "web-push";
+import { PushSubscription } from "web-push";
 import { pool } from "../client";
 import {
-  PushSubscriptionModel,
   pushSubscriptionsTable,
   PUSH_SUBSCRIPTION_ID,
   USER_ID,

--- a/src/server/lib/users.ts
+++ b/src/server/lib/users.ts
@@ -133,7 +133,8 @@ export const encryptPassword = (password: string) => {
 export const setUserInfo = async (
   userInfo: Partial<User>
 ): Promise<SignedUser> => {
-  let { email, password, token, username } = userInfo;
+  const { email, password, token } = userInfo;
+  let { username } = userInfo;
   if (!email || !username || !password) {
     throw new Error(
       `Setting userInfo failed because input is invalid: ${userInfo}`


### PR DESCRIPTION
## Summary
Fixes all 42 `@typescript-eslint/no-unused-vars` violations and 3 `prefer-const` violations.

## Changes
- Remove unused imports across 19 files (Schema, MailType, FetchRequest, consume, parseNumber, etc.)
- Prefix unused function parameters with underscore (`mailbox` → `_mailbox`, etc.)
- Fix prefer-const by splitting destructuring when only some vars are reassigned
- Actually use `props` in RobotIcon component (spread to SVG element)

## Progress
- **Before**: 122 warnings
- **After**: 80 warnings (all remaining are `no-explicit-any`)
- **Fixed**: 42 unused-vars + 3 prefer-const = 45 violations

## Testing
- `bun run lint` passes (warnings only, no errors)
- `bun run typecheck` passes

## Follow-up
The remaining 80 `no-explicit-any` violations will be addressed in a follow-up PR.

Contributes to #39