### PR TITLE
fix: generate distinct messageId and UIDs for self-send inbox copy

### DIFF
--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -44,6 +44,24 @@ export const sendMail = async (
     const messageId = response?.id || randomUUID();
     const sentMail = await getSentMail(user, mailToSend, messageId, files);
     await saveMail(sentMail, userId);
+    if (isToMyself(mailToSend.to)) {
+      // If the email is sent to myself, also save a copy in the inbox.
+      // Must use a distinct messageId and UIDs to avoid violating the
+      // (user_id, message_id) unique constraint.
+      const inboxMessageId = `<${randomUUID()}@${getUserDomain(username)}>`;
+      const [inboxDomainUid, inboxAccountUid] = await Promise.all([
+        getDomainUidNext(userId, false),
+        getAccountUidNext(userId, mailToSend.to.split(",")[0].trim(), false)
+      ]);
+      const inboxUid = new MailUid({
+        domain: inboxDomainUid || 0,
+        account: inboxAccountUid || 0
+      });
+      await saveMail(
+        new Mail({ ...sentMail, sent: false, messageId: inboxMessageId, uid: inboxUid }),
+        userId
+      );
+    }
 
     return response;
   } catch (error: unknown) {


### PR DESCRIPTION
## Summary

Fixes the duplicate key constraint violation when sending email to yourself.

## Root Cause

`sendMail()` saved the sent copy, then tried to save an inbox copy using the same `messageId` (and same UIDs). The `(user_id, message_id)` unique constraint rejected the second insert:

```
error: duplicate key value violates unique constraint "mails_user_message_unique"
detail: Key (user_id, message_id)=(..., <same-id@domain>) already exists.
```

## Fix

When `isToMyself()` is true, generate fresh identifiers for the inbox copy:
1. **New `messageId`** — `randomUUID()`-based, distinct from the sent copy
2. **New `uid`** — fresh domain + account UID sequence values fetched with `sent=false`

```typescript
const inboxMessageId = `<${randomUUID()}@${getUserDomain(username)}>`;
const [inboxDomainUid, inboxAccountUid] = await Promise.all([
  getDomainUidNext(userId, false),
  getAccountUidNext(userId, mailToSend.to.split(',')[0].trim(), false)
]);
```

## Testing

1. Start inbox dev server
2. Send an email to yourself (same address as logged-in user)
3. Confirm no constraint violation in server logs
4. Confirm email appears in both Sent and Inbox

Closes #147