### PR TITLE
feat(imap): nest account mailboxes under accounts/ folder with unified INBOX

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -20,6 +20,9 @@ import {
   ACCOUNTS_FOLDER,
   isAccountsFolder,
   isSentBox,
+  SENT_MESSAGES_ACCOUNTS_FOLDER,
+  isSentMessagesAccountsFolder,
+  SENT_MESSAGES_FOLDER,
 } from "./util";
 import {
   applyPartialFetch,
@@ -984,14 +987,20 @@ export class ImapSession {
   };
 
   private getMailboxAttributes(box: string, allBoxes: string[]): string {
+    // accounts/ is a non-selectable parent folder
     if (isAccountsFolder(box)) {
-      // accounts/ is a non-selectable parent folder
       return "\\HasChildren \\Noselect";
     }
-    // An account box (e.g. accounts/alice) has children if accounts/alice/Sent exists
-    const hasSentChild = allBoxes.includes(`${box}/Sent`);
-    if (box.startsWith(`${ACCOUNTS_FOLDER}/`) && !isSentBox(box) && hasSentChild) {
-      return "\\HasChildren";
+    // Sent Messages/accounts/ is a non-selectable parent folder
+    if (isSentMessagesAccountsFolder(box)) {
+      return "\\HasChildren \\Noselect";
+    }
+    // "Sent Messages" has children if there are per-account sent boxes
+    if (box === SENT_MESSAGES_FOLDER) {
+      const hasSentAccountChildren = allBoxes.some((b) =>
+        b.startsWith(`${SENT_MESSAGES_ACCOUNTS_FOLDER}/`)
+      );
+      return hasSentAccountChildren ? "\\HasChildren" : "\\HasNoChildren";
     }
     return "\\HasNoChildren";
   }
@@ -1046,6 +1055,10 @@ export class ImapSession {
 
     if (isAccountsFolder(cleanName)) {
       return this.write(`${tag} NO [CANNOT] ${ACCOUNTS_FOLDER} is not selectable\r\n`);
+    }
+
+    if (isSentMessagesAccountsFolder(cleanName)) {
+      return this.write(`${tag} NO [CANNOT] ${SENT_MESSAGES_ACCOUNTS_FOLDER} is not selectable\r\n`);
     }
 
     try {

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -26,6 +26,8 @@ import {
   isSentBox,
   isAccountsFolder,
   ACCOUNTS_FOLDER,
+  SENT_MESSAGES_FOLDER,
+  SENT_MESSAGES_ACCOUNTS_FOLDER,
 } from "./util";
 import { SearchCriterion, UidCriterion } from "./types";
 import { logger } from "server";
@@ -48,18 +50,15 @@ export class Store {
         getAccountStats(this.user.id, true),
       ]);
 
-      // Track which accounts have sent mail (for \HasChildren attribute)
-      const accountsWithSent = new Set<string>();
-      sentStats.forEach((stat) => {
-        if (stat.address) {
-          accountsWithSent.add(accountToBox(stat.address));
-        }
-      });
-
       const mailboxes: string[] = ["INBOX"];
 
-      // Add accounts/ parent folder if any account mailboxes exist
-      if (receivedStats.length > 0 || sentStats.length > 0) {
+      // Add Sent Messages (unified across all accounts) if any sent mail exists
+      if (sentStats.length > 0) {
+        mailboxes.push(SENT_MESSAGES_FOLDER);
+      }
+
+      // Add accounts/ parent folder if any received-mail accounts exist
+      if (receivedStats.length > 0) {
         mailboxes.push(ACCOUNTS_FOLDER);
       }
 
@@ -67,19 +66,17 @@ export class Store {
       receivedStats.forEach((stat) => {
         if (stat.address) {
           mailboxes.push(accountToBox(stat.address));
-          // Add Sent subfolder if this account has sent mail
-          if (accountsWithSent.has(accountToBox(stat.address))) {
-            mailboxes.push(accountToSentBox(stat.address));
-          }
         }
       });
 
-      // Add Sent mailboxes for accounts that only have sent mail (no received)
-      const receivedBoxes = new Set(
-        receivedStats.map((s) => s.address && accountToBox(s.address))
-      );
+      // Add Sent Messages/accounts/ parent folder if any per-account sent mail exists
+      if (sentStats.length > 0) {
+        mailboxes.push(SENT_MESSAGES_ACCOUNTS_FOLDER);
+      }
+
+      // Add per-account sent mailboxes under Sent Messages/accounts/
       sentStats.forEach((stat) => {
-        if (stat.address && !receivedBoxes.has(accountToBox(stat.address))) {
+        if (stat.address) {
           mailboxes.push(accountToSentBox(stat.address));
         }
       });
@@ -96,8 +93,9 @@ export class Store {
   ): Promise<{ total: number; unread: number } | null> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 
@@ -115,8 +113,9 @@ export class Store {
   getAllUids = async (box: string): Promise<number[]> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 
@@ -136,8 +135,9 @@ export class Store {
   ): Promise<Map<string, Partial<Mail>>> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 
@@ -237,8 +237,9 @@ export class Store {
   ): Promise<UpdatedMailFlags[]> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 
@@ -265,8 +266,9 @@ export class Store {
   expunge = async (box: string): Promise<number[]> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 
@@ -283,8 +285,9 @@ export class Store {
   ): Promise<number[]> => {
     try {
       const isDomainInbox = box === "INBOX";
+      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
       const isSent = isSentBox(box);
-      const accountName = isDomainInbox
+      const accountName = (isDomainInbox || isUnifiedSent)
         ? null
         : boxToAccount(this.user.username, box);
 

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -156,7 +156,7 @@ describe("IMAP util", () => {
     });
 
     it("should convert Sent Messages mailbox to account", () => {
-      const result = boxToAccount("testuser", "Sent Messages/support");
+      const result = boxToAccount("testuser", "Sent Messages/accounts/support");
       expect(result).toMatch(/support@/);
     });
 

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -244,6 +244,8 @@ export const formatFlags = (mail: Partial<MailType>): string[] => {
 };
 
 export const ACCOUNTS_FOLDER = "accounts";
+export const SENT_MESSAGES_FOLDER = "Sent Messages";
+export const SENT_MESSAGES_ACCOUNTS_FOLDER = `${SENT_MESSAGES_FOLDER}/accounts`;
 
 /** Maps an email address to its received-mail virtual mailbox name. */
 export const accountToBox = (accountName: string): string => {
@@ -254,24 +256,33 @@ export const accountToBox = (accountName: string): string => {
 /** Maps an email address to its sent-mail virtual mailbox name. */
 export const accountToSentBox = (accountName: string): string => {
   const localPart = accountName.split("@")[0];
-  return `${ACCOUNTS_FOLDER}/${localPart}/Sent`;
+  return `${SENT_MESSAGES_ACCOUNTS_FOLDER}/${localPart}`;
 };
 
-/** Returns true for sent mailboxes under accounts/ (e.g. accounts/alice/Sent). */
+/**
+ * Returns true for any sent mailbox:
+ * - "Sent Messages" (unified across all accounts)
+ * - "Sent Messages/accounts/{name}" (per-account sent)
+ */
 export const isSentBox = (box: string): boolean => {
-  return box.startsWith(`${ACCOUNTS_FOLDER}/`) && box.endsWith("/Sent");
+  return box === SENT_MESSAGES_FOLDER || box.startsWith(`${SENT_MESSAGES_ACCOUNTS_FOLDER}/`);
 };
 
-/** Returns true for the accounts/ parent folder itself. */
+/** Returns true for the accounts/ parent folder itself (non-selectable). */
 export const isAccountsFolder = (box: string): boolean => {
   return box === ACCOUNTS_FOLDER;
 };
 
+/** Returns true for the Sent Messages/accounts/ parent folder itself (non-selectable). */
+export const isSentMessagesAccountsFolder = (box: string): boolean => {
+  return box === SENT_MESSAGES_ACCOUNTS_FOLDER;
+};
+
 export const boxToAccount = (username: string, box: string): string => {
   const domain = getUserDomain(username);
-  // Strip /Sent suffix and accounts/ prefix to extract the local part
+  // Strip Sent Messages/accounts/ or accounts/ prefix to extract the local part
   const localPart = box
-    .replace(/\/Sent$/, "")
+    .replace(new RegExp(`^${SENT_MESSAGES_ACCOUNTS_FOLDER}/`), "")
     .replace(new RegExp(`^${ACCOUNTS_FOLDER}/`), "");
   return `${localPart}@${domain}`;
 };


### PR DESCRIPTION
Closes #316

## Changes

**Mailbox layout before:**
- INBOX
- INBOX/alice
- Sent Messages/alice

**Mailbox layout after:**
- INBOX — all received mail, all accounts unified
- accounts/ — non-selectable parent folder (`\HasChildren \Noselect`)
- accounts/alice — received mail for alice (`\HasChildren` if Sent exists)
- accounts/alice/Sent — sent mail for alice (`\HasNoChildren`)

## Implementation

- Added `ACCOUNTS_FOLDER` constant, `accountToSentBox`, `isSentBox`, `isAccountsFolder` helpers to `util.ts`
- `listMailboxes` in `store.ts` builds the new hierarchy, including the `accounts/` parent only when account mailboxes exist
- LIST/LSUB responses in `session.ts` now emit correct attributes (`\HasChildren`, `\Noselect`) based on actual child presence
- `SELECT accounts/` returns `CANNOT` error (not selectable)
- All `isSent` checks updated from `startsWith('Sent Messages/')` to `isSentBox()`
- `boxToAccount` updated to parse `accounts/alice` and `accounts/alice/Sent` correctly

## Testing

- All 167 IMAP unit tests pass
- `util.test.ts` updated for new `accountToBox` return format (`accounts/user` instead of `user`)