### PR TITLE
fix: display actual API error message on login failure

### DIFF
--- a/src/client/SignIn/index.tsx
+++ b/src/client/SignIn/index.tsx
@@ -35,7 +35,11 @@ const Home = () => {
   if (mutation.isLoading) infoMessage = "🧐 Checking...";
   if (mutation.isError) infoMessage = "🤯 Server error";
   if (mutation.data?.status === "success") infoMessage = "🤗 Welcome!";
-  if (mutation.data?.status === "failed") infoMessage = "🤔 Wrong Password";
+  if (mutation.data?.status === "failed") {
+    infoMessage = mutation.data?.message
+      ? `🤔 ${mutation.data.message}`
+      : "🤔 Wrong Password";
+  }
 
   useEffect(() => {
     const isSuccess = mutation.data?.status === "success";


### PR DESCRIPTION
## Summary
Shows the actual error message from the API response instead of always displaying 'Wrong Password' when login fails.

## Problem
When login fails due to rate limiting (429), the UI shows '🤔 Wrong Password' instead of the actual error message 'Too many login attempts, try again later'.

## Solution
Use the `message` field from the API response when available:
```tsx
if (mutation.data?.status === "failed") {
  infoMessage = mutation.data?.message
    ? \`🤔 \${mutation.data.message}\`
    : "🤔 Wrong Password";
}
```

## Testing
- [x] TypeScript compiles without errors
- [ ] E2E: Trigger rate limiting → verify correct error message shown
- [ ] E2E: Enter wrong password → verify 'Wrong Password' still shown

Closes #105