### PR TITLE
fix: add 30s timeout to Mailgun client and handle ECONNRESET

### DIFF
--- a/src/server/lib/mails/mailgun.ts
+++ b/src/server/lib/mails/mailgun.ts
@@ -55,7 +55,8 @@ export const sendMailgunMail = async (
   const mailgun = new Mailgun(FormData);
   const mg = mailgun.client({
     username: "api",
-    key: MAILGUN_KEY
+    key: MAILGUN_KEY,
+    timeout: 30000
   });
 
   const mailgunMessage: MailgunMessageData = {

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -62,6 +62,8 @@ export const sendMail = async (
       message = "Too many requests. Please try again later.";
     } else if (err?.code === "ENOTFOUND" || err?.code === "ECONNREFUSED") {
       message = "Unable to reach email service. Please try again later.";
+    } else if (err?.code === "ECONNRESET" || (error as { details?: string })?.details === "socket hang up") {
+      message = err?.message || "Failed to send email. Please try again.";
     }
 
     throw new MailSendingError(message);


### PR DESCRIPTION
## Problem

When sending emails with attachments, malformed or oversized attachments cause Mailgun to drop the connection mid-upload. Without a timeout configured, the Mailgun client hangs for ~5 minutes waiting for a response that never comes. The socket eventually resets (`ECONNRESET`), but by then the frontend has already timed out — leaving the user with no visible error.

Prod logs confirmed:
```
Email sending request failed [k [Error]: ECONNRESET] {
  status: 400,
  details: 'socket hang up',
  type: 'MailgunAPIError'
}
```

## Fix

- Add `timeout: 30000` to the Mailgun client so failures surface within 30 seconds instead of 5 minutes
- Add `ECONNRESET` / `socket hang up` handling to the error mapper in `send.ts` so the error is correctly propagated as a `MailSendingError` to the caller (previously fell through to the generic catch)

## Behavior

- Mailgun still rejects malformed attachments (correct behavior, unchanged)
- The error now reaches the user within 30s instead of timing out silently