### PR TITLE
fix: select only header columns in getMailHeaders to prevent OOM crashes

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -12,6 +12,16 @@ import {
   UID_ACCOUNT,
   TO_ADDRESS,
   FROM_ADDRESS,
+  SUBJECT,
+  DATE,
+  FROM_TEXT,
+  TO_TEXT,
+  CC_ADDRESS,
+  CC_TEXT,
+  BCC_ADDRESS,
+  BCC_TEXT,
+  SENT,
+  INSIGHT,
 } from "../models";
 
 export interface SaveMailInput {
@@ -180,8 +190,18 @@ export const getMailHeaders = async (
     const addressCondition = options.sent
       ? `${FROM_ADDRESS} @> $3::jsonb`
       : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb)`;
+    // Select only columns needed for mail headers — excludes html/text/attachments
+    // to avoid loading full email bodies into memory for every concurrent request.
+    const headerColumns = [
+      MAIL_ID, USER_ID, SUBJECT, DATE,
+      FROM_ADDRESS, FROM_TEXT,
+      TO_ADDRESS, TO_TEXT,
+      CC_ADDRESS, CC_TEXT,
+      BCC_ADDRESS, BCC_TEXT,
+      READ, SAVED, SENT, INSIGHT,
+    ].join(", ");
     let sql = `
-      SELECT * FROM mails 
+      SELECT ${headerColumns} FROM mails 
       WHERE user_id = $1 
         AND sent = $2
         AND ${addressCondition}


### PR DESCRIPTION
## Problem

Fixes #159 — production server restarts with 502 errors when multiple accounts are loaded concurrently.

**Root cause:** `getMailHeaders` used `SELECT *` on the mails table, loading full email bodies (html, text, attachments) even though the headers endpoint only needs metadata. With the default pagination size of 10,000 and multiple simultaneous requests, memory spikes until the Docker container is OOM-killed.

## Fix

Replace `SELECT *` with a specific column list containing only what the headers endpoint actually needs:

```sql
-- Before
SELECT * FROM mails WHERE user_id = $1 AND sent = $2 AND ...

-- After  
SELECT mail_id, user_id, subject, date,
       from_address, from_text, to_address, to_text,
       cc_address, cc_text, bcc_address, bcc_text,
       read, saved, sent, insight
FROM mails WHERE user_id = $1 AND sent = $2 AND ...
```

This excludes `html`, `text`, `attachments` — which can be hundreds of KB per email — reducing per-request memory by ~90%+ on mailboxes with substantive content.

## Testing

- TypeScript compiles cleanly
- The `MailHeaderData` mapping in `headers.ts` only uses the columns that are now explicitly selected — no data loss
- The body route (`getBodyRoute`) uses a separate `getMailById` query that still does `SELECT *` — that's correct behavior

Closes #159