### PR TITLE
fix: add keyboard accessibility to interactive div elements

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -185,9 +185,24 @@ const Accounts = ({
       if (selectedAccount === accountName) classes.push("clicked");
       else classes.push("cursor");
 
+      const onKeyDownAccount: KeyboardEventHandler<HTMLDivElement> = (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClickAccount();
+        }
+      };
+
       return (
         <div key={i}>
-          <div className={classes.join(" ")} onClick={onClickAccount}>
+          <div
+            className={classes.join(" ")}
+            onClick={onClickAccount}
+            onKeyDown={onKeyDownAccount}
+            role="button"
+            tabIndex={0}
+            aria-label={`${accountName?.split("@")[0] || "Unknown"} account`}
+            aria-pressed={selectedAccount === accountName}
+          >
             <span>{accountName?.split("@")[0] || "Unknown"}</span>
             {unreadNo && selectedCategory !== Category.SavedMails ? (
               <div className="numberBall">{unreadNo}</div>
@@ -260,8 +275,24 @@ const Accounts = ({
       if (selectedCategory === e) classes.push("clicked");
       if (e === Category.Search) classes.push("flex");
 
+      const onKeyDownCategory: KeyboardEventHandler<HTMLDivElement> = (ev) => {
+        if (ev.key === "Enter" || ev.key === " ") {
+          ev.preventDefault();
+          onClickCategory();
+        }
+      };
+
       return (
-        <div key={i} className={classes.join(" ")} onClick={onClickCategory}>
+        <div
+          key={i}
+          className={classes.join(" ")}
+          onClick={onClickCategory}
+          onKeyDown={onKeyDownCategory}
+          role="button"
+          tabIndex={0}
+          aria-label={e === Category.Search ? "Search" : e.split(" ")[0]}
+          aria-pressed={selectedCategory === e}
+        >
           {e === Category.Search ? (
             <SearchIcon />
           ) : (

--- a/src/client/Box/components/Mails/components/MailHeader.tsx
+++ b/src/client/Box/components/Mails/components/MailHeader.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useContext } from "react";
+import React, { ComponentProps, KeyboardEvent, useContext } from "react";
 import { Context, getDateForMailHeader } from "client";
 import { MailAddressValueType, MailHeaderData } from "common";
 
@@ -24,11 +24,27 @@ const MailHeader = (props: MailHeaderProps) => {
   if (cc?.value && !Array.isArray(cc.value)) cc.value = [cc.value];
   if (bcc?.value && !Array.isArray(bcc.value)) bcc.value = [bcc.value];
 
+  const subject = mail.subject || "Email";
+  const from = mail?.from?.value?.map((e) => e?.name || e?.address).join(", ") || "";
+
   return (
     <div
       className="header cursor"
       onClick={onClick}
+      onKeyDown={
+        onClick
+          ? (e: KeyboardEvent<HTMLDivElement>) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick(e as unknown as React.MouseEvent<HTMLDivElement>);
+              }
+            }
+          : undefined
+      }
       onMouseLeave={onMouseLeave}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      aria-label={from ? `Email from ${from}: ${subject}` : subject}
     >
       <div className="mailcard-small content">{duration}</div>
       <div className={"mailcard-small content" + (isActive ? "" : " closed")}>

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -1,4 +1,5 @@
 import {
+  KeyboardEvent,
   useState,
   useContext,
   useEffect,
@@ -200,6 +201,14 @@ const RenderedMail = ({
     setIsSummaryOpen((v) => !v);
   };
 
+  const makeKeyHandler =
+    (fn: () => void) => (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        fn();
+      }
+    };
+
   const classes = ["mailcard"];
 
   if (!mail.read) classes.push("unread");
@@ -282,8 +291,12 @@ const RenderedMail = ({
               key="star"
               className="iconBox cursor"
               onClick={onClickStar}
+              onKeyDown={makeKeyHandler(onClickStar)}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
+              role="button"
+              tabIndex={0}
+              aria-label={mail.saved ? "Unstar email" : "Star email"}
             >
               {mail.saved ? (
                 <SolidStarIcon className="star" />
@@ -295,8 +308,12 @@ const RenderedMail = ({
               key="reply"
               className="iconBox cursor"
               onClick={onClickReply}
+              onKeyDown={makeKeyHandler(onClickReply)}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
+              role="button"
+              tabIndex={0}
+              aria-label="Reply"
             >
               <ReplyIcon />
             </div>
@@ -304,8 +321,12 @@ const RenderedMail = ({
               key="share"
               className="iconBox cursor"
               onClick={onClickShare}
+              onKeyDown={makeKeyHandler(onClickShare)}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
+              role="button"
+              tabIndex={0}
+              aria-label="Forward email"
             >
               <ShareIcon />
             </div>
@@ -313,28 +334,50 @@ const RenderedMail = ({
               key="trash"
               className="iconBox cursor"
               onClick={onClickTrash}
+              onKeyDown={makeKeyHandler(onClickTrash)}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
+              role="button"
+              tabIndex={0}
+              aria-label="Delete email"
             >
               <TrashIcon />
             </div>
           </>
         ) : (
           <>
-            {(summary?.length || actionItems?.length) ? (
-              <div key="robot" className="iconBox cursor" onClick={onClickRobot}>
+            {!!(summary?.length || actionItems?.length) && (
+              <div
+                className="iconBox cursor"
+                onClick={onClickRobot}
+                onKeyDown={makeKeyHandler(onClickRobot)}
+                role="button"
+                tabIndex={0}
+                aria-label={isSummaryOpen ? "Hide AI summary" : "Show AI summary"}
+              >
                 <RobotIcon />
               </div>
-            ) : null}
-            {mail.saved ? (
-              <div key="star" className="iconBox cursor" onClick={onClickStar}>
+            )}
+            {mail.saved && (
+              <div
+                className="iconBox cursor"
+                onClick={onClickStar}
+                onKeyDown={makeKeyHandler(onClickStar)}
+                role="button"
+                tabIndex={0}
+                aria-label="Unstar email"
+              >
                 <SolidStarIcon className="star" />
               </div>
-            ) : null}
+            )}
             <div
               key="kebab"
               className="iconBox cursor"
               onClick={() => setOpenedKebab(mail.id)}
+              onKeyDown={makeKeyHandler(() => setOpenedKebab(mail.id))}
+              role="button"
+              tabIndex={0}
+              aria-label="More actions"
             >
               <KebabIcon />
             </div>

--- a/src/client/Header/components/LeftMenu/index.tsx
+++ b/src/client/Header/components/LeftMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { KeyboardEvent, useContext } from "react";
 import { Context } from "client";
 import HamburgerIcon from "./components/HamburgerIcon";
 
@@ -19,7 +19,19 @@ const LeftMenu = () => {
   };
 
   return (
-    <div className="menu left cursor" onClick={onClickHamburger}>
+    <div
+      className="menu left cursor"
+      onClick={onClickHamburger}
+      onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClickHamburger();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={isAccountsOpen ? "Close account panel" : "Open account panel"}
+    >
       <div id="hamburger" className="iconBox">
         <div>
           <HamburgerIcon />

--- a/src/client/Header/components/RightMenu/index.tsx
+++ b/src/client/Header/components/RightMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { KeyboardEvent, useContext } from "react";
 import { Context } from "client";
 import WriteIcon from "./components/WriteIcon";
 
@@ -10,7 +10,19 @@ const RightMenu = () => {
   };
 
   return (
-    <div className="menu right cursor" onClick={onClickWriter}>
+    <div
+      className="menu right cursor"
+      onClick={onClickWriter}
+      onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClickWriter();
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-label={isWriterOpen ? "Close compose" : "Compose new email"}
+    >
       <div id="write" className="iconBox">
         <WriteIcon />
       </div>


### PR DESCRIPTION
## Summary

Closes #229

Adds keyboard accessibility to all clickable `<div>` elements in the inbox client. Previously, keyboard-only users could not navigate emails, switch accounts, or compose messages.

## Changes

### Mail card header (`MailHeader.tsx`)
- `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space), `aria-label` with sender + subject

### Accounts panel (`Accounts/index.tsx`)
- Account list items: `role="button"`, `tabIndex={0}`, `onKeyDown`, `aria-pressed` for selection state
- Category tabs (Received/Sent/Saved/Search): same treatment

### Icon action buttons (`Mails/index.tsx`)
- Star, Reply, Forward, Delete, Robot (AI summary), Kebab star — all now `role="button"`, `tabIndex={0}`, descriptive `aria-label`
- Shared `makeKeyHandler` helper to keep Enter/Space handling DRY

### Header menus (`LeftMenu/index.tsx`, `RightMenu/index.tsx`)
- Hamburger (account panel toggle): `role="button"`, `tabIndex={0}`, dynamic `aria-label`
- Compose button: same treatment

## WCAG Compliance
- **2.1.1 Keyboard** ✓ — all interactive elements reachable and operable via keyboard
- **4.1.2 Name, Role, Value** ✓ — all elements have role + accessible name

## E2E Testing
- Started app (`bun run dev`)
- Tabbed through account list — each account focuses and activates with Enter/Space
- Tabbed to mail cards — Enter opens mail
- Tabbed to star/reply/delete icons — all activate on Enter/Space
- Hamburger and compose buttons respond to Enter/Space
- TypeScript compiles clean (`npx tsc --noEmit`)