### PR TITLE
fix: include saved, insight, cc, bcc fields in search results

### DIFF
--- a/src/server/lib/mails/search.ts
+++ b/src/server/lib/mails/search.ts
@@ -1,4 +1,4 @@
-import { MailHeaderData, SignedUser, MailAddressValueType } from "common";
+import { MailHeaderData, SignedUser, MailAddressValueType, Insight } from "common";
 import {
   searchMails,
   SearchMailModel,
@@ -29,6 +29,14 @@ export const searchMail = async (
         ? { value: m.to_address as MailAddressValueType[], text: m.to_text || "" }
         : undefined,
       read: m.read,
+      saved: m.saved,
+      insight: m.insight as Insight | undefined,
+      cc: m.cc_address
+        ? { value: m.cc_address as MailAddressValueType[], text: m.cc_text || "" }
+        : undefined,
+      bcc: m.bcc_address
+        ? { value: m.bcc_address as MailAddressValueType[], text: m.bcc_text || "" }
+        : undefined,
       highlight: m.highlight,
     });
   });


### PR DESCRIPTION
## Summary

Search results from `/api/mails/search/:value` were missing several fields that the normal headers endpoint includes: `saved`, `insight`, `cc`, and `bcc`.

## Root Cause

In `src/server/lib/mails/search.ts`, the `searchMail` function constructs `MailHeaderData` objects without passing these fields, even though they're available from the `SearchMailModel` (which extends `MailModel` and includes all mail columns via `SELECT *`).

The headers endpoint in `src/server/lib/mails/headers.ts` correctly includes all these fields.

## Impact

- **Saved/star indicator**: Search results never showed the star icon, even for saved emails
- **Toggle behavior**: Toggling save on a search result started from `false` instead of actual value
- **AI insight**: Robot icon never appeared on search results
- **CC/BCC missing**: Reply/forward from search results omitted CC/BCC recipients

## Fix

Added the missing fields to align with `headers.ts` mapping:
- `saved: m.saved`
- `insight: m.insight as Insight | undefined`
- `cc` and `bcc` address mappings

## Testing

1. Started app, logged in as admin
2. Searched for "Compose Test" — a known saved email
3. Before fix: `saved=false` in API response
4. After fix: `saved=true` in API response ✅
5. TypeScript compiles clean (`tsc --noEmit`)

Closes #355