### PR TITLE
feat(imap): move accounts folder under INBOX

### DIFF
--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -133,15 +133,15 @@ describe("IMAP util", () => {
 
   describe("accountToBox", () => {
     it("should extract local part from email under accounts/ folder", () => {
-      expect(accountToBox("user@example.com")).toBe("accounts/user");
+      expect(accountToBox("user@example.com")).toBe("INBOX/accounts/user");
     });
 
     it("should handle email with dots in local part", () => {
-      expect(accountToBox("first.last@example.com")).toBe("accounts/first.last");
+      expect(accountToBox("first.last@example.com")).toBe("INBOX/accounts/first.last");
     });
 
     it("should handle email with plus addressing", () => {
-      expect(accountToBox("user+tag@example.com")).toBe("accounts/user+tag");
+      expect(accountToBox("user+tag@example.com")).toBe("INBOX/accounts/user+tag");
     });
   });
 
@@ -150,8 +150,8 @@ describe("IMAP util", () => {
     // The default is "mydomain", so for admin user it returns "mydomain"
     // For other users it returns "username.mydomain"
 
-    it("should convert INBOX mailbox to account for admin", () => {
-      const result = boxToAccount("admin", "INBOX/support");
+    it("should convert INBOX/accounts mailbox to account for admin", () => {
+      const result = boxToAccount("admin", "INBOX/accounts/support");
       expect(result).toMatch(/support@/);
     });
 

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -243,7 +243,7 @@ export const formatFlags = (mail: Partial<MailType>): string[] => {
   return flags;
 };
 
-export const ACCOUNTS_FOLDER = "accounts";
+export const ACCOUNTS_FOLDER = "INBOX/accounts";
 export const SENT_MESSAGES_FOLDER = "Sent Messages";
 export const SENT_MESSAGES_ACCOUNTS_FOLDER = `${SENT_MESSAGES_FOLDER}/accounts`;
 


### PR DESCRIPTION
## Change

Moves the received-mail virtual mailbox hierarchy from `accounts/` to `INBOX/accounts/`:

**Before:**
```
INBOX
accounts/
accounts/alice
Sent Messages/
Sent Messages/accounts/alice
```

**After:**
```
INBOX
INBOX/accounts/
INBOX/accounts/alice
Sent Messages/
Sent Messages/accounts/alice
```

## Implementation

Single constant change: `ACCOUNTS_FOLDER = "INBOX/accounts"` in `util.ts`. All dependent functions (`accountToBox`, `boxToAccount`, `isAccountsFolder`, `getMailboxAttributes`) derive from this constant and update automatically.

## Testing

All 167 IMAP unit tests pass. Tests updated to reflect new `INBOX/accounts/` paths.