### PR TITLE
fix: revert USER node to restore TLS cert access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@ FROM node:22-slim
 
 WORKDIR /app
 
-COPY --chown=node:node --from=builder /app/build ./build
-COPY --chown=node:node healthcheck.js ./healthcheck.js
-
-USER node
+COPY --from=builder /app/build ./build
+COPY healthcheck.js ./healthcheck.js
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
   CMD node ./healthcheck.js


### PR DESCRIPTION
## Problem

PR #210 switched the container to run as `USER node` (uid 1000), but broke SMTP TLS on startup:

```
EACCES: permission denied, open '/etc/letsencrypt/live/npm-1/privkey.pem'
```

The `/etc/letsencrypt` volume is mounted `:ro` and `privkey.pem` is only readable by root. The `node` user cannot access it, causing the container to start unhealthy.

## Fix

Revert `USER node` and the associated `--chown=node:node` flags. This restores TLS cert access.

The primary motivation for #210 was avoiding root for port 25 — that's still achieved via the `25:2525` Docker port mapping, regardless of which user the container runs as.

## Follow-up

A proper non-root solution would require an entrypoint script that copies certs to a writable location with `node:node` ownership before dropping privileges. Tracked separately.

Fixes the production outage introduced by #210.