### PR TITLE
fix: add allow-popups to iframe sandbox to restore link navigation

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -224,7 +224,7 @@ const MailBody = ({ mailId }: Props) => {
           srcDoc={processHtmlForViewer(data.html)}
           onLoad={onLoadIframe}
           ref={iframeElement}
-          sandbox="allow-same-origin"
+          sandbox="allow-same-origin allow-popups"
         />
       </div>
     );


### PR DESCRIPTION
## Problem

Closes #175

After adding `sandbox="allow-same-origin"` in #123, clicking links in email bodies stopped working. The iframe's sandbox blocks all navigation/popups by default.

## Root Cause

The `onLoadIframe` handler already sets `target="_blank"` on all anchor elements, but `allow-popups` is required for those pop-ups to actually open. Without it, clicks are silently swallowed.

## Fix

Changed:
```
sandbox="allow-same-origin"
```
To:
```
sandbox="allow-same-origin allow-popups"
```

## Security

- `allow-scripts` is still **absent** — JavaScript in email content cannot execute (XSS protection from #123 preserved)
- `allow-same-origin` retained — needed for the `onLoadIframe` handler to access iframe DOM
- `allow-popups` added — allows user-initiated link navigation to open in new tabs

## Testing

1. Start server: `bun run dev`
2. Open an email with links in the body
3. Click a link — should open in new tab
4. Verify JavaScript links (`javascript:alert()`) still do nothing (no scripts allowed)