### PR TITLE
fix: clear selectedAccount when switching category tabs if account not found

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -236,6 +236,24 @@ const Accounts = ({
     const categoryComponents = Object.values(Category).map((e, i) => {
       const onClickCategory = () => {
         setSelectedCategory(e);
+        // Clear selectedAccount if it doesn't exist in the new category's account list.
+        // Prevents stale selection showing an account not visible in the sidebar.
+        if (e !== Category.Search && query.data) {
+          let newCategoryAccounts: Account[] = [];
+          if (e === Category.NewMails) {
+            newCategoryAccounts = received.filter((a) => a.unread_doc_count);
+          } else if (e === Category.AllMails) {
+            newCategoryAccounts = received;
+          } else if (e === Category.SavedMails) {
+            newCategoryAccounts = received.filter((a) => a.saved_doc_count);
+          } else if (e === Category.SentMails) {
+            newCategoryAccounts = sent;
+          }
+          const exists = newCategoryAccounts.some((a) => a.key === selectedAccount);
+          if (!exists) {
+            setSelectedAccount(newCategoryAccounts[0]?.key || "");
+          }
+        }
       };
       const classes = [];
       if (selectedCategory === e) classes.push("clicked");


### PR DESCRIPTION
## Problem

Closes #214

When switching between category tabs (All/Sent/New/Saved), `selectedAccount` was not validated against the new category's account list. A sent-only account (e.g. "Unknown") stays selected when switching to All, where it doesn't appear in the sidebar — causing a confusing empty mail list.

## Root Cause

`onClickCategory` called `setSelectedCategory(e)` but never checked whether `selectedAccount` exists in the new category. The account lists differ by category: Sent shows `sent[]`, All/New/Saved show `received[]` (with filters).

## Fix

In `onClickCategory`, compute the visible account list for the destination category using the same logic as `sortedAccountData`. If `selectedAccount` is absent, reset to the first available account (or empty string).

```tsx
const exists = newCategoryAccounts.some((a) => a.key === selectedAccount);
if (!exists) {
  setSelectedAccount(newCategoryAccounts[0]?.key || "");
}
```

## E2E Testing

- Select a Sent-only account in the Sent tab
- Switch to All tab → account is reset to first received account
- Switch between All/New/Saved → account persists when it exists in the new list
- 250 unit tests pass