### PR TITLE
docs: add timer cleanup and process lifecycle patterns

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -302,6 +302,38 @@ This pattern is used in the IMAP EXPUNGE implementation where deleted messages r
 - Session IDs are cryptographically random
 - Per-user UIDVALIDITY tracking prevents cross-user data leaks
 
+### Timer and Resource Cleanup
+
+Server-side timers and resource references must be cleaned up when they expire or are replaced:
+
+```typescript
+// BAD: stale references accumulate
+const timers: Record<string, Timeout> = {};
+const startTimer = (id: string) => {
+  timers[id] = setTimeout(() => { /* ... */ }, DURATION);
+  // ← old timer for same id still fires, reference leaks
+};
+
+// GOOD: clear previous timer, clean up reference
+const startTimer = (id: string) => {
+  if (timers[id]) clearTimeout(timers[id]);
+  timers[id] = setTimeout(() => {
+    delete timers[id]; // clean up reference after firing
+    // ...
+  }, DURATION);
+};
+```
+
+### Process Lifecycle Handlers
+
+Process-level handlers (`SIGINT`, `SIGTERM`, `unhandledRejection`, `uncaughtException`) belong in the application entry point (`start.ts`), not in library modules. Shutdown should drain resources in order:
+
+1. Stop accepting new connections (close HTTP/IMAP/SMTP servers)
+2. Close database pool
+3. Exit process
+
+Library modules should not register global process handlers as side effects of import.
+
 ## Query Optimization
 
 ### Select Only Needed Columns


### PR DESCRIPTION
Add two new sections to DEVELOPMENT.md Security Considerations:

### Timer and Resource Cleanup
Documents the pattern for cleaning up server-side timer references — clearing previous timers before replacing them, and deleting references after they fire. Addresses the `expiryTimer` pattern in users.ts.

Related: #302

### Process Lifecycle Handlers
Documents that process-level signal handlers belong in `start.ts`, not in library modules. Matches the pattern established in PR #212 where handlers were moved from postgres/client.ts to start.ts.

---

**E2E:** Verified DEVELOPMENT.md renders correctly and new sections integrate properly within the Security Considerations section.