### PR TITLE
chore: add smoke test for / in Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ FROM node:22-slim
 WORKDIR /app
 
 COPY --from=builder /app/build ./build
+COPY healthcheck.js ./healthcheck.js
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
-  CMD node -e "fetch('http://localhost:3004/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+  CMD node ./healthcheck.js
 
 CMD ["node", "./build/server/bundle.js"]

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,23 @@
+// Docker healthcheck: verifies both the API and the static frontend are reachable.
+// The API check catches database/server failures; the root check catches missing
+// static file serving (e.g. NODE_ENV guard not firing, build output missing).
+const BASE = "http://localhost:" + (process.env.PORT || 3004);
+
+async function check(path, opts = {}) {
+  const res = await fetch(BASE + path);
+  if (!res.ok) throw new Error(path + " returned " + res.status);
+  if (opts.contentType) {
+    const ct = res.headers.get("content-type") || "";
+    if (!ct.includes(opts.contentType))
+      throw new Error(path + " content-type was " + ct);
+  }
+}
+
+try {
+  await check("/api/health");
+  await check("/", { contentType: "text/html" });
+  process.exit(0);
+} catch (e) {
+  console.error("Healthcheck failed:", e.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Problem

The Docker healthcheck only hit `/api/health`. This meant the container stayed `healthy` even when static file serving was broken — as happened in the 2026-03-26 prod outage where `budget.hoie.kim` returned 404 on `/` for 30+ minutes with no alarm fired.

## Fix

Replace the inline one-liner with a `healthcheck.js` file that checks two endpoints:
- `/api/health` — catches DB/server failures (existing check)
- `/` — catches missing static file serving; expects HTTP 200 + `text/html` content-type

If either check fails, it logs a descriptive error and exits 1 → container goes unhealthy → monitor fires.

## healthcheck.js
```js
const BASE = 'http://localhost:' + (process.env.3004 || PORT);

async function check(path, opts = {}) {
  const res = await fetch(BASE + path);
  if (!res.ok) throw new Error(path + ' returned ' + res.status);
  if (opts.contentType) {
    const ct = res.headers.get('content-type') || '';
    if (!ct.includes(opts.contentType))
      throw new Error(path + ' content-type was ' + ct);
  }
}

try {
  await check('/api/health');
  await check('/', { contentType: 'text/html' });
  process.exit(0);
} catch (e) {
  console.error('Healthcheck failed:', e.message);
  process.exit(1);
}
```