### PR TITLE
Fix IMAP EXAMINE to return READ-ONLY per RFC 3501

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -64,6 +64,7 @@ const throttler = new Throttler();
 export class ImapSession {
   public selectedMailbox: string | null = null;
   private selectedMailboxMessageCount: number = 0;
+  public mailboxReadOnly: boolean = false;
   private store: Store | null = null;
   private authenticated: boolean = false;
   private isIdling: boolean = false;
@@ -166,8 +167,7 @@ export class ImapSession {
   };
 
   examineMailbox = async (tag: string, name: string) => {
-    // EXAMINE is like SELECT but read-only - for now, treat the same
-    return this.selectMailbox(tag, name);
+    return this.selectMailbox(tag, name, true);
   };
 
   fetchMessagesTyped = async (
@@ -879,6 +879,10 @@ export class ImapSession {
       return this.write(`${tag} BAD No mailbox selected\r\n`);
     }
 
+    if (this.mailboxReadOnly) {
+      return this.write(`${tag} NO [READ-ONLY] Mailbox is read-only\r\n`);
+    }
+
     // Determine if we're working with UIDs or sequence numbers
     const isUidStore = storeRequest.sequenceSet.type === "uid" || isUidCommand;
 
@@ -1148,7 +1152,7 @@ export class ImapSession {
     }
   };
 
-  selectMailbox = async (tag: string, name: string) => {
+  selectMailbox = async (tag: string, name: string, readOnly: boolean = false) => {
     if (!this.authenticated || !this.store) {
       return this.write(`${tag} NO Not authenticated.\r\n`);
     }
@@ -1170,6 +1174,7 @@ export class ImapSession {
 
     try {
       this.selectedMailbox = cleanName;
+      this.mailboxReadOnly = readOnly;
       
       // Build sequence number mapping for this mailbox
       await this.buildSequenceMapping();
@@ -1203,7 +1208,9 @@ export class ImapSession {
       this.write(`* OK [UIDNEXT ${uidNext}] Predicted next UID\r\n`);
       this.write(`* FLAGS (\\Seen \\Flagged \\Deleted \\Draft \\Answered)\r\n`);
       this.write(`* OK [PERMANENTFLAGS (\\Seen \\Flagged \\Deleted \\Draft \\Answered \\*)] Flags permitted\r\n`);
-      this.write(`${tag} OK [READ-WRITE] SELECT completed\r\n`);
+      const mode = readOnly ? "READ-ONLY" : "READ-WRITE";
+      const command = readOnly ? "EXAMINE" : "SELECT";
+      this.write(`${tag} OK [${mode}] ${command} completed\r\n`);
     } catch (error) {
       logger.error("Error selecting mailbox", { component: "imap", name }, error);
       this.write(`${tag} NO SELECT failed\r\n`);
@@ -1217,6 +1224,10 @@ export class ImapSession {
 
     if (!this.selectedMailbox) {
       return this.write(`${tag} BAD No mailbox selected\r\n`);
+    }
+
+    if (this.mailboxReadOnly) {
+      return this.write(`${tag} NO [READ-ONLY] Mailbox is read-only\r\n`);
     }
 
     try {


### PR DESCRIPTION
## Summary

Fixes EXAMINE command to properly implement RFC 3501 §6.3.2 read-only semantics.

## Problem

`EXAMINE` was directly aliased to `selectMailbox()` which always returned `[READ-WRITE] SELECT completed`. Per RFC 3501, EXAMINE must:
1. Return `[READ-ONLY]` instead of `[READ-WRITE]`
2. Prevent state-modifying commands (STORE, EXPUNGE)

This breaks Apple Mail, Thunderbird, and other IMAP clients that use EXAMINE to peek at mailbox status without modifying flags.

## Changes

- `selectMailbox()` now accepts a `readOnly` parameter
- `examineMailbox()` passes `readOnly: true`
- Session tracks `mailboxReadOnly` state
- STORE and EXPUNGE return `NO [READ-ONLY]` when mailbox was opened via EXAMINE
- Response text: `EXAMINE completed` vs `SELECT completed`

## Testing

**E2E verified via raw IMAP:**
```
a002 EXAMINE INBOX
→ a002 OK [READ-ONLY] EXAMINE completed  ✅ (was: [READ-WRITE] SELECT completed)

a003 STORE 1 +FLAGS (\Seen)
→ a003 NO [READ-ONLY] Mailbox is read-only  ✅ (was: flags modified)

a004 EXPUNGE
→ a004 NO [READ-ONLY] Mailbox is read-only  ✅ (was: messages expunged)

a005 SELECT INBOX
→ a005 OK [READ-WRITE] SELECT completed  ✅ (still works normally)
```

All 250 existing tests pass. TypeScript compiles clean.

Closes #270
Related to #33