### PR TITLE
docs: IMAP parser contract, client compat notes, and shutdown order

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -234,6 +234,66 @@ Key functions:
 
 **Note:** The IMAP layer still uses the legacy `sent` column for mailbox routing. A future refactor should align IMAP with the address-based approach.
 
+### IMAP Parser-to-Consumer Contract
+
+**Parsers produce self-contained criterion objects.** Each parsed criterion has its value embedded as a property — never rely on adjacent array indices.
+
+```typescript
+// Parser output for "SEARCH FROM user@example.com UNSEEN":
+[
+  { type: "FROM", value: "user@example.com" },  // value is a property
+  { type: "UNSEEN" }                              // no value needed
+]
+
+// ✅ Correct — read from the criterion object
+for (const criterion of criteria) {
+  switch (criterion.type) {
+    case "FROM":
+      filter.from = criterion.value;  // value is on the object
+      break;
+  }
+}
+
+// ❌ Wrong — don't index into the array for values
+for (let i = 0; i < criteria.length; i++) {
+  if (criteria[i].type === "FROM") {
+    value = criteria[++i];  // BUG: next element is a separate criterion
+  }
+}
+```
+
+This pattern also applies to FETCH data items and STORE operations — each parsed item is self-contained.
+
+### IMAP Client Compatibility
+
+Different mail clients send different IMAP commands. Known quirks:
+
+- **iOS Mail**: Expects `BODY[1]` to return decoded content, uses `BODY.PEEK[HEADER.FIELDS (...)]`, requires accurate `RFC822.SIZE` for display
+- **Thunderbird**: Uses `UID FETCH ... (FLAGS BODY.PEEK[HEADER.FIELDS (Date From Subject ...)])` in batches
+- **Apple Mail (macOS)**: Similar to iOS but also uses `NAMESPACE` and `GETQUOTAROOT`
+
+When fixing IMAP bugs, always test with the affected client and document which client triggered the issue in the PR description.
+
+### Graceful Shutdown Order
+
+Shutdown must follow this order to avoid connection errors:
+
+1. Stop accepting new connections (HTTP, IMAP, SMTP servers)
+2. Close idle IMAP connections via `idleManager.shutdown()`
+3. Wait for in-flight requests to complete
+4. Close database pool
+
+```typescript
+// Correct order (see start.ts)
+httpServer.close();
+imapServer.close();
+smtpServer.close();
+await idleManager.shutdown();
+await pool.end();
+```
+
+Closing DB before servers causes "connection terminated" errors on active requests.
+
 ## Database
 
 ### PostgreSQL Setup


### PR DESCRIPTION
Updates DEVELOPMENT.md with three patterns from recent IMAP work:

### Parser-to-Consumer Contract
Documents that parsed criterion objects are self-contained (values are properties, not adjacent array elements). This was the root cause of the SEARCH criteria extraction bug (#337).

### Client Compatibility Notes
Documents known quirks of iOS Mail, Thunderbird, and Apple Mail based on the 15+ IMAP fixes merged in the past two weeks. Helps future contributors know which clients to test.

### Graceful Shutdown Order
Documents the correct shutdown sequence (servers → idle manager → DB pool) based on PR #212.

## E2E Testing
Verified DEVELOPMENT.md renders correctly and patterns match current codebase behavior.