### PR TITLE
Normalize all SMTP ports

### DIFF
--- a/src/server/lib/mails/mailgun.ts
+++ b/src/server/lib/mails/mailgun.ts
@@ -1,9 +1,6 @@
 import FormData from "form-data";
 import Mailgun from "mailgun.js";
-import type {
-  MailgunMessageData,
-  CustomFile
-} from "mailgun.js/definitions";
+import type { MailgunMessageData, CustomFile } from "mailgun.js/definitions";
 import { MailDataToSend } from "common";
 import { getText, getUserDomain } from "server";
 import { UploadedFileDynamicArray } from "./send";
@@ -32,6 +29,9 @@ export const sendMailgunMail = async (
   const { sender, senderFullName, to, cc, bcc, subject, html, inReplyTo } =
     mail;
 
+  const tos = to.split(",").map((addr) => addr.trim());
+  const envelopTo = tos.filter((addr) => !addr.endsWith(`@${EMAIL_DOMAIN}`));
+
   const text = getText(html);
   const userDomain = getUserDomain(username);
   const from = `${senderFullName} <${sender}@${userDomain}>`;
@@ -44,13 +44,14 @@ export const sendMailgunMail = async (
 
   const mailgunMessage: MailgunMessageData = {
     from,
-    to,
+    to: envelopTo,
     cc,
     bcc,
     subject,
     html,
     text,
     attachment: getAttachments(files),
+    "h:To": to,
     "h:In-Reply-To": inReplyTo
   };
 

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -45,11 +45,9 @@ export const sendMail = async (
 
     console.info("Email sending request succeeded");
 
-    if (!isToMyself(mailToSend.to)) {
-      const messageId = response.id || randomUUID();
-      const sentMail = await getSentMail(user, mailToSend, messageId, files);
-      await saveMail(sentMail, userId);
-    }
+    const messageId = response.id || randomUUID();
+    const sentMail = await getSentMail(user, mailToSend, messageId, files);
+    await saveMail(sentMail, userId);
 
     return response;
   } catch (error: any) {


### PR DESCRIPTION
## Changes

Makes port 25, 465 and 587 do the same thing. If the destination is the host, process it as an incoming mail. If the sender is the host, process it as an outgoing mail(with auth).

One difference among these ports: port 465 does implicit TLS while the others do it explicitly by STARTTLS process. This is handled by SMTP server and configured by setting `secure: true` for port 465 and `secure: false` for the others.