### PR TITLE
fix(imap): remove STARTTLS from port 993 CAPABILITY, add to port 143

### DIFF
--- a/src/server/lib/imap/capabilities.ts
+++ b/src/server/lib/imap/capabilities.ts
@@ -10,9 +10,11 @@ export const getCapabilities = (port = 143) => {
     "AUTH=PLAIN"
   ];
 
-  if (port === 993) {
+  if (port === 143) {
+    // Advertise STARTTLS on plain port to allow upgrade
     capabilities.push("STARTTLS");
   }
+  // Do NOT advertise STARTTLS on port 993 — connection is already TLS-wrapped
 
   return capabilities.join(" ");
 };


### PR DESCRIPTION
## Problem

Port 993 CAPABILITY advertises `STARTTLS`, which is wrong — the connection is already TLS-wrapped. This caused iOS Mail to fail with **"Cannot Connect Using SSL"** during account setup.

Per RFC 3501, `STARTTLS` must NOT be advertised on an already-encrypted port. Clients like iOS Mail see it and attempt a second TLS upgrade, which fails.

The fix also moves `STARTTLS` to port 143 where it belongs, allowing clients to upgrade a plain connection to TLS.

## Testing

After this fix, iOS Mail connects successfully to `mail.hoie.kim:993` with SSL enabled.