### PR TITLE
security: ignore .env files by default in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,9 @@
 
 # misc
 .DS_Store
+.env
 .env.*
 !.env.example
-!.env
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Problem

The `.gitignore` had:
```
.env.*
!.env.example
!.env
```

The `!.env` line explicitly **un-ignores** `.env`, meaning real environment files containing secrets can be accidentally committed to the public repo. This caused PR #85 where a `.env` file was committed and had to be explicitly removed.

## Fix

```
.env
.env.*
!.env.example
```

All `.env` files are now ignored by default. Only `.env.example` (template with no secrets) is tracked.

## E2E Testing
- Verified `git check-ignore -v .env` now correctly reports the file as ignored (output: `.gitignore:16:.env`)
- `.env.example` still tracked (unaffected)
- No functional code changes

Closes #157