### PR TITLE
fix(smtp): suppress ETIMEDOUT errors from alarm

### DIFF
--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -43,7 +43,8 @@ const registerListeners = (
       // smtp-server-level strings for connection-drop cases
       msg.includes("Socket closed") ||                       // client disconnected before TLS handshake
       msg.includes("Failed to establish TLS session") ||     // smtp-server generic TLS failure wrapper
-      msg.includes("read ECONNRESET")                        // client dropped connection mid-handshake
+      msg.includes("read ECONNRESET") ||                      // client dropped connection mid-handshake
+      msg.includes("read ETIMEDOUT")                          // client connected but stopped responding (scanner idle timeout)
     ) return;
     console.error(`SMTP Server(${port}) Error: ${err}`);
     sendAlarm(


### PR DESCRIPTION
## Problem

`read ETIMEDOUT` alarms have been firing from external scanners connecting to SMTP ports and then going silent mid-session. These are not server-side failures — they're client-side timeouts (scanner connects, doesn't complete the handshake, connection times out).

This was generating alarm noise in #prod-alarms alongside the other TLS noise errors already suppressed in #404/#406/#410.

## Fix

Add `read ETIMEDOUT` to the existing suppression list in `smtp.ts` alongside `read ECONNRESET` and the OpenSSL TLS handshake error patterns.

## Testing

Deploy and verify no `ETIMEDOUT` alarms fire from scanner connections while real SMTP errors (auth failures, delivery errors) still trigger alarms.