### PR TITLE
fix: Apply rate limiter only to POST requests

### DIFF
--- a/src/server/lib/http/routes/users/index.ts
+++ b/src/server/lib/http/routes/users/index.ts
@@ -8,9 +8,15 @@ import { loginLimiter, tokenLimiter } from "../../rate-limit";
 
 const usersRouter = Router();
 
-// Apply rate limiters using route paths
-usersRouter.use(postLoginRoute.path, loginLimiter);
-usersRouter.use(postTokenRoute.path, tokenLimiter);
+// Apply rate limiters only to POST requests (not GET status checks)
+usersRouter.use(postLoginRoute.path, (req, res, next) => {
+  if (req.method === "POST") return loginLimiter(req, res, next);
+  next();
+});
+usersRouter.use(postTokenRoute.path, (req, res, next) => {
+  if (req.method === "POST") return tokenLimiter(req, res, next);
+  next();
+});
 
 const routes = [
   getLoginRoute,


### PR DESCRIPTION
## Problem
`router.use(path, middleware)` applies to ALL HTTP methods (GET, POST, PUT, etc.), not just POST.

This caused GET /api/users/login (auth status check) to count against the login rate limit, locking users out before they could even attempt to log in.

## Solution
Wrap the limiters in a method check:

```typescript
usersRouter.use(postLoginRoute.path, (req, res, next) => {
  if (req.method === "POST") return loginLimiter(req, res, next);
  next();
});
```

## Testing
- All 170 unit tests pass
- E2E verification needed: Rate limiter should only trigger on POST, GET should return normally

## E2E Testing Plan
1. Start server locally
2. Make repeated GET /api/users/login requests - should NOT get 429
3. Make POST /api/users/login requests - should get 429 after 5 attempts

Closes #126
Closes #112