### PR TITLE
security: fix timing enumeration, add security headers, validate req.body

### DIFF
--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -15,6 +15,17 @@ export const initializeHttp = async () => {
     app.set("trust proxy", 1);
   }
 
+  // Security headers
+  app.use((_req, res, next) => {
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
+    if (process.env.NODE_ENV === "production") {
+      res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+    }
+    next();
+  });
+
   app.use(json({ limit: "10mb" }));
   app.use(
     fileupload({

--- a/src/server/lib/http/routes/users/post-login.ts
+++ b/src/server/lib/http/routes/users/post-login.ts
@@ -1,28 +1,48 @@
 import bcrypt from "bcryptjs";
-import { MaskedUser, User } from "common";
+import { MaskedUser } from "common";
 import { getUser } from "server";
 import { Route } from "../route";
 
 export type LoginPostResponse = MaskedUser;
 
+// Valid bcrypt hash used as a constant-time dummy to prevent timing-based
+// username enumeration. bcrypt.compare still runs its full cost-10 work
+// when the user is not found, so response time is indistinguishable.
+const DUMMY_HASH = "$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy";
+
 export const postLoginRoute = new Route<LoginPostResponse>(
   "POST",
   "/login",
   async (req) => {
-    const inputUser = req.body as User;
+    // Validate body shape before processing.
+    const body = req.body;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return { status: "failed", message: "Invalid request body." };
+    }
 
-    const user = await getUser(inputUser);
-    const signedUser = user?.getSigned();
-    if (!inputUser.password || !user || !signedUser) {
+    const { email, username, password } = body as Record<string, unknown>;
+
+    if (typeof password !== "string" || !password) {
+      return { status: "failed", message: "Invalid credentials." };
+    }
+    if (email !== undefined && typeof email !== "string") {
+      return { status: "failed", message: "Invalid credentials." };
+    }
+    if (username !== undefined && typeof username !== "string") {
       return { status: "failed", message: "Invalid credentials." };
     }
 
-    const pwMatches = await bcrypt.compare(
-      inputUser.password,
-      user.password as string
-    );
+    const inputUser = { email: email as string | undefined, username: username as string | undefined };
+    const user = await getUser(inputUser);
+    const signedUser = user?.getSigned();
 
-    if (!pwMatches) {
+    // Always run bcrypt.compare regardless of whether the user exists.
+    // This prevents timing attacks that could reveal valid usernames.
+    const pwMatches = user
+      ? await bcrypt.compare(password, user.password as string)
+      : await bcrypt.compare(password, DUMMY_HASH).then(() => false);
+
+    if (!pwMatches || !signedUser) {
       return { status: "failed", message: "Invalid credentials." };
     }
 

--- a/src/server/lib/http/routes/users/post-set-info.ts
+++ b/src/server/lib/http/routes/users/post-set-info.ts
@@ -8,7 +8,28 @@ export const postSetInfoRoute = new Route<SetInfoPostResponse>(
   "POST",
   "/set-info",
   async (req) => {
-    const user = await setUserInfo(req.body);
+    // Validate body shape before passing to setUserInfo.
+    const body = req.body;
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return { status: "failed", message: "Invalid request body." };
+    }
+
+    const { email, username, password, token } = body as Record<string, unknown>;
+
+    if (typeof email !== "string" || !email) {
+      return { status: "failed", message: "email is required and must be a string." };
+    }
+    if (typeof username !== "string" || !username) {
+      return { status: "failed", message: "username is required and must be a string." };
+    }
+    if (typeof password !== "string" || !password) {
+      return { status: "failed", message: "password is required and must be a string." };
+    }
+    if (token !== undefined && typeof token !== "string") {
+      return { status: "failed", message: "token must be a string." };
+    }
+
+    const user = await setUserInfo({ email, username, password, token: token as string | undefined });
     req.session.user = user;
     return { status: "success", body: user };
   }


### PR DESCRIPTION
## Summary

Three security/quality fixes bundled together (all single-file or small scope).

### Closes #261 — Timing-based username enumeration in login
Always run `bcrypt.compare` even when the user is not found, using a pre-computed dummy hash. This makes the response time indistinguishable whether or not the username exists. Same pattern used in budget PR (hoiekim/budget#136).

### Closes #262 — HTTP security headers
Added middleware in `src/server/lib/http/index.ts`:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Strict-Transport-Security` (production only)

### Closes #263 — req.body shape validation in login and set-info routes
Both routes now validate the body is an object and required fields are strings before processing. Returns clear error messages instead of opaque 500s.

## Testing

`bun run tsc --noEmit` passes cleanly.