### PR TITLE
fix: preserve selectedAccount when switching to empty category tab

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -264,8 +264,11 @@ const Accounts = ({
         else if (e === Category.SavedMails) targetAccounts = received.filter((a) => a.saved_doc_count);
         else if (e === Category.Search) targetAccounts = searchHistory;
         else targetAccounts = received;
-        if (!targetAccounts.some((a) => a.key === selectedAccount)) {
-          setSelectedAccount(targetAccounts[0]?.key || "");
+        if (
+          targetAccounts.length > 0 &&
+          !targetAccounts.some((a) => a.key === selectedAccount)
+        ) {
+          setSelectedAccount(targetAccounts[0].key);
         }
       };
       const classes = [];


### PR DESCRIPTION
Preserves the selected account when switching to a category tab that has no mails — previously the selection was reset to null causing an empty inbox view.

Closes #224
Closes #336

Replaces #347 — the previous branch had unrelated IMAP commits bundled in.