### PR TITLE
docs: fix error field name and add soft-delete pattern to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -148,7 +148,7 @@ try {
   if (result) res.json(result);
 } catch (error: any) {
   console.error(error);
-  res.status(500).json({ status: "error", info: error?.message });
+  res.status(500).json({ status: "error", message: error?.message });
 }
 ```
 
@@ -249,6 +249,16 @@ The `sandbox` attribute restricts:
 Additional defense layers:
 - HTML sanitization (planned: #124)
 - CSP headers (planned: #151)
+
+### Data Deletion Strategy
+
+Prefer **soft-delete** over hard-delete for user-facing data:
+
+- Mark records as deleted (e.g., `expunged` flag) rather than removing rows
+- Soft-deleted records are excluded from normal queries but preserved for recovery
+- Hard deletion is reserved for cleanup tasks or explicit user requests
+
+This pattern is used in the IMAP EXPUNGE implementation where deleted messages retain their data until explicitly purged.
 
 ### IMAP Security
 


### PR DESCRIPTION
Two small DEVELOPMENT.md updates:

### Fix stale error field reference
The error handling example still showed `info` field but the code was updated to `message` in PR #102. Fixed to match.

### Add soft-delete pattern
Documents the soft-delete strategy used in the IMAP EXPUNGE implementation. This pattern (marking as deleted vs removing rows) should be the default for user-facing data.

**E2E testing:** Documentation-only change.

Closes: N/A