### PR TITLE
fix(smtp): broaden TLS cipher compatibility for external MTAs

### DIFF
--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -178,6 +178,11 @@ export const initializeSmtp = async () => {
   if (isSslAvailable) {
     options.key = readFileSync(SSL_CERTIFICATE_KEY);
     options.cert = readFileSync(SSL_CERTIFICATE);
+    // Broaden TLS compatibility for external MTAs (e.g. Postfix, Exchange) that
+    // may offer cipher suites excluded from OpenSSL 3's stricter defaults.
+    // TLSv1.2 minimum is maintained; known-weak ciphers remain disabled.
+    options.minVersion = "TLSv1.2";
+    options.ciphers = "HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA";
   } else {
     console.warn("SMTP: SSL certificate not found.");
   }


### PR DESCRIPTION
## Problem

Prod alarm: SMTP server on port 2525 throwing `no shared cipher` during TLS handshake.

```
Error: SSL routines:tls_post_process_client_hello:no shared cipher
```

This error fires at the cipher negotiation phase (ClientHello), before the certificate is even presented — so it is not a cert domain mismatch issue. The external MTA offers cipher suites that OpenSSL 3 (shipped with Node 18+) has removed from its default allowed list, causing the handshake to abort and the inbound email to be dropped.

## Fix

Add explicit `minVersion` and `ciphers` to the SMTP server TLS options when SSL is configured:

```ts
options.minVersion = "TLSv1.2";
options.ciphers = "HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA";
```

- **TLS 1.2 minimum preserved** — no protocol downgrade
- **Known-weak ciphers remain disabled** — aNULL, eNULL, EXPORT, DES, RC4, MD5, PSK, SRP, CAMELLIA all excluded
- **Broader compatibility** — re-enables modern cipher suites that OpenSSL 3 dropped from defaults but are not considered insecure

## Testing

Deploy to prod and verify the `no shared cipher` alarm stops firing. The fix takes effect on server restart (cert reload not needed since the options are set at initialization).