### PR TITLE
chore: remove debug console.log from IMAP parsers

### DIFF
--- a/src/server/lib/imap/parsers/mailbox-parsers.ts
+++ b/src/server/lib/imap/parsers/mailbox-parsers.ts
@@ -23,9 +23,6 @@ export const parseList = (
   // Parse reference name (can be quoted string or atom)
   const referenceName = parseString(context);
   if (!referenceName.success) {
-    console.log(
-      `[PARSER] Failed to parse reference name at position ${context.position}`
-    );
     return {
       success: false,
       error: "Invalid reference name in LIST",
@@ -52,9 +49,6 @@ export const parseList = (
   }
 
   if (!mailboxName.success) {
-    console.log(
-      `[PARSER] Failed to parse mailbox name at position ${context.position}`
-    );
     return {
       success: false,
       error: "Invalid mailbox name in LIST",


### PR DESCRIPTION
## Summary
Removes debug console.log statements from IMAP parser code.

## Changes
- Removed debug logging from `parseList()` function in `mailbox-parsers.ts`
- Error messages are preserved in the return values

## Testing
- TypeScript compiles ✅
- Parsers still return proper error messages, just without console output

Closes #96