### PR TITLE
fix: exclude expunged emails from full-text search results

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -295,6 +295,7 @@ export const searchMails = async (
       FROM mails 
       WHERE user_id = $1 
         AND search_vector @@ plainto_tsquery('english', $2)
+        AND expunged = FALSE
       ORDER BY rank DESC, date DESC
       LIMIT 1000
     `;


### PR DESCRIPTION
## Summary

Excludes soft-deleted (expunged) emails from full-text search results.

## Problem

The `searchMails` query was missing `AND expunged = FALSE`, so emails deleted via IMAP EXPUNGE would still appear in search results. Every other mail query in the codebase (IMAP search, header listing, UID range queries, unread counts) already filters out expunged emails — FTS was the only outlier.

## Change

```sql
-- Before
WHERE user_id = $1
  AND search_vector @@ plainto_tsquery('english', $2)

-- After
WHERE user_id = $1
  AND search_vector @@ plainto_tsquery('english', $2)
  AND expunged = FALSE
```

One-line fix in `src/server/lib/postgres/repositories/mails.ts`.

## e2e Testing

- Started dev server (`bun run dev`)
- Soft-deleted an email via IMAP EXPUNGE
- Searched for keywords from that email — no longer appears in results
- Searched for keywords from a non-deleted email — still appears correctly

## Related

Closes #194