### PR TITLE
fix: pass unread/saved counts for sent accounts; exclude drafts from inbox views

### DIFF
--- a/src/server/lib/mails/accounts.ts
+++ b/src/server/lib/mails/accounts.ts
@@ -31,6 +31,8 @@ export const getAccounts = async (
     return new Account({
       key: stat.address,
       doc_count: stat.count,
+      unread_doc_count: stat.unread,
+      saved_doc_count: stat.saved,
       updated: stat.latest,
     });
   });

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -280,6 +280,7 @@ export const getMailHeaders = async (
       WHERE user_id = $1 
         AND ${addressCondition}
         AND expunged = FALSE
+        AND draft = FALSE
     `;
     const values: ParamValue[] = [user_id, addressJson];
     let paramIdx = 3;


### PR DESCRIPTION
## Summary

Two data consistency bugs found during user testing.

### Bug 1: Sent accounts missing unread/saved counts (Closes #384)

**File:** `src/server/lib/mails/accounts.ts`

The `getAccounts()` function mapped sent stats but omitted `unread_doc_count` and `saved_doc_count`, so both defaulted to 0 in the Account constructor. This meant:
- Starred (`\Flagged`) sent emails never showed in the sent sidebar saved count
- Unread sent emails (e.g., marked unread via IMAP) would not show the unread badge

Confirmed in DB: `admin@inbox.app` has a self-email that is saved — the old API returned `saved_doc_count: 0`, the fix returns `1` correctly.

**Fix:** Two lines — pass `unread_doc_count: stat.unread` and `saved_doc_count: stat.saved` to the Account constructor for sent accounts.

### Bug 2: Draft emails visible in All/Saved views (Closes #385)

**File:** `src/server/lib/postgres/repositories/mails.ts`

`getMailHeaders()` had no `draft = FALSE` filter. If an IMAP client APPENDs a message with `\Draft` to INBOX (a common pattern — Thunderbird, Apple Mail), the email would appear in the web UI's All view (and Saved view if also `\Flagged`).

Currently confirmed: 12 emails with `draft=true AND saved=true` exist in the DB. None happen to have `admin@inbox.app` in to/cc/bcc, so the bug isn't visible right now — but any draft with a matching recipient address would show incorrectly.

**Fix:** Add `AND draft = FALSE` to the `getMailHeaders()` WHERE clause.

## Testing

- All 254 existing tests pass: `bun run test`
- Verified in dev: `/api/mails/accounts` now returns `saved_doc_count: 1` for `admin@inbox.app` sent (was 0)
- No TypeScript regressions in my changes (pre-existing router-dom errors in #295)