### PR TITLE
fix: Add UNIQUE constraint on mails(user_id, message_id) to prevent duplicates

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -77,6 +77,28 @@ export const initializePostgres = async (): Promise<void> => {
       ON mails USING GIN(search_vector)
     `);
 
+    // Add unique constraint on (user_id, message_id) to prevent duplicate emails
+    // First check if constraint exists to avoid error on existing databases
+    const constraintCheck = await pool.query(`
+      SELECT constraint_name FROM information_schema.table_constraints
+      WHERE table_name = 'mails' AND constraint_type = 'UNIQUE'
+      AND constraint_name = 'mails_user_id_message_id_key'
+    `);
+    if (constraintCheck.rows.length === 0) {
+      // Remove any existing duplicates before adding constraint
+      await pool.query(`
+        DELETE FROM mails a USING mails b
+        WHERE a.mail_id > b.mail_id
+        AND a.user_id = b.user_id
+        AND a.message_id = b.message_id
+      `);
+      await pool.query(`
+        ALTER TABLE mails
+        ADD CONSTRAINT mails_user_id_message_id_key UNIQUE (user_id, message_id)
+      `);
+      console.info("Added unique constraint on mails(user_id, message_id)");
+    }
+
     // Create trigger function for auto-updating search_vector
     await pool.query(`
       CREATE OR REPLACE FUNCTION mails_search_vector_trigger() RETURNS trigger AS $$

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -219,6 +219,7 @@ export const mailsTable = createTable({
   name: MAILS,
   primaryKey: MAIL_ID,
   schema: mailSchema,
+  constraints: [`UNIQUE (${USER_ID}, ${MESSAGE_ID})`],
   ModelClass: MailModel,
   supportsSoftDelete: false,
   indexes: [


### PR DESCRIPTION
## Summary

Adds a UNIQUE constraint on `(user_id, message_id)` to the mails table to prevent duplicate emails from being saved.

Closes #141

## Changes

1. **Schema update** (mail.ts): Added `UNIQUE (user_id, message_id)` constraint to `mailsTable` definition for new databases

2. **Migration** (initialize.ts): For existing databases:
   - Check if constraint already exists
   - Remove any existing duplicate emails (keeping the first one by mail_id)
   - Add the UNIQUE constraint

## Root Cause

The `saveMail` function was inserting emails without checking for existing `(user_id, message_id)` pairs. This allowed duplicate emails when the same email was processed multiple times (e.g., during SMTP retry or concurrent requests).

## Testing

- [x] TypeScript compiles without errors
- [x] All 218 existing unit tests pass
- [ ] E2E: Verify migration runs successfully on existing database (pending)
- [ ] E2E: Verify duplicate inserts are rejected (pending)

## Risk

Low - The constraint is additive and the migration safely handles existing duplicates by keeping the first occurrence.