### PR TITLE
fix(imap): return all messages in FETCH — mail_id always included in query, 1:* limit fixed

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -57,6 +57,7 @@ const throttler = new Throttler();
 
 export class ImapSession {
   public selectedMailbox: string | null = null;
+  private selectedMailboxMessageCount: number = 0;
   private store: Store | null = null;
   private authenticated: boolean = false;
   private isIdling: boolean = false;
@@ -204,14 +205,17 @@ export class ImapSession {
   };
 
   private countSequenceSetMessages(sequenceSet: SequenceSet): number {
+    // Cap * (MAX_SAFE_INTEGER) at the actual mailbox size so limit checks
+    // work correctly for ranges like 1:* or *:*
+    const mailboxSize = this.selectedMailboxMessageCount ?? 0;
     let count = 0;
     for (const range of sequenceSet.ranges) {
       if (range.end === undefined) {
-        // Single message
         count += 1;
       } else {
-        // Range of messages
-        count += range.end - range.start + 1;
+        const start = Math.min(range.start, mailboxSize);
+        const end = range.end === Number.MAX_SAFE_INTEGER ? mailboxSize : Math.min(range.end, mailboxSize);
+        count += Math.max(0, end - start + 1);
       }
     }
     return count;
@@ -1115,12 +1119,14 @@ export class ImapSession {
 
       if (countResult === null) {
         this.selectedMailbox = null;
+      this.selectedMailboxMessageCount = 0;
         this.seqToUid = [];
         this.uidToSeq.clear();
         return this.write(`${tag} NO Mailbox does not exist\r\n`);
       }
 
       const { total, unread } = countResult;
+      this.selectedMailboxMessageCount = total;
 
       // Get UIDVALIDITY for this user (initialized on first IMAP access)
       const uidValidity = await getImapUidValidity(this.store.getUser().id);
@@ -1194,6 +1200,7 @@ export class ImapSession {
 
     // Clear the selected mailbox and sequence mapping
     this.selectedMailbox = null;
+      this.selectedMailboxMessageCount = 0;
     this.seqToUid = [];
     this.uidToSeq.clear();
     this.write(`${tag} OK CLOSE completed\r\n`);
@@ -1207,6 +1214,7 @@ export class ImapSession {
 
     this.store = null;
     this.selectedMailbox = null;
+      this.selectedMailboxMessageCount = 0;
     this.seqToUid = [];
     this.uidToSeq.clear();
     this.authenticated = false;

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -562,6 +562,10 @@ export const getMailsByRange = async (
     const safeFields = resolvedFields.filter((f) =>
       PartialMailModel.validFields.has(f)
     );
+    // Always include mail_id — it is the Map key; without it all rows collapse to key=undefined
+    if (!safeFields.includes("mail_id")) {
+      safeFields.unshift("mail_id");
+    }
     const fieldList = safeFields.length > 0 ? safeFields.join(", ") : "*";
 
     if (account === null) {


### PR DESCRIPTION
## Problems (iOS Mail shows mailboxes but no messages)

### 1. Map key collision in `getMailsByRange`

`getMailsByRange()` stores results in a `Map<string, PartialMailModel>` keyed by `row.mail_id`. But `mail_id` was not always in the requested fields — for FLAGS-only fetches it was never requested. Result: all 36 rows were stored under key `undefined` and only the last one survived.

**Fix:** Always prepend `mail_id` to `safeFields` so the key is always present.

### 2. `1:*` range counted as billions of messages

`countSequenceSetMessages()` computed the range literally — `*` parses to `Number.MAX_SAFE_INTEGER`, so `1:*` = ~9 quadrillion messages, which always exceeded the FETCH limit. This blocked every `UID FETCH 1:*` even for tiny mailboxes.

**Fix:** Cap `*` at `selectedMailboxMessageCount` (set during SELECT), so `1:*` correctly counts as 'number of messages in mailbox'.

## Verified locally
```
UID FETCH 1:* (FLAGS INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS (...)])
→ OK, 36 messages returned (was: 1 message)
```