### PR TITLE
fix: use 'message' field in error response, remove debug logs

### DIFF
--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -15,8 +15,6 @@ const call = async <T = unknown>(path: string, options?: RequestInit) => {
     return r.json();
   });
 
-  console.log(`<${method}> ${path}`, response);
-
   return response;
 };
 
@@ -62,7 +60,6 @@ export const read = async <T = unknown>(
 
             try {
               const response: ApiResponse<T> = JSON.parse(e);
-              console.log(`<${method}> ${path}`, response);
               callback(response);
             } catch (error) {
               console.error(error);

--- a/src/server/lib/http/routes/route.ts
+++ b/src/server/lib/http/routes/route.ts
@@ -59,7 +59,7 @@ export class Route<T> {
       } catch (error: unknown) {
         console.error(error);
         const message = error instanceof Error ? error.message : String(error);
-        res.status(500).json({ status: "error", info: message });
+        res.status(500).json({ status: "error", message });
       }
     }
     next();


### PR DESCRIPTION
## Changes

### 1. Error response field fix
Error responses were using `{ status: 'error', info: message }` but the `ApiResponse` type defines `message` as the field name. Changed to match the type definition.

### 2. Remove debug console.log
Removed console.log statements from `src/client/lib/call.ts` that were logging every API request/response to the browser console. These were debugging statements that should not be in production.

## Testing

- TypeScript compiles
- CI tests pass

Closes #99
Closes #100