### PR TITLE
fix: validate password confirmation matches before submitting sign-up form

### DIFF
--- a/src/client/SignUp/index.tsx
+++ b/src/client/SignUp/index.tsx
@@ -34,6 +34,7 @@ const SignUp = () => {
   const [usernameInput, setUsernameInput] = useState(username || "");
   const [passwordInput, setPasswordInput] = useState("");
   const [passwordConfirmInput, setPasswordConfirmInput] = useState("");
+  const [passwordMismatch, setPasswordMismatch] = useState(false);
 
   const onChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
     setEmailInput(e.target.value);
@@ -45,10 +46,12 @@ const SignUp = () => {
 
   const onChangePassword = (e: ChangeEvent<HTMLInputElement>) => {
     setPasswordInput(e.target.value);
+    setPasswordMismatch(false);
   };
 
   const onChangePasswordConfirm = (e: ChangeEvent<HTMLInputElement>) => {
     setPasswordConfirmInput(e.target.value);
+    setPasswordMismatch(false);
   };
 
   type DynamicResponse = SetInfoPostResponse | TokenPostResponse;
@@ -64,6 +67,7 @@ const SignUp = () => {
 
   if (email) {
     infoMessage = "🤐 Please set your user information.";
+    if (passwordMismatch) infoMessage = "⚠️ Passwords do not match. Please try again.";
     if (mutation.isLoading) infoMessage = "🧐 Setting your information...";
     if (mutation.isError) infoMessage = "🤯 Server error";
     if (mutation.data?.status === "success") infoMessage = "🤗 All set up!";
@@ -93,6 +97,11 @@ const SignUp = () => {
   }, [mutation.data, setUserInfo]);
 
   const onClickSignUp = () => {
+    if (email && passwordInput && passwordInput !== passwordConfirmInput) {
+      setPasswordMismatch(true);
+      return;
+    }
+    setPasswordMismatch(false);
     mutation.mutate({
       email: emailInput,
       token,


### PR DESCRIPTION
## Problem

Closes #227

The sign-up form has a "password to confirm" field that appears once the user starts typing a password. However, `onClickSignUp` never checked whether the two fields matched before submitting — the form silently submitted with the unconfirmed password.

## Root Cause

In `SignUp/index.tsx`, `onClickSignUp` calls `mutation.mutate({ ..., password: passwordInput })` without comparing `passwordInput` and `passwordConfirmInput`. The confirmation field existed in state and was rendered but was never read at submission time.

## Fix

- Block form submission when `passwordInput !== passwordConfirmInput`; set a `passwordMismatch` flag instead
- Display `⚠️ Passwords do not match. Please try again.` in the info message area
- Reset `passwordMismatch` whenever either password field changes (so the error clears as the user types)
- Guard is conditional on `email` being present (set-info flow only — the initial email-submit step doesn't involve passwords)

## Changes

- `src/client/SignUp/index.tsx`: add `passwordMismatch` state, pre-submit validation, error message, and reset handlers

## E2E Testing

Tested the sign-up flow locally:
1. Started dev server (`bun run dev`)
2. Navigated to `/set-info/<email>?t=<token>`
3. Entered password, left confirm field empty → clicked Set Up → ⚠️ error shown, form not submitted
4. Entered mismatched passwords → ⚠️ error shown, form not submitted
5. Typed in either field → error clears immediately
6. Entered matching passwords → form submitted successfully, user created