### PR TITLE
security: escape HTML in search highlights to prevent XSS

### DIFF
--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -212,9 +212,18 @@ const RenderedMail = ({
   let searchHighlight;
 
   if ("highlight" in mail && mail.highlight) {
-    searchHighlight = Object.values(mail.highlight).map((e) => {
-      const __html = "..." + e.join("... ...") + "...";
-      return <div dangerouslySetInnerHTML={{ __html }}></div>;
+    const escapeHighlight = (html: string) => {
+      const escaped = html
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      return escaped
+        .replace(/&lt;em&gt;/g, "<em>")
+        .replace(/&lt;\/em&gt;/g, "</em>");
+    };
+    searchHighlight = Object.values(mail.highlight).map((e, index) => {
+      const __html = "..." + e.map(escapeHighlight).join("... ...") + "...";
+      return <div key={`highlight_${index}`} dangerouslySetInnerHTML={{ __html }} />;
     });
   }
 


### PR DESCRIPTION
## Problem

Closes #173

PostgreSQL `ts_headline()` does not HTML-escape source text — it only wraps matched terms in `<em>` tags. The client was rendering this output directly via `dangerouslySetInnerHTML` without sanitization.

**Attack scenario:** An email with subject `<img src=x onerror=alert(document.cookie)> Amazon` would produce this highlight when searching "Amazon":

```html
<img src=x onerror=alert(document.cookie)> <em>Amazon</em>
```

Rendered unsanitized → arbitrary JS execution in the user's browser session. Can steal session, read/send emails as the user.

Note: The iframe sandbox from #121 does **not** protect this code path — highlights are rendered in the main React tree, not in the sandboxed iframe.

## Fix

Escape all HTML entities first, then restore only the safe `<em>`/`</em>` tags that `ts_headline` produces:

```tsx
const escapeHighlight = (html: string) => {
  const escaped = html
    .replace(/&/g, "&amp;")
    .replace(/</g, "&lt;")
    .replace(/>/g, "&gt;");
  return escaped
    .replace(/&lt;em&gt;/g, "<em>")
    .replace(/&lt;\/em&gt;/g, "</em>");
};
```

Also fixed missing `key` prop on highlight `<div>` elements.

## Testing

1. Start server: `bun run dev`
2. Send/import an email with HTML in subject: `<img src=x onerror=alert(1)> test`
3. Search for "test"
4. Verify: highlight renders as escaped text, no alert fires
5. Verify: search term highlighting (`<em>`) still works visually