### PR TITLE
security: fix timing attack in IMAP LOGIN/AUTHENTICATE

### DIFF
--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -54,6 +54,12 @@ import { idleManager } from "./idle-manager";
 import { getCapabilities } from "./capabilities";
 import { ImapRequestHandler } from "./handler";
 
+// Dummy hash used to prevent username enumeration via timing attacks.
+// When a user is not found, we still run bcrypt.compare so response time
+// is indistinguishable from a real failed-password attempt.
+const DUMMY_HASH =
+  "$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy";
+
 type FetchResponsePart =
   | {
       type: "simple";
@@ -721,16 +727,13 @@ export class ImapSession {
       const user = await getUser(inputUser);
       const signedUser = user?.getSigned();
 
-      if (!password || !user || !signedUser) {
-        this.authenticated = false;
-        return this.write(
-          `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
-        );
-      }
+      // Always run bcrypt to prevent username enumeration via timing
+      const pwMatches = await bcrypt.compare(
+        password,
+        user?.password ?? DUMMY_HASH
+      );
 
-      const pwMatches = await bcrypt.compare(password, user.password as string);
-
-      if (!pwMatches) {
+      if (!password || !user || !signedUser || !pwMatches) {
         this.authenticated = false;
         return this.write(
           `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
@@ -1165,18 +1168,13 @@ export class ImapSession {
     const user = await getUser(inputUser);
     const signedUser = user?.getSigned();
 
-    if (!inputUser.password || !user || !signedUser) {
-      return this.write(
-        `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
-      );
-    }
-
+    // Always run bcrypt to prevent username enumeration via timing
     const pwMatches = await bcrypt.compare(
-      inputUser.password,
-      user.password as string
+      cleanPassword,
+      user?.password ?? DUMMY_HASH
     );
 
-    if (!pwMatches) {
+    if (!cleanPassword || !user || !signedUser || !pwMatches) {
       return this.write(
         `${tag} NO [AUTHENTICATIONFAILED] Invalid credentials.\r\n`
       );


### PR DESCRIPTION
## Problem

Both `login()` and `authenticate()` in `session.ts` skipped `bcrypt.compare` when the user was not found, returning immediately (~0ms) vs ~100ms for a valid user with wrong password. This timing difference allowed username enumeration.

Closes #363

## Fix

Added a `DUMMY_HASH` constant. When a user is not found, `bcrypt.compare` is still run against the dummy hash, making response time constant regardless of whether the username is valid.

Same pattern as hoiekim/budget#136 which fixed the same issue in the HTTP login endpoint.

## Changes

- `src/server/lib/imap/session.ts` — both `login()` and `authenticate()` methods

## E2E Testing

Tested IMAP login with valid credentials (still works), invalid username (no timing leak), and invalid password for valid user (consistent ~100ms response).