### PR TITLE
security: hide internal error details in 500 responses in production

### DIFF
--- a/src/server/lib/http/routes/route.ts
+++ b/src/server/lib/http/routes/route.ts
@@ -1,4 +1,5 @@
 import { Router, RequestHandler, Request, Response, NextFunction } from "express";
+import { logger } from "../../logger";
 
 export type Method = "GET" | "POST" | "DELETE";
 
@@ -57,8 +58,13 @@ export class Route<T> {
         else res.end();
         return;
       } catch (error: unknown) {
-        console.error(error);
-        const message = error instanceof Error ? error.message : String(error);
+        logger.error("Route handler error", { method: this.method, path: this.path }, error);
+        const message =
+          process.env.NODE_ENV === "production"
+            ? "Internal server error"
+            : error instanceof Error
+              ? error.message
+              : String(error);
         res.status(500).json({ status: "error", message });
       }
     }


### PR DESCRIPTION
## Problem

The `Route` class error handler returned `error.message` verbatim to HTTP clients. This leaks:
- Database host/port from PostgreSQL connection errors
- File system paths from file read errors
- Library internals from third-party packages

```typescript
// Before
const message = error instanceof Error ? error.message : String(error);
res.status(500).json({ status: "error", message });
```

## Fix

Return a generic message in production, preserve detail in dev:

```typescript
logger.error("Route handler error", { method: this.method, path: this.path }, error);
const message =
  process.env.NODE_ENV === "production"
    ? "Internal server error"
    : error instanceof Error
      ? error.message
      : String(error);
res.status(500).json({ status: "error", message });
```

Also switches from `console.error` to structured `logger.error` for consistent log formatting. Logger imported directly from `../../logger` to avoid circular import through the `server` barrel.

## Testing
- In dev mode: errors still show descriptive messages
- In production (`NODE_ENV=production`): all 500s return `"Internal server error"`
- Internal details always appear in server logs

Closes #319