### PR TITLE
fix(imap): add NAMESPACE, ENABLE, UNSELECT, GETQUOTAROOT command support

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -339,6 +339,26 @@ export class ImapRequestHandler {
           await this.session.startTls(tag);
           break;
 
+        case "NAMESPACE":
+          // RFC 2342: single personal namespace, no other/shared namespaces
+          this.session.write(`* NAMESPACE (("" "/")) NIL NIL\r\n${tag} OK NAMESPACE completed\r\n`);
+          break;
+
+        case "ENABLE":
+          // RFC 5161: acknowledge requested capabilities; we don't activate any extensions
+          this.session.write(`* ENABLED\r\n${tag} OK ENABLE completed\r\n`);
+          break;
+
+        case "UNSELECT":
+          // RFC 3691: like CLOSE but without expunging; deselect the current mailbox
+          this.session.closeMailbox(tag, true);
+          break;
+
+        case "GETQUOTAROOT":
+          // RFC 2087: quota not supported, return empty quota
+          this.session.write(`${tag} NO Quota not supported\r\n`);
+          break;
+
         default:
           this.session.write(`${tag} BAD Unknown command\r\n`);
           break;

--- a/src/server/lib/imap/parsers/command-parser.ts
+++ b/src/server/lib/imap/parsers/command-parser.ts
@@ -194,6 +194,48 @@ const parseImapRequest = (
         consumed: context.position
       };
 
+    case "NAMESPACE":
+      return {
+        success: true,
+        value: { type: "NAMESPACE" },
+        consumed: context.position
+      };
+
+    case "ENABLE": {
+      // ENABLE <capability> [<capability> ...]
+      const caps: string[] = [];
+      skipWhitespace(context);
+      while (context.position < context.length) {
+        const capAtom = parseAtom(context);
+        if (!capAtom.success) break;
+        caps.push(capAtom.value!.toUpperCase());
+        skipWhitespace(context);
+      }
+      return {
+        success: true,
+        value: { type: "ENABLE", data: { capabilities: caps } },
+        consumed: context.position
+      };
+    }
+
+    case "UNSELECT":
+      return {
+        success: true,
+        value: { type: "UNSELECT" },
+        consumed: context.position
+      };
+
+    case "GETQUOTAROOT": {
+      skipWhitespace(context);
+      const mbAtom = parseAtom(context);
+      const mb = mbAtom.success ? mbAtom.value! : "INBOX";
+      return {
+        success: true,
+        value: { type: "GETQUOTAROOT", data: { mailbox: mb } },
+        consumed: context.position
+      };
+    }
+
     default:
       return {
         success: false,

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -1252,7 +1252,7 @@ export class ImapSession {
     }
   };
 
-  closeMailbox = (tag: string) => {
+  closeMailbox = (tag: string, unselect = false) => {
     if (!this.authenticated || !this.store) {
       return this.write(`${tag} NO Not authenticated.\r\n`);
     }
@@ -1263,10 +1263,11 @@ export class ImapSession {
 
     // Clear the selected mailbox and sequence mapping
     this.selectedMailbox = null;
-      this.selectedMailboxMessageCount = 0;
+    this.selectedMailboxMessageCount = 0;
     this.seqToUid = [];
     this.uidToSeq.clear();
-    this.write(`${tag} OK CLOSE completed\r\n`);
+    const verb = unselect ? "UNSELECT" : "CLOSE";
+    this.write(`${tag} OK ${verb} completed\r\n`);
   };
 
   logout = async (tag: string) => {

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -451,7 +451,11 @@ export type ImapRequest =
   | { type: "ID" }
   | { type: "DONE" }
   | { type: "LOGOUT" }
-  | { type: "STARTTLS" };
+  | { type: "STARTTLS" }
+  | { type: "NAMESPACE" }
+  | { type: "ENABLE"; data: { capabilities: string[] } }
+  | { type: "UNSELECT" }
+  | { type: "GETQUOTAROOT"; data: { mailbox: string } };
 
 // Response types for better type safety
 export interface ImapResponse {


### PR DESCRIPTION
## Problem

iOS Mail sends `NAMESPACE` (RFC 2342) immediately after login to understand the mailbox folder hierarchy. The command was unhandled, returning `BAD Unknown command`, which caused iOS Mail to either give up on sub-folder discovery or misinterpret the mailbox structure — manifesting as empty account mailboxes and 'server not responding' symptoms.

`ENABLE` (RFC 5161) was the same: advertised in `CAPABILITY` but returned `BAD` when actually sent.

## Changes

| Command | Before | After |
|---------|--------|-------|
| `NAMESPACE` | `BAD Unknown command` | `* NAMESPACE (("\"\"") "/")) NIL NIL` + `OK` |
| `ENABLE` | `BAD Unknown command` | `* ENABLED` + `OK` |
| `UNSELECT` (RFC 3691) | `BAD Unknown command` | Deselects mailbox without expunge + `OK` |
| `GETQUOTAROOT` | `BAD Unknown command` | Graceful `NO Quota not supported` |

`closeMailbox` updated to accept an optional `unselect` flag so `UNSELECT` emits the correct tagged response.

## Testing

- Verified `NAMESPACE` returns `* NAMESPACE (("""/")) NIL NIL` via live `nc` test
- Verified `ENABLE CONDSTORE` returns `* ENABLED` + `OK`
- All 250 tests pass
- TypeScript compiles clean (`bun tsc --noEmit`)

## Related

Follows #321 (iOS Mail body rendering fixes). `NAMESPACE` was the missing piece causing iOS Mail to show account sub-mailboxes as empty.