### PR TITLE
fix(smtp): suppress final_key_share TLS 1.3 noise alarm

### DIFF
--- a/src/server/lib/smtp.ts
+++ b/src/server/lib/smtp.ts
@@ -38,7 +38,8 @@ const registerListeners = (
       msg.includes("tls_early_post_process_client_hello") || // ClientHello stage rejections
       msg.includes("tls_post_process_client_hello") ||       // post-ClientHello cipher/extension failures
       msg.includes("tls_validate_record_header") ||          // malformed/wrong-protocol record header
-      msg.includes("extract_keyshares") ||                   // TLS 1.3 key exchange failure
+      msg.includes("extract_keyshares") ||                   // TLS 1.3 key exchange failure (bad key share)
+      msg.includes("final_key_share") ||                     // TLS 1.3 key exchange failure (no suitable key share)
       msg.includes("tls_choose_sigalg") ||                   // signature algorithm negotiation failure
       msg.includes("tls_get_more_records") ||                // oversized/malformed TLS record
       // smtp-server-level strings for connection-drop cases


### PR DESCRIPTION
## Summary
- Adds `final_key_share` to the SMTP server error suppression list
- This error comes from a client-side TLS 1.3 incompatibility (no suitable key share offered) — not a server bug
- Same category as the existing `extract_keyshares` suppression

## Root cause
Port 465 (SMTPS) alarm on 4/19/26 10:24 PM PST:
```
Error: SSL routines:final_key_share:no suitable key share
```
The `final_key_share` OpenSSL function is called when finalizing TLS 1.3 key exchange. When the client offers no compatible key share, OpenSSL rejects it here. This is a client-side incompatibility (scanner or old MTA), not a server error.

## Test plan
- [ ] Deploy to staging, connect with a TLS 1.2-only client to port 465 — no alarm fires
- [ ] Connect with a valid TLS 1.3 client — connection succeeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)