### PR TITLE
security: add file size limits to express-fileupload

### DIFF
--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -16,7 +16,14 @@ export const initializeHttp = async () => {
   }
 
   app.use(json({ limit: "10mb" }));
-  app.use(fileupload());
+  app.use(
+    fileupload({
+      limits: { fileSize: 25 * 1024 * 1024 }, // 25MB max per file
+      abortOnLimit: true,
+      useTempFiles: true,
+      tempFileDir: "/tmp/",
+    })
+  );
   app.use(
     session({
       secret: process.env.SECRET || "secret",


### PR DESCRIPTION
## Summary

Adds configuration to `express-fileupload` to enforce a 25MB per-file size limit and use temp files instead of in-memory buffering.

## Changes

**Before:**
```ts
app.use(fileupload());
```

**After:**
```ts
app.use(
  fileupload({
    limits: { fileSize: 25 * 1024 * 1024 }, // 25MB max per file
    abortOnLimit: true,
    useTempFiles: true,
    tempFileDir: "/tmp/",
  })
);
```

## Impact

- **`abortOnLimit: true`** — requests with files over 25MB are rejected instead of OOMing the process
- **`useTempFiles: true`** — large uploads are streamed to disk rather than held in memory
- 25MB limit is reasonable for email attachments (matches common mail server defaults)

Closes #150