### PR TITLE
fix: handle empty senderFullName in from/replyTo headers

### DIFF
--- a/src/server/lib/mails/mailgun.ts
+++ b/src/server/lib/mails/mailgun.ts
@@ -38,7 +38,9 @@ export const sendMailgunMail = async (
 
   const text = getText(html);
   const userDomain = getUserDomain(username);
-  const from = `${senderFullName} <${sender}@${userDomain}>`;
+  const from = senderFullName
+    ? `${senderFullName} <${sender}@${userDomain}>`
+    : `${sender}@${userDomain}`;
 
   const mailgun = new Mailgun(FormData);
   const mg = mailgun.client({

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -96,16 +96,16 @@ const getSentMail = async (
     attachments,
     messageId: `<${messageId}@${userDomain}>`,
     from: {
-      value: [{ name: senderFullName, address: fromEmail }],
-      text: `${senderFullName} <${fromEmail}>`
+      value: [{ name: senderFullName || undefined, address: fromEmail }],
+      text: senderFullName ? `${senderFullName} <${fromEmail}>` : fromEmail
     },
     to: { value: [{ address: to }], text: to },
     cc: !cc ? undefined : { value: [{ address: cc }], text: cc },
     bcc: !bcc ? undefined : { value: [{ address: bcc }], text: bcc },
-    envelopeFrom: [{ name: senderFullName, address: fromEmail }],
+    envelopeFrom: [{ name: senderFullName || undefined, address: fromEmail }],
     envelopeTo: [{ address: to }],
     replyTo: {
-      value: [{ name: senderFullName, address: fromEmail }],
+      value: [{ name: senderFullName || undefined, address: fromEmail }],
       text: fromEmail
     },
     read: true,


### PR DESCRIPTION
## Summary

Closes #245

When a user sends an email without setting a display name (`senderFullName = ""`), the `from.text` field was malformed:
- **Before:** `" <admin@inbox.app>"` (leading space + angle brackets)
- **After:** `"admin@inbox.app"` (clean email-only format)

## Root Cause

Template literal `${senderFullName} <${fromEmail}>` with an empty `senderFullName` produces a leading space. Same issue in mailgun.ts.

## Changes

### `src/server/lib/mails/send.ts`
- `from.value[0].name`: `senderFullName || undefined` — avoids storing empty string as name
- `from.text`: ternary — ``${name} <${email}>`` if name present, else just email
- `envelopeFrom[0].name`: same undefined coercion
- `replyTo.value[0].name`: same undefined coercion

### `src/server/lib/mails/mailgun.ts`
- `from` string: ternary for same clean behavior when sending via Mailgun

## E2E Testing
- Sent email without display name → verified `from.text` is now `"admin@inbox.app"` (no leading space)
- Sent email with display name → verified `from.text` is `"Test User <admin@inbox.app>"` (unchanged)
- TypeScript compiles clean