### PR TITLE
security: migrate Math.random() to crypto.randomBytes

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -16,5 +16,10 @@ export const callWithDelay = <T>(callback: () => Promise<T>, delay: number) => {
 };
 
 export const getRandomId = () => {
-  return (65536 + Math.floor(Math.random() * 983040)).toString(16);
+  // Use Web Crypto API (available in both browser and Node.js 19+)
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 };

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -3,6 +3,7 @@ import bcrypt from "bcryptjs";
 import { Socket } from "net";
 import { TLSSocket } from "tls";
 import { readFileSync } from "fs";
+import crypto from "crypto";
 import { MailType, Throttler } from "common";
 import { getUser, markRead, getDomainUidNext, getAccountUidNext, getImapUidValidity } from "server";
 import { Store } from "./store";
@@ -71,9 +72,7 @@ export class ImapSession {
     private handler: ImapRequestHandler,
     public socket: Socket
   ) {
-    this.sessionId = `session_${Date.now()}_${Math.random()
-      .toString(36)
-      .substr(2, 9)}`;
+    this.sessionId = `session_${crypto.randomBytes(8).toString("hex")}`;
   }
 
   getCapabilities = () => {


### PR DESCRIPTION
## Summary

Replaces remaining `Math.random()` calls with cryptographically secure alternatives.

## Changes

### `src/common/util.ts` - `getRandomId()`
- **Before:** `Math.floor(Math.random() * ...)`
- **After:** `crypto.getRandomValues()` (Web Crypto API)

Uses the Web Crypto API which is available in:
- All modern browsers
- Node.js 19+ (via global `crypto`)
- Bun (native support)

### `src/server/lib/imap/session.ts` - Session ID generation
- **Before:** `session_\${Date.now()}_\${Math.random().toString(36).substr(2, 9)}`
- **After:** `session_\${crypto.randomBytes(8).toString('hex')}`

Uses Node.js `crypto` module for server-only code.

## Risk Assessment

**Low risk** - these are internal identifiers, not authentication tokens. However:
- Cryptographic randomness is better hygiene
- Prevents potential future misuse if code is repurposed
- Consistent with the security improvements in #62

## Testing

- All 130 existing tests pass
- TypeScript compiles cleanly
- ESLint passes (no new warnings)

Contributes to #90