### PR TITLE
fix: split comma-separated recipients into separate address entries in sent mail

### DIFF
--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -96,6 +96,13 @@ const getSentMail = async (
 
   const uid = new MailUid({ domain: domainUid || 0, account: accountUid || 0 });
 
+  const parseAddresses = (str: string) =>
+    str
+      .split(",")
+      .map((addr) => addr.trim())
+      .filter(Boolean)
+      .map((address) => ({ address }));
+
   return new Mail({
     subject,
     text,
@@ -107,11 +114,11 @@ const getSentMail = async (
       value: [{ name: senderFullName || undefined, address: fromEmail }],
       text: senderFullName ? `${senderFullName} <${fromEmail}>` : fromEmail
     },
-    to: { value: [{ address: to }], text: to },
-    cc: !cc ? undefined : { value: [{ address: cc }], text: cc },
-    bcc: !bcc ? undefined : { value: [{ address: bcc }], text: bcc },
+    to: { value: parseAddresses(to), text: to },
+    cc: !cc ? undefined : { value: parseAddresses(cc), text: cc },
+    bcc: !bcc ? undefined : { value: parseAddresses(bcc), text: bcc },
     envelopeFrom: [{ name: senderFullName || undefined, address: fromEmail }],
-    envelopeTo: [{ address: to }],
+    envelopeTo: parseAddresses(to),
     replyTo: {
       value: [{ name: senderFullName || undefined, address: fromEmail }],
       text: fromEmail


### PR DESCRIPTION
## Summary

Fixes the sent mail copy incorrectly storing multiple recipients as a single combined address entry.

## Problem (Closes #287)

`getSentMail()` in `src/server/lib/mails/send.ts` was storing the raw comma-separated recipient string as a single address:

```typescript
// Before: entire string as one entry
to: { value: [{ address: to }], text: to },
```

When sending to `alice@example.com, bob@example.com`:
```json
{ "value": [{ "address": "alice@example.com, bob@example.com" }] }
```

This affected `to`, `cc`, `bcc`, and `envelopeTo`. The actual email sending via Mailgun was unaffected (it uses a separate parser), but the stored copy had incorrect structure.

## Fix

Added a `parseAddresses()` helper that splits on commas, trims whitespace, and maps each address to `{ address }` objects:

```typescript
const parseAddresses = (str: string) =>
  str.split(',').map(addr => addr.trim()).filter(Boolean).map(address => ({ address }));
```

Applied to `to`, `cc`, `bcc` value arrays and `envelopeTo`.

## Changes

- `src/server/lib/mails/send.ts` — add `parseAddresses()`, apply to all recipient fields

## Testing

1. Start inbox server: `bun run dev`
2. Send an email to multiple recipients (`alice@example.com, bob@example.com`)
3. Check Sent view — recipients display correctly as separate entries
4. TypeScript compiles without errors ✓