### PR TITLE
security: add CI check to block committed private keys and cert files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
           # Check for private key content patterns in staged diff
           KEY_PATTERNS=$(git diff origin/${{ github.base_ref }}...HEAD -- . \
-            ':!*.md' ':!*.txt' ':!*.lock' ':!bun.lockb' \
+            ':!*.md' ':!*.txt' ':!*.lock' ':!bun.lockb' ':!.github/workflows/**' \
             | grep -E '^\+.*(BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY|BEGIN CERTIFICATE)' || true)
           if [ -n "$KEY_PATTERNS" ]; then
             echo "ERROR: Private key or certificate content detected in diff:"


### PR DESCRIPTION
## Summary

Adds a `secrets-scan` job to CI that runs on every PR and blocks merging if private keys or certificate files are detected.

## What this catches

- **File extension check**: Blocks `*.key`, `*.pem`, `*.p12`, `*.pfx`, `*.crt`, `*.cer` files in the PR diff
- **Content pattern check**: Scans diff content for `BEGIN PRIVATE KEY`, `BEGIN RSA PRIVATE KEY`, `BEGIN EC PRIVATE KEY`, `BEGIN OPENSSH PRIVATE KEY`, `BEGIN CERTIFICATE` patterns

## Why

A self-signed private key (`certs/server.key`) was committed to a branch and pushed to GitHub, triggering a GitGuardian alert on Mar 29, 2026. The file was in old branch history and survived a rebase. While `.gitignore` lists `certs/`, that only prevents new tracking — it doesn't remove already-tracked files.

This CI check enforces the rule at the repo level without requiring local hook installation.

## Testing

The check runs on PR diff against `origin/${{ github.base_ref }}`. It checks:
1. File names in the changed file list
2. Content lines in the diff (lines starting with `+`) for key header patterns

Closes #402