### PR TITLE
security: Add sandbox attribute to email iframe

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -224,6 +224,7 @@ const MailBody = ({ mailId }: Props) => {
           srcDoc={processHtmlForViewer(data.html)}
           onLoad={onLoadIframe}
           ref={iframeElement}
+          sandbox="allow-same-origin"
         />
       </div>
     );


### PR DESCRIPTION
## Problem
The email body viewer renders email HTML in an iframe without the `sandbox` attribute, allowing malicious emails to execute JavaScript in the user's browser context.

**This is a critical XSS vulnerability for an email client.**

## Solution
Add `sandbox="allow-same-origin"` to the email body iframe. This:
- **Blocks JavaScript execution** in email content
- **Blocks form submission** from emails
- **Blocks plugin instantiation**
- **Blocks top-level navigation**
- **Preserves** same-origin access needed for iframe sizing/styling

## Testing
- Build passes
- Manual verification: emails still render correctly, but JS is blocked

## References
- MDN sandbox attribute: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#sandbox

Closes #121