### PR TITLE
fix: remove duplicate expunged = FALSE condition in searchMailsByUid

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -853,9 +853,6 @@ export const searchMailsByUid = async (
       }
     }
 
-    // Always exclude expunged messages from search
-    conditions.push("expunged = FALSE");
-
     const sql = `
       SELECT ${uidField} as uid FROM mails 
       WHERE ${conditions.join(" AND ")}


### PR DESCRIPTION
## Summary

Removes a redundant `expunged = FALSE` condition in `searchMailsByUid`.

## Root Cause

The conditions array is initialized with `'expunged = FALSE'` as one of its initial elements:
```ts
const conditions: string[] = ["user_id = $1", "sent = $2", "expunged = FALSE"];
```

Then after the criteria loop, it was pushed again:
```ts
// Always exclude expunged messages from search
conditions.push("expunged = FALSE");
```

This resulted in SQL like `... AND expunged = FALSE AND ... AND expunged = FALSE`.

## Fix

Remove the duplicate push. The initial declaration already covers this.

## Testing
- Existing IMAP SEARCH behavior is unchanged
- SQL generated has a single `expunged = FALSE` condition

Closes #320