### PR TITLE
feat: add Docker healthcheck for inbox container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ WORKDIR /app
 
 COPY --from=builder /app/build ./build
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD wget -qO- http://localhost:3004/api/health || exit 1
+
 CMD ["node", "./build/server/bundle.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,12 @@ services:
       - postgres
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3004/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
     restart: always
     volumes:
       - attachments:/app/attachments


### PR DESCRIPTION
## Summary

Adds a Docker HEALTHCHECK to both Dockerfile and docker-compose.yml using the existing /api/health endpoint.

- **Dockerfile**: HEALTHCHECK instruction before CMD — works in production Docker environments
- **docker-compose.yml**: healthcheck block on the inbox service — enables depends_on health conditions and visibility via docker ps

**Endpoint**: GET /api/health — checks DB, HTTP, SMTP (port 25), IMAP (port 143)
**Interval**: 30s | **Timeout**: 10s | **Start period**: 60s (longer for SMTP/IMAP init) | **Retries**: 3

Discovered during prod alarm drill (2026-03-25): monitor showed healthcheck as 'none' for hoie-inbox-1.