### PR TITLE
fix: preserve account selection when switching category tabs

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -235,7 +235,6 @@ const Accounts = ({
 
     const categoryComponents = Object.values(Category).map((e, i) => {
       const onClickCategory = () => {
-        setSelectedAccount("");
         setSelectedCategory(e);
       };
       const classes = [];

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -340,7 +340,6 @@ const RenderedMails = ({ page }: { page: number }) => {
     isWriterOpen,
     setReplyData,
     selectedAccount,
-    setSelectedAccount,
     selectedCategory
   } = useContext(Context);
 
@@ -372,11 +371,7 @@ const RenderedMails = ({ page }: { page: number }) => {
       return body?.map((d) => new MailHeaderData(d)) || [];
     } else throw new Error(message);
   };
-  const query = useQuery<MailHeaderData[]>(queryUrl, getMails, {
-    onSuccess: (data) => {
-      if (!data?.length) setSelectedAccount("");
-    }
-  });
+  const query = useQuery<MailHeaderData[]>(queryUrl, getMails);
 
   if (query.isLoading) {
     return (


### PR DESCRIPTION
## Problem

Two related issues caused the selected account to reset unexpectedly:

**#144: Account selection resets when switching category tabs**
`Accounts/index.tsx` called `setSelectedAccount('')` inside `onClickCategory`, deselecting the account on every category switch — even when the same account is valid in the new tab.

**#140: Clicking category deselects the current account**
`RenderedMails` had an `onSuccess` callback calling `setSelectedAccount('')` when a mail query returned empty results. This caused the account to deselect when switching to an empty tab (e.g., empty 'New') even when the user had a valid account selected.

## Fix

- Remove `setSelectedAccount('')` from `onClickCategory` in Accounts
- Remove the `onSuccess` callback from `RenderedMails` query — empty state rendering handles this at the render level

## Testing

- TypeScript: `npx tsc --noEmit` — clean
- Tested: switch between category tabs with an account selected — account stays selected
- Tested: switch to empty category tab (e.g., 'New' with no unread) — account stays selected

Closes #140
Closes #144