### PR TITLE
fix: suppress external scanner TLS errors from SMTP alarm

### DIFF
--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -18,10 +18,17 @@ const registerListeners = (
   callback: () => void
 ) => {
   server.on("error", (err) => {
-    // "Socket closed while initiating TLS" is logged when a client connects
-    // and immediately closes without completing the handshake (e.g. port
-    // scanners, healthcheck TCP probes). This is not actionable — suppress it.
-    if (err.message?.includes("Socket closed")) return;
+    // Suppress noise from external port scanners and misconfigured clients.
+    // These errors originate from the remote side failing TLS negotiation —
+    // they do not indicate a server-side problem.
+    if (
+      err.message?.includes("Socket closed") ||       // client disconnected before TLS handshake
+      err.message?.includes("no shared cipher") ||    // client cipher suites incompatible with server
+      err.message?.includes("http request") ||        // plain HTTP sent to TLS-only port
+      err.message?.includes("wrong version number") || // old/incompatible TLS version
+      err.message?.includes("packet length too long") || // malformed TLS record
+      err.message?.includes("Failed to establish TLS session") // generic handshake failure
+    ) return;
     console.error(`SMTP Server(${port}) Error: ${err}`);
     sendAlarm(
       "SMTP Server Error",


### PR DESCRIPTION
## Summary

Port scanners and misconfigured clients regularly hit the SMTP ports (465, 587, 2525) with incompatible TLS, plain HTTP, or malformed records. These produce recurring `SSL routines` errors that fire the Discord alarm webhook — but they originate from the **remote side** failing TLS negotiation, not from a server-side problem.

The SMTP server itself stays healthy throughout; these are just noisy false positives.

## Changes

Extends the existing `Socket closed` suppression in `smtp.ts` to cover all observed scanner error patterns:

| Error string | Cause |
|---|---|
| `Socket closed` | (existing) client disconnects before handshake |
| `no shared cipher` | client cipher suites incompatible with server |
| `http request` | plain HTTP sent to TLS-only port |
| `wrong version number` | old/incompatible TLS version |
| `packet length too long` | malformed TLS record |
| `Failed to establish TLS session` | generic handshake failure |

Real server-side SMTP issues (expired cert, bad key file, port bind failure) surface at startup or as healthcheck failures — not as per-connection SSL errors. Those will still fire the alarm.

## Testing

Started SMTP server locally, verified:
- Normal mail delivery still logs and works
- TLS handshake failures from openssl s_client with mismatched ciphers are now silently dropped

Closes #