### PR TITLE
fix: use TLS handshake for implicit TLS ports in healthcheck (465, 993)

### DIFF
--- a/src/server/lib/http/routes/health.ts
+++ b/src/server/lib/http/routes/health.ts
@@ -1,9 +1,11 @@
 import { Router } from "express";
 import { createConnection } from "net";
+import { connect as tlsConnect } from "tls";
 import { pool } from "../../postgres/client";
 
 const healthRouter = Router();
 
+/** TCP check — for plain or STARTTLS ports (just verify port is open). */
 const checkPort = (port: number, host = "127.0.0.1"): Promise<boolean> =>
   new Promise((resolve) => {
     const socket = createConnection({ port, host }, () => {
@@ -11,6 +13,28 @@ const checkPort = (port: number, host = "127.0.0.1"): Promise<boolean> =>
       resolve(true);
     });
     socket.setTimeout(1000);
+    socket.on("error", () => resolve(false));
+    socket.on("timeout", () => {
+      socket.destroy();
+      resolve(false);
+    });
+  });
+
+/**
+ * TLS check — for implicit TLS ports (465, 993).
+ * Completes the TLS handshake so the server doesn't log "Socket closed
+ * while initiating TLS" from a bare TCP probe.
+ */
+const checkTlsPort = (port: number, host = "127.0.0.1"): Promise<boolean> =>
+  new Promise((resolve) => {
+    const socket = tlsConnect(
+      { port, host, rejectUnauthorized: false },
+      () => {
+        socket.destroy();
+        resolve(true);
+      }
+    );
+    socket.setTimeout(3000);
     socket.on("error", () => resolve(false));
     socket.on("timeout", () => {
       socket.destroy();
@@ -44,8 +68,8 @@ healthRouter.get("/", async (_req, res) => {
   checks[`smtp:${smtpPort}`] = smtpOk ? "ok" : "unhealthy";
   if (!smtpOk) allHealthy = false;
 
-  // SMTP TLS (port 465 — implicit TLS)
-  const smtpTlsOk = await checkPort(465);
+  // SMTP TLS (port 465 — implicit TLS; use TLS handshake to avoid noise logs)
+  const smtpTlsOk = await checkTlsPort(465);
   checks["smtp:465"] = smtpTlsOk ? "ok" : "unhealthy";
   if (!smtpTlsOk) allHealthy = false;
 
@@ -59,8 +83,8 @@ healthRouter.get("/", async (_req, res) => {
   checks["imap:143"] = imapOk ? "ok" : "unhealthy";
   if (!imapOk) allHealthy = false;
 
-  // IMAP TLS (port 993 — implicit TLS)
-  const imapTlsOk = await checkPort(993);
+  // IMAP TLS (port 993 — implicit TLS; use TLS handshake to avoid noise logs)
+  const imapTlsOk = await checkTlsPort(993);
   checks["imap:993"] = imapTlsOk ? "ok" : "unhealthy";
   if (!imapTlsOk) allHealthy = false;
 


### PR DESCRIPTION
Raw TCP probes on ports 465 (SMTP TLS) and 993 (IMAP TLS) caused the server to log `Socket closed while initiating TLS` every 30s from the Docker healthcheck.

Add `checkTlsPort()` that completes the TLS handshake (`rejectUnauthorized: false` for self-signed certs) before destroying the socket. Plain/STARTTLS ports (25, 587, 143) keep raw TCP since they don't start TLS on connect.