### PR TITLE
fix: read attachment data from tempFilePath when useTempFiles is enabled

### DIFF
--- a/src/server/lib/mails/mailgun.ts
+++ b/src/server/lib/mails/mailgun.ts
@@ -1,4 +1,5 @@
 import FormData from "form-data";
+import fs from "fs";
 import Mailgun from "mailgun.js";
 import type { MailgunMessageData, CustomFile } from "mailgun.js/definitions";
 import { MailDataToSend } from "common";
@@ -8,9 +9,18 @@ import { UploadedFile } from "express-fileupload";
 
 const { EMAIL_DOMAIN = "mydomain", MAILGUN_KEY = "mailgun_key" } = process.env;
 
+/**
+ * Returns the file data as a Buffer.
+ * With useTempFiles:true, file.data is an empty Buffer — read from tempFilePath instead.
+ */
+const getFileData = (file: UploadedFile): Buffer => {
+  if (file.tempFilePath) return fs.readFileSync(file.tempFilePath);
+  return file.data;
+};
+
 const getAttachments = (files?: UploadedFileDynamicArray): CustomFile[] => {
   const parseFile = (file: UploadedFile): CustomFile => ({
-    data: file.data,
+    data: getFileData(file),
     filename: file.name,
     contentType: file.mimetype,
     knownLength: file.size

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "crypto";
+import fs from "fs";
 import { UploadedFile } from "express-fileupload";
 import {
   AttachmentType,
@@ -121,12 +122,16 @@ const getAttachmentsToSave = async (files?: UploadedFileDynamicArray) => {
 
   const attachmentsToSave: AttachmentType[] = [];
 
-  const parseFile = async ({ name, data, mimetype, size }: UploadedFile) => {
+  const parseFile = async (file: UploadedFile) => {
+    // With useTempFiles:true, file.data is an empty Buffer — read from tempFilePath.
+    const buffer = file.tempFilePath
+      ? fs.readFileSync(file.tempFilePath)
+      : file.data;
     attachmentsToSave.push({
-      content: { data: await saveBuffer(data) },
-      filename: name,
-      contentType: mimetype,
-      size
+      content: { data: await saveBuffer(buffer) },
+      filename: file.name,
+      contentType: file.mimetype,
+      size: file.size
     });
   };
 


### PR DESCRIPTION
## Root cause

`express-fileupload` is configured with `useTempFiles: true` (added to handle large files up to 25MB). With this option, uploaded files are written to disk (`/tmp/`) instead of held in memory. **`file.data` is always an empty Buffer** when temp files are enabled — the actual content lives at `file.tempFilePath`.

Both code paths that handle attachments were using `file.data` directly:

1. `mailgun.ts` — passes `file.data` to Mailgun → empty attachment sent to recipient
2. `send.ts` — passes `file.data` to `saveBuffer()` → empty file saved to `attachments/` folder

No exception is thrown because writing an empty buffer succeeds silently — hence no error logs.

## Fix

Check `file.tempFilePath` before using `file.data`. If present (temp file mode), read from disk with `fs.readFileSync`. Falls back to `file.data` for configurations without temp files.

```ts
const buffer = file.tempFilePath
  ? fs.readFileSync(file.tempFilePath)
  : file.data;
```