### PR TITLE
fix: clear compose draft from localStorage on logout

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -337,6 +337,18 @@ const Accounts = ({
         "/api/users/login"
       );
       if (response.status !== "success") return;
+      // Clear compose draft data so it doesn't leak to the next user on this browser
+      [
+        "name",
+        "to",
+        "cc",
+        "bcc",
+        "subject",
+        "sender",
+        "initialContent",
+        "originalMessage",
+        "isCcOpen"
+      ].forEach((key) => localStorage.removeItem(key));
       setUserInfo(undefined);
       setSelectedAccount("");
     };


### PR DESCRIPTION
## Summary

Fixes a privacy issue where compose form draft data persisted in `localStorage` after logout, allowing the next user on the same browser to see a previous user's unsent email draft.

## Root Cause

The compose form stores all fields in `localStorage` via `useLocalStorage` hooks:
- `name`, `to`, `cc`, `bcc`, `subject`, `sender`, `initialContent`, `originalMessage`, `isCcOpen`

The logout handler in `Accounts/index.tsx` called `setUserInfo(undefined)` and `setSelectedAccount("")` but never cleared these compose keys, leaving draft data readable by the next user.

## Fix

Added `localStorage.removeItem()` calls for all compose-related keys in the `onClickLogout` handler, executed immediately after the server confirms the logout. This ensures no draft data persists across user sessions.

## Testing

1. Log in as user A
2. Fill the compose form (To, Subject, Content)
3. Click logout
4. Inspect localStorage (DevTools → Application → Local Storage)
5. **Before**: `to`, `subject`, `initialContent` etc. are still present
6. **After**: all compose keys are cleared
7. Log in as user B — compose form is empty

Closes #277
