### PR TITLE
security: add auth rate limiting to IMAP and SMTP login

### DIFF
--- a/src/server/lib/auth-rate-limit.ts
+++ b/src/server/lib/auth-rate-limit.ts
@@ -1,0 +1,82 @@
+/**
+ * IP-based authentication rate limiter for IMAP and SMTP servers.
+ *
+ * Unlike the HTTP rate limiter (Express middleware), this module exposes
+ * plain functions that IMAP/SMTP session handlers can call directly.
+ *
+ * Policy:
+ *  - After MAX_FAILURES failed auth attempts from the same IP in WINDOW_MS,
+ *    the caller should terminate the connection.
+ *  - A 500ms delay is added after each failure to slow brute-force attempts.
+ *  - A successful auth resets the counter for that IP.
+ */
+
+const MAX_FAILURES = 10;
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const FAILURE_DELAY_MS = 500;
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+
+interface AttemptRecord {
+  count: number;
+  resetAt: number;
+}
+
+const attempts = new Map<string, AttemptRecord>();
+
+const getRecord = (ip: string): AttemptRecord => {
+  const now = Date.now();
+  const existing = attempts.get(ip);
+  if (existing && now < existing.resetAt) return existing;
+  const record: AttemptRecord = { count: 0, resetAt: now + WINDOW_MS };
+  attempts.set(ip, record);
+  return record;
+};
+
+/**
+ * Check whether the given IP is currently rate-limited.
+ * Returns true if the IP has exceeded the failure threshold.
+ */
+export const isAuthRateLimited = (ip: string): boolean => {
+  const record = getRecord(ip);
+  return record.count >= MAX_FAILURES;
+};
+
+/**
+ * Record a failed auth attempt for the given IP.
+ * Adds a delay to slow brute-force attacks.
+ * Returns true if the IP is now rate-limited (hit the threshold this call).
+ */
+export const recordAuthFailure = async (ip: string): Promise<boolean> => {
+  const record = getRecord(ip);
+  record.count++;
+  // Delay to slow brute-force attempts
+  await new Promise<void>((resolve) => setTimeout(resolve, FAILURE_DELAY_MS));
+  return record.count >= MAX_FAILURES;
+};
+
+/**
+ * Reset the failure counter for the given IP on successful auth.
+ */
+export const resetAuthFailures = (ip: string): void => {
+  attempts.delete(ip);
+};
+
+/**
+ * Clean up expired attempt records.
+ */
+export const cleanupExpiredAuthAttempts = (): number => {
+  const now = Date.now();
+  let cleaned = 0;
+  for (const [ip, record] of attempts) {
+    if (now >= record.resetAt) {
+      attempts.delete(ip);
+      cleaned++;
+    }
+  }
+  return cleaned;
+};
+
+// Schedule periodic cleanup
+setInterval(() => {
+  cleanupExpiredAuthAttempts();
+}, CLEANUP_INTERVAL_MS);

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -14,6 +14,7 @@ import {
   getMailboxesByUser,
 } from "server";
 import { logger } from "server";
