### PR TITLE
fix: rename adjustMailContentSize and clean up setTimeout on unmount

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -46,6 +46,15 @@ const MailBody = ({ mailId }: Props) => {
   const query = useQuery<MailBodyData>(queryUrl, getMail);
 
   const iframeElement = useRef<HTMLIFrameElement>(null);
+  const pendingTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  // Cancel all pending timers when the component unmounts
+  useEffect(() => {
+    return () => {
+      pendingTimers.current.forEach(clearTimeout);
+      pendingTimers.current = [];
+    };
+  }, []);
 
   useEffect(() => {
     if (
@@ -62,7 +71,7 @@ const MailBody = ({ mailId }: Props) => {
     }
   }, [setIsWriterOpen, replyData, setReplyData, query]);
 
-  const audjstMailContnetSize = useCallback(
+  const adjustMailContentSize = useCallback(
     (iframeDom: HTMLIFrameElement | null) => {
       if (!iframeDom || !iframeDom.contentWindow) return;
       const content = iframeDom.contentWindow.document.body;
@@ -150,7 +159,8 @@ const MailBody = ({ mailId }: Props) => {
       if (!content) return;
 
       content.addEventListener("click", () => {
-        setTimeout(() => audjstMailContnetSize(iframeDom), 50);
+        const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);
+        pendingTimers.current.push(id);
       });
 
       Array.from(content.querySelectorAll("a")).forEach((e) => {
@@ -205,8 +215,9 @@ const MailBody = ({ mailId }: Props) => {
           }
         });
 
-      audjstMailContnetSize(iframeDom);
-      setTimeout(() => audjstMailContnetSize(iframeDom), 50);
+      adjustMailContentSize(iframeDom);
+      const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);
+      pendingTimers.current.push(id);
     };
 
     return (


### PR DESCRIPTION
## Changes

Two fixes in `MailBody.tsx`:

### 1. Typo fix: `audjstMailContnetSize` → `adjustMailContentSize` (Closes #230)

The function name had both a transposition (`adj**u**st` → `adj**u**st`) and mangled word (`Contnet` → `Content`). Renamed consistently throughout the file.

### 2. Timer cleanup on unmount (Closes #231)

The `onLoadIframe` handler created `setTimeout` calls without tracking the IDs:

```ts
setTimeout(() => adjustMailContentSize(iframeDom), 50);              // on load
setTimeout(() => adjustMailContentSize(iframeDom), 50);              // on click
```

If the component unmounted before a 50ms timer fired, it would attempt to resize a detached iframe element. Fixed by:
- Adding a `pendingTimers` ref to collect all timer IDs
- Adding a `useEffect` cleanup that calls `clearTimeout` on each ID when the component unmounts

## Testing

- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Started app, opened an email — iframe renders and resizes correctly
- [x] Navigated away quickly after opening email — no console errors from stale timers
- [x] Function is callable by its new name in all code paths

Closes #230
Closes #231