### PR TITLE
refactor: let repository errors propagate instead of returning undefined

### DIFF
--- a/src/server/lib/postgres/repositories/users.ts
+++ b/src/server/lib/postgres/repositories/users.ts
@@ -15,37 +15,27 @@ export const writeUser = async (
   const { user_id, username, password, email } = user;
   const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
 
-  try {
-    const row: Record<string, unknown> = { username, password: hashedPassword };
-    if (user_id) row.user_id = user_id;
-    if (email) row.email = email;
+  const row: Record<string, unknown> = { username, password: hashedPassword };
+  if (user_id) row.user_id = user_id;
+  if (email) row.email = email;
 
-    const result = await usersTable.upsert(row);
-    if (result) return { _id: result.user_id as string };
-    return undefined;
-  } catch (error) {
-    console.error("Failed to write user:", error);
-    return undefined;
-  }
+  const result = await usersTable.upsert(row);
+  if (result) return { _id: result.user_id as string };
+  return undefined;
 };
 
 export const searchUser = async (
   user: Partial<MaskedUser>
 ): Promise<User | undefined> => {
-  try {
-    const filters: Record<string, unknown> = {};
-    if (user.user_id) filters[USER_ID] = user.user_id;
-    if (user.username) filters.username = user.username;
-    if (user.email) filters[EMAIL] = user.email;
+  const filters: Record<string, unknown> = {};
+  if (user.user_id) filters[USER_ID] = user.user_id;
+  if (user.username) filters.username = user.username;
+  if (user.email) filters[EMAIL] = user.email;
 
-    if (Object.keys(filters).length === 0) return undefined;
+  if (Object.keys(filters).length === 0) return undefined;
 
-    const model = await usersTable.queryOne(filters);
-    return model?.toUser();
-  } catch (error) {
-    console.error("Failed to search user:", error);
-    return undefined;
-  }
+  const model = await usersTable.queryOne(filters);
+  return model?.toUser();
 };
 
 export const updateUser = async (user: PartialUser): Promise<boolean> => {
@@ -60,78 +50,52 @@ export const updateUser = async (user: PartialUser): Promise<boolean> => {
 
   if (Object.keys(updates).length === 0) return false;
 
-  try {
-    const model = await usersTable.update(user_id, updates);
-    return model !== null;
-  } catch (error) {
-    console.error("Failed to update user:", error);
-    return false;
-  }
+  const model = await usersTable.update(user_id, updates);
+  return model !== null;
 };
 
 export const getUserById = async (
   user_id: string
 ): Promise<User | undefined> => {
-  try {
-    const model = await usersTable.queryOne({ [USER_ID]: user_id });
-    return model?.toUser();
-  } catch (error) {
-    console.error("Failed to get user by ID:", error);
-    return undefined;
-  }
+  const model = await usersTable.queryOne({ [USER_ID]: user_id });
+  return model?.toUser();
 };
 
 export const deleteUser = async (user_id: string): Promise<boolean> => {
-  try {
-    return await usersTable.softDelete(user_id);
-  } catch (error) {
-    console.error("Failed to delete user:", error);
-    return false;
-  }
+  return await usersTable.softDelete(user_id);
 };
 
 export const getUserByEmail = async (
   email: string
 ): Promise<User | undefined> => {
-  try {
-    const model = await usersTable.queryOne({ [EMAIL]: email });
-    return model?.toUser();
-  } catch (error) {
-    console.error("Failed to get user by email:", error);
-    return undefined;
-  }
+  const model = await usersTable.queryOne({ [EMAIL]: email });
+  return model?.toUser();
 };
 
 /**
  * Get the IMAP UIDVALIDITY for a user.
  * Per RFC 3501, UIDVALIDITY is a value that, combined with UIDs, uniquely
  * identifies messages. If it changes, clients must discard cached message state.
- * 
+ *
  * On first IMAP access, initializes UIDVALIDITY to current Unix timestamp.
  * This ensures uniqueness and that the value only increases over time.
  */
 export const getImapUidValidity = async (user_id: string): Promise<number> => {
-  try {
-    const model = await usersTable.queryOne({ [USER_ID]: user_id });
-    if (!model) {
-      throw new Error(`User not found: ${user_id}`);
-    }
-
-    // If already set, return the stored value
-    if (model.imap_uid_validity !== null) {
-      return model.imap_uid_validity;
-    }
-
-    // Initialize to current Unix timestamp (seconds since epoch)
-    // This ensures uniqueness and monotonically increasing values
-    const uidValidity = Math.floor(Date.now() / 1000);
-    
-    await usersTable.update(user_id, { [IMAP_UID_VALIDITY]: uidValidity });
-    
-    return uidValidity;
-  } catch (error) {
-    console.error("Failed to get IMAP UIDVALIDITY:", error);
-    // Return a fallback value - timestamp ensures uniqueness
-    return Math.floor(Date.now() / 1000);
+  const model = await usersTable.queryOne({ [USER_ID]: user_id });
+  if (!model) {
+    throw new Error(`User not found: ${user_id}`);
   }
+
+  // If already set, return the stored value
+  if (model.imap_uid_validity !== null) {
+    return model.imap_uid_validity;
+  }
+
+  // Initialize to current Unix timestamp (seconds since epoch)
+  // This ensures uniqueness and monotonically increasing values
+  const uidValidity = Math.floor(Date.now() / 1000);
+
+  await usersTable.update(user_id, { [IMAP_UID_VALIDITY]: uidValidity });
+
+  return uidValidity;
 };


### PR DESCRIPTION
## Problem

Repository functions in `users.ts` caught all DB errors and returned `undefined`, making it impossible for callers to distinguish 'user not found' (expected) from 'database unavailable' (error).

Closes #109

## Changes

Removed `try/catch` wrappers from all functions in `src/server/lib/postgres/repositories/users.ts`:
- `writeUser`
- `searchUser`
- `updateUser`
- `getUserById`
- `deleteUser`
- `getUserByEmail`
- `getImapUidValidity`

DB errors now propagate to callers. Route handlers are wrapped by `Route.handler` try/catch which returns a 500 on unexpected errors. IMAP session methods handle errors at the handler level.

## Safety

- `Route.handler` in `route.ts` has a `try/catch` wrapping all route callbacks
- IMAP handler has error handling at the connection level
- `getImapUidValidity` explicitly throws for user-not-found (maintained)

## E2E Testing

- Login, logout, and user management flows tested via browser — all working correctly
- DB errors now surface as 500 responses rather than silent `undefined` returns