+import { isAuthRateLimited, recordAuthFailure, resetAuthFailures } from "../auth-rate-limit";
 import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
 import {
@@ -711,6 +712,14 @@ export class ImapSession {
       return;
     }
 
+    const ip = this.socket.remoteAddress ?? "unknown";
+
+    if (isAuthRateLimited(ip)) {
+      this.write(`${tag} NO [AUTHENTICATIONFAILED] Too many failed attempts\r\n`);
+      this.socket.end();
+      return;
+    }
+
     try {
       // Decode base64 initial response
       const decoded = Buffer.from(initialResponse, "base64").toString("utf8");
@@ -735,6 +744,12 @@ export class ImapSession {
 
       if (!password || !user || !signedUser || !pwMatches) {
         this.authenticated = false;
+        const limited = await recordAuthFailure(ip);
+        if (limited) {
+          this.write(`${tag} NO [AUTHENTICATIONFAILED] Too many failed attempts\r\n`);
+          this.socket.end();
+          return;
+        }
         return this.write(
           `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
         );
@@ -742,6 +757,7 @@ export class ImapSession {
 
       this.store = new Store(signedUser);
       this.authenticated = true;
+      resetAuthFailures(ip);
 
       this.write(
         `${tag} OK [CAPABILITY ${this.getCapabilities()}] AUTHENTICATE completed\r\n`
@@ -1158,6 +1174,14 @@ export class ImapSession {
       return this.write(`${tag} BAD LOGIN requires username and password\r\n`);
     }
 
+    const ip = this.socket.remoteAddress ?? "unknown";
+
+    if (isAuthRateLimited(ip)) {
+      this.write(`${tag} NO [AUTHENTICATIONFAILED] Too many failed attempts\r\n`);
+      this.socket.end();
+      return;
+    }
+
     const [username, password] = args;
 
     // Remove quotes if present
@@ -1175,6 +1199,12 @@ export class ImapSession {
     );
 
     if (!cleanPassword || !user || !signedUser || !pwMatches) {
+      const limited = await recordAuthFailure(ip);
+      if (limited) {
+        this.write(`${tag} NO [AUTHENTICATIONFAILED] Too many failed attempts\r\n`);
+        this.socket.end();
+        return;
+      }
       return this.write(
         `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
       );
@@ -1182,6 +1212,7 @@ export class ImapSession {
 
     this.store = new Store(signedUser);
     this.authenticated = true;
+    resetAuthFailures(ip);
 
     return this.write(
       `${tag} OK [CAPABILITY ${this.getCapabilities()}] LOGIN completed\r\n`

--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -9,6 +9,7 @@ import {
 import { simpleParser } from "mailparser";
 import { saveMailHandler, sendMail, getUser } from "server";
 import { IncomingMail, MailDataToSend } from "common";
+import { isAuthRateLimited, recordAuthFailure, resetAuthFailures } from "./auth-rate-limit";
 
 const registerListeners = (
   server: SMTPServer,
@@ -28,12 +29,29 @@ const registerListeners = (
 
 export const onAuth: SMTPServerOptions["onAuth"] = async (auth, session, cb) => {
   if (session.user) return cb(null, { user: session.user });
+
+  const ip = session.remoteAddress ?? "unknown";
+
+  if (isAuthRateLimited(ip)) {
+    return cb(new Error("Too many failed authentication attempts"));
+  }
+
   const { username, password } = auth;
   const user = await getUser({ username });
   const signedUser = user?.getSigned();
-  if (!password || !user || !signedUser) return cb(null, { user: undefined });
+
+  if (!password || !user || !signedUser) {
+    await recordAuthFailure(ip);
+    return cb(null, { user: undefined });
+  }
+
   const pwMatches = await bcrypt.compare(password, user.password!);
-  if (!pwMatches) return cb(null, { user: undefined });
+  if (!pwMatches) {
+    await recordAuthFailure(ip);
+    return cb(null, { user: undefined });
+  }
+
+  resetAuthFailures(ip);
   cb(null, { user: username });
 };
 


### PR DESCRIPTION
## Summary

IMAP and SMTP authentication had no rate limiting, allowing unlimited brute-force attempts on a single connection. This adds per-IP tracking of failed auth attempts for both protocols.

## Changes

### New: `src/server/lib/auth-rate-limit.ts`
A shared rate limiter module (separate from the HTTP Express middleware) exposing plain functions that IMAP/SMTP handlers can call:

| Function | Description |
|----------|-------------|
| `isAuthRateLimited(ip)` | Returns true if IP has hit the threshold |
| `recordAuthFailure(ip)` | Increments counter + adds 500ms delay |
| `resetAuthFailures(ip)` | Clears counter on successful auth |

**Policy:** 10 failed attempts per IP within 15 minutes triggers the block.

### Updated: `src/server/lib/imap/session.ts`
Both `login` and `authenticate` methods now:
1. Check rate limit at entry — if blocked, send `NO [AUTHENTICATIONFAILED] Too many failed attempts` and close connection
2. On credential failure: call `recordAuthFailure` (adds 500ms delay); if now over threshold, close connection
3. On success: call `resetAuthFailures`

### Updated: `src/server/lib/smtp.ts`
`onAuth` handler now:
1. Checks rate limit at entry — if blocked, returns auth error
2. On credential failure: calls `recordAuthFailure`
3. On success: calls `resetAuthFailures`

## Testing
- All 250 existing tests pass ✅
- Server build succeeds ✅

Closes #282