### PR TITLE
fix(imap): remove \Noselect from sub-mailboxes

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -1065,10 +1065,7 @@ export class ImapSession {
     try {
       const boxes = await this.store.listMailboxes();
       boxes.forEach((box) => {
-        // Sub-mailboxes (INBOX/x, Sent Messages/x) are virtual — mark \Noselect
-        const isSubMailbox = box.includes("/");
-        const flags = isSubMailbox ? "\\Noselect \\HasNoChildren" : "\\HasNoChildren";
-        const response = `* LIST (${flags}) "/" "${box}"\r\n`;
+        const response = `* LIST (\\HasNoChildren) "/" "${box}"\r\n`;
         this.write(response);
       });
       this.write(`${tag} OK LIST completed\r\n`);


### PR DESCRIPTION
## Problem

After #310 (domain filter), sub-mailboxes like `INBOX/admin` and `Sent Messages/admin` now contain the user's own accounts with real messages. But #309 marked all sub-mailboxes `\Noselect`, so iOS Mail cannot open any of them.

The `\Noselect` was added when sub-mailboxes contained external CC/BCC addresses (always empty) — it made sense then. Now that only the user's own domain addresses are listed, they are real selectable folders.

## Fix

Remove `\Noselect`. All mailboxes are `\HasNoChildren` and fully selectable.

## Verified locally
- `INBOX`: 36 messages, `UID FETCH 1:* (FLAGS)` returns OK
- `INBOX/admin`: 2 messages, selectable
- All mailboxes in LIST use `(\HasNoChildren)` only