### PR TITLE
reliability: add process-level error handlers for unhandled rejections

### DIFF
--- a/src/server/lib/postgres/client.ts
+++ b/src/server/lib/postgres/client.ts
@@ -47,3 +47,17 @@ process.on("SIGTERM", async () => {
   await pool.end();
   process.exit(0);
 });
+
+process.on("unhandledRejection", (reason) => {
+  console.error("Unhandled promise rejection:", reason);
+});
+
+process.on("uncaughtException", async (error) => {
+  console.error("Uncaught exception:", error);
+  try {
+    await pool.end();
+  } catch (e) {
+    // ignore pool shutdown errors during crash
+  }
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem
The inbox server runs IMAP, SMTP, and HTTP concurrently. Without process-level error handlers, unhandled promise rejections and uncaught exceptions can crash the server silently in Node.js/Bun (v15+), leaving no log trail and no cleanup of connections.

## Solution
Add `unhandledRejection` and `uncaughtException` handlers in `postgres/client.ts` (alongside the existing SIGINT/SIGTERM handlers):

- **`unhandledRejection`**: Logs the rejection reason without crashing (non-fatal)
- **`uncaughtException`**: Logs the error, closes the DB pool gracefully, then exits with code 1

This ensures crashes are always logged and the DB pool is cleaned up.

## Testing
- Existing SIGINT/SIGTERM graceful shutdown behavior unchanged
- Server starts normally

Closes #179