### PR TITLE
UX: add logout confirmation dialog and accessible button label

### DIFF
--- a/src/client/Box/components/Accounts/index.scss
+++ b/src/client/Box/components/Accounts/index.scss
@@ -103,6 +103,34 @@
               height: 22px;
             }
           }
+
+          button.icon-button {
+            background: none;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            color: inherit;
+
+            svg {
+              height: 20px;
+            }
+
+            &:hover svg {
+              height: 24px;
+            }
+
+            &:active svg {
+              height: 22px;
+            }
+
+            &:focus-visible {
+              outline: 2px solid currentColor;
+              outline-offset: 2px;
+              border-radius: 3px;
+            }
+          }
         }
 
         > div {

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -333,6 +333,8 @@ const Accounts = ({
     };
 
     const onClickLogout = async () => {
+      const confirmed = window.confirm("Are you sure you want to log out?");
+      if (!confirmed) return;
       const response = await call.delete<LoginDeleteResponse>(
         "/api/users/login"
       );
@@ -350,7 +352,14 @@ const Accounts = ({
               <RefreshIcon onClick={onClickRefresh} />
             </div>
             <div className="flex">
-              <LogoutIcon onClick={onClickLogout} />
+              <button
+                className="icon-button"
+                onClick={onClickLogout}
+                aria-label="Logout"
+                title="Logout"
+              >
+                <LogoutIcon />
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Closes #130

The logout button was icon-only with no label and no confirmation, making accidental logout easy and the action undiscoverable for screen readers/keyboard users.

## Changes

**`src/client/Box/components/Accounts/index.tsx`**
- Wrap `LogoutIcon` in a semantic `<button>` element with `aria-label="Logout"` and `title="Logout"` tooltip
- Add `window.confirm()` dialog before the API call to prevent accidental logout

**`src/client/Box/components/Accounts/index.scss`**
- Add `.icon-button` CSS rule: strips default button chrome, inherits the existing icon sizing/hover/active transitions from the `.flex svg` rules, adds `:focus-visible` outline for keyboard navigation

## E2E Testing

- Built (`bun run build`) — clean, no new warnings
- Logout button now shows "Logout" tooltip on hover
- Clicking shows browser confirm dialog; Cancel aborts, OK proceeds with logout
- Tab navigation reaches the button; Enter/Space triggers the action
- Keyboard focus shows visible outline (`:focus-visible`)