### PR TITLE
fix: validate password confirmation on sign-up

### DIFF
--- a/src/client/SignUp/index.tsx
+++ b/src/client/SignUp/index.tsx
@@ -93,6 +93,13 @@ const SignUp = () => {
   }, [mutation.data, setUserInfo]);
 
   const onClickSignUp = () => {
+    if (email) {
+      if (!passwordInput) return;
+      if (passwordInput !== passwordConfirmInput) {
+        alert("Passwords do not match. Please try again.");
+        return;
+      }
+    }
     mutation.mutate({
       email: emailInput,
       token,
@@ -125,7 +132,7 @@ const SignUp = () => {
             <input
               className="login_ui"
               placeholder="username"
-              type="username"
+              type="text"
               value={usernameInput}
               onKeyDown={onKeyDownInput}
               onChange={onChangeUsername}


### PR DESCRIPTION
## Problem
The sign-up form collected a "password to confirm" field but never compared it to the actual password before calling the mutation. A user could type mismatched passwords and successfully create an account with the first password — potentially locking themselves out.

## Changes
- Validate `passwordInput === passwordConfirmInput` in `onClickSignUp` before submitting
- Alert the user if passwords don't match
- Fix invalid HTML: `type="username"` → `type="text"` ("username" is not a valid HTML5 input type)

## Testing
- TypeScript compiles cleanly
- Manually verified: mismatched passwords now show alert and block submission

Closes #227