### PR TITLE
fix: reset persisted Search category on page load to prevent sort order bug

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -82,7 +82,11 @@ const App = ({ user: session }: Props) => {
   );
   const [selectedCategory, setSelectedCategory] = useLocalStorage(
     "selectedCategory",
-    Category.AllMails
+    Category.AllMails,
+    // Search is transient (requires a live search query + preSearchAccount ref
+    // that don't survive a page reload). Restoring Category.Search would use
+    // the account address as the search term, producing confusing sort order.
+    (v) => (v === Category.Search ? Category.AllMails : v)
   );
   const [searchHistory, setSearchHistory] = useState<
     ContextType["searchHistory"]

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -241,8 +241,11 @@ const Accounts = ({
           // Entering search: save current account so we can restore it later
           preSearchAccount.current = selectedAccount;
         } else if (selectedCategory === Category.Search) {
-          // Leaving search: restore the pre-search account
-          setSelectedAccount(preSearchAccount.current);
+          // Leaving search: restore the pre-search account if we have one
+          // (preSearchAccount is a ref and won't survive a page reload)
+          if (preSearchAccount.current) {
+            setSelectedAccount(preSearchAccount.current);
+          }
         }
         setSelectedCategory(e);
         // Reset selectedAccount if it doesn't exist in the new category's account list

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -1,10 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
 
-export const useLocalStorage = <T>(key: string, initialValue: T) => {
+export const useLocalStorage = <T>(
+  key: string,
+  initialValue: T,
+  sanitize?: (value: T) => T
+) => {
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
       const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
+      const parsed: T = item ? JSON.parse(item) : initialValue;
+      return sanitize ? sanitize(parsed) : parsed;
     } catch (error) {
       console.error(error);
       return initialValue;


### PR DESCRIPTION
## Summary

Fixes the bug where email sort order breaks when `selectedCategory='Search'` persists to localStorage across page reloads.

## Root Cause

When `Category.Search` is stored in localStorage and restored on reload, the Mails component fetches `/api/mails/search/<account>` — using the account email address as the search query. The search endpoint returns results sorted by relevance, not date, grouping self-emails (address matches both from/to) at the top and external emails at the bottom regardless of date.

## Changes

### `src/client/lib/hooks.ts`
- Added optional `sanitize?: (value: T) => T` parameter to `useLocalStorage`
- Applied during the `useState` lazy initializer — no double render, no extra `useEffect`

### `src/client/App.tsx`
- Pass sanitizer that remaps `Category.Search → Category.AllMails` on load
- `Category.Search` is transient state: it requires an active search query and `preSearchAccount` ref, neither of which survive a page reload

### `src/client/Box/components/Accounts/index.tsx`
- Guard `setSelectedAccount(preSearchAccount.current)` when leaving search: an empty ref (after a reload) was clearing the selected account

## Testing

1. Log in → select an account → click the search icon → enter a search term
2. Hard reload the page (`Cmd+Shift+R`)
3. **Before fix:** email list shows self-emails at top, external emails at bottom (wrong order)
4. **After fix:** email list shows All Mails in correct date-descending order, no stale search state

Closes #272