### PR TITLE
fix(imap): fix FETCH field mapping regression and BODY[HEADER.FIELDS] response

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -512,6 +512,38 @@ export class ImapSession {
         fields.add("messageId");
         break;
 
+      case "HEADER_FIELDS": {
+        // Map IMAP header field names to MailType fields needed from DB
+        const headerFieldMap: Record<string, (keyof MailType)[]> = {
+          "FROM": ["from"],
+          "TO": ["to"],
+          "CC": ["cc"],
+          "BCC": ["bcc"],
+          "REPLY-TO": ["replyTo"],
+          "SUBJECT": ["subject"],
+          "DATE": ["date"],
+          "MESSAGE-ID": ["messageId"],
+        };
+        const requested = bodyFetch.section.fields ?? [];
+        if (bodyFetch.section.not) {
+          // HEADER.FIELDS.NOT: load all header fields to exclude the listed ones
+          fields.add("subject");
+          fields.add("from");
+          fields.add("to");
+          fields.add("cc");
+          fields.add("bcc");
+          fields.add("date");
+          fields.add("messageId");
+        } else {
+          // HEADER.FIELDS: load only the requested fields
+          for (const f of requested) {
+            const mapped = headerFieldMap[f.toUpperCase()];
+            if (mapped) mapped.forEach((k) => fields.add(k));
+          }
+        }
+        break;
+      }
+
       case "MIME_PART":
         fields.add("text");
         fields.add("html");
@@ -562,6 +594,38 @@ export class ImapSession {
 
       case "HEADER":
         return formatHeaders(mail, docId) + "\r\n";
+
+      case "HEADER_FIELDS": {
+        const allHeaders = formatHeaders(mail, docId);
+        const requestedFields = section.fields.map((f: string) => f.toUpperCase());
+        const lines = allHeaders.split("\r\n");
+        const filtered: string[] = [];
+        let i = 0;
+        while (i < lines.length) {
+          const line = lines[i];
+          if (line === "") break; // end of headers
+          // Continuation lines (folded headers) start with whitespace
+          if (line.match(/^[ \t]/) && filtered.length > 0) {
+            filtered[filtered.length - 1] += "\r\n" + line;
+            i++;
+            continue;
+          }
+          const colonIdx = line.indexOf(":");
+          if (colonIdx > 0) {
+            const fieldName = line.substring(0, colonIdx).toUpperCase();
+            const include = section.not
+              ? !requestedFields.includes(fieldName)
+              : requestedFields.includes(fieldName);
+            if (include) {
+              filtered.push(line);
+            }
+          }
+          i++;
+        }
+        return filtered.length > 0
+          ? filtered.join("\r\n") + "\r\n\r\n"
+          : "\r\n";
+      }
 
       case "MIME_PART":
         return getBodyPart(mail, section.partNumber);

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -123,7 +123,7 @@ export class Store {
         start,
         end,
         useUid,
-        fields.map((f) => this.mapFieldName(f))
+        fields.flatMap((f) => this.mapFieldName(f))
       );
 
       const mails = new Map<string, Partial<Mail>>();
@@ -199,7 +199,7 @@ export class Store {
     }
   };
 
-  private mapFieldName(field: string): string {
+  private mapFieldName(field: string): string[] {
     const fieldMap: Record<string, string[]> = {
       messageId: ["message_id"],
       uid: ["uid_domain", "uid_account"],
@@ -209,7 +209,7 @@ export class Store {
       bcc: ["bcc_address", "bcc_text"],
       replyTo: ["reply_to_address", "reply_to_text"],
     };
-    return (fieldMap[field] || [field]).join(", ");
+    return fieldMap[field] || [field];
   }
 
   setFlags = async (


### PR DESCRIPTION
## Problem

Two bugs found during Phase 3 IMAP testing (after PRs #258 and #268 merged):

### Bug 1: All FETCH commands crashing — regression from #203

`mapFieldName()` in `store.ts` returns compound strings like `"uid_domain, uid_account"`, but `getMailsByRange()` (updated in #203) now validates each field element individually against `PartialMailModel.validFields`. The compound string never matches, so uid/from/to/cc/bcc fields are silently dropped. Result: `mail.uid` is undefined and every FETCH crashes with:

```
Error: undefined is not an object (evaluating 'mail.uid.domain')
```

### Bug 2: BODY[HEADER.FIELDS] always returning empty — regression from #258

Two missing cases:
1. `addBodyFields()` had no `HEADER_FIELDS` case, so no DB fields were loaded. `formatHeaders()` received an empty mail object and returned nothing.
2. `getBodyContent()` had no `HEADER_FIELDS` case, so it returned `null`.

## Fix

**Bug 1:** `mapFieldName()` now returns `string[]`. Call site uses `flatMap()` to flatten before passing to `getMailsByRange()`.

**Bug 2:** Added `HEADER_FIELDS` case to both `addBodyFields()` and `getBodyContent()`:
- `addBodyFields`: maps requested IMAP field names (FROM, SUBJECT, DATE, etc.) to `MailType` keys and adds them to the DB query. For `HEADER.FIELDS.NOT`, loads all header fields.
- `getBodyContent`: filters `formatHeaders()` output to only the requested fields, with proper folded-header handling.

## Testing (raw IMAP via netcat/Python)

```
✅ FETCH FLAGS
✅ FETCH BODY[]
✅ FETCH BODYSTRUCTURE
✅ FETCH BODY[HEADER]
✅ FETCH BODY[HEADER.FIELDS (FROM)]
✅ FETCH BODY[HEADER.FIELDS (SUBJECT DATE)]
✅ FETCH BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE)]
✅ FETCH BODY[HEADER.FIELDS.NOT (DATE)]
```

Closes #202 (FETCH crashes — field mapping regression)
Related to #257 (BODY[HEADER.FIELDS] — addBodyFields + getBodyContent fix)