### PR TITLE
UX: show '(No Subject)' fallback for emails with empty subject

### DIFF
--- a/src/client/Box/components/Mails/components/MailHeader.tsx
+++ b/src/client/Box/components/Mails/components/MailHeader.tsx
@@ -61,7 +61,11 @@ const MailHeader = (props: MailHeaderProps) => {
       ) : (
         <></>
       )}
-      <div className="mailcard-subject content">{mail.subject}</div>
+      <div className="mailcard-subject content">
+        {mail.subject || (
+          <span className="no-subject">(No Subject)</span>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/client/Box/components/Mails/index.scss
+++ b/src/client/Box/components/Mails/index.scss
@@ -124,6 +124,11 @@
         font-size: 20px;
         margin-top: 0.5rem;
         margin-bottom: 0.3rem;
+
+        .no-subject {
+          font-style: italic;
+          opacity: 0.5;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Emails with an empty or missing `Subject:` header show a blank line in the mail list. This PR adds a graceful fallback.

## Changes

- **MailHeader.tsx**: Display `<span class="no-subject">(No Subject)</span>` when `mail.subject` is falsy
- **index.scss**: Style `.no-subject` as italic + 50% opacity, matching the convention used by Apple Mail, Thunderbird, and Gmail

## Testing

Tested by reviewing the component logic:
- `mail.subject` truthy → rendered as-is (no change)
- `mail.subject` empty string or undefined → renders italic muted "(No Subject)"

Closes #291