### PR TITLE
docs: add async file I/O and auth rate limiting patterns to DEVELOPMENT.md

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -352,6 +352,40 @@ This pattern was critical in PR #161 where `getMailHeaders` was selecting all co
 <input aria-label="Search emails" value={query} onChange={onChange} />
 ```
 
+### File I/O in Async Context
+
+**Use async filesystem APIs, not sync wrappers in Promise constructors.**
+
+```typescript
+// ❌ Bad - sync I/O blocks the event loop despite Promise wrapper
+return new Promise((resolve, reject) => {
+  try {
+    fs.writeFileSync(path, data);
+    resolve(id);
+  } catch (e) { reject(e); }
+});
+
+// ✅ Good - truly async
+await fs.promises.writeFile(path, data);
+return id;
+```
+
+**Directory creation:** Use `{ recursive: true }` instead of check-then-create:
+
+```typescript
+// ❌ TOCTOU race
+if (!fs.existsSync(dir)) fs.mkdirSync(dir);
+
+// ✅ Idempotent
+await fs.promises.mkdir(dir, { recursive: true });
+```
+
+### IMAP/SMTP Authentication Rate Limiting
+
+IMAP and SMTP auth attempts should be rate-limited per IP, similar to the HTTP login limiter. Unlike HTTP connections behind a reverse proxy, IMAP/SMTP connections are direct — an attacker can try unlimited passwords on a single persistent connection.
+
+Rate limit counters should be shared across HTTP/IMAP/SMTP to prevent protocol-switching attacks.
+
 ## CI/CD
 
 ### Pull Request Checks


### PR DESCRIPTION
## Changes

Adds two new patterns to DEVELOPMENT.md:

### File I/O in Async Context
Documents the anti-pattern of wrapping `writeFileSync` in Promise constructors (gives false impression of async behavior while still blocking the event loop). Recommends `fs.promises` APIs and `mkdir({ recursive: true })` over check-then-create.

### IMAP/SMTP Authentication Rate Limiting
Documents the need for rate limiting across all auth protocols (HTTP, IMAP, SMTP) with shared counters to prevent protocol-switching brute force attacks.

### Context
- Related issues: #282 (IMAP/SMTP auth rate limiting), #283 (saveBuffer sync-in-promise)

### E2E Testing
Documentation-only change. Verified markdown renders correctly and no code changes.