### PR TITLE
fix: add expunged = FALSE filter to getSpamMails

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1007,7 +1007,7 @@ export const getSpamMails = async (user_id: string): Promise<MailModel[]> => {
   try {
     const sql = `
       SELECT * FROM mails 
-      WHERE user_id = $1 AND is_spam = TRUE AND sent = FALSE
+      WHERE user_id = $1 AND is_spam = TRUE AND sent = FALSE AND expunged = FALSE
       ORDER BY date DESC
     `;
     const result = await pool.query(sql, [user_id]);


### PR DESCRIPTION
## Summary

`getSpamMails` was missing `AND expunged = FALSE`, allowing soft-deleted emails to appear in the spam list after being expunged via IMAP.

## Root Cause

All other mail query functions in `mails.ts` include `AND expunged = FALSE` — found during audit of #194. `getSpamMails` was the only one that slipped through.

## Fix

Single-line change: add `AND expunged = FALSE` to the WHERE clause.

## Testing

250 tests pass, 0 fail.

Closes #259