### PR TITLE
feat(db): add mailboxes table schema (Phase 3 foundation)

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -8,6 +8,7 @@ import {
   usersTable,
   sessionsTable,
   mailsTable,
+  mailboxesTable,
   pushSubscriptionsTable,
 } from "./models";
 
@@ -17,6 +18,7 @@ export const index = "inbox" + (version ? `-${version}` : "");
 const tables: Table<unknown, Schema>[] = [
   usersTable,
   sessionsTable,
+  mailboxesTable, // Must be before mails due to foreign key reference
   mailsTable,
   pushSubscriptionsTable,
 ];

--- a/src/server/lib/postgres/models/index.ts
+++ b/src/server/lib/postgres/models/index.ts
@@ -2,5 +2,6 @@ export * from "./common";
 export * from "./base";
 export * from "./user";
 export * from "./mail";
+export * from "./mailbox";
 export * from "./session";
 export * from "./push_subscription";

--- a/src/server/lib/postgres/models/mailbox.ts
+++ b/src/server/lib/postgres/models/mailbox.ts
@@ -1,0 +1,110 @@
+import { Model, createTable } from "./base";
+
+// Table and column names
+export const MAILBOXES = "mailboxes";
+export const MAILBOX_ID = "mailbox_id";
+export const MAILBOX_USER_ID = "user_id";
+export const MAILBOX_NAME = "name";
+export const MAILBOX_ADDRESS = "address"; // email address associated with this mailbox
+export const MAILBOX_PARENT_ID = "parent_id";
+export const MAILBOX_UID_VALIDITY = "uid_validity";
+export const MAILBOX_UID_NEXT = "uid_next";
+export const MAILBOX_SUBSCRIBED = "subscribed";
+export const MAILBOX_SPECIAL_USE = "special_use"; // \Inbox, \Sent, \Drafts, \Trash, etc.
+export const MAILBOX_CREATED = "created";
+
+// Type guards
+const isString = (v: unknown): v is string => typeof v === "string";
+const isNullableString = (v: unknown): v is string | null =>
+  v === null || typeof v === "string";
+const isNumber = (v: unknown): v is number => typeof v === "number";
+const isBoolean = (v: unknown): v is boolean => typeof v === "boolean";
+
+export interface MailboxJSON {
+  mailbox_id: string;
+  user_id: string;
+  name: string;
+  address: string | null;
+  parent_id: string | null;
+  uid_validity: number;
+  uid_next: number;
+  subscribed: boolean;
+  special_use: string | null;
+  created: string;
+}
+
+const mailboxSchema = {
+  [MAILBOX_ID]: "UUID PRIMARY KEY DEFAULT gen_random_uuid()",
+  [MAILBOX_USER_ID]: "UUID NOT NULL REFERENCES users(user_id) ON DELETE CASCADE",
+  [MAILBOX_NAME]: "VARCHAR(255) NOT NULL",
+  [MAILBOX_ADDRESS]: "VARCHAR(255)", // nullable - not all mailboxes have an address
+  [MAILBOX_PARENT_ID]: "UUID REFERENCES mailboxes(mailbox_id) ON DELETE CASCADE",
+  [MAILBOX_UID_VALIDITY]: "INTEGER NOT NULL DEFAULT 1",
+  [MAILBOX_UID_NEXT]: "INTEGER NOT NULL DEFAULT 1",
+  [MAILBOX_SUBSCRIBED]: "BOOLEAN NOT NULL DEFAULT TRUE",
+  [MAILBOX_SPECIAL_USE]: "VARCHAR(50)", // \Inbox, \Sent, \Drafts, \Trash, \Junk, \Archive
+  [MAILBOX_CREATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
+};
+
+type MailboxSchema = typeof mailboxSchema;
+
+export class MailboxModel extends Model<MailboxJSON, MailboxSchema> {
+  declare mailbox_id: string;
+  declare user_id: string;
+  declare name: string;
+  declare address: string | null;
+  declare parent_id: string | null;
+  declare uid_validity: number;
+  declare uid_next: number;
+  declare subscribed: boolean;
+  declare special_use: string | null;
+  declare created: string;
+
+  static typeChecker = {
+    mailbox_id: isString,
+    user_id: isString,
+    name: isString,
+    address: isNullableString,
+    parent_id: isNullableString,
+    uid_validity: isNumber,
+    uid_next: isNumber,
+    subscribed: isBoolean,
+    special_use: isNullableString,
+    created: isNullableString,
+  };
+
+  constructor(data: unknown) {
+    super(data, MailboxModel.typeChecker);
+  }
+
+  toJSON(): MailboxJSON {
+    return {
+      mailbox_id: this.mailbox_id,
+      user_id: this.user_id,
+      name: this.name,
+      address: this.address,
+      parent_id: this.parent_id,
+      uid_validity: this.uid_validity,
+      uid_next: this.uid_next,
+      subscribed: this.subscribed,
+      special_use: this.special_use,
+      created: this.created,
+    };
+  }
+}
+
+export const mailboxesTable = createTable({
+  name: MAILBOXES,
+  primaryKey: MAILBOX_ID,
+  schema: mailboxSchema,
+  ModelClass: MailboxModel,
+  supportsSoftDelete: false,
+  indexes: [
+    { column: MAILBOX_USER_ID },
+    { column: MAILBOX_NAME },
+    { column: MAILBOX_ADDRESS },
+    { column: MAILBOX_PARENT_ID },
+  ],
+});
+
+export const mailboxColumns = Object.keys(mailboxesTable.schema);


### PR DESCRIPTION
## Summary
Adds the database schema foundation for Phase 3 multi-account mailbox structure.

## Changes

### New Model: `mailbox.ts`
Creates `mailboxes` table with:
- `mailbox_id` (UUID primary key)
- `user_id` (foreign key to users)
- `name` (mailbox display name)
- `address` (associated email address, nullable)
- `parent_id` (for hierarchical mailboxes)
- `uid_validity`, `uid_next` (IMAP UID management)
- `subscribed` (IMAP subscription status)
- `special_use` (\\Inbox, \\Sent, \\Drafts, etc.)

### Indexes
- user_id (for user mailbox listing)
- name (for mailbox lookups)
- address (for routing)
- parent_id (for hierarchy traversal)

## Prerequisites
- PR #93 (Phase 2 COPY/MOVE commands)

## What's Next (not in this PR)
- Mailbox repository functions (CRUD operations)
- Migration script for existing mails → mailboxes
- IMAP NAMESPACE command implementation
- SMTP routing to mailboxes
- Update IMAP LIST/SELECT to use mailboxes table

## Testing
- Build passes
- All 170 tests pass

## E2E Testing
- [x] Started server, verified mailboxes table created with correct schema

Closes #10