### PR TITLE
refactor: add sent field to MailHeaderData and update header mapping

### DIFF
--- a/src/common/models/mails/MailData.ts
+++ b/src/common/models/mails/MailData.ts
@@ -3,10 +3,16 @@ import { AttachmentType, MailAddressType } from "./Mail";
 import { Insight } from "./Insight";
 import { Model } from "../Model";
 
+/**
+ * Partial mail model for inbox list views. Only includes metadata fields —
+ * excludes html, text, attachments to avoid loading full bodies into memory.
+ * Corresponds to the partial SELECT performed by getMailHeaders().
+ */
 export interface MailHeaderDataType {
   id: string;
   read: boolean;
   saved: boolean;
+  sent: boolean;
   date: DateString;
   subject: string;
   from?: MailAddressType;
@@ -29,6 +35,7 @@ export class MailHeaderData
   declare date: DateString;
   declare read: boolean;
   declare saved: boolean;
+  declare sent: boolean;
   declare from?: MailAddressType;
   declare to?: MailAddressType;
   declare cc?: MailAddressType;
@@ -46,6 +53,7 @@ export class MailHeaderData
     if (!data?.date) this.date = new Date().toISOString();
     if (!data?.read) this.read = false;
     if (!data?.saved) this.saved = false;
+    if (!data?.sent) this.sent = false;
   }
 }
 

--- a/src/server/lib/mails/headers.ts
+++ b/src/server/lib/mails/headers.ts
@@ -61,6 +61,7 @@ export const getMailHeaders = async (
         : undefined,
       read: m.read,
       saved: m.saved,
+      sent: m.sent,
       insight: m.insight as Insight | undefined,
     });
   });


### PR DESCRIPTION
## Summary

Closes #219

`MailHeaderData` (the partial mail model for inbox list views) was missing the `sent` field even though `getMailHeaders()` already SELECTs it from the DB and the mapping layer had it available via `m.sent`.

## Changes

**`src/common/models/mails/MailData.ts`**
- Added `sent: boolean` to `MailHeaderDataType` interface
- Added `declare sent: boolean` to `MailHeaderData` class
- Added `if (!data?.sent) this.sent = false` to constructor
- Added JSDoc comment explaining this is a partial model (no html/text/attachments) — the partial SELECT pattern that prevents the OOM crash from #159

**`src/server/lib/mails/headers.ts`**
- Added `sent: m.sent` to the `new MailHeaderData({...})` mapping call

## Context

The crash in #159 was caused by `getMailHeaders` using `SELECT *` which loaded full email bodies into memory for every list view. The fix switched to partial SELECT (metadata only). However, the `sent` field — which IS included in the partial SELECT — was never forwarded to the client model.

## TypeScript

`bun run tsc --noEmit` — clean.

## E2E Testing

1. Started inbox dev server
2. Opened inbox and sent mail tabs — both load correctly
3. Verified `/api/mails/headers/:account` response now includes `sent: true/false` on each mail
4. No console errors