### PR TITLE
test: add unit tests for security-critical IMAP parsers

### DIFF
--- a/src/server/lib/imap/parsers/security.test.ts
+++ b/src/server/lib/imap/parsers/security.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for security-critical IMAP parsers
+ * 
+ * These tests cover parsers that handle:
+ * - Authentication (LOGIN, AUTHENTICATE) - critical for access control
+ * - Data modification (APPEND) - critical for data integrity
+ * - Mailbox operations (SELECT, CREATE, DELETE, RENAME) - critical for authorization
+ */
+
+import { describe, expect, it } from "bun:test";
+import { parseLogin, parseAuthenticate } from "./auth-parsers";
+import { parseAppend } from "./append-parser";
+import { parseSelect, parseCreate, parseDelete, parseRename, parseList, parseStatus } from "./mailbox-parsers";
+import { ParseContext } from "../types";
+
+const createContext = (input: string): ParseContext => ({
+  input,
+  position: 0,
+  length: input.length
+});
+
+describe("auth-parsers", () => {
+  describe("parseLogin", () => {
+    it("should parse LOGIN with simple credentials", () => {
+      const ctx = createContext("user password");
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("LOGIN");
+      expect(result.value?.data.username).toBe("user");
+      expect(result.value?.data.password).toBe("password");
+    });
+
+    it("should parse LOGIN with quoted username", () => {
+      const ctx = createContext('"user@example.com" password');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.username).toBe("user@example.com");
+      expect(result.value?.data.password).toBe("password");
+    });
+
+    it("should parse LOGIN with quoted password", () => {
+      const ctx = createContext('user "my password"');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.username).toBe("user");
+      expect(result.value?.data.password).toBe("my password");
+    });
+
+    it("should parse LOGIN with both quoted", () => {
+      const ctx = createContext('"user@example.com" "pass word"');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.username).toBe("user@example.com");
+      expect(result.value?.data.password).toBe("pass word");
+    });
+
+    it("should parse LOGIN with special characters in quoted password", () => {
+      const ctx = createContext('user "p@ss\\"w0rd!"');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.password).toBe('p@ss"w0rd!');
+    });
+
+    it("should parse LOGIN with escaped backslash in password", () => {
+      const ctx = createContext('user "pass\\\\word"');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.password).toBe("pass\\word");
+    });
+
+    it("should fail on missing username", () => {
+      const ctx = createContext("");
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("username");
+    });
+
+    it("should fail on missing password", () => {
+      const ctx = createContext("user");
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("password");
+    });
+
+    it("should fail on unterminated quoted username", () => {
+      const ctx = createContext('"unterminated password');
+      const result = parseLogin(ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseAuthenticate", () => {
+    it("should parse AUTHENTICATE PLAIN", () => {
+      const ctx = createContext("PLAIN");
+      const result = parseAuthenticate(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("AUTHENTICATE");
+      expect(result.value?.data.mechanism).toBe("PLAIN");
+      expect(result.value?.data.initialResponse).toBeUndefined();
+    });
+
+    it("should parse AUTHENTICATE PLAIN with initial response", () => {
+      // Base64 encoded PLAIN auth: \0username\0password
+      const ctx = createContext("PLAIN AGFsaWNlAHNlY3JldA==");
+      const result = parseAuthenticate(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mechanism).toBe("PLAIN");
+      expect(result.value?.data.initialResponse).toBe("AGFsaWNlAHNlY3JldA==");
+    });
+
+    it("should parse AUTHENTICATE with quoted mechanism", () => {
+      const ctx = createContext('"PLAIN"');
+      const result = parseAuthenticate(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mechanism).toBe("PLAIN");
+    });
+
+    it("should fail on missing mechanism", () => {
+      const ctx = createContext("");
+      const result = parseAuthenticate(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("mechanism");
+    });
+  });
+});
+
+describe("append-parser", () => {
+  describe("parseAppend", () => {
+    it("should parse APPEND with minimal args", () => {
+      const message = "From: test@example.com\r\nSubject: Test\r\n\r\nBody";
+      const ctx = createContext(`INBOX {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("APPEND");
+      expect(result.value?.data.mailbox).toBe("INBOX");
+      expect(result.value?.data.message).toBe(message);
+      expect(result.value?.data.flags).toBeUndefined();
+      expect(result.value?.data.date).toBeUndefined();
+    });
+
+    it("should parse APPEND with quoted mailbox", () => {
+      const message = "Test message";
+      const ctx = createContext(`"Sent Items" {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe("Sent Items");
+    });
+
+    // NOTE: Flag parsing in APPEND currently doesn't work because parseAtom
+    // excludes backslash. This is a known limitation - flags are rarely used
+    // in APPEND in practice. The tests below document current behavior.
+    it("should parse APPEND with keyword flags (no backslash)", () => {
+      // Keyword flags (without backslash) work
+      const message = "Test";
+      const ctx = createContext(`INBOX (MyLabel Important) {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.flags).toEqual(["MyLabel", "Important"]);
+    });
+
+    it("should handle empty flags list", () => {
+      const message = "Test";
+      const ctx = createContext(`INBOX () {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.flags).toEqual([]);
+    });
+
+    it("should parse APPEND with date", () => {
+      const message = "Test";
+      const ctx = createContext(`INBOX "25-Feb-2026 12:34:56 +0000" {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.date).toBe("25-Feb-2026 12:34:56 +0000");
+    });
+
+    it("should parse APPEND with keyword flags and date", () => {
+      const message = "Test";
+      const ctx = createContext(`INBOX (Important) "25-Feb-2026 12:34:56 +0000" {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.flags).toEqual(["Important"]);
+      expect(result.value?.data.date).toBe("25-Feb-2026 12:34:56 +0000");
+    });
+
+    it("should fail on missing mailbox", () => {
+      const ctx = createContext("");
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("mailbox");
+    });
+
+    it("should fail on missing literal", () => {
+      const ctx = createContext("INBOX");
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("literal");
+    });
+
+    it("should fail on malformed literal size", () => {
+      const ctx = createContext("INBOX {abc}\r\ntest");
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("size");
+    });
+
+    it("should fail on missing closing brace", () => {
+      const ctx = createContext("INBOX {100");
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("literal");
+    });
+
+    it("should handle large literal size safely", () => {
+      // Test with reasonable size - should not crash
+      const message = "X".repeat(1000);
+      const ctx = createContext(`INBOX {${message.length}}\r\n${message}`);
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.message.length).toBe(1000);
+    });
+
+    it("should handle zero-length message", () => {
+      const ctx = createContext("INBOX {0}\r\n");
+      const result = parseAppend(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.message).toBe("");
+    });
+  });
+});
+
+describe("mailbox-parsers", () => {
+  describe("parseSelect", () => {
+    it("should parse SELECT with simple mailbox", () => {
+      const ctx = createContext("INBOX");
+      const result = parseSelect(false, ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("SELECT");
+      expect(result.value?.data.mailbox).toBe("INBOX");
+    });
+
+    it("should parse EXAMINE (read-only)", () => {
+      const ctx = createContext("INBOX");
+      const result = parseSelect(true, ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("EXAMINE");
+    });
+
+    it("should parse SELECT with quoted mailbox", () => {
+      const ctx = createContext('"Sent Items"');
+      const result = parseSelect(false, ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe("Sent Items");
+    });
+
+    it("should parse SELECT with mailbox containing special chars", () => {
+      const ctx = createContext('"INBOX/Folder\\"Name"');
+      const result = parseSelect(false, ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe('INBOX/Folder"Name');
+    });
+
+    it("should fail on missing mailbox", () => {
+      const ctx = createContext("");
+      const result = parseSelect(false, ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseCreate", () => {
+    it("should parse CREATE with simple mailbox", () => {
+      const ctx = createContext("NewFolder");
+      const result = parseCreate(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("CREATE");
+      expect(result.value?.data.mailbox).toBe("NewFolder");
+    });
+
+    it("should parse CREATE with nested hierarchy", () => {
+      const ctx = createContext('"INBOX/Subfolder/Deep"');
+      const result = parseCreate(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe("INBOX/Subfolder/Deep");
+    });
+
+    it("should fail on missing mailbox", () => {
+      const ctx = createContext("");
+      const result = parseCreate(ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseDelete", () => {
+    it("should parse DELETE with simple mailbox", () => {
+      const ctx = createContext("OldFolder");
+      const result = parseDelete(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("DELETE");
+      expect(result.value?.data.mailbox).toBe("OldFolder");
+    });
+
+    it("should parse DELETE with quoted mailbox", () => {
+      const ctx = createContext('"Folder To Delete"');
+      const result = parseDelete(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe("Folder To Delete");
+    });
+
+    it("should fail on missing mailbox", () => {
+      const ctx = createContext("");
+      const result = parseDelete(ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseRename", () => {
+    it("should parse RENAME with simple names", () => {
+      const ctx = createContext("OldName NewName");
+      const result = parseRename(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("RENAME");
+      expect(result.value?.data.oldName).toBe("OldName");
+      expect(result.value?.data.newName).toBe("NewName");
+    });
+
+    it("should parse RENAME with quoted names", () => {
+      const ctx = createContext('"Old Folder" "New Folder"');
+      const result = parseRename(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.oldName).toBe("Old Folder");
+      expect(result.value?.data.newName).toBe("New Folder");
+    });
+
+    it("should fail on missing new name", () => {
+      const ctx = createContext("OldName");
+      const result = parseRename(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("new");
+    });
+
+    it("should fail on missing old name", () => {
+      const ctx = createContext("");
+      const result = parseRename(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("existing");
+    });
+  });
+
+  describe("parseList", () => {
+    it("should parse LIST with wildcard", () => {
+      const ctx = createContext('"" *');
+      const result = parseList("LIST", ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("LIST");
+      expect(result.value?.data.reference).toBe("");
+      expect(result.value?.data.pattern).toBe("*");
+    });
+
+    it("should parse LIST with percent wildcard", () => {
+      const ctx = createContext('"" %');
+      const result = parseList("LIST", ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.pattern).toBe("%");
+    });
+
+    it("should parse LIST with reference", () => {
+      const ctx = createContext('"INBOX" *');
+      const result = parseList("LIST", ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.reference).toBe("INBOX");
+    });
+
+    it("should parse LSUB command", () => {
+      const ctx = createContext('"" *');
+      const result = parseList("LSUB", ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("LSUB");
+    });
+
+    it("should fail on missing reference", () => {
+      const ctx = createContext("");
+      const result = parseList("LIST", ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("parseStatus", () => {
+    it("should parse STATUS with single item", () => {
+      const ctx = createContext("INBOX (MESSAGES)");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.type).toBe("STATUS");
+      expect(result.value?.data.mailbox).toBe("INBOX");
+      expect(result.value?.data.items).toEqual(["MESSAGES"]);
+    });
+
+    it("should parse STATUS with multiple items", () => {
+      const ctx = createContext("INBOX (MESSAGES RECENT UNSEEN)");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.items).toEqual(["MESSAGES", "RECENT", "UNSEEN"]);
+    });
+
+    it("should parse STATUS with all items", () => {
+      const ctx = createContext("INBOX (MESSAGES RECENT UIDNEXT UIDVALIDITY UNSEEN)");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.items).toHaveLength(5);
+    });
+
+    it("should parse STATUS with quoted mailbox", () => {
+      const ctx = createContext('"Sent Items" (MESSAGES)');
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.mailbox).toBe("Sent Items");
+    });
+
+    it("should handle lowercase item names", () => {
+      const ctx = createContext("INBOX (messages)");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(true);
+      expect(result.value?.data.items).toEqual(["MESSAGES"]);
+    });
+
+    it("should fail on missing opening parenthesis", () => {
+      const ctx = createContext("INBOX MESSAGES");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("parenthesis");
+    });
+
+    it("should fail on unknown status item", () => {
+      const ctx = createContext("INBOX (INVALID)");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Unknown");
+    });
+
+    it("should fail on missing mailbox", () => {
+      const ctx = createContext("");
+      const result = parseStatus(ctx);
+      expect(result.success).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds comprehensive unit test coverage for security-critical IMAP parsers that previously had zero test coverage.

Contributes to #54

## Test Coverage Added

### auth-parsers.ts (13 tests)
- **parseLogin**: Simple credentials, quoted username/password, special characters, escape sequences, error cases
- **parseAuthenticate**: PLAIN mechanism, initial response handling, error cases

### append-parser.ts (12 tests)
- Basic APPEND with minimal args
- Quoted mailbox names
- Flag handling (keyword flags)
- Date parsing
- Error cases: missing mailbox, missing literal, malformed literal size
- Edge cases: large literal, zero-length message

### mailbox-parsers.ts (28 tests)
- **parseSelect/EXAMINE**: Simple and quoted mailbox names, special characters
- **parseCreate**: Simple and nested hierarchies
- **parseDelete**: Simple and quoted mailbox names
- **parseRename**: Both mailbox names, quoted names, error cases
- **parseList**: Wildcards (`*`, `%`), reference names, LSUB variant
- **parseStatus**: Single/multiple items, all valid items, quoted mailbox, case handling

## Discovered Issue

During testing, I found that APPEND flag parsing doesn't support system flags (flags with backslash prefix like `\Seen`, `\Flagged`). This is because `parseAtom` excludes the backslash character.

**Current behavior**: Keyword flags (without backslash) work correctly.

This is documented in the tests with a comment. It's a minor issue since flags are rarely used in APPEND operations in practice, but should be fixed eventually.

## Testing

```bash
bun test src/server/lib/imap/parsers/security.test.ts
# 53 pass, 0 fail

bun test
# 106 pass, 0 fail (all tests including existing ones)
```