### PR TITLE
fix(imap): handle missing attachment size in RFC822.SIZE

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -355,7 +355,7 @@ export class ImapSession {
         const encodedHtml = encodeText(mail.html || "");
         const htmlSize = Buffer.byteLength(encodedHtml, "utf-8");
         const attachmentSize = (mail.attachments ?? []).reduce(
-          (acc, { size }) => acc + Math.ceil(size / 3) * 4,
+          (acc, { size }) => acc + (size ? Math.ceil(size / 3) * 4 : 0),
           0
         );
         const size = textSize + htmlSize + attachmentSize;


### PR DESCRIPTION
## Problem

`RFC822.SIZE` returned `NaN` for messages where attachments don't have a `size` field (older emails stored with only `content`/`filename`/`contentType`).

`Math.ceil(undefined / 3) * 4 = NaN` propagated to the total, giving `RFC822.SIZE NaN` in FETCH responses. iOS Mail uses this to decide how much data to download; a NaN value could cause display glitches.

## Fix

Guard with `size ? Math.ceil(size/3)*4 : 0` — attachments without a size contribute 0 bytes.