### PR TITLE
security: add connection limits to IMAP and SMTP servers

### DIFF
--- a/src/server/lib/imap/index.ts
+++ b/src/server/lib/imap/index.ts
@@ -15,6 +15,8 @@ export const getImapListener = (port: number) => {
   };
 };
 
+const IMAP_MAX_CONNECTIONS = 100;
+
 export const initializeImap = async () => {
   const servers: import("net").Server[] = [];
 
@@ -22,6 +24,7 @@ export const initializeImap = async () => {
     const port = 143;
     const imapListener = getImapListener(port);
     const server = createServer(imapListener);
+    server.maxConnections = IMAP_MAX_CONNECTIONS;
     server.listen(port, () => {
       logger.info("IMAP server listening", { component: "imap", port });
       res(server);
@@ -41,6 +44,7 @@ export const initializeImap = async () => {
       };
 
       const server = createTLSServer(tlsOptions, imapListener);
+      server.maxConnections = IMAP_MAX_CONNECTIONS;
       server.listen(port, () => {
         logger.info("IMAP server listening over TLS", { component: "imap", port });
         res(server);

--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -138,10 +138,12 @@ const onDataOutgoing = async (
   }
 };
 
+const SMTP_MAX_CLIENTS = 100;
+
 export const initializeSmtp = async () => {
   const servers: SMTPServer[] = [];
 
-  const options: SMTPServerOptions = { authOptional: true, onAuth, onData };
+  const options: SMTPServerOptions = { authOptional: true, onAuth, onData, maxClients: SMTP_MAX_CLIENTS };
 
   const { SSL_CERTIFICATE, SSL_CERTIFICATE_KEY } = process.env;
   const isSslAvailable = SSL_CERTIFICATE && SSL_CERTIFICATE_KEY;


### PR DESCRIPTION
## Problem

Both IMAP (`imap/index.ts`) and SMTP (`smtp.ts`) servers are created without connection limits. A single client can open thousands of simultaneous connections, exhausting:
- OS file descriptors (default ~256-1024 on macOS)
- Memory (`ImapSession` allocates buffers and Maps per connection)
- Thread pool slots

## Fix

**IMAP** (ports 143 and 993): set `server.maxConnections = 100` on both `net.Server` and `tls.Server` instances. When the limit is reached, Node.js stops accepting new connections (the OS queues them in the listen backlog) and resumes when slots free up.

**SMTP** (ports 25, 465, 587): add `maxClients: 100` to `SMTPServerOptions`. The `smtp-server` package enforces this limit and rejects excess connections with a 421 response.

100 concurrent connections is generous for a personal email server.

## Testing

TypeScript compiles cleanly. Limits were chosen conservatively — 100 is well above any realistic personal-use load.

Closes #253