### PR TITLE
security: run Docker container as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,10 @@ FROM node:22-slim
 
 WORKDIR /app
 
-COPY --from=builder /app/build ./build
-COPY healthcheck.js ./healthcheck.js
+COPY --chown=node:node --from=builder /app/build ./build
+COPY --chown=node:node healthcheck.js ./healthcheck.js
+
+USER node
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
   CMD node ./healthcheck.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - ./.env.local
     ports:
       - "3004:3004"
-      - "25:25"
+      - "25:2525"
     links:
       - postgres
     depends_on:
@@ -28,6 +28,7 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=inbox
       - POSTGRES_DATABASE=inbox
+      - SMTP_PORT=2525
 
   postgres:
     image: postgres:16-alpine

--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -174,7 +174,7 @@ export const initializeSmtp = async () => {
   }
 
   const smtpServer = await new Promise<SMTPServer>((res) => {
-    const port = 25;
+    const port = process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : 25;
     const server = new SMTPServer({ ...options, secure: false });
     registerListeners(server, port, () => {
       console.log(`SMTP server listening on port ${port}`);


### PR DESCRIPTION
## Summary

Switch the production Docker container to run as the built-in `node` user (uid 1000) from `node:22-slim`. Bind SMTP internally on port 2525 (mapped to host port 25 via Docker) to avoid needing `setcap`/`libcap2-bin` entirely.

## Problem

The Dockerfile had no `USER` directive, so the container ran as root. Port 25 (SMTP) is a privileged port (< 1024), which previously required either running as root or using `setcap`.

## Fix

**smtp.ts** — make SMTP port configurable via `SMTP_PORT` env var (defaults to 25 for backwards compat):
```ts
const port = process.env.SMTP_PORT ? parseInt(process.env.SMTP_PORT, 10) : 25;
```

**docker-compose.yml** — map host port 25 to internal port 2525, set `SMTP_PORT=2525`:
```yaml
ports:
  - "25:2525"
environment:
  - SMTP_PORT=2525
```

**Dockerfile** — no `apt-get`/`setcap` needed; use built-in `node` user with `--chown` at copy time:
```dockerfile
COPY --chown=node:node --from=builder /app/build ./build
COPY --chown=node:node healthcheck.js ./healthcheck.js

USER node
```

All other ports are already unprivileged (3004 HTTP, 143/993 IMAP, 465/587 SMTP TLS).

## Testing

- Dockerfile lints cleanly, no extra apt layers
- Runtime stage runs as `node` (non-root); app files owned by `node:node`
- SMTP still reachable on host port 25 via Docker port mapping

Closes #205