### PR TITLE
fix: use MailHeaderResult to avoid MailModel constructor failure in getMailHeaders

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -24,6 +24,30 @@ import {
   INSIGHT,
 } from "../models";
 
+/**
+ * Represents the subset of mail fields returned by getMailHeaders.
+ * This is a partial view that excludes body fields (html, text, attachments, etc.)
+ * for performance reasons.
+ */
+export interface MailHeaderResult {
+  mail_id: string;
+  user_id: string;
+  subject: string;
+  date: string;
+  from_address: object | null;
+  from_text: string | null;
+  to_address: object | null;
+  to_text: string | null;
+  cc_address: object | null;
+  cc_text: string | null;
+  bcc_address: object | null;
+  bcc_text: string | null;
+  read: boolean;
+  saved: boolean;
+  sent: boolean;
+  insight: object | null;
+}
+
 export interface SaveMailInput {
   user_id: string;
   message_id: string;
@@ -188,7 +212,7 @@ export const getMailHeaders = async (
   user_id: string,
   address: string,
   options: GetMailHeadersOptions
-): Promise<MailModel[]> => {
+): Promise<MailHeaderResult[]> => {
   try {
     const addressJson = JSON.stringify([{ address }]);
     // For sent mails, check from_address only
@@ -234,7 +258,7 @@ export const getMailHeaders = async (
     }
 
     const result = await pool.query(sql, values);
-    return result.rows.map((row: unknown) => new MailModel(row));
+    return result.rows as MailHeaderResult[];
   } catch (error) {
     console.error("Failed to get mail headers:", error);
     return [];


### PR DESCRIPTION
## Problem

Issue #159 identified that `getMailHeaders` was using `SELECT *`, which loads full email bodies (`html`, `text`, `attachments`) for every account on every page load. With large mailboxes this caused OOM → server crash → 502 Bad Gateway.

PR #161 correctly narrowed the SELECT to only header columns. But the return was still:

```ts
return result.rows.map((row: unknown) => new MailModel(row));
```

`MailModel`'s constructor validates **all** fields via `typeChecker`, including ones no longer in the SELECT (`message_id`, `html`, `text`, `deleted`, `draft`, `answered`, `uid_domain`, `uid_account`, `spam_score`, `is_spam`, etc.). When those fields are absent from the row, the constructor throws. The `catch` block catches it and returns `[]` — so every mail header request silently returned an empty list, making the inbox appear broken after #161 merged.

## Fix

Introduces `MailHeaderResult` — a typed interface with exactly the columns selected — and returns rows directly:

```ts
return result.rows as MailHeaderResult[];
```

No MailModel construction, no validation of irrelevant fields. The existing mapping in `headers.ts` already only uses these columns, so no data is lost.

## E2E Testing

- Started dev server (`bun run dev`), client on :3000, API on :3004
- Clicked "admin" account → 3 emails rendered with correct sender/subject/timestamp ✓
- Clicked "test" account → 2 emails rendered correctly ✓
- No JS errors in browser console ✓
- TypeScript build passes (`bun run build-server`) ✓

Closes #159