### PR TITLE
refactor: add type-safe filters to Table class methods

### DIFF
--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -80,6 +80,20 @@ export interface TableSearchFilters extends Omit<SearchFilters, "filters"> {
   filters?: Record<string, ParamValue>;
 }
 
+/**
+ * Type-safe filter keys: restricts filters to valid column names from the schema.
+ * This provides compile-time typo prevention and IDE autocomplete for filter keys.
+ */
+export type SchemaFilterKey<TSchema extends Schema> = keyof TSchema & string;
+
+/**
+ * Type-safe filters: maps schema keys to ParamValue.
+ * Restricts filter keys to valid column names defined in the schema.
+ */
+export type TypeSafeFilters<TSchema extends Schema> = {
+  [K in SchemaFilterKey<TSchema>]?: ParamValue | unknown;
+};
+
 export abstract class Table<
   TJSON,
   TSchema extends Schema,
@@ -94,7 +108,7 @@ export abstract class Table<
   abstract readonly supportsSoftDelete: boolean;
 
   async query(
-    filters: Record<string, ParamValue | unknown> = {}
+    filters: TypeSafeFilters<TSchema> = {}
   ): Promise<TModel[]> {
     const { sql, values } = buildSelectWithFilters(this.name, "*", {
       filters,
@@ -105,7 +119,7 @@ export abstract class Table<
   }
 
   async queryOne(
-    filters: Record<string, ParamValue | unknown>
+    filters: TypeSafeFilters<TSchema>
   ): Promise<TModel | null> {
     const { sql, values } = buildSelectWithFilters(this.name, "*", {
       filters,
@@ -172,7 +186,7 @@ export abstract class Table<
   }
 
   async deleteWhere(
-    filters: Record<string, ParamValue | unknown>
+    filters: TypeSafeFilters<TSchema>
   ): Promise<number> {
     const entries = Object.entries(filters).filter(([, v]) => v !== undefined);
     if (entries.length === 0) {
@@ -186,7 +200,7 @@ export abstract class Table<
   }
 
   async updateWhere(
-    filters: Record<string, ParamValue | unknown>,
+    filters: TypeSafeFilters<TSchema>,
     data: QueryData,
     returning?: string[]
   ): Promise<Record<string, unknown>[]> {
@@ -213,7 +227,7 @@ export abstract class Table<
 
   async queryByIds(
     ids: ParamValue[],
-    additionalFilters: Record<string, ParamValue | unknown> = {}
+    additionalFilters: TypeSafeFilters<TSchema> = {}
   ): Promise<TModel[]> {
     if (ids.length === 0) return [];
     const placeholders = ids.map((_, i) => `$${i + 1}`).join(", ");


### PR DESCRIPTION
## Summary
Adds compile-time type safety to Table class filter methods, providing IDE autocomplete and typo prevention for filter keys.

## Changes
- Added `SchemaFilterKey<TSchema>` type alias to restrict keys to valid schema columns
- Added `TypeSafeFilters<TSchema>` mapped type for type-safe filter objects
- Updated `query()`, `queryOne()`, `deleteWhere()`, `updateWhere()`, and `queryByIds()` to use the new types

## Benefits
- **Typo prevention**: Filter keys that don't exist in the schema cause compile-time errors
- **IDE support**: Autocomplete shows valid column names when typing filter keys
- **Self-documenting**: Code more clearly shows which columns are being filtered

## Example
```typescript
// Before: any string accepted, typos become runtime bugs
await table.query({ user_id: 1, nmae: 'foo' }); // 'nmae' typo not caught

// After: only valid schema keys accepted
await table.query({ user_id: 1, nmae: 'foo' }); // Compile error: 'nmae' not in schema
```

## Testing
- Build passes
- All 116 tests pass

Contributes to #79