### PR TITLE
chore: remove debug console.log from client call.ts

### DIFF
--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -15,8 +15,6 @@ const call = async <T = unknown>(path: string, options?: RequestInit) => {
     return r.json();
   });
 
-  console.log(`<${method}> ${path}`, response);
-
   return response;
 };
 
@@ -62,7 +60,6 @@ export const read = async <T = unknown>(
 
             try {
               const response: ApiResponse<T> = JSON.parse(e);
-              console.log(`<${method}> ${path}`, response);
               callback(response);
             } catch (error) {
               console.error(error);


### PR DESCRIPTION
## Summary
Removes debug logging that logs every API response to the browser console.

## Problem
`src/client/lib/call.ts` had debug logging that logged every API response:
```typescript
console.log(\`<${method}> ${path}\`, response);
```

This appeared in both the regular `call` function and the `read` streaming function.

## Impact
- Clutters browser console in production
- Potential information leakage (API responses logged)

## Fix
Removed both console.log statements.

## Testing
- [x] TypeScript compiles
- Trivial change - removes logging, no functional impact

Closes #100