### PR TITLE
fix: use proper form element for login page

### DIFF
--- a/src/client/SignIn/index.tsx
+++ b/src/client/SignIn/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useContext, useEffect, ChangeEvent, KeyboardEvent } from "react";
+import { useState, useContext, useEffect, ChangeEvent, FormEvent } from "react";
 import { useMutation } from "react-query";
 import { Link } from "react-router-dom";
 import { SignedUser, SignedUserType } from "common";
@@ -47,7 +47,8 @@ const Home = () => {
     }
   }, [mutation.data, setUserInfo]);
 
-  const onClickLogin = async () => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const body: LoginBody = { password: passwordInput };
     if (usernameInput.includes("@")) body.email = usernameInput;
     else body.username = usernameInput;
@@ -55,32 +56,30 @@ const Home = () => {
     mutation.mutate(body);
   };
 
-  const onKeyDownInput = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") onClickLogin();
-  };
-
   return (
     <div className="container_login">
-      <blockquote className="login_card">
+      <form className="login_card" onSubmit={onSubmit}>
         <h3 className="greeting">Please log in</h3>
         <div className="info_message">{infoMessage}</div>
         <input
           className="login_ui"
           placeholder="username or email"
-          type="username"
+          type="text"
+          name="username"
+          autoComplete="username"
           value={usernameInput}
-          onKeyDown={onKeyDownInput}
           onChange={onChangeUsername}
         />
         <input
           className="login_ui"
           placeholder="password"
           type="password"
+          name="password"
+          autoComplete="current-password"
           value={passwordInput}
-          onKeyDown={onKeyDownInput}
           onChange={onChangePassword}
         />
-        <button className="login_ui" onClick={onClickLogin}>
+        <button className="login_ui" type="submit">
           <LoginIcon />
           <span>Login</span>
         </button>
@@ -96,7 +95,7 @@ const Home = () => {
             <Link to="/set-info">Sign Up</Link>
           </div>
         </div>
-      </blockquote>
+      </form>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
Replaces the `<blockquote>` element with a proper `<form>` element for the login page.

## Changes
- Replace `<blockquote>` with `<form>` element for proper semantics
- Add `name` and `autoComplete` attributes for password manager support
- Use native form submission (`onSubmit`) instead of manual Enter key handling
- Change `type="username"` to `type="text"` (valid HTML)

## Benefits
- **Password managers** can now properly detect the login form
- **Browser autofill** works correctly
- **Accessibility** - screen readers expect form semantics for login
- **Native behavior** - Enter key submission via form, not custom handler

## Testing
- [x] TypeScript compiles without errors
- [ ] E2E: Login page loads correctly
- [ ] E2E: Enter key submits the form
- [ ] E2E: Password manager recognizes the form

Closes #106