### PR TITLE
fix: reset selectedAccount when switching to category where it doesn't exist

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -236,6 +236,16 @@ const Accounts = ({
     const categoryComponents = Object.values(Category).map((e, i) => {
       const onClickCategory = () => {
         setSelectedCategory(e);
+        // Reset selectedAccount if it doesn't exist in the new category's account list
+        let targetAccounts: Account[];
+        if (e === Category.SentMails) targetAccounts = sent;
+        else if (e === Category.NewMails) targetAccounts = received.filter((a) => a.unread_doc_count);
+        else if (e === Category.SavedMails) targetAccounts = received.filter((a) => a.saved_doc_count);
+        else if (e === Category.Search) targetAccounts = searchHistory;
+        else targetAccounts = received;
+        if (!targetAccounts.some((a) => a.key === selectedAccount)) {
+          setSelectedAccount(targetAccounts[0]?.key || "");
+        }
       };
       const classes = [];
       if (selectedCategory === e) classes.push("clicked");


### PR DESCRIPTION
## Summary

Fixes a UX issue where `selectedAccount` persists across category tab switches even when the selected account doesn't exist in the new category.

## Root Cause

The `onClickCategory` handler only called `setSelectedCategory(e)` without validating whether the current `selectedAccount` exists in the new category's account list. This caused the header to show an account that wasn't visible in the sidebar.

## Fix

After setting the new category, validate that `selectedAccount` exists in the target account list. If not, reset to the first available account (or empty string if the category is empty):

```tsx
const onClickCategory = () => {
  setSelectedCategory(e);
  // Validate selectedAccount exists in new category
  let targetAccounts = ...;
  if (!targetAccounts.some((a) => a.key === selectedAccount)) {
    setSelectedAccount(targetAccounts[0]?.key || "");
  }
};
```

## Example Scenario Fixed

1. Switch to **Sent** tab → select **Unknown@inbox.app** (a sent-only account)
2. Switch back to **All** tab
3. Previously: header shows "Unknown@inbox.app", content shows empty, no account highlighted in sidebar
4. Now: auto-selects first available received account

Closes #214