### PR TITLE
feat: healthcheck all IMAP and SMTP ports

### DIFF
--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,6 +1,12 @@
-// Docker healthcheck: verifies both the API and the static frontend are reachable.
-// The API check catches database/server failures; the root check catches missing
-// static file serving (e.g. NODE_ENV guard not firing, build output missing).
+// Docker healthcheck for inbox.
+// Checks:
+//   - HTTP API health endpoint (covers DB + all IMAP/SMTP ports via /api/health)
+//   - HTTP frontend (catches missing static file serving)
+//
+// The /api/health endpoint internally verifies TCP connectivity on all ports:
+//   SMTP: 25, 465, 587 | IMAP: 143, 993
+// so a single fetch to /api/health is sufficient to detect mail server failures.
+
 const BASE = "http://localhost:" + (process.env.PORT || 3004);
 
 async function check(path, opts = {}) {
@@ -11,10 +17,19 @@ async function check(path, opts = {}) {
     if (!ct.includes(opts.contentType))
       throw new Error(path + " content-type was " + ct);
   }
+  if (opts.allHealthy) {
+    const body = await res.json();
+    const checks = body?.body?.checks || {};
+    const failed = Object.entries(checks)
+      .filter(([, v]) => v !== "ok")
+      .map(([k]) => k);
+    if (failed.length > 0)
+      throw new Error("Unhealthy services: " + failed.join(", "));
+  }
 }
 
 try {
-  await check("/api/health");
+  await check("/api/health", { allHealthy: true });
   await check("/", { contentType: "text/html" });
   process.exit(0);
 } catch (e) {

--- a/src/server/lib/http/routes/health.ts
+++ b/src/server/lib/http/routes/health.ts
@@ -34,15 +34,30 @@ healthRouter.get("/", async (_req, res) => {
   // HTTP — always ok; this request proves the server is up
   checks.http = "ok";
 
-  // SMTP (port 25)
+  // SMTP (port 25 — plain)
   const smtpOk = await checkPort(25);
-  checks.smtp = smtpOk ? "ok" : "unhealthy";
+  checks["smtp:25"] = smtpOk ? "ok" : "unhealthy";
   if (!smtpOk) allHealthy = false;
 
-  // IMAP (port 143)
+  // SMTP TLS (port 465 — implicit TLS)
+  const smtpTlsOk = await checkPort(465);
+  checks["smtp:465"] = smtpTlsOk ? "ok" : "unhealthy";
+  if (!smtpTlsOk) allHealthy = false;
+
+  // SMTP STARTTLS (port 587)
+  const smtpStarttlsOk = await checkPort(587);
+  checks["smtp:587"] = smtpStarttlsOk ? "ok" : "unhealthy";
+  if (!smtpStarttlsOk) allHealthy = false;
+
+  // IMAP (port 143 — plain/STARTTLS)
   const imapOk = await checkPort(143);
-  checks.imap = imapOk ? "ok" : "unhealthy";
+  checks["imap:143"] = imapOk ? "ok" : "unhealthy";
   if (!imapOk) allHealthy = false;
+
+  // IMAP TLS (port 993 — implicit TLS)
+  const imapTlsOk = await checkPort(993);
+  checks["imap:993"] = imapTlsOk ? "ok" : "unhealthy";
+  if (!imapTlsOk) allHealthy = false;
 
   const statusCode = allHealthy ? 200 : 503;
   res.status(statusCode).json({


### PR DESCRIPTION
## What

Extends `/api/health` to check TCP connectivity on all mail server ports, and updates `healthcheck.js` to fail if any port is unhealthy.

### Ports checked

| Check | Port | Protocol |
|---|---|---|
| `smtp:25` | 25 | Plain SMTP |
| `smtp:465` | 465 | Implicit TLS |
| `smtp:587` | 587 | STARTTLS |
| `imap:143` | 143 | Plain / STARTTLS |
| `imap:993` | 993 | Implicit TLS |

Previously only port 25 and 143 were checked. 465, 587, and 993 were invisible to monitoring.

### healthcheck.js

Now calls `/api/health` with `allHealthy: true` — parses the response body and fails if any service is not `"ok"`. Also still checks `/` for HTML content (catches missing frontend).

### Sample response when all healthy

```json
{
  "status": "success",
  "body": {
    "healthy": true,
    "checks": {
      "database": "ok",
      "http": "ok",
      "smtp:25": "ok",
      "smtp:465": "ok",
      "smtp:587": "ok",
      "imap:143": "ok",
      "imap:993": "ok"
    }
  }
}
```