### PR TITLE
docs: add IMAP mailbox hierarchy and client compatibility patterns

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -350,6 +350,26 @@ Per-client known quirks:
 
 When fixing IMAP bugs, always test with the affected client and document which client triggered the issue in the PR description.
 
+### Graceful Shutdown Order
+
+Shutdown must follow this order to avoid connection errors:
+
+1. Stop accepting new connections (HTTP, IMAP, SMTP servers)
+2. Close idle IMAP connections via `idleManager.shutdown()`
+3. Wait for in-flight requests to complete
+4. Close database pool
+
+```typescript
+// Correct order (see start.ts)
+httpServer.close();
+imapServer.close();
+smtpServer.close();
+await idleManager.shutdown();
+await pool.end();
+```
+
+Closing DB before servers causes "connection terminated" errors on active requests.
+
 ## Database
 
 ### PostgreSQL Setup


### PR DESCRIPTION
Updates DEVELOPMENT.md with patterns from the recent IMAP stabilization work (PRs #307-#322):

- **Mailbox hierarchy**: Documents the `accounts/` nesting structure, utility functions, domain filtering, and NAMESPACE response
- **Client compatibility**: Documents lessons learned from Apple Mail/iOS Mail testing — BODYSTRUCTURE encoding consistency, RFC822.SIZE accuracy, CAPABILITY per-port, AUTHENTICATE PLAIN flow, supported extensions, sub-mailbox flags
- **IMAP Parser-to-Consumer Contract**: Restored accidentally deleted section documenting how parsers communicate results to consumers
- **Per-client quirks**: Restored accidentally deleted section documenting Apple Mail/iOS Mail-specific behavior
- **Graceful Shutdown Order**: Restored accidentally deleted section documenting server shutdown sequence

These patterns emerged from a batch of 15+ IMAP fixes that resolved client compatibility issues.