### PR TITLE
test: add coverage for IMAP search-parsers and fetch-parsers

### DIFF
--- a/src/server/lib/imap/parsers/fetch-parsers.test.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for fetch-parsers.ts (IMAP FETCH command parsing)
+ * Covers FETCH data items for inbox #340
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseCommand } from "./index";
+import type { FetchDataItem } from "../types";
+
+function parseFetch(args: string) {
+  const result = parseCommand(`A001 FETCH ${args}`);
+  if (!result.success || result.value?.request.type !== "FETCH") {
+    throw new Error(`FETCH parse failed: ${result.error}`);
+  }
+  return result.value.request.data as { sequenceSet: unknown; dataItems: FetchDataItem[] };
+}
+
+// ---------------------------------------------------------------------------
+// Simple data items
+// ---------------------------------------------------------------------------
+
+describe("fetch-parsers > simple data items", () => {
+  const simpleItems = [
+    "ENVELOPE",
+    "FLAGS",
+    "INTERNALDATE",
+    "RFC822",
+    "RFC822.HEADER",
+    "RFC822.SIZE",
+    "RFC822.TEXT",
+    "UID",
+    "BODYSTRUCTURE",
+  ];
+
+  for (const item of simpleItems) {
+    it(`should parse ${item} as single item`, () => {
+      const data = parseFetch(`1 ${item}`);
+      expect(data.dataItems).toHaveLength(1);
+      expect(data.dataItems[0].type).toBe(item);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Sequence sets
+// ---------------------------------------------------------------------------
+
+describe("fetch-parsers > sequence sets", () => {
+  it("should parse single message number", () => {
+    const data = parseFetch("1 FLAGS");
+    expect(data.dataItems[0].type).toBe("FLAGS");
+  });
+
+  it("should parse range sequence", () => {
+    const data = parseFetch("1:10 FLAGS");
+    expect(data.dataItems[0].type).toBe("FLAGS");
+  });
+
+  it("should parse wildcard sequence", () => {
+    const data = parseFetch("1:* FLAGS");
+    expect(data.dataItems[0].type).toBe("FLAGS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parenthesized list of data items
+// ---------------------------------------------------------------------------
+
+describe("fetch-parsers > parenthesized lists", () => {
+  it("should parse (FLAGS) as a list with one item", () => {
+    const data = parseFetch("1 (FLAGS)");
+    expect(data.dataItems).toHaveLength(1);
+    expect(data.dataItems[0].type).toBe("FLAGS");
+  });
+
+  it("should parse (FLAGS UID) as a list with two items", () => {
+    const data = parseFetch("1 (FLAGS UID)");
+    expect(data.dataItems).toHaveLength(2);
+    expect(data.dataItems[0].type).toBe("FLAGS");
+    expect(data.dataItems[1].type).toBe("UID");
+  });
+
+  it("should parse (FLAGS UID ENVELOPE) as a list with three items", () => {
+    const data = parseFetch("1 (FLAGS UID ENVELOPE)");
+    expect(data.dataItems).toHaveLength(3);
+    expect(data.dataItems.map((i) => i.type)).toEqual(["FLAGS", "UID", "ENVELOPE"]);
+  });
+
+  it("should parse (RFC822.SIZE INTERNALDATE) correctly", () => {
+    const data = parseFetch("1 (RFC822.SIZE INTERNALDATE)");
+    expect(data.dataItems).toHaveLength(2);
+    expect(data.dataItems[0].type).toBe("RFC822.SIZE");
+    expect(data.dataItems[1].type).toBe("INTERNALDATE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// BODY data items
+// ---------------------------------------------------------------------------
+
+describe("fetch-parsers > BODY data items", () => {
+  it("should parse BODY as full body fetch", () => {
+    const data = parseFetch("1 BODY");
+    expect(data.dataItems).toHaveLength(1);
+    expect(data.dataItems[0].type).toBe("BODY");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.peek).toBe(false);
+  });
+
+  it("should parse BODY[] as full body fetch", () => {
+    const data = parseFetch("1 BODY[]");
+    expect(data.dataItems).toHaveLength(1);
+    expect(data.dataItems[0].type).toBe("BODY");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.section?.type).toBe("FULL");
+  });
+
+  it("should parse BODY.PEEK[] as peek body fetch", () => {
+    const data = parseFetch("1 BODY.PEEK[]");
+    expect(data.dataItems).toHaveLength(1);
+    expect(data.dataItems[0].type).toBe("BODY");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.peek).toBe(true);
+  });
+
+  it("should parse BODY[HEADER]", () => {
+    const data = parseFetch("1 BODY[HEADER]");
+    expect(data.dataItems).toHaveLength(1);
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.section?.type).toBe("HEADER");
+  });
+
+  it("should parse BODY[TEXT]", () => {
+    const data = parseFetch("1 BODY[TEXT]");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.section?.type).toBe("TEXT");
+  });
+
+  it("should parse BODY[HEADER.FIELDS (FROM TO SUBJECT DATE)]", () => {
+    const data = parseFetch("1 BODY[HEADER.FIELDS (FROM TO SUBJECT DATE)]");
+    expect(data.dataItems).toHaveLength(1);
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.section?.type).toBe("HEADER_FIELDS");
+    if (bodyItem.section?.type !== "HEADER_FIELDS") throw new Error("expected HEADER_FIELDS section");
+    expect(bodyItem.section.fields).toContain("FROM");
+    expect(bodyItem.section.fields).toContain("TO");
+    expect(bodyItem.section.fields).toContain("SUBJECT");
+    expect(bodyItem.section.fields).toContain("DATE");
+  });
+
+  it("should parse BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE)]", () => {
+    const data = parseFetch("1 BODY.PEEK[HEADER.FIELDS (FROM TO SUBJECT DATE)]");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.peek).toBe(true);
+    expect(bodyItem.section?.type).toBe("HEADER_FIELDS");
+  });
+
+  it("should parse BODY[1] for first MIME part", () => {
+    const data = parseFetch("1 BODY[1]");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.section?.type).toBe("MIME_PART");
+  });
+
+  it("should parse BODY[] with partial range <0.2048>", () => {
+    const data = parseFetch("1 BODY[]<0.2048>");
+    const bodyItem = data.dataItems[0];
+    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
+    expect(bodyItem.partial).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Common FETCH combinations (iOS Mail / Thunderbird patterns)
+// ---------------------------------------------------------------------------
+
+describe("fetch-parsers > real-world FETCH patterns", () => {
+  it("should parse (UID FLAGS ENVELOPE BODYSTRUCTURE) — typical list view", () => {
+    const data = parseFetch("1:* (UID FLAGS ENVELOPE BODYSTRUCTURE)");
+    const types = data.dataItems.map((i) => i.type);
+    expect(types).toContain("UID");
+    expect(types).toContain("FLAGS");
+    expect(types).toContain("ENVELOPE");
+    expect(types).toContain("BODYSTRUCTURE");
+  });
+
+  it("should parse (UID BODY.PEEK[]) — full message fetch", () => {
+    const data = parseFetch("1 (UID BODY.PEEK[])");
+    const types = data.dataItems.map((i) => i.type);
+    expect(types).toContain("UID");
+    expect(types).toContain("BODY");
+  });
+
+  it("should parse (UID RFC822.SIZE INTERNALDATE FLAGS) — metadata fetch", () => {
+    const data = parseFetch("1:* (UID RFC822.SIZE INTERNALDATE FLAGS)");
+    const types = data.dataItems.map((i) => i.type);
+    expect(types).toContain("UID");
+    expect(types).toContain("RFC822.SIZE");
+    expect(types).toContain("INTERNALDATE");
+    expect(types).toContain("FLAGS");
+  });
+});

--- a/src/server/lib/imap/parsers/search-parsers.test.ts
+++ b/src/server/lib/imap/parsers/search-parsers.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Tests for search-parsers.ts (IMAP SEARCH command parsing)
+ * Covers all major search criterion types for inbox #340
+ *
+ * NOTE: Some criteria with arguments (KEYWORD, BEFORE, FROM, etc.) currently
+ * fail because the parser lacks skipWhitespace() before argument parsing.
+ * Those tests are marked with _TODO notes and test the current behavior.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseCommand } from "./index";
+import type { SearchCriterion } from "../types";
+
+// Helper to parse a SEARCH command — does NOT assert success
+function tryParseSearch(criteriaStr: string) {
+  return parseCommand(`A001 SEARCH ${criteriaStr}`);
+}
+
+// Helper that asserts success and returns criteria
+function parseSearch(criteriaStr: string): SearchCriterion[] {
+  const result = tryParseSearch(criteriaStr);
+  if (!result.success || result.value?.request.type !== "SEARCH") {
+    throw new Error(`SEARCH parse failed: ${result.error}`);
+  }
+  return result.value.request.data.criteria as SearchCriterion[];
+}
+
+// ---------------------------------------------------------------------------
+// Simple flag criteria (no arguments) — these all work correctly
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > simple flag criteria", () => {
+  const simpleCriteria: string[] = [
+    "ALL",
+    "ANSWERED",
+    "DELETED",
+    "FLAGGED",
+    "NEW",
+    "OLD",
+    "RECENT",
+    "SEEN",
+    "UNANSWERED",
+    "UNDELETED",
+    "UNFLAGGED",
+    "UNSEEN",
+    "DRAFT",
+    "UNDRAFT",
+  ];
+
+  for (const criterion of simpleCriteria) {
+    it(`should parse ${criterion}`, () => {
+      const criteria = parseSearch(criterion);
+      expect(criteria).toHaveLength(1);
+      expect(criteria[0].type).toBe(criterion);
+    });
+  }
+
+  it("should parse multiple simple criteria together", () => {
+    const criteria = parseSearch("UNSEEN ANSWERED");
+    expect(criteria).toHaveLength(2);
+    expect(criteria[0].type).toBe("UNSEEN");
+    expect(criteria[1].type).toBe("ANSWERED");
+  });
+
+  it("should parse three simple criteria", () => {
+    const criteria = parseSearch("UNSEEN UNFLAGGED RECENT");
+    expect(criteria).toHaveLength(3);
+    expect(criteria.map((c) => c.type)).toEqual(["UNSEEN", "UNFLAGGED", "RECENT"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KEYWORD / UNKEYWORD — argument parsing currently broken (no skipWhitespace)
+// These tests document the current (broken) behavior
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > KEYWORD / UNKEYWORD (broken - missing skipWhitespace)", () => {
+  it("KEYWORD argument parsing fails without whitespace skip", () => {
+    // Parser calls parseAtom() for the flag name without first calling skipWhitespace()
+    // so it fails because the cursor is at ' MyFlag' (space before the arg)
+    const result = tryParseSearch("KEYWORD MyFlag");
+    // Current behavior: fails because no whitespace skip before argument
+    // Once fixed, this should succeed with criteria[0].type === "KEYWORD" && criteria[0].flag === "MyFlag"
+    expect(result.success).toBe(false);
+  });
+
+  it("UNKEYWORD argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("UNKEYWORD OldFlag");
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Date criteria — argument parsing currently broken (no skipWhitespace)
+// These tests document the current (broken) behavior
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > date criteria (broken - missing skipWhitespace)", () => {
+  it("BEFORE argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("BEFORE 1-Mar-2026");
+    // Current behavior: fails — no skipWhitespace before parseDate()
+    // Once fixed: criteria[0].type === "BEFORE" && criteria[0].date instanceof Date
+    expect(result.success).toBe(false);
+  });
+
+  it("ON argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("ON 15-Jan-2026");
+    expect(result.success).toBe(false);
+  });
+
+  it("SINCE argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SINCE 1-Jan-2026");
+    expect(result.success).toBe(false);
+  });
+
+  it("SENTBEFORE argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SENTBEFORE 1-Mar-2026");
+    expect(result.success).toBe(false);
+  });
+
+  it("SENTON argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SENTON 15-Jan-2026");
+    expect(result.success).toBe(false);
+  });
+
+  it("SENTSINCE argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SENTSINCE 1-Jan-2026");
+    expect(result.success).toBe(false);
+  });
+
+  it("returns failure for truly invalid date format (either case)", () => {
+    // Whether or not the whitespace bug is present, an invalid date should fail
+    const result = tryParseSearch("SINCE not-a-date");
+    // Either fails from the whitespace bug or from invalid date — either way, no valid SINCE
+    if (result.success && result.value?.request.type === "SEARCH") {
+      const criteria = result.value.request.data.criteria as SearchCriterion[];
+      const sinceCriteria = criteria.filter((c) => c.type === "SINCE");
+      expect(sinceCriteria).toHaveLength(0);
+    } else {
+      expect(result.success).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Text/header criteria — also broken (no skipWhitespace)
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > text criteria (broken - missing skipWhitespace)", () => {
+  it("FROM argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("FROM user");
+    expect(result.success).toBe(false);
+  });
+
+  it("TO argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("TO recipient");
+    expect(result.success).toBe(false);
+  });
+
+  it("CC argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("CC someone");
+    expect(result.success).toBe(false);
+  });
+
+  it("BCC argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("BCC someone");
+    expect(result.success).toBe(false);
+  });
+
+  it("SUBJECT argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SUBJECT meeting");
+    expect(result.success).toBe(false);
+  });
+
+  it("BODY argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("BODY hello");
+    expect(result.success).toBe(false);
+  });
+
+  it("TEXT argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("TEXT world");
+    expect(result.success).toBe(false);
+  });
+
+  it("HEADER argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("HEADER X-Field value");
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UID / size criteria — also broken (no skipWhitespace)
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > UID and size criteria (broken - missing skipWhitespace)", () => {
+  it("UID criterion with sequence set fails without whitespace skip", () => {
+    const result = tryParseSearch("UID 1:10");
+    // The UID SEARCH keyword triggers a different code path (parseSequenceSet) — let's check
+    if (result.success && result.value?.request.type === "SEARCH") {
+      // May succeed via the sequence set path
+      const criteria = result.value.request.data.criteria as SearchCriterion[];
+      expect(criteria.length).toBeGreaterThan(0);
+    } else {
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it("LARGER size argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("LARGER 10000");
+    expect(result.success).toBe(false);
+  });
+
+  it("SMALLER size argument parsing fails without whitespace skip", () => {
+    const result = tryParseSearch("SMALLER 5000");
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NOT / OR logical operators
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > logical operators", () => {
+  it("NOT with a single simple criterion works", () => {
+    const criteria = parseSearch("NOT SEEN");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].type).toBe("NOT");
+    if (criteria[0].type !== "NOT") throw new Error("expected NOT");
+    // NOT stores a single criterion (not an array)
+    expect(criteria[0].criterion.type).toBe("SEEN");
+  });
+
+  it("NOT with ANSWERED", () => {
+    const criteria = parseSearch("NOT ANSWERED");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].type).toBe("NOT");
+    if (criteria[0].type !== "NOT") throw new Error("expected NOT");
+    expect(criteria[0].criterion.type).toBe("ANSWERED");
+  });
+
+  it("OR with two simple criteria uses left/right", () => {
+    const criteria = parseSearch("OR SEEN UNSEEN");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].type).toBe("OR");
+    if (criteria[0].type !== "OR") throw new Error("expected OR");
+    // OR stores left/right (not an array)
+    expect(criteria[0].left.type).toBe("SEEN");
+    expect(criteria[0].right.type).toBe("UNSEEN");
+  });
+
+  it("OR with FLAGGED and ANSWERED", () => {
+    const criteria = parseSearch("OR FLAGGED ANSWERED");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].type).toBe("OR");
+    if (criteria[0].type !== "OR") throw new Error("expected OR");
+    expect(criteria[0].left.type).toBe("FLAGGED");
+    expect(criteria[0].right.type).toBe("ANSWERED");
+  });
+
+  it("OR requires exactly 2 criteria — fails with 1", () => {
+    const result = tryParseSearch("OR SEEN");
+    expect(result.success).toBe(false);
+  });
+
+  it("NOT requires exactly 1 criterion — fails with 0", () => {
+    const result = tryParseSearch("NOT");
+    // returns false or empty criteria
+    if (result.success && result.value?.request.type === "SEARCH") {
+      const criteria = result.value.request.data.criteria as SearchCriterion[];
+      expect(criteria.length).toBe(0);
+    } else {
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it("NOT DELETED followed by UNSEEN fails because NOT consumes rest of criteria", () => {
+    // NOT calls parseSearchCriteria() recursively — it consumes ALL remaining criteria
+    // so "NOT DELETED UNSEEN" gives notCriteria.value.length === 2 → NOT fails
+    // Valid pattern: NOT DELETED alone, or wrap in parens (not currently supported)
+    const result = tryParseSearch("NOT DELETED UNSEEN");
+    // Current behavior: fails because NOT requires exactly 1 criterion but gets 2
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SEARCH ALL
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > SEARCH ALL", () => {
+  it("should parse SEARCH ALL as a single criterion", () => {
+    const criteria = parseSearch("ALL");
+    expect(criteria).toHaveLength(1);
+    expect(criteria[0].type).toBe("ALL");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parse error: complete SEARCH command structure
+// ---------------------------------------------------------------------------
+
+describe("search-parsers > command structure", () => {
+  it("should include tag in parsed result", () => {
+    const result = tryParseSearch("ALL");
+    expect(result.success).toBe(true);
+    expect(result.value?.tag).toBe("A001");
+  });
+
+  it("should return SEARCH type", () => {
+    const result = tryParseSearch("ALL");
+    expect(result.success).toBe(true);
+    expect(result.value?.request.type).toBe("SEARCH");
+  });
+
+  it("returns false for empty criteria string", () => {
+    const result = tryParseSearch("");
+    // Empty criteria — either returns empty array or fails
+    if (result.success && result.value?.request.type === "SEARCH") {
+      const criteria = result.value.request.data.criteria as SearchCriterion[];
+      expect(criteria.length).toBe(0);
+    } else {
+      expect(result.success).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds test coverage for two of the least-tested IMAP parser files, addressing issue #340.

## Coverage Added

### search-parsers.test.ts — 47 tests (was 0)
Targets `src/server/lib/imap/parsers/search-parsers.ts` (was 12.63% line coverage).

**Working criteria (all pass correctly):**
- All 14 simple flag criteria: `ALL`, `ANSWERED`, `DELETED`, `FLAGGED`, `NEW`, `OLD`, `RECENT`, `SEEN`, `UNANSWERED`, `UNDELETED`, `UNFLAGGED`, `UNSEEN`, `DRAFT`, `UNDRAFT`
- Multiple criteria combined: `UNSEEN ANSWERED`, `UNSEEN UNFLAGGED RECENT`
- `NOT SEEN`, `NOT ANSWERED` — uses `criterion` (not array)
- `OR SEEN UNSEEN` — uses `left`/`right` (not array)

**Broken criteria documented (no skipWhitespace before argument):**
- `KEYWORD`, `UNKEYWORD`, `BEFORE`, `ON`, `SINCE`, `SENTBEFORE`, `SENTON`, `SENTSINCE`, `FROM`, `TO`, `CC`, `BCC`, `SUBJECT`, `BODY`, `TEXT`, `HEADER`, `LARGER`, `SMALLER`
- All fail because `parseAtom()` is called immediately after the keyword name without `skipWhitespace()` — cursor is at " arg" (space before arg) so atom returns empty/fails
- This is the root cause of the SEARCH DATE bug reported in #304

### fetch-parsers.test.ts — 28 tests (was 0)
Targets `src/server/lib/imap/parsers/fetch-parsers.ts` (was 24.26% line coverage).

- All 9 simple data items: `ENVELOPE`, `FLAGS`, `INTERNALDATE`, `RFC822`, `RFC822.HEADER`, `RFC822.SIZE`, `RFC822.TEXT`, `UID`, `BODYSTRUCTURE`
- Parenthesized lists: 1 to 4 items
- Sequence sets: single, range (`1:10`), wildcard (`1:*`)
- `BODY`, `BODY[]`, `BODY.PEEK[]`, `BODY[HEADER]`, `BODY[TEXT]`, `BODY[HEADER.FIELDS (FROM TO SUBJECT DATE)]`, `BODY[1]` (MIME_PART), `BODY[]<0.2048>` (partial)
- Real-world patterns from iOS Mail / Thunderbird

## Test Results
```
bun test src/server/lib/imap/parsers/search-parsers.test.ts   # 47 pass, 0 fail
bun test src/server/lib/imap/parsers/fetch-parsers.test.ts    # 28 pass, 0 fail
```

Closes #340