### PR TITLE
fix(imap): fix APPEND literal accumulation and IDLE DONE spurious BAD response

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -26,17 +26,68 @@ export class ImapRequestHandler {
 
     let buffer = "";
 
+    // State for APPEND literal accumulation
+    let pendingAppendLine: string | null = null;
+    let literalBytesNeeded = 0;
+
     socket.on("data", async (data) => {
       try {
         buffer += data.toString();
 
         // Process complete lines
         let lineEnd;
-        while ((lineEnd = buffer.indexOf("\r\n")) !== -1) {
+        while (true) {
+          // If accumulating literal data for APPEND, consume raw bytes first
+          if (pendingAppendLine !== null) {
+            if (buffer.length < literalBytesNeeded) {
+              // Wait for more data
+              break;
+            }
+            // We have enough bytes — reconstruct the full APPEND input and parse
+            const literalData = buffer.substring(0, literalBytesNeeded);
+            buffer = buffer.substring(literalBytesNeeded);
+            // Skip optional \r\n after literal
+            if (buffer.startsWith("\r\n")) {
+              buffer = buffer.substring(2);
+            }
+
+            const fullInput = pendingAppendLine + "\r\n" + literalData;
+            pendingAppendLine = null;
+            literalBytesNeeded = 0;
+
+            try {
+              const parseResult = parseCommand(fullInput.trim());
+              if (parseResult.success && parseResult.value) {
+                const { tag, request } = parseResult.value;
+                await this.handleRequest(tag, request);
+              } else {
+                logger.debug("Parse failed (APPEND literal)", {
+                  component: "imap.parser",
+                  error: parseResult.error
+                });
+                const tag = fullInput.trim().split(" ")[0] || "BAD";
+                session.write(`${tag} BAD ${parseResult.error || "Invalid APPEND command"}\r\n`);
+              }
+            } catch (error) {
+              logger.error("Error processing APPEND literal", { component: "imap" }, error);
+              session.write(`* BAD Internal server error\r\n`);
+            }
+            continue;
+          }
+
+          lineEnd = buffer.indexOf("\r\n");
+          if (lineEnd === -1) break;
+
           const line = buffer.substring(0, lineEnd);
           buffer = buffer.substring(lineEnd + 2);
 
           if (line.trim()) {
+            // When session is in IDLE mode, skip normal command processing —
+            // the IDLE data handler on session.ts handles DONE exclusively.
+            if (session.isInIdleMode()) {
+              continue;
+            }
+
             logger.debug("IMAP command received", {
               component: "imap",
               command: line.trim(),
@@ -49,6 +100,30 @@ export class ImapRequestHandler {
                 "* NO [TEMPORARY UNAVAILABLE] Server is busy. Please try again later.\r\n"
               );
               continue;
+            }
+
+            // Detect APPEND command with a literal size indicator {N} or {N+}
+            // e.g. "a001 APPEND INBOX (\Seen) {512}"
+            // When found, switch to literal accumulation mode instead of parsing now.
+            const literalMatch = /\{(\d+)(\+?)\}\s*$/.exec(line.trim());
+            if (literalMatch) {
+              const upperLine = line.trim().toUpperCase();
+              // Only intercept APPEND literals here; other commands with literals
+              // (e.g. LOGIN with quoted strings) don't need this treatment.
+              const parts = upperLine.split(/\s+/);
+              const commandWord = parts[1] || parts[0];
+              if (commandWord === "APPEND") {
+                pendingAppendLine = line.trim();
+                literalBytesNeeded = parseInt(literalMatch[1], 10);
+                // Synchronizing literals {N} (without +) require a continuation
+                // response before the client will send the literal data.
+                // Non-synchronizing literals {N+} (LITERAL+) do not.
+                const isSynchronizing = !literalMatch[2];
+                if (isSynchronizing) {
+                  session.write("+ go ahead\r\n");
+                }
+                continue;
+              }
             }
 
             try {


### PR DESCRIPTION
## Summary

Fixes two IMAP protocol compliance bugs that block client compatibility (#33).

## Bug 1: APPEND command broken — literal data not consumed (Closes #266)

**Root cause:** `handler.ts` processes socket data line-by-line (splitting on `\r\n`). When a client sends:
```
a002 APPEND INBOX (\Seen) {75}\r\n
From: test@example.com\r\n...
```
Only the command line was passed to the parser. The literal data arrived in subsequent chunks and was incorrectly parsed as separate IMAP commands, producing `BAD Unknown command` responses and silently discarding the message.

**Fix:** Added literal accumulation state to the data handler. When an APPEND command with a `{N}` or `{N+}` literal is detected, the handler buffers exactly N bytes from subsequent data, then reconstructs the full command+literal input and passes it to the parser in one call. Sends `+ go ahead` continuation for synchronizing literals; LITERAL+ literals need no continuation.

## Bug 2: IDLE DONE produces spurious `BAD Invalid command` (Closes #267)

**Root cause:** `session.ts` adds a dedicated `handleIdleData` listener for the DONE command, but the main `data` handler in `handler.ts` remained active. When DONE arrived, both handlers fired: `handleIdleData` correctly sent `OK IDLE terminated`; the main loop parsed `DONE` as a command tag (no matching command), emitting `DONE BAD Invalid command`.

**Fix:** Added an `isInIdleMode()` guard in the main handler loop. Any data received while in IDLE mode is skipped by the command processor and handled exclusively by the IDLE data listener.

## Testing

```bash
# IDLE DONE — before: produced spurious BAD; after: clean OK
(echo -e 'a001 LOGIN admin inbox\r\na002 SELECT INBOX\r\na003 IDLE\r\n'; sleep 3; echo -e 'DONE\r\n'; sleep 1) | nc -w5 127.0.0.1 143

# APPEND — before: returned OK immediately, message not stored; after: message stored
MSG=$'From: test@example.com\r\nSubject: IMAP Append Test\r\n\r\nTest.'
LEN=${#MSG}
(echo -e "a001 LOGIN admin inbox\r\na002 APPEND INBOX (\\Seen) {${LEN}}\r\n${MSG}a003 SELECT INBOX\r\na004 LOGOUT\r\n"; sleep 3) | nc -w5 127.0.0.1 143
```

All 167 IMAP parser tests pass (`bun test src/server/lib/imap/`). TypeScript compiles cleanly.