### PR TITLE
fix(imap): use MAX(uid) instead of COUNT(*) for UID generation

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -372,13 +372,13 @@ export const getDomainUidNext = async (
 ): Promise<number> => {
   try {
     const sql = `
-      SELECT COUNT(*) as count FROM mails 
+      SELECT COALESCE(MAX(${UID_DOMAIN}), 0) + 1 AS next_uid FROM mails
       WHERE user_id = $1 AND sent = $2
     `;
     const result = await pool.query(sql, [user_id, sent]);
-    return parseInt(result.rows[0]?.count || "0", 10) + 1;
+    return parseInt(result.rows[0]?.next_uid || "1", 10);
   } catch (error) {
-    console.error("Error getting next UID:", error);
+    console.error("Error getting next domain UID:", error);
     return 1;
   }
 };
@@ -396,15 +396,15 @@ export const getAccountUidNext = async (
       ? `${FROM_ADDRESS} @> $2::jsonb`
       : `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb)`;
     const sql = `
-      SELECT COUNT(*) as count FROM mails 
-      WHERE user_id = $1 
+      SELECT COALESCE(MAX(${UID_ACCOUNT}), 0) + 1 AS next_uid FROM mails
+      WHERE user_id = $1
         AND ${addressCondition}
         AND sent = $3
     `;
     const result = await pool.query(sql, [user_id, addressJson, sent]);
-    return parseInt(result.rows[0]?.count || "0", 10) + 1;
+    return parseInt(result.rows[0]?.next_uid || "1", 10);
   } catch (error) {
-    console.error("Error getting account UID next:", error);
+    console.error("Error getting next account UID:", error);
     return 1;
   }
 };


### PR DESCRIPTION
## Summary

Fixes duplicate IMAP UIDs caused by using `COUNT(*)` to assign the next UID.

Closes #239

## Root Cause

`getDomainUidNext` and `getAccountUidNext` computed the next UID as `COUNT(*) + 1`. When any mail is expunged, the count drops below the highest assigned UID, causing the next insert to get a UID already in use. This violates RFC 3501 §2.3.1.1 which requires UIDs to be unique and non-decreasing within a mailbox.

## Fix

Switch to `COALESCE(MAX(uid_domain/uid_account), 0) + 1`, which always produces a UID strictly greater than any previously assigned value — matching the approach already used in the COPY operation path.

## Before / After

**Before:**
```sql
SELECT COUNT(*) as count FROM mails WHERE user_id = $1 AND sent = $2
-- returns 4 after expunge → assigns uid=5, collides with existing uid=5
```

**After:**
```sql
SELECT COALESCE(MAX(uid_account), 0) + 1 AS next_uid FROM mails WHERE ...
-- returns 6 (max existing) + 1 = 7 → no collision
```

## E2E Testing

- Started dev server, sent and received emails
- Confirmed `uid_account` values in the mails table are sequential and non-duplicate
- Verified `IMAP SEARCH ALL` no longer returns duplicate sequence numbers