### PR TITLE
privacy: block remote content in email viewer via CSP meta tag

### DIFF
--- a/src/client/lib/html.ts
+++ b/src/client/lib/html.ts
@@ -93,6 +93,7 @@ export const processHtmlForViewer = (html: string) => {
   // tags, event handlers, and dangerous URI schemes.
   const sanitized = sanitizeEmailHtml(html);
   return `
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src data: cid:; font-src 'none';">
 <style>
   body {
       margin: 0;


### PR DESCRIPTION
Closes #350

## Summary
Injects a restrictive Content-Security-Policy meta tag into the email viewer iframe to block tracking pixels and external resource loading.

## Changes
- `src/client/lib/html.ts`: add CSP meta tag to `processHtmlForViewer`

## Testing
Opened an HTML email with external images — images no longer load, no external requests made.