### PR TITLE
fix(imap): deduplicate LIST mailbox entries and trim whitespace

### DIFF
--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -53,34 +53,44 @@ export class Store {
         getAccountStats(this.user.id, true, userDomain),
       ]);
 
-      const mailboxes: string[] = ["INBOX"];
+      const seen = new Set<string>();
+      const addMailbox = (name: string) => {
+        const trimmed = name.trim();
+        if (!seen.has(trimmed)) {
+          seen.add(trimmed);
+          mailboxes.push(trimmed);
+        }
+      };
+
+      const mailboxes: string[] = [];
+      addMailbox("INBOX");
 
       // Add Sent Messages (unified across all accounts) if any sent mail exists
       if (sentStats.length > 0) {
-        mailboxes.push(SENT_MESSAGES_FOLDER);
+        addMailbox(SENT_MESSAGES_FOLDER);
       }
 
       // Add accounts/ parent folder if any received-mail accounts exist
       if (receivedStats.length > 0) {
-        mailboxes.push(ACCOUNTS_FOLDER);
+        addMailbox(ACCOUNTS_FOLDER);
       }
 
-      // Add received mail accounts under accounts/
+      // Add received mail accounts under accounts/ (deduplicated)
       receivedStats.forEach((stat) => {
         if (stat.address) {
-          mailboxes.push(accountToBox(stat.address));
+          addMailbox(accountToBox(stat.address));
         }
       });
 
       // Add Sent Messages/accounts/ parent folder if any per-account sent mail exists
       if (sentStats.length > 0) {
-        mailboxes.push(SENT_MESSAGES_ACCOUNTS_FOLDER);
+        addMailbox(SENT_MESSAGES_ACCOUNTS_FOLDER);
       }
 
-      // Add per-account sent mailboxes under Sent Messages/accounts/
+      // Add per-account sent mailboxes under Sent Messages/accounts/ (deduplicated)
       sentStats.forEach((stat) => {
         if (stat.address) {
-          mailboxes.push(accountToSentBox(stat.address));
+          addMailbox(accountToSentBox(stat.address));
         }
       });
 


### PR DESCRIPTION
## Summary

Fixes duplicate mailbox entries in IMAP LIST responses when multiple email addresses share the same local part (e.g. `test@inbox.app` and `test@hoie.kim` both becoming `INBOX/test`).

Also trims whitespace from local parts to prevent mailbox names like `mcdonalds ` (trailing space).

Closes #234

## Changes

- **`src/server/lib/imap/store.ts`**: Use a `Set<string>` to track seen mailbox names in `listMailboxes()`. Call `.trim()` on the result of `accountToBox()` before constructing the full mailbox path.

## Root Cause

`accountToBox()` extracts the local part of an email address (`split('@')[0]`). When the database contains emails from multiple domains with the same local part (e.g. `annie@bratko.net` and `annie@hoie.kim`), the function produces the same mailbox name, and the old code pushed duplicates into the result array.

## Testing

### Before fix:
```
$ LIST "" "*"  →  INBOX/test (2x), INBOX/annie (2x), INBOX/hoie (2x), Sent Messages/admin (2x), INBOX/mcdonalds  (trailing space)
```

### After fix:
```
$ LIST "" "*"  →  All mailbox names unique, no trailing whitespace
```

Verified via raw IMAP:
```bash
# Check for duplicates (empty = no duplicates found)
... | awk -F'"' '{print $4}' | sort | uniq -d
# Result: (empty)

# Check for trailing whitespace (empty = clean)
... | grep 'mcdonalds'
# Result: INBOX/mcdonalds (no trailing space)
```