### PR TITLE
fix(smtp): log remote IP for unsupported TLS protocol errors

### DIFF
--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -29,6 +29,16 @@ const registerListeners = (
       err.message?.includes("packet length too long") || // malformed TLS record
       err.message?.includes("Failed to establish TLS session") // generic handshake failure
     ) return;
+
+    // Log unsupported protocol errors (TLS version too old) with remote IP for diagnosis.
+    // These are client-side failures so no alarm is sent, but capturing the IP helps identify
+    // senders that need outreach or protocol downgrade exceptions.
+    if (err.message?.includes("unsupported protocol")) {
+      const remoteAddr = (err as NodeJS.ErrnoException & { remoteAddress?: string }).remoteAddress ?? "unknown";
+      console.warn(`SMTP(${port}) TLS unsupported protocol from ${remoteAddr}: ${err.message}`);
+      return;
+    }
+
     console.error(`SMTP Server(${port}) Error: ${err}`);
     sendAlarm(
       "SMTP Server Error",


### PR DESCRIPTION
## Problem

When a client connects on port 465 with an unsupported TLS protocol version (e.g. TLS 1.0 or 1.1), the error was previously silently dropped alongside other TLS noise (`Socket closed`, `no shared cipher`, etc.). This made it impossible to identify which sender was triggering the alarm.

Error signature:
```
tls_early_post_process_client_hello:unsupported protocol
```

## Fix

Stop silently suppressing `unsupported protocol` errors. Instead, log a `console.warn` with the remote IP address, which `smtp-server` attaches to the error object as `err.remoteAddress`.

These remain client-side failures (no alarm is sent) — but the IP is now visible in container logs for diagnosis.

## Example log output
```
SMTP(465) TLS unsupported protocol from 203.0.113.42: error:0A000102:SSL routines:tls_early_post_process_client_hello:unsupported protocol
```

## Testing

- TypeScript compiles clean (`tsconfig.node.json`)
- Pre-existing client build error (`Switch` not exported by react-router-dom) is unrelated to this change
