### PR TITLE
security: reduce JSON body size limit from 50MB to 1MB

### DIFF
--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -15,7 +15,7 @@ export const initializeHttp = async () => {
     app.set("trust proxy", 1);
   }
 
-  app.use(json({ limit: "50mb" }));
+  app.use(json({ limit: "1mb" }));
   app.use(fileupload());
   app.use(
     session({


### PR DESCRIPTION
## Problem
The JSON body parser was configured with a 50MB limit. For an email client, legitimate JSON payloads are small (email metadata, settings). Email content and attachments go through `express-fileupload`, not JSON parsing. This excessive limit exposes the server to memory exhaustion attacks.

## Solution
Reduce JSON body size limit to 1MB. No legitimate JSON payloads approach this size.

## Testing
- Verified normal API calls work within 1MB
- Large file uploads still work via multipart/form-data (unaffected by JSON limit)

Closes #178