### PR TITLE
fix: isolate rate limiter counters per limiter instance

### DIFF
--- a/src/server/lib/http/rate-limit.test.ts
+++ b/src/server/lib/http/rate-limit.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// We test the module internals by importing after mocking express types
+// so we can construct fake Request/Response objects.
+const mockNext = mock(() => {});
+
+const makeReq = (ip: string) =>
+  ({
+    ip,
+    socket: { remoteAddress: ip },
+  }) as unknown as import("express").Request;
+
+const makeRes = () => {
+  const res: Record<string, unknown> = {};
+  res.status = mock((code: number) => {
+    res._code = code;
+    return res;
+  });
+  res.json = mock((body: unknown) => {
+    res._body = body;
+    return res;
+  });
+  return res as unknown as import("express").Response;
+};
+
+describe("createLimiter", () => {
+  it("allows requests below the limit", async () => {
+    const { createLimiter } = await import("./rate-limit");
+    const limiter = createLimiter(3, "too many");
+    const req = makeReq("1.2.3.4");
+    const res = makeRes();
+    const next = mock(() => {});
+
+    limiter(req, res, next);
+    limiter(req, res, next);
+    limiter(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(3);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("blocks requests over the limit", async () => {
+    const { createLimiter } = await import("./rate-limit");
+    const limiter = createLimiter(2, "rate limited");
+    const req = makeReq("10.0.0.1");
+    const res = makeRes();
+    const next = mock(() => {});
+
+    limiter(req, res, next); // 1
+    limiter(req, res, next); // 2
+    limiter(req, res, next); // 3 — should be blocked
+
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(429);
+  });
+
+  it("isolates counters between different limiters (regression for #221)", async () => {
+    const { createLimiter } = await import("./rate-limit");
+
+    // limiterA allows 5 attempts; limiterB allows 3
+    const limiterA = createLimiter(5, "A limit");
+    const limiterB = createLimiter(3, "B limit");
+
+    const ip = "192.168.1.1";
+    const reqA = makeReq(ip);
+    const reqB = makeReq(ip);
+    const resA = makeRes();
+    const resB = makeRes();
+    const nextA = mock(() => {});
+    const nextB = mock(() => {});
+
+    // Exhaust limiterB (3 calls)
+    limiterB(reqB, resB, nextB);
+    limiterB(reqB, resB, nextB);
+    limiterB(reqB, resB, nextB);
+    expect(nextB).toHaveBeenCalledTimes(3);
+
+    // limiterB is now at its max — next call should be blocked
+    limiterB(reqB, resB, nextB);
+    expect(nextB).toHaveBeenCalledTimes(3); // still 3, not 4
+
+    // limiterA should be UNAFFECTED — counter is isolated
+    limiterA(reqA, resA, nextA);
+    limiterA(reqA, resA, nextA);
+    limiterA(reqA, resA, nextA);
+    expect(nextA).toHaveBeenCalledTimes(3);
+    expect(resA.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("cleanupExpiredAttempts", () => {
+  it("cleans up records across all limiter Maps", async () => {
+    const { createLimiter, cleanupExpiredAttempts } = await import(
+      "./rate-limit"
+    );
+    const limiter = createLimiter(5, "cleanup test");
+    const req = makeReq("5.5.5.5");
+    const res = makeRes();
+    const next = mock(() => {});
+
+    limiter(req, res, next);
+
+    // Manually force expiry by calling cleanup — records haven't expired so
+    // cleaned count may be 0, but the call should not throw.
+    expect(() => cleanupExpiredAttempts()).not.toThrow();
+  });
+});

--- a/src/server/lib/http/rate-limit.ts
+++ b/src/server/lib/http/rate-limit.ts
@@ -8,16 +8,25 @@ interface AttemptRecord {
   resetAt: number;
 }
 
-// Shared attempt storage for all limiters
-const attempts = new Map<string, AttemptRecord>();
+// Tracks all per-limiter attempt Maps so the scheduler can clean them all.
+const allAttemptMaps: Map<string, AttemptRecord>[] = [];
 
 /**
  * Create a rate limiter middleware.
+ *
+ * Each call to createLimiter gets its own isolated attempt Map so that
+ * separate limiters (e.g. loginLimiter and tokenLimiter) do not share
+ * counters. Previously a single shared Map caused token requests to
+ * consume login quota and vice versa.
  *
  * @param maxAttempts Maximum attempts allowed within the window
  * @param message Error message to return when limit is exceeded
  */
 export const createLimiter = (maxAttempts: number, message: string) => {
+  // Per-limiter isolated storage — not shared with any other limiter.
+  const attempts = new Map<string, AttemptRecord>();
+  allAttemptMaps.push(attempts);
+
   return (req: Request, res: Response, next: NextFunction) => {
     const ip = req.ip || req.socket.remoteAddress || "unknown";
     const now = Date.now();
@@ -38,17 +47,19 @@ export const createLimiter = (maxAttempts: number, message: string) => {
 };
 
 /**
- * Clean up expired attempt records.
+ * Clean up expired attempt records across all limiter Maps.
  * Called periodically to prevent memory buildup.
  */
 export const cleanupExpiredAttempts = (): number => {
   const now = Date.now();
   let cleaned = 0;
 
-  for (const [ip, record] of attempts) {
-    if (now >= record.resetAt) {
-      attempts.delete(ip);
-      cleaned++;
+  for (const attempts of allAttemptMaps) {
+    for (const [ip, record] of attempts) {
+      if (now >= record.resetAt) {
+        attempts.delete(ip);
+        cleaned++;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes the bug where `loginLimiter` and `tokenLimiter` shared a single `attempts` Map, causing token requests to consume login quota and vice versa.

Closes #221

## Root Cause

```typescript
// Before: shared Map for ALL limiters
const attempts = new Map<string, AttemptRecord>();
```

Both `loginLimiter` (max 5) and `tokenLimiter` (max 3) read/wrote the same Map entry for a given IP. A user who made 3 token requests would only have 2 login attempts before being rate-limited (429).

## Fix

Move the Map inside `createLimiter()` so each limiter gets its own isolated counter:

```typescript
export const createLimiter = (maxAttempts: number, message: string) => {
  // Per-limiter isolated storage
  const attempts = new Map<string, AttemptRecord>();
  allAttemptMaps.push(attempts); // for cleanup scheduler
  // ...
};
```

A module-level `allAttemptMaps` registry lets the cleanup scheduler still visit all Maps.

## Tests

Added 4 unit tests (`rate-limit.test.ts`):
- Allows requests below the limit ✅
- Blocks requests over the limit ✅
- **Regression test**: verifies limiterA and limiterB counters are isolated ✅
- Cleanup scheduler does not throw ✅

## E2E Testing

1. Started inbox dev server (`bun run dev`)
2. Made 3 POST requests to `/api/users/token` from same IP
3. Verified login attempts still had a fresh counter (not consumed by token requests)
4. Made 5 POST requests to `/api/users/login` — correctly rate-limited on the 6th attempt
5. App loads and auth flows work normally