### PR TITLE
ci: enforce coverage thresholds via bunfig.toml

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,8 @@
+[test]
+# Exclude test files themselves from the coverage report
+coverageSkipTestFiles = true
+
+# Conservative baseline thresholds — enforce CI fails on coverage regression.
+# Current state (Mar 2026): ~53% lines, ~31% functions.
+# Thresholds set a few points below current levels; ratchet up as coverage improves.
+coverageThreshold = { lines = 0.50, functions = 0.28 }


### PR DESCRIPTION
## Summary

Closes #36.

Adds `bunfig.toml` to configure Bun test runner with coverage thresholds. Bun v1.x supports `coverageThreshold` natively — when coverage drops below the threshold, `bun test` exits non-zero, blocking CI.

## Configuration

```toml
[test]
coverageSkipTestFiles = true
coverageThreshold = { lines = 0.50, functions = 0.28 }
```

## Threshold rationale

Current coverage (Mar 2026): ~53% lines, ~31% functions. Thresholds are set a few points below to prevent regression without failing existing PRs. The plan is to ratchet these up as coverage improves.

## How it works

CI already runs `bun run test:coverage` (`bun test --coverage --coverage-reporter=lcov`). Since `--coverage` is present, the `bunfig.toml` thresholds are automatically enforced — no workflow changes needed.

## Testing

```
bun test --coverage
# All files | 30.93 | 53.14 |
# 254 pass, 0 fail — exit 0 ✓
```

Verified locally: thresholds pass at current coverage levels.