### PR TITLE
fix: add error handling to call utility for network/parse failures

### DIFF
--- a/src/client/lib/call.ts
+++ b/src/client/lib/call.ts
@@ -1,6 +1,6 @@
 import { ApiResponse } from "server";
 
-const call = async <T = unknown>(path: string, options?: RequestInit) => {
+const call = async <T = unknown>(path: string, options?: RequestInit): Promise<ApiResponse<T>> => {
   const method = options?.method || "GET";
   const body = options?.body;
 
@@ -11,11 +11,14 @@ const call = async <T = unknown>(path: string, options?: RequestInit) => {
     (init as RequestInit).body = JSON.stringify(body);
   }
 
-  const response: ApiResponse<T> = await fetch(path, init).then((r) => {
-    return r.json();
-  });
-
-  return response;
+  try {
+    const httpResponse = await fetch(path, init);
+    const response: ApiResponse<T> = await httpResponse.json();
+    return response;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Network or parse error";
+    return { status: "error", message };
+  }
 };
 
 call.get = <T>(path: string) => call<T>(path);
@@ -56,13 +59,19 @@ call.postFormData = async <T = unknown>(
   formData: FormData
 ): Promise<ApiResponse<T>> => {
   console.log(`<POST:formData> ${path}`);
-  const response = await fetch(path, {
-    method: "POST",
-    body: formData
-  });
-  const result: ApiResponse<T> = await response.json();
-  console.log(`<POST:formData> ${path}`, result);
-  return result;
+  try {
+    const response = await fetch(path, {
+      method: "POST",
+      body: formData
+    });
+    const result: ApiResponse<T> = await response.json();
+    console.log(`<POST:formData> ${path}`, result);
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Network or parse error";
+    console.error(`<POST:formData> ${path}`, message);
+    return { status: "error", message };
+  }
 };
 
 export { call };


### PR DESCRIPTION
## Summary

Wraps `fetch` calls in `src/client/lib/call.ts` in try/catch blocks and returns `{ status: 'error', message }` instead of throwing unhandled exceptions.

## Problem

The `call` utility (base function and `call.postFormData`) had no error handling for:
1. Network failures (`fetch` throws on timeout, offline, DNS failure)
2. JSON parse failures (server returns HTML error page, empty body, etc.)

## Changes

- `call()`: wrapped `fetch` + `.json()` in try/catch; returns `ApiResponse` error shape on failure
- `call.postFormData()`: same treatment, with console.error logging
- Return type made explicit: `Promise<ApiResponse<T>>`
- `call.text()` and `call.binary()` already threw explicitly — left as-is (callers handle those)

## Testing

- Build passes ✓
- Existing success path behavior unchanged
- Network/parse failures return `{ status: 'error', message: '...' }` instead of throwing

Closes #122