### PR TITLE
fix: ensure compose panel Send button is always visible

### DIFF
--- a/src/client/Box/components/Writer/index.scss
+++ b/src/client/Box/components/Writer/index.scss
@@ -1,8 +1,17 @@
 .writer {
+  display: flex;
+  flex-direction: column;
   height: calc(100% - 10px);
+  max-height: calc(100% - 10px);
   margin-top: 5px;
   padding-top: 1rem;
   padding-right: calc(1rem + 50px);
+  overflow: hidden;
+
+  // Form field sections (From, To, Subject) should not shrink
+  > div:not(.writer-body):not(.writer-buttons) {
+    flex-shrink: 0;
+  }
 
   span {
     white-space: nowrap;
@@ -92,13 +101,16 @@
   }
 
   .writer-body {
-    height: calc(100% - 16rem);
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
 
     .writer-content-wrap {
       display: flex;
       flex-direction: column;
       width: 100%;
       height: calc(100% - 0.5rem - 20px);
+      max-height: calc(100% - 0.5rem - 20px);
 
       .writer-content {
         padding: 0 0.5rem;
@@ -140,6 +152,7 @@
     justify-content: center;
     width: 100%;
     margin-top: 1rem;
+    flex-shrink: 0;
 
     button {
       margin: 0 0.5rem;


### PR DESCRIPTION
## Summary
The compose panel (Writer) would extend beyond the viewport at certain widths (e.g., 1568px, 1600px), making the Send button invisible and inaccessible.

## Changes
- Convert `.writer` to flexbox layout with `flex-direction: column`
- Add `overflow: hidden` to prevent content from extending beyond bounds
- Add `max-height` constraint to match height calculation
- Use `flex: 1` and `min-height: 0` for `.writer-body` to allow it to shrink
- Add `flex-shrink: 0` to form fields and `.writer-buttons` to ensure they don't collapse

## E2E Testing
Tested the compose panel at multiple viewport sizes:

### At 1600x900:
- Opened compose panel by clicking the edit icon
- All form fields (From, To, Subject, Content) visible
- **Send button visible and accessible at bottom**

### At 1568x900 (reported problematic width):
- Opened compose panel
- All form fields visible
- **Send button visible and accessible at bottom**

### At 1600x600 (shorter height):
- Opened compose panel
- Form fields maintain size, content area shrinks appropriately
- **Send button visible and accessible at bottom**

## Root Cause
The original CSS used fixed height calculations (`height: calc(100% - 16rem)`) for the content area without proper flexbox constraints. At certain viewport dimensions, this caused the total height of elements to exceed the container, pushing the Send button out of view.

The fix uses flexbox to ensure:
1. Form fields (From, To, Subject) don't shrink
2. Content area flexes to fill available space
3. Send button always stays at the bottom, never pushed out of view

Closes #113