### PR TITLE
ci: tag Docker images with short SHA for versioning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,13 +34,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Get short SHA
+        id: sha
+        run: echo "short=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/inbox:latest
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/inbox:latest
+            ${{ secrets.DOCKER_HUB_USERNAME }}/inbox:sha-${{ steps.sha.outputs.short }}
 
   deploy:
     needs: [check-secrets, docker-build-push]


### PR DESCRIPTION
## Summary

Each deployment now pushes Docker images with multiple tags for easy rollback:
- `latest`: always points to most recent build
- `sha-<7-char-hash>`: unique identifier tied to git commit

## Example

After merging, Docker Hub will have:
```
hoiekim/inbox:latest
hoiekim/inbox:sha-abc1234
```

## Rollback Usage

```bash
# Revert to a specific version
docker pull hoiekim/inbox:sha-abc1234
```

## Testing

- Verified GitHub Actions workflow syntax
- No functional changes to application code

---
Contributes to #60