### PR TITLE
feat: local delivery for host domain addresses

### DIFF
--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -5,7 +5,9 @@ import {
   Mail,
   MailDataToSend,
   MailUid,
-  SignedUser
+  SignedUser,
+  MaskedUser,
+  IncomingMail
 } from "common";
 import {
   getDomain,
@@ -14,10 +16,13 @@ import {
   getText,
   saveBuffer,
   getDomainUidNext,
-  getAccountUidNext
+  getAccountUidNext,
+  getUser
 } from "server";
 import { sendMailgunMail } from "./mailgun";
 import { validateMailData, MailValidationError } from "./validation";
+import { convertMail, addressToUsername } from "./receive";
+import { notifyNewMails } from "../push";
 
 export class MailSendingError extends Error {
   constructor(message: string) {
@@ -40,17 +45,44 @@ export const sendMail = async (
   }
 
   const { id: userId, username } = user;
+
+  // Split recipients into local and external
+  const { localRecipients, externalRecipients } = splitRecipients(
+    mailToSend.to,
+    mailToSend.cc,
+    mailToSend.bcc
+  );
+
+  const messageId = randomUUID();
+  let mailgunResponse: Awaited<ReturnType<typeof sendMailgunMail>>;
+
   try {
-    const response = await sendMailgunMail(username, mailToSend, files);
-    const messageId = response?.id || randomUUID();
-    const sentMail = await getSentMail(user, mailToSend, messageId, files);
-    await saveMail(sentMail, userId);
-    if (isToMyself(mailToSend.to)) {
-      // If the email is sent to myself, also save a copy in the inbox
-      await saveMail(new Mail({ ...sentMail, sent: false }), userId);
+    // Send to external recipients via Mailgun (if any)
+    if (externalRecipients.to || externalRecipients.cc || externalRecipients.bcc) {
+      const externalMailData = new MailDataToSend({
+        ...mailToSend,
+        to: externalRecipients.to || "",
+        cc: externalRecipients.cc,
+        bcc: externalRecipients.bcc
+      });
+      mailgunResponse = await sendMailgunMail(username, externalMailData, files);
     }
 
-    return response;
+    // Save sender's copy to Sent folder
+    const sentMail = await getSentMail(
+      user,
+      mailToSend,
+      mailgunResponse?.id || messageId,
+      files
+    );
+    await saveMail(sentMail, userId);
+
+    // Deliver to local recipients directly
+    if (localRecipients.length > 0) {
+      await deliverToLocalRecipients(user, mailToSend, sentMail, localRecipients);
+    }
+
+    return mailgunResponse;
   } catch (error: any) {
     console.error("Email sending request failed", error);
 
@@ -149,14 +181,132 @@ export const addressParser = (str: string) => {
   return result;
 };
 
-const isToMyself = (to: string) => {
-  const toDomains = addressParser(to)?.map(({ email }) => {
-    const splitString = email.split("@")[1].split(".");
-    const length = splitString.length;
-    return splitString[length - 2] + "." + splitString[length - 1];
+interface SplitRecipientsResult {
+  localRecipients: string[];
+  externalRecipients: {
+    to?: string;
+    cc?: string;
+    bcc?: string;
+  };
+}
+
+/**
+ * Split recipients into local (on host domain) and external addresses.
+ * Returns unique local usernames and comma-separated external address strings.
+ */
+const splitRecipients = (
+  to: string,
+  cc?: string,
+  bcc?: string
+): SplitRecipientsResult => {
+  const domain = getDomain();
+  const localUsernames = new Set<string>();
+
+  const splitField = (field?: string): { local: string[]; external: string[] } => {
+    if (!field) return { local: [], external: [] };
+    const parsed = addressParser(field);
+    const local: string[] = [];
+    const external: string[] = [];
+
+    for (const { email } of parsed) {
+      if (isLocalAddress(email, domain)) {
+        local.push(email);
+        localUsernames.add(addressToUsername(email));
+      } else {
+        external.push(email);
+      }
+    }
+
+    return { local, external };
+  };
+
+  const toSplit = splitField(to);
+  const ccSplit = splitField(cc);
+  const bccSplit = splitField(bcc);
+
+  return {
+    localRecipients: Array.from(localUsernames),
+    externalRecipients: {
+      to: toSplit.external.length > 0 ? toSplit.external.join(",") : undefined,
+      cc: ccSplit.external.length > 0 ? ccSplit.external.join(",") : undefined,
+      bcc: bccSplit.external.length > 0 ? bccSplit.external.join(",") : undefined
+    }
+  };
+};
+
+/**
+ * Check if an email address belongs to the host domain.
+ */
+const isLocalAddress = (email: string, domain: string): boolean => {
+  const parts = email.split("@");
+  if (parts.length !== 2) return false;
+  const emailDomain = parts[1].toLowerCase();
+  // Match exact domain or subdomains (e.g., user.domain.com for domain.com)
+  return emailDomain === domain || emailDomain.endsWith(`.${domain}`);
+};
+
+/**
+ * Deliver mail directly to local recipients' inboxes.
+ */
+const deliverToLocalRecipients = async (
+  sender: SignedUser,
+  mailToSend: MailDataToSend,
+  sentMail: Mail,
+  localUsernames: string[]
+): Promise<void> => {
+  const deliveryPromises = localUsernames.map(async (username) => {
+    // Don't double-deliver to sender (they already have it in Sent)
+    if (username === sender.username) return;
+
+    const recipient = await getUser({ username });
+    if (!recipient) {
+      console.warn(`Local delivery failed: user "${username}" not found`);
+      return;
+    }
+
+    // Convert sent mail to incoming format for the recipient
+    const incomingMail = sentMailToIncoming(sentMail, mailToSend);
+    const recipientMail = await convertMail(recipient as MaskedUser, incomingMail);
+
+    await saveMail(recipientMail, recipient.id);
+    console.info(`Delivered mail locally to user: ${username}`);
   });
 
-  const domain = getDomain();
+  await Promise.all(deliveryPromises);
 
-  return !!toDomains?.find((e: string) => e === domain);
+  // Send push notifications to local recipients
+  const recipientsToNotify = localUsernames.filter((u) => u !== sender.username);
+  if (recipientsToNotify.length > 0) {
+    await notifyNewMails(recipientsToNotify);
+  }
+};
+
+/**
+ * Convert a sent Mail object to IncomingMail format for local delivery.
+ */
+const sentMailToIncoming = (sentMail: Mail, mailToSend: MailDataToSend): IncomingMail => {
+  const { to, cc, bcc } = mailToSend;
+
+  // Build envelope recipients from all fields
+  const allRecipients = [
+    ...addressParser(to).map(({ email }) => ({ address: email })),
+    ...(cc ? addressParser(cc).map(({ email }) => ({ address: email })) : []),
+    ...(bcc ? addressParser(bcc).map(({ email }) => ({ address: email })) : [])
+  ];
+
+  return {
+    messageId: sentMail.messageId,
+    subject: sentMail.subject,
+    date: sentMail.date,
+    html: sentMail.html,
+    text: sentMail.text,
+    from: sentMail.from,
+    to: sentMail.to,
+    cc: sentMail.cc,
+    // Don't include bcc in the recipient's view
+    replyTo: sentMail.replyTo,
+    envelopeFrom: sentMail.envelopeFrom,
+    envelopeTo: allRecipients,
+    attachments: sentMail.attachments
+  } as IncomingMail;
 };


### PR DESCRIPTION
## Summary
Skip Mailgun and save directly when sending to addresses on the host domain.

Contributes to #59

## Problem
When sending mail to an address under the host domain (e.g., `user@hoie.kim` when the server hosts `hoie.kim`), the mail was going through Mailgun unnecessarily, and may not appear in the recipient's mailbox.

## Solution
1. Parse all recipients (to, cc, bcc)
2. Split into local (on EMAIL_DOMAIN) and external
3. Send to external via Mailgun (only if there are external recipients)
4. Save sender's copy to Sent folder
5. Deliver to local recipients' inboxes directly
6. Send push notifications to local recipients

## Changes

### src/server/lib/mails/send.ts
- `splitRecipients(to, cc, bcc)`: Separates addresses into local vs external
- `isLocalAddress(email, domain)`: Checks if address is on host domain
- `deliverToLocalRecipients()`: Delivers mail directly to users' inboxes
- `sentMailToIncoming()`: Converts sent mail format to incoming format

## Edge Cases Handled
- **All local**: Skip Mailgun entirely, save to Sent, deliver locally
- **All external**: Current behavior (Mailgun only)
- **Mixed**: Local delivery + Mailgun for external addresses
- **Self-send**: Don't double-deliver to sender (they have Sent copy)
- **Subdomains**: Matches `user.domain.com` for `domain.com`

## Testing
- Type check passes (`npm run typecheck`)
- Lint passes (`npm run lint`)
- Manual testing: Send mail between local users, verify direct delivery