### PR TITLE
docs: fix README send restriction, remove duplicate test requirements section

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,13 +126,6 @@ Security-critical parsers have dedicated test coverage:
 - APPEND parser (message upload)
 - Mailbox parsers (SELECT, EXAMINE, STATUS, etc.)
 
-### Test Requirements
-
-**Always write unit tests for new code files.** When adding a new utility, helper, or module:
-- Create `<filename>.test.ts` alongside the source file
-- Test the public interface and edge cases
-- PRs adding new code without tests will require justification
-
 ### Bun `mock.module` — Global Scope Warning
 
 **`mock.module()` replaces modules globally for the entire test run**, not just the current test file. This has caused repeated CI failures.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Here's how Inbox works, assuming domain name is `domain.com`.
 
 * Users will receive emails through `*@username.domain.com`
 * Exceptionally, `admin` user will receive emails through `*@domain.com`
-* Sending email is not supported for non-admin users(for now).
+* All users can send emails using Mailgun (requires `MAILGUN_KEY` env var).
 
 Following is an example of running Inbox as a web service.
 * https://mail.hoie.kim


### PR DESCRIPTION
## Changes

### README.md
- Update send capability note: sending email is now supported for all users (via Mailgun), not just admin
  - Code: `post-send.ts` has no admin check; Mailgun credentials control delivery
  - Old text was a stale `(for now)` note that was never updated

### DEVELOPMENT.md
- Remove duplicate `### Test Requirements` section (was at line 126)
  - The comprehensive `### Test Requirements (Mandatory)` section at line 93 covers all the same content
  - The shorter duplicate added confusion about which rules applied
