### PR TITLE
fix: add key prop to search highlight divs

### DIFF
--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -209,9 +209,9 @@ const RenderedMail = ({
   let searchHighlight;
 
   if ("highlight" in mail && mail.highlight) {
-    searchHighlight = Object.values(mail.highlight).map((e) => {
+    searchHighlight = Object.values(mail.highlight).map((e, index) => {
       const __html = "..." + e.join("... ...") + "...";
-      return <div dangerouslySetInnerHTML={{ __html }}></div>;
+      return <div key={`highlight_${index}`} dangerouslySetInnerHTML={{ __html }} />;
     });
   }
 


### PR DESCRIPTION
## Problem

Closes #154

React warns: `Each child in a list should have a unique "key" prop` in `RenderedMail` when viewing search results.

## Root Cause

```tsx
// Before — missing key:
searchHighlight = Object.values(mail.highlight).map((e) => {
  const __html = '...' + e.join('... ...') + '...';
  return <div dangerouslySetInnerHTML={{ __html }}></div>;
});
```

## Fix

```tsx
// After — index-based key:
searchHighlight = Object.values(mail.highlight).map((e, index) => {
  const __html = '...' + e.join('... ...') + '...';
  return <div key={`highlight_${index}`} dangerouslySetInnerHTML={{ __html }} />;
});
```

## Testing

- Opened the app, performed a search query, verified no React key warnings in console
- Search highlights render correctly

## Files Changed
- `src/client/Box/components/Mails/index.tsx` — added `key` prop to highlight divs