### PR TITLE
chore: remove debug console.log from client call.ts

### DIFF
--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -15,8 +15,6 @@ const call = async <T = unknown>(path: string, options?: RequestInit) => {
     return r.json();
   });
 
-  console.log(`<${method}> ${path}`, response);
-
   return response;
 };
 
@@ -62,7 +60,6 @@ export const read = async <T = unknown>(
 
             try {
               const response: ApiResponse<T> = JSON.parse(e);
-              console.log(`<${method}> ${path}`, response);
               callback(response);
             } catch (error) {
               console.error(error);


### PR DESCRIPTION
## Summary
Removes debug console.log statements from the client API call helper.

## Changes
- Removed `console.log(`<${method}> ${path}`, response)` from `call()` function
- Removed `console.log(`<${method}> ${path}`, response)` from `read()` function

These were debug statements that log every API request/response to the browser console.

## Testing
- TypeScript compiles ✅
- No functional changes - only removes console output

Closes #100