### PR TITLE
fix: check SSL cert files exist before reading in SMTP and IMAP servers

### DIFF
--- a/src/server/lib/imap/index.ts
+++ b/src/server/lib/imap/index.ts
@@ -2,7 +2,7 @@ import { createServer, Socket } from "net";
 import { createServer as createTLSServer } from "tls";
 import { ImapRequestHandler } from "./handler";
 import { getCapabilities } from "./capabilities";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import { logger } from "server";
 
 export { idleManager } from "./idle-manager";
@@ -35,7 +35,18 @@ export const initializeImap = async () => {
   servers.push(imapServer);
 
   const { SSL_CERTIFICATE, SSL_CERTIFICATE_KEY } = process.env;
-  if (SSL_CERTIFICATE && SSL_CERTIFICATE_KEY) {
+  const sslConfigured = SSL_CERTIFICATE && SSL_CERTIFICATE_KEY;
+  const sslFilesExist = sslConfigured && existsSync(SSL_CERTIFICATE_KEY) && existsSync(SSL_CERTIFICATE);
+
+  if (sslConfigured && !sslFilesExist) {
+    logger.warn("IMAP: SSL certificate files not found — TLS server not started", {
+      component: "imap",
+      cert: SSL_CERTIFICATE,
+      key: SSL_CERTIFICATE_KEY,
+    });
+  }
+
+  if (sslFilesExist) {
     const imapTlsServer = await new Promise<import("net").Server>((res) => {
       const port = 993;
       const imapListener = getImapListener(port);
@@ -53,8 +64,8 @@ export const initializeImap = async () => {
       });
     });
     servers.push(imapTlsServer);
-  } else {
-    logger.warn("IMAP: SSL certificate not found, TLS server not started", { component: "imap" });
+  } else if (!sslConfigured) {
+    logger.warn("IMAP: SSL certificate not configured, TLS server not started", { component: "imap" });
   }
 
   return servers;

--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -1,5 +1,5 @@
 import bcrypt from "bcryptjs";
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import {
   SMTPServer,
   SMTPServerOptions,
@@ -199,7 +199,16 @@ export const initializeSmtp = async () => {
   const options: SMTPServerOptions = { authOptional: true, onAuth, onData, maxClients: SMTP_MAX_CLIENTS };
 
   const { SSL_CERTIFICATE, SSL_CERTIFICATE_KEY } = process.env;
-  const isSslAvailable = SSL_CERTIFICATE && SSL_CERTIFICATE_KEY;
+  const sslConfigured = SSL_CERTIFICATE && SSL_CERTIFICATE_KEY;
+  const sslFilesExist = sslConfigured && existsSync(SSL_CERTIFICATE_KEY) && existsSync(SSL_CERTIFICATE);
+  const isSslAvailable = sslFilesExist;
+
+  if (sslConfigured && !sslFilesExist) {
+    logger.warn("SMTP: SSL certificate files not found — starting without TLS", {
+      cert: SSL_CERTIFICATE,
+      key: SSL_CERTIFICATE_KEY,
+    });
+  }
 
   if (isSslAvailable) {
     options.key = readFileSync(SSL_CERTIFICATE_KEY);
@@ -209,8 +218,8 @@ export const initializeSmtp = async () => {
     // TLSv1.2 minimum is maintained; known-weak ciphers remain disabled.
     options.minVersion = "TLSv1.2";
     options.ciphers = "HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA";
-  } else {
-    logger.warn("SMTP: SSL certificate not found.");
+  } else if (!sslConfigured) {
+    logger.warn("SMTP: SSL certificate not configured.");
   }
 
   const smtpServer = await new Promise<SMTPServer>((res) => {


### PR DESCRIPTION
## Problem

When `SSL_CERTIFICATE` / `SSL_CERTIFICATE_KEY` env vars are set but the cert files don't exist on disk (e.g. in a local dev environment), `readFileSync` throws an unhandled exception that crashes server startup silently — no clean error message, just a crash.

Found during user-testing on Apr 4.

## Fix

Added `existsSync` check before attempting to read cert files in both `smtp.ts` and `imap/index.ts`.

**Behavior after fix:**
- Env vars set + files present → TLS server starts normally (no change)
- Env vars set + files **missing** → logs a `WARN` with the expected paths, skips TLS server startup
- Env vars not set → existing warn ("not configured") unchanged

## Testing

Reproduced locally: set `SSL_CERTIFICATE=certs/server.crt` in `.env` without the file present. Before: unhandled promise rejection crash. After: clean WARN log, server starts on plain ports.
