### PR TITLE
fix: improve compose form UX with validation and proper error messages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "inbox",
       "dependencies": {
+        "@tiptap/extension-placeholder": "^2.0.0",
         "bcryptjs": "^3.0.3",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -329,6 +330,8 @@
     "@tiptap/extension-ordered-list": ["@tiptap/extension-ordered-list@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-M7A4tLGJcLPYdLC4CI2Gwl8LOrENQW59u3cMVa+KkwG1hzSJyPsbDpa1DI6oXPC2WtYiTf22zrbq3gVvH+KA2w=="],
 
     "@tiptap/extension-paragraph": ["@tiptap/extension-paragraph@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-elYVn2wHJJ+zB9LESENWOAfI4TNT0jqEN34sMA/hCtA4im1ZG2DdLHwkHIshj/c4H0dzQhmsS/YmNC5Vbqab/A=="],
+
+    "@tiptap/extension-placeholder": ["@tiptap/extension-placeholder@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0", "@tiptap/pm": "^2.7.0" } }, "sha512-IjsgSVYJRjpAKmIoapU0E2R4E2FPY3kpvU7/1i7PUYisylqejSJxmtJPGYw0FOMQY9oxnEEvfZHMBA610tqKpg=="],
 
     "@tiptap/extension-strike": ["@tiptap/extension-strike@2.27.2", "", { "peerDependencies": { "@tiptap/core": "^2.7.0" } }, "sha512-HHIjhafLhS2lHgfAsCwC1okqMsQzR4/mkGDm4M583Yftyjri1TNA7lzhzXWRFWiiMfJxKtdjHjUAQaHuteRTZw=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@tiptap/extension-placeholder": "^2.0.0",
     "bcryptjs": "^3.0.3",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/src/client/Box/components/Writer/index.scss
+++ b/src/client/Box/components/Writer/index.scss
@@ -201,5 +201,13 @@
         padding: 0;
       }
     }
+
+    p.is-editor-empty:first-child::before {
+      color: #adb5bd;
+      content: attr(data-placeholder);
+      float: left;
+      height: 0;
+      pointer-events: none;
+    }
   }
 }

--- a/src/client/Box/components/Writer/index.tsx
+++ b/src/client/Box/components/Writer/index.tsx
@@ -10,6 +10,7 @@ import {
 import { useMutation } from "react-query";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
 
 import { ApiResponse, SendMailPostBody, SendMailPostResponse } from "server";
 
@@ -91,7 +92,7 @@ const Writer = () => {
   const [sender, setSender] = useLocalStorage("sender", "");
   const [initialContent, setInitialContent] = useLocalStorage(
     "initialContent",
-    "Say something really cool here!"
+    ""
   );
   const [originalMessage, setOriginalMessage] = useLocalStorage(
     "originalMessage",
@@ -107,7 +108,12 @@ const Writer = () => {
   const [editorKey, setEditorKey] = useState(1);
 
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [
+      StarterKit,
+      Placeholder.configure({
+        placeholder: "Say something really cool here!",
+      }),
+    ],
     content: initialContent
   });
 
@@ -173,7 +179,7 @@ const Writer = () => {
 
   const onSuccessSendMail = (data: ApiResponse<SendMailPostResponse>) => {
     if (data.status !== "success") {
-      return alert("Failed to send. Please Try again");
+      return alert(data.message || "Failed to send. Please try again.");
     }
     alert("Your mail is sent successfully");
     setIsWriterOpen(false);
@@ -226,6 +232,8 @@ const Writer = () => {
   };
 
   const onClickSend = () => {
+    if (!sender.trim()) return alert("Please enter a sender account name.");
+    if (!to.trim()) return alert("Please enter a recipient email address.");
     if (!window.confirm("Do you want to send it?")) return;
 
     const formData = new FormData();


### PR DESCRIPTION
## Problems Fixed

### #176 — Compose form lacks validation and shows generic send error
1. No client-side validation allowed sending with empty sender/recipient
2. Server error messages (e.g., "Sender is required") were ignored — only generic "Failed to send" shown

### #184 — Compose editor uses hardcoded default content instead of placeholder
The editor initialized with `"Say something really cool here!"` as actual editable content — users had to manually delete it, and if they forgot, that text was sent as the email body (confirmed: a test email in DB had this as its body).

## Solution

**Validation (#176):**
- Added client-side checks before the confirm dialog: sender account and recipient must be non-empty
- Error message now shows `data.message` from server response, falling back to generic message

**Placeholder (#184):**
- Installed `@tiptap/extension-placeholder@^2.0.0`
- Changed `initialContent` default from hardcoded string to `""` (empty)
- Added Placeholder extension with the text as proper greyed-out hint
- Added CSS for placeholder styling (`.is-editor-empty::before`)

## Testing
- Opened compose form: placeholder text shows greyed out, not selectable
- Clicking send with empty sender: alert "Please enter a sender account name."
- Clicking send with empty recipient: alert "Please enter a recipient email address."
- Server validation errors now display correctly

Closes #176
Closes #184