### PR TITLE
fix: warn at startup when EMAIL_DOMAIN is not configured

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -130,4 +130,15 @@ export const initializeAdminUser = async (): Promise<void> => {
   if (!createdAdminUserId) throw new Error("Failed to create admin user");
 
   console.info("Successfully initialized PostgreSQL database and setup admin user.");
+
+  // Warn if EMAIL_DOMAIN is not explicitly configured.
+  // Without a correct domain, getAccountStats() filters all emails out (domain condition)
+  // causing the inbox to appear empty even when emails exist.
+  if (!process.env.EMAIL_DOMAIN) {
+    console.warn(
+      "[CONFIG WARNING] EMAIL_DOMAIN is not set. Defaulting to 'mydomain'.\n" +
+        "  The inbox will appear empty if your emails are addressed to a different domain.\n" +
+        "  Set EMAIL_DOMAIN=yourdomain.com in your .env file to see incoming emails."
+    );
+  }
 };


### PR DESCRIPTION
## Summary

Add a startup warning when `EMAIL_DOMAIN` is not set in the environment.

## Problem

When `EMAIL_DOMAIN` is not configured, it defaults to `'mydomain'`. The `getAccountStats()` query filters emails by domain:

```sql
AND address ILIKE '%@' || $3  -- where $3 is getUserDomain(username)
```

If actual emails are addressed to a different domain (e.g. `@hoie.kim`), they're filtered out entirely — causing the inbox to appear empty even when thousands of emails exist.

This is a silent misconfiguration that's very confusing to debug:
- App starts normally
- No errors in logs
- DB has 4000+ emails
- UI shows "This category is empty"

## Solution

Add a `console.warn` in `initializeAdminUser()` when `EMAIL_DOMAIN` is not explicitly set:

```
[CONFIG WARNING] EMAIL_DOMAIN is not set. Defaulting to 'mydomain'.
  The inbox will appear empty if your emails are addressed to a different domain.
  Set EMAIL_DOMAIN=yourdomain.com in your .env file to see incoming emails.
```

## Testing

- Start app without `EMAIL_DOMAIN` set → warning appears in startup logs
- Start app with `EMAIL_DOMAIN=hoie.kim` → no warning

Closes #155