### PR TITLE
debug: suppress health check logs, add forwarded IP headers to request logs

### DIFF
--- a/src/server/lib/http/routes/index.ts
+++ b/src/server/lib/http/routes/index.ts
@@ -10,13 +10,21 @@ import healthRouter from "./health";
 const apiRouter = Router();
 
 apiRouter.use((req, _res, next) => {
+  // Skip logging for health check requests (e.g. from reverse proxy)
+  if (req.url === "/health") {
+    next();
+    return;
+  }
+
   console.info(`<${req.method}> /api${req.url}`);
   console.group();
   const date = new Date();
   const offset = date.getTimezoneOffset() / -60;
   const offsetString = (offset > 0 ? "+" : "") + offset + "H";
   console.info(`at: ${date.toLocaleString()}, ${offsetString}`);
-  console.info(`from: ${req.ip}`);
+  console.info(`ip: ${req.ip}`);
+  console.info(`x-forwarded-for: ${req.headers["x-forwarded-for"] ?? "(none)"}`);
+  console.info(`x-real-ip: ${req.headers["x-real-ip"] ?? "(none)"}`);
   console.groupEnd();
   next();
 });


### PR DESCRIPTION
## Problem

The prod logs are flooded with `GET /api/health` requests from the reverse proxy, making it impossible to see actual user traffic. Additionally, when diagnosing the IP forwarding / rate limiting issue, we can't see what headers Express is actually receiving from nginx.

## Changes

- **Skip logging for `/api/health`** — suppresses the proxy health check noise entirely
- **Log `x-forwarded-for` and `x-real-ip` headers** — shows exactly what nginx is passing; helps diagnose whether trust proxy is working correctly

## What to look for after deploy

Real user requests should now show:
```
<GET> /api/some-endpoint
  ip: <real client IP>           ← should NOT be 127.0.0.1 for user traffic
  x-forwarded-for: <client IP>  ← set by nginx
  x-real-ip: <client IP>        ← set by nginx
```

If `x-forwarded-for` is present but `ip` is still `127.0.0.1`, the issue is `trust proxy` depth. If `x-forwarded-for` is `(none)`, nginx isn't forwarding headers.