### PR TITLE
feat: remove light mode — default to dark mode only

### DIFF
--- a/src/client/Box/components/Accounts/index.scss
+++ b/src/client/Box/components/Accounts/index.scss
@@ -1,62 +1,34 @@
 @use "sass:color";
 @use "../../../variables" as *;
 
-@media (prefers-color-scheme: light) {
-  .tab-holder {
-    .categories {
-      background-color: color.adjust($color-light, $lightness: -10%);
+.tab-holder {
+  .categories {
+    background-color: color.adjust($color-dark, $lightness: -6%);
 
-      div.clicked {
-        background-color: color.adjust($color-light, $lightness: -5%);
-      }
-    }
-
-    .accounts {
-      background-color: color.adjust($color-light, $lightness: -5%);
-
-      .sort_icon {
-        > div > svg {
-          color: color.adjust($color-dark, $alpha: -0.75);
-        }
-      }
-
-      .sort_box {
-        background-color: color.adjust($color-light, $lightness: 5%);
-      }
+    div.clicked {
+      background-color: color.adjust($color-dark, $lightness: -2%);
     }
   }
-}
 
-@media (prefers-color-scheme: dark) {
-  .tab-holder {
-    .categories {
-      background-color: color.adjust($color-dark, $lightness: -6%);
+  .accounts {
+    background-color: color.adjust($color-dark, $lightness: -2%);
 
-      div.clicked {
-        background-color: color.adjust($color-dark, $lightness: -2%);
+    .sort_icon {
+      > div > svg {
+        color: color.adjust($color-light, $alpha: -0.75);
       }
     }
 
-    .accounts {
-      background-color: color.adjust($color-dark, $lightness: -2%);
+    .sort_box {
+      background-color: color.adjust($color-dark, $lightness: 2%);
+    }
 
-      .sort_icon {
-        > div > svg {
-          color: color.adjust($color-light, $alpha: -0.75);
-        }
-      }
+    .sort_select {
+      background-color: color.adjust($color-dark, $lightness: 0%);
+    }
 
-      .sort_box {
-        background-color: color.adjust($color-dark, $lightness: 2%);
-      }
-
-      .sort_select {
-        background-color: color.adjust($color-dark, $lightness: 0%);
-      }
-
-      .sort_option:hover {
-        background-color: color.adjust($color-dark, $lightness: 3%);
-      }
+    .sort_option:hover {
+      background-color: color.adjust($color-dark, $lightness: 3%);
     }
   }
 }

--- a/src/client/Box/components/Mails/index.scss
+++ b/src/client/Box/components/Mails/index.scss
@@ -19,13 +19,7 @@
 
   h1 {
     font-weight: 500;
-
-    @media (prefers-color-scheme: dark) {
-      color: $color-point;
-    }
-    @media (prefers-color-scheme: light) {
-      color: color.adjust($color-point, $lightness: -10%);
-    }
+    color: $color-point;
   }
 
   h1,
@@ -137,16 +131,10 @@
       padding: 5px 0;
       border-radius: 3px;
 
-      @media (prefers-color-scheme: dark) {
-        background-color: color.adjust($color-dark, $lightness: 2%);
-        box-shadow:
-          1px 1px 2px color.adjust($color-dark, $lightness: -5%) inset,
-          -0.5px -0.5px 2px color.adjust($color-dark, $lightness: 10%) inset;
-      }
-
-      @media (prefers-color-scheme: light) {
-        background-color: $color-light;
-      }
+      background-color: color.adjust($color-dark, $lightness: 2%);
+      box-shadow:
+        1px 1px 2px color.adjust($color-dark, $lightness: -5%) inset,
+        -0.5px -0.5px 2px color.adjust($color-dark, $lightness: 10%) inset;
 
       ul {
         margin: 0;
@@ -224,24 +212,12 @@
         }
       }
 
-      @media (prefers-color-scheme: dark) {
-        div {
-          color: color.adjust($color-light, $lightness: -10%);
+      div {
+        color: color.adjust($color-light, $lightness: -10%);
 
-          em {
-            color: $color-point;
-            background-color: rgba(255, 255, 255, 0.1);
-          }
-        }
-      }
-      @media (prefers-color-scheme: light) {
-        div {
-          color: color.adjust($color-dark, $lightness: 10%);
-
-          em {
-            color: color.adjust($color-point, $lightness: -10%);
-            background-color: rgba(0, 0, 0, 0.05);
-          }
+        em {
+          color: $color-point;
+          background-color: rgba(255, 255, 255, 0.1);
         }
       }
     }

--- a/src/client/Header/index.scss
+++ b/src/client/Header/index.scss
@@ -1,16 +1,8 @@
 @use "sass:color";
 @use "../variables" as *;
 
-@media (prefers-color-scheme: light) {
-  #title_bar {
-    background-color: color.adjust($color-light, $lightness: -20%);
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  #title_bar {
-    background-color: color.adjust($color-dark, $lightness: -8%);
-  }
+#title_bar {
+  background-color: color.adjust($color-dark, $lightness: -8%);
 }
 
 #title_bar {

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -38,17 +38,4 @@ export const useLocalStorage = <T>(
   ] as const;
 };
 
-export const useDarkTheme = () => {
-  const getCurrentTheme = () =>
-    window.matchMedia("(prefers-color-scheme: dark)").matches;
-  const [isDarkTheme, setIsDarkTheme] = useState(getCurrentTheme());
-  const mqListener = (e: MediaQueryListEvent) => setIsDarkTheme(e.matches);
 
-  useEffect(() => {
-    const darkThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
-    darkThemeMq.addEventListener("change", mqListener);
-    return () => darkThemeMq.removeEventListener("change", mqListener);
-  }, []);
-
-  return isDarkTheme;
-};


### PR DESCRIPTION
## Summary

Removes all `prefers-color-scheme` media query handling and defaults the app to dark mode only.

## Problem (Closes #378)

Several SCSS files had both `prefers-color-scheme: dark` and `prefers-color-scheme: light` blocks. The app targets dark mode only, so the light mode rules were dead code and the dark mode rules needed no conditional wrapper.

## Changes

- `Box/components/Mails/index.scss` — promote dark styles for h1, .insight, .search_highlight; remove light styles
- `Box/components/Accounts/index.scss` — replace dual media blocks with single dark-mode rules; remove light mode styles
- `Header/index.scss` — promote `#title_bar` dark background; remove light media block
- `lib/hooks.ts` — remove unused `useDarkTheme` hook (no callers)

## Testing

1. `bun run dev` — app loads with dark styles ✓
2. TypeScript compiles without errors ✓
3. All component styling visually correct in dark mode ✓