### PR TITLE
fix: use 'message' field in error response instead of 'info'

### DIFF
--- a/src/server/lib/http/routes/route.ts
+++ b/src/server/lib/http/routes/route.ts
@@ -59,7 +59,7 @@ export class Route<T> {
       } catch (error: unknown) {
         console.error(error);
         const message = error instanceof Error ? error.message : String(error);
-        res.status(500).json({ status: "error", info: message });
+        res.status(500).json({ status: "error", message });
       }
     }
     next();


### PR DESCRIPTION
## Summary
Fixes error response field mismatch between server and client.

## Problem
The `Route` class returned error responses with `info` field:
```typescript
res.status(500).json({ status: "error", info: message });
```

But the `ApiResponse` interface expects `message`:
```typescript
interface ApiResponse<T> {
  message?: string;  // Not 'info'
}
```

## Impact
Error messages from server exceptions were lost on the client - users saw generic errors instead of helpful messages.

## Fix
Single line change: `info: message` → `message`

## Testing
- [x] TypeScript compiles
- Trivial change, no functional testing needed

Closes #99