### PR TITLE
docs: update DEVELOPMENT.md — coverage thresholds, mailbox layout, and stale sent-column note

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -282,7 +282,7 @@ Key functions:
 - `getMailHeaders()` — filters by `from_address` or `to_address` based on view
 - `getAccountStats()` — counts using address matching (not `sent` flag)
 
-**Self-email:** When a user sends mail to themselves, the sent-mail copy is saved to the DB with `sent: true` and `envelopeTo` pointing to the destination address (which equals the sender's address). It appears in the Sent view via the `sent` flag and in the Received view because the `to_address` matches the user's address — no special-casing required.
+**Self-email:** When a user sends mail to themselves, the sent-mail copy is saved with the sender's address as `from_address` and the recipient's address (same address) as `to_address`. It appears in the Sent view because `from_address` matches the user, and in the Received view because `to_address` matches the user — no special-casing required.
 
 ### IMAP Parser-to-Consumer Contract
 


### PR DESCRIPTION
## Summary

Three doc updates from daily ops review (2026-03-27):

### 1. Coverage threshold enforcement (bunfig.toml, PR #367)
Added note that `bunfig.toml` now enforces minimum coverage thresholds in CI. Docs previously only mentioned running `bun test --coverage` manually.

### 2. IMAP mailbox layout table
Added a clear table documenting the current 6-mailbox layout introduced in PRs #317 and #329:
- `INBOX` — unified inbox
- `Sent Messages` — unified sent
- `accounts/<name>` — per-account received (under non-selectable `accounts/` parent)
- `Sent Messages/accounts/<name>` — per-account sent (under non-selectable parent)

### 3. Stale IMAP sent-column note removed
The previous note said 'The IMAP layer still uses the legacy `sent` column for mailbox routing'. This was incorrect — sent mail detection now uses address matching throughout. Replaced with accurate description of the self-email local delivery mechanism (confirmed by Hoie in Discord IMAP thread).