### PR TITLE
security: regenerate session ID on login to prevent session fixation

### DIFF
--- a/src/server/lib/http/routes/users/post-login.ts
+++ b/src/server/lib/http/routes/users/post-login.ts
@@ -26,6 +26,12 @@ export const postLoginRoute = new Route<LoginPostResponse>(
       return { status: "failed", message: "Invalid credentials." };
     }
 
+    await new Promise<void>((resolve, reject) => {
+      req.session.regenerate((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
     req.session.user = signedUser;
 
     return { status: "success", body: signedUser };


### PR DESCRIPTION
## Summary

Fixes session fixation vulnerability in the login flow by calling `req.session.regenerate()` before assigning user data to the session.

## Problem

After successful authentication, the old code simply wrote to the existing session:
```typescript
req.session.user = signedUser;
```

An attacker could pre-set a session cookie (via XSS or subdomain cookie injection), wait for the victim to log in, and then access the authenticated session using the known session ID.

## Fix

Call `req.session.regenerate()` after auth succeeds, before writing user data. This issues a new session ID and invalidates the old one:

```typescript
await new Promise<void>((resolve, reject) => {
  req.session.regenerate((err) => {
    if (err) reject(err);
    else resolve();
  });
});
req.session.user = signedUser;
```

## Testing

- TypeScript compiles without errors
- Started dev server, logged in successfully — session works as expected after regeneration

Closes #204