### PR TITLE
fix(imap): clean up IDLE session on unexpected socket close

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -184,6 +184,7 @@ export class ImapRequestHandler {
 
     socket.on("close", () => {
       logger.debug("IMAP connection closed", { component: "imap" });
+      session.cleanup();
     });
 
     socket.on("error", (error) => {

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -1367,6 +1367,24 @@ export class ImapSession {
     return this.sessionId;
   };
 
+  /**
+   * Clean up session resources on socket disconnect.
+   * Must be called when the socket closes unexpectedly so that
+   * IDLE manager entries and any other in-flight state are released.
+   */
+  cleanup = () => {
+    if (this.isIdling) {
+      idleManager.removeIdleSession(this.sessionId);
+      this.socket.off("data", this.handleIdleData);
+      this.isIdling = false;
+      this.idleTag = null;
+      logger.debug("IDLE session cleaned up on socket close", {
+        component: "imap",
+        sessionId: this.sessionId
+      });
+    }
+  };
+
   startTls = async (tag: string) => {
     const { SSL_CERTIFICATE = "", SSL_CERTIFICATE_KEY = "" } = process.env;
 


### PR DESCRIPTION
## Problem

When an IMAP socket closes unexpectedly (disconnect, timeout, error), `idleManager.removeIdleSession()` was never called from the `socket.on('close')` handler in `handler.ts`. Stale `IdleSession` entries accumulated in the `idleSessions` Map, and the 29-minute heartbeat interval would attempt to write to destroyed sockets.

## Fix

Added a public `cleanup()` method to `ImapSession` that:
- Calls `idleManager.removeIdleSession(this.sessionId)` 
- Removes the `handleIdleData` socket listener
- Resets `isIdling` and `idleTag` state

The `handler.ts` `socket.on('close')` callback now calls `session.cleanup()`, ensuring IDLE state is always torn down regardless of how the connection ends.

## Testing

TypeScript compiles cleanly. The fix is straightforward: the close handler now mirrors the cleanup already done in the normal `DONE` flow (`endIdle`).

Closes #252