### PR TITLE
refactor: migrate pool.query() calls in push_subscriptions to table methods

### DIFF
--- a/src/server/lib/postgres/models/push_subscription.ts
+++ b/src/server/lib/postgres/models/push_subscription.ts
@@ -8,7 +8,8 @@ import {
   UPDATED,
   PUSH_SUBSCRIPTIONS,
 } from "./common";
-import { Model, createTable } from "./base";
+import { Model, Table, Constraints } from "./base";
+import { pool } from "../client";
 
 // Type guards
 const isString = (v: unknown): v is string => typeof v === "string";
@@ -71,13 +72,46 @@ export class PushSubscriptionModel extends Model<PushSubscriptionJSON, PushSubsc
   }
 }
 
-export const pushSubscriptionsTable = createTable({
-  name: PUSH_SUBSCRIPTIONS,
-  primaryKey: PUSH_SUBSCRIPTION_ID,
-  schema: pushSubscriptionSchema,
-  ModelClass: PushSubscriptionModel,
-  supportsSoftDelete: false,
-  indexes: [{ column: USER_ID }],
-});
+class PushSubscriptionsTable extends Table<
+  PushSubscriptionJSON,
+  PushSubscriptionSchema,
+  PushSubscriptionModel
+> {
+  readonly name = PUSH_SUBSCRIPTIONS;
+  readonly primaryKey = PUSH_SUBSCRIPTION_ID;
+  readonly schema = pushSubscriptionSchema;
+  readonly constraints: Constraints = [];
+  readonly indexes = [{ column: USER_ID }];
+  readonly ModelClass = PushSubscriptionModel;
+  readonly supportsSoftDelete = false;
+
+  /**
+   * Returns all subscriptions for the given list of user IDs.
+   */
+  async getByUserIds(userIds: string[]): Promise<PushSubscriptionModel[]> {
+    if (userIds.length === 0) return [];
+    const placeholders = userIds.map((_, i) => `$${i + 1}`).join(", ");
+    const sql = `SELECT * FROM ${this.name} WHERE ${USER_ID} IN (${placeholders})`;
+    const result = await pool.query(sql, userIds);
+    return result.rows.map((row: unknown) => new PushSubscriptionModel(row));
+  }
+
+  /**
+   * Deletes push subscriptions whose `updated` timestamp is older than the given cutoff.
+   * @param cutoff ISO timestamp string; rows with updated < cutoff are deleted.
+   * @returns Number of rows deleted.
+   */
+  async deleteOlderThan(cutoff: string): Promise<number> {
+    const sql = `
+      DELETE FROM ${this.name}
+      WHERE ${UPDATED} < $1
+      RETURNING ${this.primaryKey}
+    `;
+    const result = await pool.query(sql, [cutoff]);
+    return result.rowCount ?? 0;
+  }
+}
+
+export const pushSubscriptionsTable = new PushSubscriptionsTable();
 
 export const pushSubscriptionColumns = Object.keys(pushSubscriptionsTable.schema);

--- a/src/server/lib/postgres/repositories/push_subscriptions.ts
+++ b/src/server/lib/postgres/repositories/push_subscriptions.ts
@@ -1,6 +1,5 @@
 import crypto from "crypto";
 import { PushSubscription } from "web-push";
-import { pool } from "../client";
 import {
   pushSubscriptionsTable,
   PUSH_SUBSCRIPTION_ID,
@@ -66,13 +65,7 @@ export const deleteSubscription = async (
 export const cleanSubscriptions = async (): Promise<number> => {
   try {
     const cutoffDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
-    const sql = `
-      DELETE FROM push_subscriptions 
-      WHERE updated < $1
-      RETURNING push_subscription_id
-    `;
-    const result = await pool.query(sql, [cutoffDate]);
-    return result.rowCount ?? 0;
+    return await pushSubscriptionsTable.deleteOlderThan(cutoffDate);
   } catch (error) {
     console.error("Failed to clean push subscriptions:", error);
     return 0;
@@ -91,32 +84,24 @@ export const getSubscriptions = async (
     if (users.length === 0) return [];
 
     const userIds = users.map((u) => u.id);
-    const placeholders = userIds.map((_, i) => `$${i + 1}`).join(", ");
-
-    const sql = `
-      SELECT * FROM push_subscriptions 
-      WHERE user_id IN (${placeholders})
-    `;
-
-    const result = await pool.query(sql, userIds);
-
+    const rows = await pushSubscriptionsTable.getByUserIds(userIds);
     const userMap = new Map(users.map((u) => [u.id, u]));
 
-    return result.rows
-      .map((row: Record<string, unknown>): ComputedPushSubscription | null => {
-        const user = userMap.get(row.user_id as string);
+    return rows
+      .map((row): ComputedPushSubscription | null => {
+        const user = userMap.get(row.user_id);
         if (!user) return null;
 
         return {
-          endpoint: row.endpoint as string,
+          endpoint: row.endpoint,
           keys: {
-            p256dh: row.keys_p256dh as string,
-            auth: row.keys_auth as string,
+            p256dh: row.keys_p256dh,
+            auth: row.keys_auth,
           },
-          push_subscription_id: row.push_subscription_id as string,
+          push_subscription_id: row.push_subscription_id,
           username: user.username,
           lastNotified: new Date(row.last_notified as string),
-          updated: new Date(row.updated as string),
+          updated: new Date(row.updated),
         };
       })
       .filter((s): s is ComputedPushSubscription => s !== null);


### PR DESCRIPTION
## Summary

Completes the pool.query() migration started in PR #248 (sessions + spam_allowlists). This PR covers the remaining repository file with direct pool.query() calls.

**push_subscriptions.ts** (2 pool.query calls removed):
- Convert `pushSubscriptionsTable` from `createTable()` to a named `PushSubscriptionsTable` class
- Add `getByUserIds(userIds: string[])` — encapsulates `SELECT * WHERE user_id IN (...)`
- Add `deleteOlderThan(cutoff: string)` — encapsulates `DELETE WHERE updated < $1`
- `cleanSubscriptions()` now delegates to `pushSubscriptionsTable.deleteOlderThan()`
- `getSubscriptions()` now delegates to `pushSubscriptionsTable.getByUserIds()`
- Direct `pool` import removed from the repository file

## Motivation

Per [DEVELOPMENT.md Table Class Methods convention](../blob/main/DEVELOPMENT.md): all DB operations in repository files should go through table class methods. Direct `pool.query()` calls in repositories are migration debt.

## No Behavior Changes

Same SQL queries, same logic. TypeScript compiles cleanly.

Closes #244 (together with PR #248)