### PR TITLE
fix: Apply rate limiter only to POST requests

### DIFF
--- a/src/server/lib/http/routes/users/index.ts
+++ b/src/server/lib/http/routes/users/index.ts
@@ -8,9 +8,15 @@ import { loginLimiter, tokenLimiter } from "../../rate-limit";
 
 const usersRouter = Router();
 
-// Apply rate limiters using route paths
-usersRouter.use(postLoginRoute.path, loginLimiter);
-usersRouter.use(postTokenRoute.path, tokenLimiter);
+// Apply rate limiters only to POST requests (use() applies to all methods)
+usersRouter.use(postLoginRoute.path, (req, res, next) => {
+  if (req.method === "POST") return loginLimiter(req, res, next);
+  next();
+});
+usersRouter.use(postTokenRoute.path, (req, res, next) => {
+  if (req.method === "POST") return tokenLimiter(req, res, next);
+  next();
+});
 
 const routes = [
   getLoginRoute,


### PR DESCRIPTION
## Problem
`router.use(path, middleware)` applies to ALL HTTP methods (GET, POST, PUT, etc.), not just POST.

This caused GET /api/users/login (login status check) to count against the login rate limit, potentially locking users out without making actual login attempts.

## Solution
Wrap the limiters in a method check to only apply to POST requests:

```typescript
usersRouter.use(postLoginRoute.path, (req, res, next) => {
  if (req.method === "POST") return loginLimiter(req, res, next);
  next();
});
```

## Testing
- All 170 unit tests pass
- E2E: Rate limiter only triggers on POST, GET returns normally

Closes #112