### PR TITLE
fix: exclude expunged emails from account stats counts

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -405,6 +405,7 @@ export const getAccountStats = async (
           ${addressExpansion}
         FROM mails 
         WHERE user_id = $1 AND sent = $2 
+          AND expunged = FALSE
           AND ${addressNotNull}
       )
       SELECT 


### PR DESCRIPTION
## Summary

`getAccountStats()` was missing `AND expunged = FALSE` in its CTE query. This caused soft-deleted (expunged via IMAP) emails to be included in the account sidebar counts, while being correctly hidden from the email list views.

**Result:** Sidebar could show inflated email counts that don't match the visible emails.

## Changes

One-line addition to the CTE WHERE clause in `getAccountStats()`:
```sql
AND expunged = FALSE
```

This brings `getAccountStats()` in line with all other query functions (`getMailHeaders`, `searchMails`, UID queries, etc.) which already filter expunged emails.

## Testing

- All 242 unit tests pass
- E2E: Started the app, verified account sidebar counts match header counts for all accounts (admin received: 3/3, test received: 2/2, admin sent: 2/2, Unknown sent: 1/1). Currently no expunged emails in test data, but code review confirms the filter was missing.
- Traced data flow: `getAccounts` → `getAccountStats` → CTE query → sidebar display. The fix ensures consistency with `getMailHeaders` which already has `expunged = FALSE`.

Closes #197