### PR TITLE
test: add 90%+ coverage for src/server/lib/http route handlers

### DIFF
--- a/src/server/lib/http/rate-limit.test.ts
+++ b/src/server/lib/http/rate-limit.test.ts
@@ -106,3 +106,16 @@ describe("cleanupExpiredAttempts", () => {
     expect(() => cleanupExpiredAttempts()).not.toThrow();
   });
 });
+
+describe("startCleanupScheduler / stopCleanupScheduler", () => {
+  it("starts and stops without throwing", async () => {
+    const { startCleanupScheduler, stopCleanupScheduler } = await import("./rate-limit");
+
+    expect(() => startCleanupScheduler()).not.toThrow();
+    // Calling again while running should be a no-op (idempotent).
+    expect(() => startCleanupScheduler()).not.toThrow();
+    expect(() => stopCleanupScheduler()).not.toThrow();
+    // Stopping again when already stopped should be a no-op.
+    expect(() => stopCleanupScheduler()).not.toThrow();
+  });
+});

--- a/src/server/lib/http/routes/health.test.ts
+++ b/src/server/lib/http/routes/health.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Mock net, tls, and postgres BEFORE importing health router ───────────────
+
+const makeSocketMock = () => {
+  const socket: Record<string, unknown> = {};
+  const handlers: Record<string, () => void> = {};
+  socket.destroy = mock(() => {});
+  socket.end = mock((cb?: () => void) => { if (cb) cb(); return socket; });
+  socket.setTimeout = mock(() => socket);
+  socket.on = mock((event: string, cb: () => void) => {
+    handlers[event] = cb;
+    return socket;
+  });
+  (socket as any)._handlers = handlers;
+  return socket;
+};
+
+let netSocketMock = makeSocketMock();
+let tlsSocketMock = makeSocketMock();
+
+// Controls what happens when a TCP connection is attempted:
+// "connect" = call the connect callback (success)
+// "error"   = fire the error event handler
+// "timeout" = fire the timeout event handler
+let netBehavior: "connect" | "error" | "timeout" = "connect";
+let tlsBehavior: "connect" | "error" | "timeout" = "connect";
+
+const mockCreateConnection = mock((_opts: unknown, cb: () => void) => {
+  const socket = makeSocketMock();
+  netSocketMock = socket;
+  setTimeout(() => {
+    if (netBehavior === "connect") cb();
+    else if (netBehavior === "error") (socket as any)._handlers["error"]?.();
+    else if (netBehavior === "timeout") (socket as any)._handlers["timeout"]?.();
+  }, 0);
+  return socket;
+});
+
+const mockTlsConnect = mock((_opts: unknown, cb: () => void) => {
+  const socket = makeSocketMock();
+  tlsSocketMock = socket;
+  setTimeout(() => {
+    if (tlsBehavior === "connect") cb();
+    else if (tlsBehavior === "error") (socket as any)._handlers["error"]?.();
+    else if (tlsBehavior === "timeout") (socket as any)._handlers["timeout"]?.();
+  }, 0);
+  return socket;
+});
+
+mock.module("net", () => ({ createConnection: mockCreateConnection }));
+mock.module("tls", () => ({ connect: mockTlsConnect }));
+
+const mockPoolQuery = mock(async () => [{ "?column?": 1 }]);
+mock.module("../../postgres/client", () => ({ pool: { query: mockPoolQuery } }));
+
+// ── Helper to call the health router GET "/" directly ─────────────────────────
+
+import type { Request, Response, NextFunction } from "express";
+import { Router } from "express";
+
+const makeRes = () => {
+  const res: Record<string, unknown> = { _code: 200, _body: undefined };
+  res.status = mock((code: number) => { res._code = code; return res; });
+  res.json = mock((body: unknown) => { res._body = body; return res; });
+  return res as unknown as Response & { _code: number; _body: unknown };
+};
+
+const makeReq = () => ({
+  method: "GET",
+  path: "/",
+} as unknown as Request);
+
+/** Invoke the first matching GET "/" layer in the health router. */
+const invokeHealthGet = async (router: Router): Promise<Response & { _code: number; _body: unknown }> => {
+  const res = makeRes();
+  const req = makeReq();
+  const next = mock(() => {});
+
+  // Find all layers with route path "/"
+  const layers = (router as any).stack as Array<{
+    route?: { path: string; methods: Record<string, boolean>; stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => void }> };
+  }>;
+
+  for (const layer of layers) {
+    if (layer.route?.path === "/" && layer.route.methods["get"]) {
+      for (const handler of layer.route.stack) {
+        await handler.handle(req, res as any, next as any);
+      }
+      break;
+    }
+  }
+
+  return res as any;
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("healthRouter GET /", () => {
+  beforeEach(() => {
+    mockPoolQuery.mockClear();
+    mockCreateConnection.mockClear();
+    mockTlsConnect.mockClear();
+    netBehavior = "connect";
+    tlsBehavior = "connect";
+  });
+
+  it("returns 200 with status:'success' when everything is healthy", async () => {
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    expect(res._code).toBe(200);
+    const body = res._body as any;
+    expect(body.status).toBe("success");
+    expect(body.body.healthy).toBe(true);
+    expect(body.body.checks.database).toBe("ok");
+    expect(body.body.checks.http).toBe("ok");
+  });
+
+  it("returns 503 when DB is unhealthy", async () => {
+    mockPoolQuery.mockImplementationOnce(async () => { throw new Error("DB down"); });
+
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    expect(res._code).toBe(503);
+    const body = res._body as any;
+    expect(body.status).toBe("error");
+    expect(body.body.healthy).toBe(false);
+    expect(body.body.checks.database).toBe("unhealthy");
+  });
+
+  it("returns 503 when a TCP port fails (error event)", async () => {
+    netBehavior = "error";
+
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    expect(res._code).toBe(503);
+    const body = res._body as any;
+    expect(body.body.healthy).toBe(false);
+  });
+
+  it("returns 503 when a TLS port fails", async () => {
+    tlsBehavior = "error";
+
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    expect(res._code).toBe(503);
+  });
+
+  it("always marks HTTP check as ok", async () => {
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    const body = res._body as any;
+    expect(body.body.checks.http).toBe("ok");
+  });
+
+  it("includes a numeric timestamp", async () => {
+    const { default: healthRouter } = await import("./health");
+    const res = await invokeHealthGet(healthRouter);
+
+    const body = res._body as any;
+    expect(typeof body.body.timestamp).toBe("number");
+    expect(body.body.timestamp).toBeGreaterThan(0);
+  });
+});

--- a/src/server/lib/http/routes/health.test.ts
+++ b/src/server/lib/http/routes/health.test.ts
@@ -12,7 +12,7 @@ const makeSocketMock = () => {
     handlers[event] = cb;
     return socket;
   });
-  (socket as any)._handlers = handlers;
+  (socket as { _handlers: Record<string, () => void> })._handlers = handlers;
   return socket;
 };
 
@@ -31,8 +31,8 @@ const mockCreateConnection = mock((_opts: unknown, cb: () => void) => {
   netSocketMock = socket;
   setTimeout(() => {
     if (netBehavior === "connect") cb();
-    else if (netBehavior === "error") (socket as any)._handlers["error"]?.();
-    else if (netBehavior === "timeout") (socket as any)._handlers["timeout"]?.();
+    else if (netBehavior === "error") (socket as { _handlers: Record<string, () => void> })._handlers["error"]?.();
+    else if (netBehavior === "timeout") (socket as { _handlers: Record<string, () => void> })._handlers["timeout"]?.();
   }, 0);
   return socket;
 });
@@ -42,8 +42,8 @@ const mockTlsConnect = mock((_opts: unknown, cb: () => void) => {
   tlsSocketMock = socket;
   setTimeout(() => {
     if (tlsBehavior === "connect") cb();
-    else if (tlsBehavior === "error") (socket as any)._handlers["error"]?.();
-    else if (tlsBehavior === "timeout") (socket as any)._handlers["timeout"]?.();
+    else if (tlsBehavior === "error") (socket as { _handlers: Record<string, () => void> })._handlers["error"]?.();
+    else if (tlsBehavior === "timeout") (socket as { _handlers: Record<string, () => void> })._handlers["timeout"]?.();
   }, 0);
   return socket;
 });
@@ -78,20 +78,20 @@ const invokeHealthGet = async (router: Router): Promise<Response & { _code: numb
   const next = mock(() => {});
 
   // Find all layers with route path "/"
-  const layers = (router as any).stack as Array<{
+  const layers = (router as unknown as { stack: unknown[] }).stack as Array<{
     route?: { path: string; methods: Record<string, boolean>; stack: Array<{ handle: (req: Request, res: Response, next: NextFunction) => void }> };
   }>;
 
   for (const layer of layers) {
     if (layer.route?.path === "/" && layer.route.methods["get"]) {
       for (const handler of layer.route.stack) {
-        await handler.handle(req, res as any, next as any);
+        await handler.handle(req, res, next);
       }
       break;
     }
   }
 
-  return res as any;
+  return res;
 };
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -110,7 +110,7 @@ describe("healthRouter GET /", () => {
     const res = await invokeHealthGet(healthRouter);
 
     expect(res._code).toBe(200);
-    const body = res._body as any;
+    const body = res._body as { status: string; body: { healthy: boolean; checks: { database: string; http: string }; timestamp: number } };
     expect(body.status).toBe("success");
     expect(body.body.healthy).toBe(true);
     expect(body.body.checks.database).toBe("ok");
@@ -124,7 +124,7 @@ describe("healthRouter GET /", () => {
     const res = await invokeHealthGet(healthRouter);
 
     expect(res._code).toBe(503);
-    const body = res._body as any;
+    const body = res._body as { status: string; body: { healthy: boolean; checks: { database: string; http: string }; timestamp: number } };
     expect(body.status).toBe("error");
     expect(body.body.healthy).toBe(false);
     expect(body.body.checks.database).toBe("unhealthy");
@@ -137,7 +137,7 @@ describe("healthRouter GET /", () => {
     const res = await invokeHealthGet(healthRouter);
 
     expect(res._code).toBe(503);
-    const body = res._body as any;
+    const body = res._body as { status: string; body: { healthy: boolean; checks: { database: string; http: string }; timestamp: number } };
     expect(body.body.healthy).toBe(false);
   });
 
@@ -154,7 +154,7 @@ describe("healthRouter GET /", () => {
     const { default: healthRouter } = await import("./health");
     const res = await invokeHealthGet(healthRouter);
 
-    const body = res._body as any;
+    const body = res._body as { status: string; body: { healthy: boolean; checks: { database: string; http: string }; timestamp: number } };
     expect(body.body.checks.http).toBe("ok");
   });
 
@@ -162,7 +162,7 @@ describe("healthRouter GET /", () => {
     const { default: healthRouter } = await import("./health");
     const res = await invokeHealthGet(healthRouter);
 
-    const body = res._body as any;
+    const body = res._body as { status: string; body: { healthy: boolean; checks: { database: string; http: string }; timestamp: number } };
     expect(typeof body.body.timestamp).toBe("number");
     expect(body.body.timestamp).toBeGreaterThan(0);
   });

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -1,0 +1,685 @@
+/**
+ * Tests for mails route handlers:
+ *   get-headers, get-accounts, get-body, delete, post-mark,
+ *   get-search, get-spam, get-domain, get-allowlist, post-allowlist,
+ *   delete-allowlist, post-send, post-spam-mark, get-attachment
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Shared mocks for "server" barrel ─────────────────────────────────────────
+
+const mockGetMailHeaders = mock(async () => []);
+const mockGetAccounts = mock(async () => ({ received: [], sent: [] }));
+const mockGetMailBody = mock(async () => null as unknown);
+const mockDeleteMail = mock(async () => {});
+const mockMarkRead = mock(async () => {});
+const mockMarkSaved = mock(async () => {});
+const mockDecrementBadgeCount = mock(async () => {});
+const mockAddressToUsername = mock((addr: string) => addr.split("@")[0]);
+const mockGetUser = mock(async () => null as unknown);
+
+// New mocks for additional routes
+const mockSearchMail = mock(async () => []);
+const mockGetSpamHeaders = mock(async () => []);
+const mockGetDomain = mock(() => "example.com");
+const mockGetAllowlistForUser = mock(async () => []);
+const mockAddAllowlistEntry = mock(async () => null as unknown);
+const mockRemoveAllowlistEntry = mock(async () => false as unknown);
+const mockSendMail = mock(async () => {});
+const mockMarkSpam = mock(async () => false as unknown);
+const mockGetAttachment = mock(() => undefined as unknown);
+const mockMailsTableQueryOne = mock(async () => null as unknown);
+const AUTH_ERROR_MESSAGE = "Authentication required";
+
+class MockMailValidationError extends Error {}
+class MockMailSendingError extends Error {}
+
+mock.module("server", () => ({
+  getMailHeaders: mockGetMailHeaders,
+  getAccounts: mockGetAccounts,
+  getMailBody: mockGetMailBody,
+  deleteMail: mockDeleteMail,
+  markRead: mockMarkRead,
+  markSaved: mockMarkSaved,
+  decrementBadgeCount: mockDecrementBadgeCount,
+  addressToUsername: mockAddressToUsername,
+  getUser: mockGetUser,
+  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+  searchMail: mockSearchMail,
+  getSpamHeaders: mockGetSpamHeaders,
+  getDomain: mockGetDomain,
+  getAllowlistForUser: mockGetAllowlistForUser,
+  addAllowlistEntry: mockAddAllowlistEntry,
+  removeAllowlistEntry: mockRemoveAllowlistEntry,
+  sendMail: mockSendMail,
+  markSpam: mockMarkSpam,
+  getAttachment: mockGetAttachment,
+  AUTH_ERROR_MESSAGE,
+  MailValidationError: MockMailValidationError,
+  MailSendingError: MockMailSendingError,
+  mailsTable: { queryOne: mockMailsTableQueryOne },
+  SpamAllowlistModel: class {},
+  // Push route exports needed when this mock is active for push.test.ts
+  getPushPublicKey: mock(() => "vapid-public-key"),
+  storeSubscription: mock(async () => null),
+  refreshSubscription: mock(async () => null),
+  // Users/token route exports
+  setUserInfo: mock(async () => null),
+  isValidEmail: mock(() => true),
+  createToken: mock(async () => ({ id: "u1", username: "u", token: "tok" })),
+  getSignedUser: mock(() => null),
+  createAuthenticationMail: mock(() => ({})),
+  startTimer: mock(() => {}),
+  version: "0.0.0",
+}));
+
+// Mock logger used directly in post-mark
+mock.module("../../../logger", () => ({
+  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+}));
+
+// ── Helper factories ──────────────────────────────────────────────────────────
+
+const makeUser = (username = "alice", id = "u1") => ({ id, username });
+
+const makeReq = (overrides: Record<string, unknown> = {}) =>
+  ({
+    method: "GET",
+    session: { user: makeUser() },
+    params: {},
+    query: {},
+    body: {},
+    ...overrides,
+  }) as unknown as import("express").Request;
+
+const makeRes = () => {
+  const res: Record<string, unknown> = { _code: 200, _body: undefined };
+  res.status = mock((code: number) => { res._code = code; return res; });
+  res.json = mock((body: unknown) => { res._body = body; return res; });
+  res.send = mock((body: unknown) => { res._body = body; return res; });
+  res.write = mock(() => true);
+  res.end = mock(() => res);
+  return res as unknown as import("express").Response & { _code: number; _body: unknown };
+};
+
+const stream = mock(() => {});
+const noopStream = stream as unknown as import("../route").Stream<unknown>;
+
+// ── get-headers route ─────────────────────────────────────────────────────────
+
+describe("getHeadersRoute", () => {
+  beforeEach(() => {
+    mockGetMailHeaders.mockClear();
+    mockAddressToUsername.mockClear();
+  });
+
+  it("returns success with mail headers for valid user", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    const fakeMails = [{ id: "m1", subject: "Hello" }];
+    mockGetMailHeaders.mockResolvedValueOnce(fakeMails as any);
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "alice@example.com" },
+      query: {},
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual(fakeMails);
+  });
+
+  it("allows admin user to access any account", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    mockGetMailHeaders.mockResolvedValueOnce([] as any);
+    mockAddressToUsername.mockReturnValueOnce("bob");
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("admin") },
+      params: { account: "bob@example.com" },
+      query: {},
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+
+  it("returns failed when user tries to access another user's account", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    mockAddressToUsername.mockReturnValueOnce("charlie");
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "charlie@example.com" },
+      query: {},
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("passes query options (sent/new/saved) to getMailHeaders", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    mockGetMailHeaders.mockResolvedValueOnce([]);
+    mockAddressToUsername.mockReturnValueOnce("alice");
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "alice@example.com" },
+      query: { sent: "1", new: "1" },
+    });
+    const res = makeRes();
+
+    await getHeadersRoute.callback(req, res as any, noopStream);
+
+    const callArgs = mockGetMailHeaders.mock.calls[0];
+    expect(callArgs[2]).toMatchObject({ sent: true, new: true, saved: false });
+  });
+});
+
+// ── get-accounts route ────────────────────────────────────────────────────────
+
+describe("getAccountsRoute", () => {
+  beforeEach(() => mockGetAccounts.mockClear());
+
+  it("returns received and sent accounts", async () => {
+    const { getAccountsRoute } = await import("./get-accounts");
+
+    const fakeAccounts = {
+      received: [{ address: "alice@example.com" }],
+      sent: [{ address: "bob@example.com" }],
+    };
+    mockGetAccounts.mockResolvedValueOnce(fakeAccounts as any);
+
+    const req = makeReq({ session: { user: makeUser("alice") } });
+    const res = makeRes();
+
+    const result = await getAccountsRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toMatchObject(fakeAccounts);
+  });
+
+  it("calls getAccounts with the session user", async () => {
+    const { getAccountsRoute } = await import("./get-accounts");
+
+    mockGetAccounts.mockResolvedValueOnce({ received: [], sent: [] } as any);
+    const user = makeUser("bob");
+    const req = makeReq({ session: { user } });
+    const res = makeRes();
+
+    await getAccountsRoute.callback(req, res as any, noopStream);
+
+    expect(mockGetAccounts).toHaveBeenCalledWith(user);
+  });
+});
+
+// ── get-body route ────────────────────────────────────────────────────────────
+
+describe("getBodyRoute", () => {
+  beforeEach(() => mockGetMailBody.mockClear());
+
+  it("returns mail body when found", async () => {
+    const { getBodyRoute } = await import("./get-body");
+
+    const fakeMail = { id: "m1", html: "<p>Hello</p>" };
+    mockGetMailBody.mockResolvedValueOnce(fakeMail);
+
+    const req = makeReq({ params: { id: "m1" } });
+    const res = makeRes();
+
+    const result = await getBodyRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual(fakeMail);
+  });
+
+  it("returns failed when mail is not found", async () => {
+    const { getBodyRoute } = await import("./get-body");
+
+    mockGetMailBody.mockResolvedValueOnce(null);
+
+    const req = makeReq({ params: { id: "missing" } });
+    const res = makeRes();
+
+    const result = await getBodyRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toBeTruthy();
+  });
+});
+
+// ── delete mail route ─────────────────────────────────────────────────────────
+
+describe("deleteMailRoute", () => {
+  beforeEach(() => {
+    mockGetMailBody.mockClear();
+    mockDeleteMail.mockClear();
+  });
+
+  it("deletes mail and returns success when mail belongs to user", async () => {
+    const { deleteMailRoute } = await import("./delete");
+
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+
+    const req = makeReq({ method: "DELETE", params: { id: "m1" } });
+    const res = makeRes();
+
+    const result = await deleteMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect(mockDeleteMail).toHaveBeenCalledWith("u1", "m1");
+  });
+
+  it("returns failed when mail not found (or belongs to another user)", async () => {
+    const { deleteMailRoute } = await import("./delete");
+
+    mockGetMailBody.mockResolvedValueOnce(null);
+
+    const req = makeReq({ method: "DELETE", params: { id: "other-m" } });
+    const res = makeRes();
+
+    const result = await deleteMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect(mockDeleteMail).not.toHaveBeenCalled();
+  });
+});
+
+// ── post-mark route ───────────────────────────────────────────────────────────
+
+describe("postMarkMailRoute", () => {
+  beforeEach(() => {
+    mockGetMailBody.mockClear();
+    mockMarkRead.mockClear();
+    mockMarkSaved.mockClear();
+    mockDecrementBadgeCount.mockClear();
+  });
+
+  it("marks mail as read and returns success", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+
+    const req = makeReq({
+      method: "POST",
+      body: { mail_id: "m1", read: true },
+    });
+    const res = makeRes();
+
+    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect(mockMarkRead).toHaveBeenCalledWith("u1", "m1");
+  });
+
+  it("marks mail as saved when save=true", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+
+    const req = makeReq({
+      method: "POST",
+      body: { mail_id: "m1", save: true },
+    });
+    const res = makeRes();
+
+    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", true);
+  });
+
+  it("marks mail as unsaved when save=false", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+
+    const req = makeReq({
+      method: "POST",
+      body: { mail_id: "m1", save: false },
+    });
+    const res = makeRes();
+
+    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", false);
+  });
+
+  it("returns failed when mail not found", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+
+    mockGetMailBody.mockResolvedValueOnce(null);
+
+    const req = makeReq({
+      method: "POST",
+      body: { mail_id: "bad-id", read: true },
+    });
+    const res = makeRes();
+
+    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it("does not call markRead when read is not explicitly true", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+
+    const req = makeReq({
+      method: "POST",
+      body: { mail_id: "m1" },
+    });
+    const res = makeRes();
+
+    await postMarkMailRoute.callback(req, res as any, noopStream);
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+});
+
+// ── get-search route ──────────────────────────────────────────────────────────
+
+describe("getSearchRoute", () => {
+  beforeEach(() => mockSearchMail.mockClear());
+
+  it("returns search results for a given value", async () => {
+    const { getSearchRoute } = await import("./get-search");
+    const fakeMails = [{ id: "m1", subject: "Test" }];
+    mockSearchMail.mockResolvedValueOnce(fakeMails as any);
+
+    const req = makeReq({ params: { value: "Test" }, query: {} });
+    const result = await getSearchRoute.callback(req, makeRes() as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual(fakeMails);
+    expect(mockSearchMail).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes field query param to searchMail", async () => {
+    const { getSearchRoute } = await import("./get-search");
+    mockSearchMail.mockResolvedValueOnce([]);
+
+    const req = makeReq({ params: { value: "hello" }, query: { field: "subject" } });
+    await getSearchRoute.callback(req, makeRes() as any, noopStream);
+
+    expect(mockSearchMail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "u1" }),
+      "hello",
+      "subject"
+    );
+  });
+});
+
+// ── get-spam route ────────────────────────────────────────────────────────────
+
+describe("getSpamMailsRoute", () => {
+  beforeEach(() => mockGetSpamHeaders.mockClear());
+
+  it("returns spam headers for authenticated user", async () => {
+    const { getSpamMailsRoute } = await import("./get-spam");
+    const spamMails = [{ id: "s1" }];
+    mockGetSpamHeaders.mockResolvedValueOnce(spamMails as any);
+
+    const req = makeReq();
+    const result = await getSpamMailsRoute.callback(req, makeRes() as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual(spamMails);
+  });
+});
+
+// ── get-domain route ──────────────────────────────────────────────────────────
+
+describe("getDomainRoute", () => {
+  beforeEach(() => mockGetDomain.mockClear());
+
+  it("returns the configured domain", async () => {
+    const { getDomainRoute } = await import("./get-domain");
+    const result = await getDomainRoute.callback(makeReq(), makeRes() as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toBe("example.com");
+  });
+});
+
+// ── get-allowlist route ───────────────────────────────────────────────────────
+
+describe("getSpamAllowlistRoute", () => {
+  beforeEach(() => mockGetAllowlistForUser.mockClear());
+
+  it("returns mapped allowlist entries", async () => {
+    const { getSpamAllowlistRoute } = await import("./get-allowlist");
+    const entries = [
+      { allowlist_id: "a1", pattern: "*@spam.com", created_at: "2026-01-01" },
+    ];
+    mockGetAllowlistForUser.mockResolvedValueOnce(entries as any);
+
+    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes() as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual([
+      { id: "a1", pattern: "*@spam.com", createdAt: "2026-01-01" },
+    ]);
+  });
+
+  it("returns empty array when no entries", async () => {
+    const { getSpamAllowlistRoute } = await import("./get-allowlist");
+    mockGetAllowlistForUser.mockResolvedValueOnce([]);
+
+    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes() as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual([]);
+  });
+});
+
+// ── post-allowlist route ──────────────────────────────────────────────────────
+
+describe("postSpamAllowlistRoute", () => {
+  beforeEach(() => mockAddAllowlistEntry.mockClear());
+
+  it("rejects missing pattern", async () => {
+    const { postSpamAllowlistRoute } = await import("./post-allowlist");
+    const req = makeReq({ body: {} });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/pattern is required/i);
+  });
+
+  it("rejects invalid pattern format", async () => {
+    const { postSpamAllowlistRoute } = await import("./post-allowlist");
+    const req = makeReq({ body: { pattern: "notavalidemail" } });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/email address/i);
+  });
+
+  it("returns failed when entry already exists (null returned)", async () => {
+    const { postSpamAllowlistRoute } = await import("./post-allowlist");
+    mockAddAllowlistEntry.mockResolvedValueOnce(null);
+    const req = makeReq({ body: { pattern: "*@spam.com" } });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/already exists/i);
+  });
+
+  it("returns success with new entry on exact email pattern", async () => {
+    const { postSpamAllowlistRoute } = await import("./post-allowlist");
+    mockAddAllowlistEntry.mockResolvedValueOnce({
+      allowlist_id: "a2",
+      pattern: "bad@spam.com",
+      created_at: "2026-04-01",
+    });
+    const req = makeReq({ body: { pattern: "bad@spam.com" } });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toMatchObject({ id: "a2", pattern: "bad@spam.com" });
+  });
+
+  it("returns success with domain wildcard pattern", async () => {
+    const { postSpamAllowlistRoute } = await import("./post-allowlist");
+    mockAddAllowlistEntry.mockResolvedValueOnce({
+      allowlist_id: "a3",
+      pattern: "*@domain.com",
+      created_at: "2026-04-01",
+    });
+    const req = makeReq({ body: { pattern: "*@domain.com" } });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toMatchObject({ pattern: "*@domain.com" });
+  });
+});
+
+// ── delete-allowlist route ────────────────────────────────────────────────────
+
+describe("deleteSpamAllowlistRoute", () => {
+  beforeEach(() => mockRemoveAllowlistEntry.mockClear());
+
+  it("returns failed when entry not found", async () => {
+    const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
+    mockRemoveAllowlistEntry.mockResolvedValueOnce(false);
+    const req = makeReq({ params: { pattern: "*%40spam.com" } });
+    const result = await deleteSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/not found/i);
+  });
+
+  it("returns success when entry removed", async () => {
+    const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
+    mockRemoveAllowlistEntry.mockResolvedValueOnce(true);
+    const req = makeReq({ params: { pattern: "*%40spam.com" } });
+    const result = await deleteSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+});
+
+// ── post-send route ───────────────────────────────────────────────────────────
+
+describe("postSendMailRoute", () => {
+  beforeEach(() => mockSendMail.mockClear());
+
+  it("returns success when mail is sent", async () => {
+    const { postSendMailRoute } = await import("./post-send");
+    mockSendMail.mockResolvedValueOnce(undefined);
+    const req = makeReq({
+      body: { to: "test@example.com", subject: "Hi", text: "Hello" },
+    });
+    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+
+  it("returns failed on MailValidationError", async () => {
+    const { postSendMailRoute } = await import("./post-send");
+    mockSendMail.mockRejectedValueOnce(new MockMailValidationError("bad mail"));
+    const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
+    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toBe("bad mail");
+  });
+
+  it("returns failed on MailSendingError", async () => {
+    const { postSendMailRoute } = await import("./post-send");
+    mockSendMail.mockRejectedValueOnce(new MockMailSendingError("send failed"));
+    const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
+    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toBe("send failed");
+  });
+
+  it("rethrows unknown errors", async () => {
+    const { postSendMailRoute } = await import("./post-send");
+    const unknownError = new Error("unexpected");
+    mockSendMail.mockRejectedValueOnce(unknownError);
+    const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
+    await expect(postSendMailRoute.callback(req, makeRes() as any, noopStream)).rejects.toThrow("unexpected");
+  });
+});
+
+// ── post-spam-mark route ──────────────────────────────────────────────────────
+
+describe("postMarkSpamMailRoute", () => {
+  beforeEach(() => mockMarkSpam.mockClear());
+
+  it("rejects when is_spam is not boolean", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    const req = makeReq({ body: { mail_id: "m1", is_spam: "yes" } });
+    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/boolean/i);
+  });
+
+  it("returns failed when mail not found or no permission", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    mockMarkSpam.mockResolvedValueOnce(null);
+    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/not found/i);
+  });
+
+  it("returns success when spam marked", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
+    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+
+  it("returns success when spam unmarked (is_spam false)", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
+    const req = makeReq({ body: { mail_id: "m1", is_spam: false } });
+    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+});
+
+// ── get-attachment route ──────────────────────────────────────────────────────
+
+describe("getAttachmentRoute", () => {
+  beforeEach(() => {
+    mockMailsTableQueryOne.mockClear();
+    mockGetAttachment.mockClear();
+  });
+
+  it("returns failed with auth error when no session user", async () => {
+    const { getAttachmentRoute } = await import("./get-attachment");
+    const req = makeReq({ session: { user: undefined } });
+    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toBe(AUTH_ERROR_MESSAGE);
+  });
+
+  it("returns failed when mail not found (IDOR protection)", async () => {
+    const { getAttachmentRoute } = await import("./get-attachment");
+    mockMailsTableQueryOne.mockResolvedValueOnce(null);
+    const req = makeReq({ params: { id: "att1" } });
+    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toBe("Not found");
+  });
+
+  it("returns failed when attachment file missing from disk", async () => {
+    const { getAttachmentRoute } = await import("./get-attachment");
+    mockMailsTableQueryOne.mockResolvedValueOnce({ id: "m1" });
+    mockGetAttachment.mockReturnValueOnce(undefined);
+    const req = makeReq({ params: { id: "att1" } });
+    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns attachment buffer when found", async () => {
+    const { getAttachmentRoute } = await import("./get-attachment");
+    const fakeBuffer = Buffer.from("file content");
+    mockMailsTableQueryOne.mockResolvedValueOnce({ id: "m1" });
+    mockGetAttachment.mockReturnValueOnce(fakeBuffer);
+    const req = makeReq({ params: { id: "att1" } });
+    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
+    expect(result).toBe(fakeBuffer);
+  });
+});

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -5,6 +5,7 @@
  *   delete-allowlist, post-send, post-spam-mark, get-attachment
  */
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { ApiResponse } from "../route";
 
 // ── Shared mocks for "server" barrel ─────────────────────────────────────────
 
@@ -117,7 +118,7 @@ describe("getHeadersRoute", () => {
     const { getHeadersRoute } = await import("./get-headers");
 
     const fakeMails = [{ id: "m1", subject: "Hello" }];
-    mockGetMailHeaders.mockResolvedValueOnce(fakeMails as any);
+    mockGetMailHeaders.mockResolvedValueOnce(fakeMails as never);
 
     const req = makeReq({
       method: "GET",
@@ -127,15 +128,15 @@ describe("getHeadersRoute", () => {
     });
     const res = makeRes();
 
-    const result = await getHeadersRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual(fakeMails);
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(fakeMails);
   });
 
   it("allows admin user to access any account", async () => {
     const { getHeadersRoute } = await import("./get-headers");
 
-    mockGetMailHeaders.mockResolvedValueOnce([] as any);
+    mockGetMailHeaders.mockResolvedValueOnce([] as never);
     mockAddressToUsername.mockReturnValueOnce("bob");
 
     const req = makeReq({
@@ -146,8 +147,8 @@ describe("getHeadersRoute", () => {
     });
     const res = makeRes();
 
-    const result = await getHeadersRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 
   it("returns failed when user tries to access another user's account", async () => {
@@ -163,8 +164,8 @@ describe("getHeadersRoute", () => {
     });
     const res = makeRes();
 
-    const result = await getHeadersRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("failed");
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("passes query options (sent/new/saved) to getMailHeaders", async () => {
@@ -181,7 +182,7 @@ describe("getHeadersRoute", () => {
     });
     const res = makeRes();
 
-    await getHeadersRoute.callback(req, res as any, noopStream);
+    await getHeadersRoute.callback(req, res, noopStream);
 
     const callArgs = mockGetMailHeaders.mock.calls[0];
     expect(callArgs[2]).toMatchObject({ sent: true, new: true, saved: false });
@@ -200,25 +201,25 @@ describe("getAccountsRoute", () => {
       received: [{ address: "alice@example.com" }],
       sent: [{ address: "bob@example.com" }],
     };
-    mockGetAccounts.mockResolvedValueOnce(fakeAccounts as any);
+    mockGetAccounts.mockResolvedValueOnce(fakeAccounts as never);
 
     const req = makeReq({ session: { user: makeUser("alice") } });
     const res = makeRes();
 
-    const result = await getAccountsRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toMatchObject(fakeAccounts);
+    const result = await getAccountsRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toMatchObject(fakeAccounts);
   });
 
   it("calls getAccounts with the session user", async () => {
     const { getAccountsRoute } = await import("./get-accounts");
 
-    mockGetAccounts.mockResolvedValueOnce({ received: [], sent: [] } as any);
+    mockGetAccounts.mockResolvedValueOnce({ received: [], sent: [] } as never);
     const user = makeUser("bob");
     const req = makeReq({ session: { user } });
     const res = makeRes();
 
-    await getAccountsRoute.callback(req, res as any, noopStream);
+    await getAccountsRoute.callback(req, res, noopStream);
 
     expect(mockGetAccounts).toHaveBeenCalledWith(user);
   });
@@ -238,9 +239,9 @@ describe("getBodyRoute", () => {
     const req = makeReq({ params: { id: "m1" } });
     const res = makeRes();
 
-    const result = await getBodyRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual(fakeMail);
+    const result = await getBodyRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(fakeMail);
   });
 
   it("returns failed when mail is not found", async () => {
@@ -251,9 +252,9 @@ describe("getBodyRoute", () => {
     const req = makeReq({ params: { id: "missing" } });
     const res = makeRes();
 
-    const result = await getBodyRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toBeTruthy();
+    const result = await getBodyRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toBeTruthy();
   });
 });
 
@@ -273,8 +274,8 @@ describe("deleteMailRoute", () => {
     const req = makeReq({ method: "DELETE", params: { id: "m1" } });
     const res = makeRes();
 
-    const result = await deleteMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await deleteMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockDeleteMail).toHaveBeenCalledWith("u1", "m1");
   });
 
@@ -286,8 +287,8 @@ describe("deleteMailRoute", () => {
     const req = makeReq({ method: "DELETE", params: { id: "other-m" } });
     const res = makeRes();
 
-    const result = await deleteMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("failed");
+    const result = await deleteMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
     expect(mockDeleteMail).not.toHaveBeenCalled();
   });
 });
@@ -313,8 +314,8 @@ describe("postMarkMailRoute", () => {
     });
     const res = makeRes();
 
-    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postMarkMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockMarkRead).toHaveBeenCalledWith("u1", "m1");
   });
 
@@ -329,8 +330,8 @@ describe("postMarkMailRoute", () => {
     });
     const res = makeRes();
 
-    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postMarkMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", true);
   });
 
@@ -345,8 +346,8 @@ describe("postMarkMailRoute", () => {
     });
     const res = makeRes();
 
-    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postMarkMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", false);
   });
 
@@ -361,8 +362,8 @@ describe("postMarkMailRoute", () => {
     });
     const res = makeRes();
 
-    const result = await postMarkMailRoute.callback(req, res as any, noopStream);
-    expect((result as any).status).toBe("failed");
+    const result = await postMarkMailRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
     expect(mockMarkRead).not.toHaveBeenCalled();
   });
 
@@ -377,7 +378,7 @@ describe("postMarkMailRoute", () => {
     });
     const res = makeRes();
 
-    await postMarkMailRoute.callback(req, res as any, noopStream);
+    await postMarkMailRoute.callback(req, res, noopStream);
     expect(mockMarkRead).not.toHaveBeenCalled();
   });
 });
@@ -390,13 +391,13 @@ describe("getSearchRoute", () => {
   it("returns search results for a given value", async () => {
     const { getSearchRoute } = await import("./get-search");
     const fakeMails = [{ id: "m1", subject: "Test" }];
-    mockSearchMail.mockResolvedValueOnce(fakeMails as any);
+    mockSearchMail.mockResolvedValueOnce(fakeMails as never);
 
     const req = makeReq({ params: { value: "Test" }, query: {} });
-    const result = await getSearchRoute.callback(req, makeRes() as any, noopStream);
+    const result = await getSearchRoute.callback(req, makeRes(), noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual(fakeMails);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(fakeMails);
     expect(mockSearchMail).toHaveBeenCalledTimes(1);
   });
 
@@ -405,7 +406,7 @@ describe("getSearchRoute", () => {
     mockSearchMail.mockResolvedValueOnce([]);
 
     const req = makeReq({ params: { value: "hello" }, query: { field: "subject" } });
-    await getSearchRoute.callback(req, makeRes() as any, noopStream);
+    await getSearchRoute.callback(req, makeRes(), noopStream);
 
     expect(mockSearchMail).toHaveBeenCalledWith(
       expect.objectContaining({ id: "u1" }),
@@ -423,13 +424,13 @@ describe("getSpamMailsRoute", () => {
   it("returns spam headers for authenticated user", async () => {
     const { getSpamMailsRoute } = await import("./get-spam");
     const spamMails = [{ id: "s1" }];
-    mockGetSpamHeaders.mockResolvedValueOnce(spamMails as any);
+    mockGetSpamHeaders.mockResolvedValueOnce(spamMails as never);
 
     const req = makeReq();
-    const result = await getSpamMailsRoute.callback(req, makeRes() as any, noopStream);
+    const result = await getSpamMailsRoute.callback(req, makeRes(), noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual(spamMails);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(spamMails);
   });
 });
 
@@ -440,10 +441,10 @@ describe("getDomainRoute", () => {
 
   it("returns the configured domain", async () => {
     const { getDomainRoute } = await import("./get-domain");
-    const result = await getDomainRoute.callback(makeReq(), makeRes() as any, noopStream);
+    const result = await getDomainRoute.callback(makeReq(), makeRes(), noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toBe("example.com");
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toBe("example.com");
   });
 });
 
@@ -457,12 +458,12 @@ describe("getSpamAllowlistRoute", () => {
     const entries = [
       { allowlist_id: "a1", pattern: "*@spam.com", created_at: "2026-01-01" },
     ];
-    mockGetAllowlistForUser.mockResolvedValueOnce(entries as any);
+    mockGetAllowlistForUser.mockResolvedValueOnce(entries as never);
 
-    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes() as any, noopStream);
+    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes(), noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual([
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual([
       { id: "a1", pattern: "*@spam.com", createdAt: "2026-01-01" },
     ]);
   });
@@ -471,10 +472,10 @@ describe("getSpamAllowlistRoute", () => {
     const { getSpamAllowlistRoute } = await import("./get-allowlist");
     mockGetAllowlistForUser.mockResolvedValueOnce([]);
 
-    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes() as any, noopStream);
+    const result = await getSpamAllowlistRoute.callback(makeReq(), makeRes(), noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual([]);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual([]);
   });
 });
 
@@ -486,26 +487,26 @@ describe("postSpamAllowlistRoute", () => {
   it("rejects missing pattern", async () => {
     const { postSpamAllowlistRoute } = await import("./post-allowlist");
     const req = makeReq({ body: {} });
-    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/pattern is required/i);
+    const result = await postSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/pattern is required/i);
   });
 
   it("rejects invalid pattern format", async () => {
     const { postSpamAllowlistRoute } = await import("./post-allowlist");
     const req = makeReq({ body: { pattern: "notavalidemail" } });
-    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/email address/i);
+    const result = await postSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/email address/i);
   });
 
   it("returns failed when entry already exists (null returned)", async () => {
     const { postSpamAllowlistRoute } = await import("./post-allowlist");
     mockAddAllowlistEntry.mockResolvedValueOnce(null);
     const req = makeReq({ body: { pattern: "*@spam.com" } });
-    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/already exists/i);
+    const result = await postSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/already exists/i);
   });
 
   it("returns success with new entry on exact email pattern", async () => {
@@ -516,9 +517,9 @@ describe("postSpamAllowlistRoute", () => {
       created_at: "2026-04-01",
     });
     const req = makeReq({ body: { pattern: "bad@spam.com" } });
-    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toMatchObject({ id: "a2", pattern: "bad@spam.com" });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toMatchObject({ id: "a2", pattern: "bad@spam.com" });
   });
 
   it("returns success with domain wildcard pattern", async () => {
@@ -529,9 +530,9 @@ describe("postSpamAllowlistRoute", () => {
       created_at: "2026-04-01",
     });
     const req = makeReq({ body: { pattern: "*@domain.com" } });
-    const result = await postSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toMatchObject({ pattern: "*@domain.com" });
+    const result = await postSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toMatchObject({ pattern: "*@domain.com" });
   });
 });
 
@@ -544,17 +545,17 @@ describe("deleteSpamAllowlistRoute", () => {
     const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
     mockRemoveAllowlistEntry.mockResolvedValueOnce(false);
     const req = makeReq({ params: { pattern: "*%40spam.com" } });
-    const result = await deleteSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/not found/i);
+    const result = await deleteSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/not found/i);
   });
 
   it("returns success when entry removed", async () => {
     const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
     mockRemoveAllowlistEntry.mockResolvedValueOnce(true);
     const req = makeReq({ params: { pattern: "*%40spam.com" } });
-    const result = await deleteSpamAllowlistRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await deleteSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 });
 
@@ -569,26 +570,26 @@ describe("postSendMailRoute", () => {
     const req = makeReq({
       body: { to: "test@example.com", subject: "Hi", text: "Hello" },
     });
-    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postSendMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 
   it("returns failed on MailValidationError", async () => {
     const { postSendMailRoute } = await import("./post-send");
     mockSendMail.mockRejectedValueOnce(new MockMailValidationError("bad mail"));
     const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
-    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toBe("bad mail");
+    const result = await postSendMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toBe("bad mail");
   });
 
   it("returns failed on MailSendingError", async () => {
     const { postSendMailRoute } = await import("./post-send");
     mockSendMail.mockRejectedValueOnce(new MockMailSendingError("send failed"));
     const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
-    const result = await postSendMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toBe("send failed");
+    const result = await postSendMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toBe("send failed");
   });
 
   it("rethrows unknown errors", async () => {
@@ -596,7 +597,7 @@ describe("postSendMailRoute", () => {
     const unknownError = new Error("unexpected");
     mockSendMail.mockRejectedValueOnce(unknownError);
     const req = makeReq({ body: { to: "x@x.com", subject: "s", text: "t" } });
-    await expect(postSendMailRoute.callback(req, makeRes() as any, noopStream)).rejects.toThrow("unexpected");
+    await expect(postSendMailRoute.callback(req, makeRes(), noopStream)).rejects.toThrow("unexpected");
   });
 });
 
@@ -608,34 +609,34 @@ describe("postMarkSpamMailRoute", () => {
   it("rejects when is_spam is not boolean", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     const req = makeReq({ body: { mail_id: "m1", is_spam: "yes" } });
-    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/boolean/i);
+    const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/boolean/i);
   });
 
   it("returns failed when mail not found or no permission", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce(null);
     const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
-    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/not found/i);
+    const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/not found/i);
   });
 
   it("returns success when spam marked", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
     const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
-    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 
   it("returns success when spam unmarked (is_spam false)", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
     const req = makeReq({ body: { mail_id: "m1", is_spam: false } });
-    const result = await postMarkSpamMailRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 });
 
@@ -650,18 +651,18 @@ describe("getAttachmentRoute", () => {
   it("returns failed with auth error when no session user", async () => {
     const { getAttachmentRoute } = await import("./get-attachment");
     const req = makeReq({ session: { user: undefined } });
-    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toBe(AUTH_ERROR_MESSAGE);
+    const result = await getAttachmentRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toBe(AUTH_ERROR_MESSAGE);
   });
 
   it("returns failed when mail not found (IDOR protection)", async () => {
     const { getAttachmentRoute } = await import("./get-attachment");
     mockMailsTableQueryOne.mockResolvedValueOnce(null);
     const req = makeReq({ params: { id: "att1" } });
-    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toBe("Not found");
+    const result = await getAttachmentRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toBe("Not found");
   });
 
   it("returns failed when attachment file missing from disk", async () => {
@@ -669,8 +670,8 @@ describe("getAttachmentRoute", () => {
     mockMailsTableQueryOne.mockResolvedValueOnce({ id: "m1" });
     mockGetAttachment.mockReturnValueOnce(undefined);
     const req = makeReq({ params: { id: "att1" } });
-    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
+    const result = await getAttachmentRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns attachment buffer when found", async () => {
@@ -679,7 +680,7 @@ describe("getAttachmentRoute", () => {
     mockMailsTableQueryOne.mockResolvedValueOnce({ id: "m1" });
     mockGetAttachment.mockReturnValueOnce(fakeBuffer);
     const req = makeReq({ params: { id: "att1" } });
-    const result = await getAttachmentRoute.callback(req, makeRes() as any, noopStream);
+    const result = await getAttachmentRoute.callback(req, makeRes(), noopStream);
     expect(result).toBe(fakeBuffer);
   });
 });

--- a/src/server/lib/http/routes/push/push.test.ts
+++ b/src/server/lib/http/routes/push/push.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { ApiResponse } from "../route";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
@@ -73,9 +74,9 @@ describe("getPublicKeyRoute", () => {
 
   it("returns the VAPID public key", async () => {
     const { getPublicKeyRoute } = await import("./get-public-key");
-    const result = await getPublicKeyRoute.callback(makeReq(), makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toBe("test-vapid-public-key");
+    const result = await getPublicKeyRoute.callback(makeReq(), makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toBe("test-vapid-public-key");
     expect(mockGetPushPublicKey).toHaveBeenCalledTimes(1);
   });
 });
@@ -89,17 +90,17 @@ describe("getRefreshRoute", () => {
     const { getRefreshRoute } = await import("./get-refresh");
     mockRefreshSubscription.mockResolvedValueOnce({ _id: "sub1" });
     const req = makeReq({ params: { id: "sub1" } });
-    const result = await getRefreshRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await getRefreshRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 
   it("returns failed when subscription is not found", async () => {
     const { getRefreshRoute } = await import("./get-refresh");
     mockRefreshSubscription.mockResolvedValueOnce(null);
     const req = makeReq({ params: { id: "nonexistent" } });
-    const result = await getRefreshRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/No subscription found/i);
+    const result = await getRefreshRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/No subscription found/i);
   });
 });
 
@@ -113,9 +114,9 @@ describe("postSubscribeRoute", () => {
     const fakeSub = { endpoint: "https://fcm.example.com", keys: { p256dh: "abc", auth: "xyz" } };
     mockStoreSubscription.mockResolvedValueOnce({ _id: "sub42" });
     const req = makeReq({ body: { subscription: fakeSub } });
-    const result = await postSubscribeRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toBe("sub42");
+    const result = await postSubscribeRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toBe("sub42");
     expect(mockStoreSubscription).toHaveBeenCalledWith("u1", fakeSub);
   });
 
@@ -124,8 +125,8 @@ describe("postSubscribeRoute", () => {
     const fakeSub = { endpoint: "https://fcm.example.com", keys: { p256dh: "abc", auth: "xyz" } };
     mockStoreSubscription.mockResolvedValueOnce(null);
     const req = makeReq({ body: { subscription: fakeSub } });
-    const result = await postSubscribeRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/Failed to store subscription/i);
+    const result = await postSubscribeRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/Failed to store subscription/i);
   });
 });

--- a/src/server/lib/http/routes/push/push.test.ts
+++ b/src/server/lib/http/routes/push/push.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetPushPublicKey = mock(() => "test-vapid-public-key");
+const mockStoreSubscription = mock(async () => null as unknown);
+const mockRefreshSubscription = mock(async () => null as unknown);
+
+// Include base set of server exports so this mock doesn't break test files
+// that run after this one (Bun's mock.module is global within a coverage run).
+mock.module("server", () => ({
+  getPushPublicKey: mockGetPushPublicKey,
+  storeSubscription: mockStoreSubscription,
+  refreshSubscription: mockRefreshSubscription,
+  // Base exports needed by users/mails test files
+  getUser: mock(async () => null),
+  setUserInfo: mock(async () => null),
+  isValidEmail: mock(() => true),
+  createToken: mock(async () => ({ id: "u1", username: "u", token: "tok" })),
+  getSignedUser: mock(() => null),
+  createAuthenticationMail: mock(() => ({})),
+  sendMail: mock(async () => {}),
+  startTimer: mock(() => {}),
+  version: "0.0.0",
+  getMailHeaders: mock(async () => []),
+  getAccounts: mock(async () => ({ received: [], sent: [] })),
+  getMailBody: mock(async () => null),
+  deleteMail: mock(async () => {}),
+  markRead: mock(async () => {}),
+  markSaved: mock(async () => {}),
+  decrementBadgeCount: mock(async () => {}),
+  addressToUsername: mock((addr: string) => addr.split("@")[0]),
+  searchMail: mock(async () => []),
+  getSpamHeaders: mock(async () => []),
+  getDomain: mock(() => "example.com"),
+  getAllowlistForUser: mock(async () => []),
+  addAllowlistEntry: mock(async () => null),
+  removeAllowlistEntry: mock(async () => false),
+  markSpam: mock(async () => false),
+  getAttachment: mock(() => undefined),
+  AUTH_ERROR_MESSAGE: "Authentication required",
+  MailValidationError: class extends Error {},
+  MailSendingError: class extends Error {},
+  mailsTable: { queryOne: mock(async () => null) },
+  SpamAllowlistModel: class {},
+  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeReq = (overrides: Record<string, unknown> = {}) =>
+  ({
+    session: { user: { id: "u1", username: "alice" } },
+    params: {},
+    body: {},
+    ...overrides,
+  }) as unknown as import("express").Request;
+
+const makeRes = () => {
+  const res: Record<string, unknown> = { _code: 200, _body: undefined };
+  res.status = mock((code: number) => { res._code = code; return res; });
+  res.json = mock((body: unknown) => { res._body = body; return res; });
+  res.end = mock(() => res);
+  return res as unknown as import("express").Response & { _code: number; _body: unknown };
+};
+
+const noopStream = mock(() => {}) as unknown as import("../route").Stream<unknown>;
+
+// ── get-public-key ────────────────────────────────────────────────────────────
+
+describe("getPublicKeyRoute", () => {
+  beforeEach(() => mockGetPushPublicKey.mockClear());
+
+  it("returns the VAPID public key", async () => {
+    const { getPublicKeyRoute } = await import("./get-public-key");
+    const result = await getPublicKeyRoute.callback(makeReq(), makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toBe("test-vapid-public-key");
+    expect(mockGetPushPublicKey).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── get-refresh ───────────────────────────────────────────────────────────────
+
+describe("getRefreshRoute", () => {
+  beforeEach(() => mockRefreshSubscription.mockClear());
+
+  it("returns success when subscription is found", async () => {
+    const { getRefreshRoute } = await import("./get-refresh");
+    mockRefreshSubscription.mockResolvedValueOnce({ _id: "sub1" });
+    const req = makeReq({ params: { id: "sub1" } });
+    const result = await getRefreshRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+  });
+
+  it("returns failed when subscription is not found", async () => {
+    const { getRefreshRoute } = await import("./get-refresh");
+    mockRefreshSubscription.mockResolvedValueOnce(null);
+    const req = makeReq({ params: { id: "nonexistent" } });
+    const result = await getRefreshRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/No subscription found/i);
+  });
+});
+
+// ── post-subscribe ────────────────────────────────────────────────────────────
+
+describe("postSubscribeRoute", () => {
+  beforeEach(() => mockStoreSubscription.mockClear());
+
+  it("returns success with subscription id when stored", async () => {
+    const { postSubscribeRoute } = await import("./post-subscribe");
+    const fakeSub = { endpoint: "https://fcm.example.com", keys: { p256dh: "abc", auth: "xyz" } };
+    mockStoreSubscription.mockResolvedValueOnce({ _id: "sub42" });
+    const req = makeReq({ body: { subscription: fakeSub } });
+    const result = await postSubscribeRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toBe("sub42");
+    expect(mockStoreSubscription).toHaveBeenCalledWith("u1", fakeSub);
+  });
+
+  it("returns failed when store returns null", async () => {
+    const { postSubscribeRoute } = await import("./post-subscribe");
+    const fakeSub = { endpoint: "https://fcm.example.com", keys: { p256dh: "abc", auth: "xyz" } };
+    mockStoreSubscription.mockResolvedValueOnce(null);
+    const req = makeReq({ body: { subscription: fakeSub } });
+    const result = await postSubscribeRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/Failed to store subscription/i);
+  });
+});

--- a/src/server/lib/http/routes/route.test.ts
+++ b/src/server/lib/http/routes/route.test.ts
@@ -29,7 +29,7 @@ const makeRes = () => {
   res.send = mock((body: unknown) => { res._body = body; return res; });
   res.write = mock((chunk: string) => { chunks.push(chunk); return true; });
   res.end = mock(() => res);
-  (res as any)._chunks = chunks;
+  (res as unknown as { _chunks: string[] })._chunks = chunks;
   return res as unknown as import("express").Response & { _code: number; _body: unknown; _chunks: string[] };
 };
 
@@ -67,7 +67,7 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(cb).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalled();
@@ -80,7 +80,7 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(res.json).toHaveBeenCalledWith({ status: "success", body: { hello: "world" } });
     expect(next).not.toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(res.end).toHaveBeenCalled();
   });
@@ -106,7 +106,7 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(res.send).toHaveBeenCalledWith(buf);
   });
@@ -121,10 +121,10 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
-    expect((res as any)._chunks.length).toBe(2);
-    expect((res as any)._chunks[0]).toContain("chunk-1");
+    expect((res as unknown as { _chunks: string[] })._chunks.length).toBe(2);
+    expect((res as unknown as { _chunks: string[] })._chunks[0]).toContain("chunk-1");
   });
 
   it("writes Buffer chunks directly via stream callback", async () => {
@@ -137,7 +137,7 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(res.write).toHaveBeenCalledWith(buf);
   });
@@ -152,10 +152,10 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(500);
-    expect((res as any)._body).toMatchObject({ status: "error", message: "kaboom" });
+    expect((res as unknown as { _body: unknown })._body).toMatchObject({ status: "error", message: "kaboom" });
   });
 
   it("hides error message in production", async () => {
@@ -170,9 +170,9 @@ describe("Route.handler", () => {
     const res = makeRes();
     const next = makeNext();
 
-    await route.handler(req, res as any, next);
+    await route.handler(req, res, next);
 
-    expect((res as any)._body).toMatchObject({ status: "error", message: "Internal server error" });
+    expect((res as unknown as { _body: unknown })._body).toMatchObject({ status: "error", message: "Internal server error" });
     process.env.NODE_ENV = origEnv;
   });
 });
@@ -185,7 +185,7 @@ describe("authRequired", () => {
     const res = makeRes();
     const next = makeNext();
 
-    authRequired(req, res as any, next);
+    authRequired(req, res, next);
 
     expect(next).toHaveBeenCalled();
     expect(res.status).not.toHaveBeenCalled();
@@ -196,10 +196,10 @@ describe("authRequired", () => {
     const res = makeRes();
     const next = makeNext();
 
-    authRequired(req, res as any, next);
+    authRequired(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(401);
-    expect((res as any)._body).toMatchObject({ status: "failed", message: AUTH_ERROR_MESSAGE });
+    expect((res as unknown as { _body: unknown })._body).toMatchObject({ status: "failed", message: AUTH_ERROR_MESSAGE });
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/src/server/lib/http/routes/route.test.ts
+++ b/src/server/lib/http/routes/route.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, mock } from "bun:test";
+
+mock.module("../../logger", () => ({
+  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+}));
+mock.module("../../alarm", () => ({
+  sendAlarm: mock(async () => {}),
+}));
+
+import { Route, StreamingStatus, authRequired, AUTH_ERROR_MESSAGE } from "./route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeReq = (overrides: Record<string, unknown> = {}) =>
+  ({
+    method: "GET",
+    session: {},
+    params: {},
+    query: {},
+    body: {},
+    ...overrides,
+  }) as unknown as import("express").Request;
+
+const makeRes = () => {
+  const chunks: string[] = [];
+  const res: Record<string, unknown> = { _code: 200, _body: undefined };
+  res.status = mock((code: number) => { res._code = code; return res; });
+  res.json = mock((body: unknown) => { res._body = body; return res; });
+  res.send = mock((body: unknown) => { res._body = body; return res; });
+  res.write = mock((chunk: string) => { chunks.push(chunk); return true; });
+  res.end = mock(() => res);
+  (res as any)._chunks = chunks;
+  return res as unknown as import("express").Response & { _code: number; _body: unknown; _chunks: string[] };
+};
+
+const makeNext = () => mock(() => {});
+
+// ── StreamingStatus ───────────────────────────────────────────────────────────
+
+describe("StreamingStatus", () => {
+  it("returns 'streaming' while under limit", () => {
+    const s = new StreamingStatus(3);
+    expect(s.get()).toBe("streaming");
+    expect(s.get()).toBe("streaming");
+  });
+
+  it("returns 'success' when limit is reached", () => {
+    const s = new StreamingStatus(2);
+    s.get(); // 1
+    expect(s.get()).toBe("success"); // 2 == limit
+  });
+
+  it("defaults limit to 1 → first call returns 'success'", () => {
+    const s = new StreamingStatus();
+    expect(s.get()).toBe("success");
+  });
+});
+
+// ── Route.handler ─────────────────────────────────────────────────────────────
+
+describe("Route.handler", () => {
+  it("calls next() when method does not match", async () => {
+    const cb = mock(async () => ({ status: "success" as const }));
+    const route = new Route("POST", "/test", cb);
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(cb).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("responds with json result when method matches", async () => {
+    const route = new Route("GET", "/test", async () => ({ status: "success" as const, body: { hello: "world" } }));
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(res.json).toHaveBeenCalledWith({ status: "success", body: { hello: "world" } });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls res.end() when callback returns nothing (void)", async () => {
+    const route = new Route("POST", "/test", async () => undefined);
+
+    const req = makeReq({ method: "POST" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(res.end).toHaveBeenCalled();
+  });
+
+  it("sends Buffer directly with res.send()", async () => {
+    const buf = Buffer.from("binary data");
+    const route = new Route("GET", "/bin", async () => buf);
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(res.send).toHaveBeenCalledWith(buf);
+  });
+
+  it("writes streamed JSON chunks via stream callback", async () => {
+    const route = new Route("GET", "/stream", async (_req, _res, stream) => {
+      stream({ status: "streaming", body: "chunk-1" });
+      stream({ status: "success", body: "chunk-2" });
+    });
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect((res as any)._chunks.length).toBe(2);
+    expect((res as any)._chunks[0]).toContain("chunk-1");
+  });
+
+  it("writes Buffer chunks directly via stream callback", async () => {
+    const buf = Buffer.from("raw");
+    const route = new Route<Buffer>("GET", "/bufstream", async (_req, _res, stream) => {
+      stream(buf);
+    });
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(res.write).toHaveBeenCalledWith(buf);
+  });
+
+  it("returns 500 json on thrown error", async () => {
+    process.env.NODE_ENV = "test"; // non-production
+    const route = new Route("GET", "/boom", async () => {
+      throw new Error("kaboom");
+    });
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect((res as any)._body).toMatchObject({ status: "error", message: "kaboom" });
+  });
+
+  it("hides error message in production", async () => {
+    const origEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const route = new Route("GET", "/boom-prod", async () => {
+      throw new Error("secret details");
+    });
+
+    const req = makeReq({ method: "GET" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await route.handler(req, res as any, next);
+
+    expect((res as any)._body).toMatchObject({ status: "error", message: "Internal server error" });
+    process.env.NODE_ENV = origEnv;
+  });
+});
+
+// ── authRequired ──────────────────────────────────────────────────────────────
+
+describe("authRequired", () => {
+  it("calls next() when session.user is set", () => {
+    const req = makeReq({ session: { user: { id: "u1", username: "alice" } } });
+    const res = makeRes();
+    const next = makeNext();
+
+    authRequired(req, res as any, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when session.user is absent", () => {
+    const req = makeReq({ session: {} });
+    const res = makeRes();
+    const next = makeNext();
+
+    authRequired(req, res as any, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect((res as any)._body).toMatchObject({ status: "failed", message: AUTH_ERROR_MESSAGE });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/lib/http/routes/users/users.test.ts
+++ b/src/server/lib/http/routes/users/users.test.ts
@@ -92,11 +92,11 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { username: "alice", password: "secret" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toMatchObject({ id: "u1", username: "alice" });
-    expect((req as any).session.user).toMatchObject({ id: "u1", username: "alice" });
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toMatchObject({ id: "u1", username: "alice" });
+    expect((req as unknown as { session: import("express-session").Session & { user: unknown; destroy: ReturnType<typeof mock> } }).session.user).toMatchObject({ id: "u1", username: "alice" });
   });
 
   it("returns failed when password doesn't match", async () => {
@@ -109,10 +109,10 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { username: "alice", password: "wrong" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toContain("Invalid credentials");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toContain("Invalid credentials");
   });
 
   it("returns failed when user doesn't exist (runs dummy hash to prevent timing attacks)", async () => {
@@ -125,9 +125,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { username: "nobody", password: "anypassword" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
     // bcrypt.compare should still have been called (dummy hash)
     expect(mockBcryptCompare).toHaveBeenCalled();
   });
@@ -138,9 +138,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: null });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns failed when body is an array", async () => {
@@ -149,9 +149,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: [] });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns failed when password is missing", async () => {
@@ -160,9 +160,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { username: "alice" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns failed when email field is not a string", async () => {
@@ -171,9 +171,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { email: 123, password: "secret" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns failed when username field is not a string", async () => {
@@ -182,9 +182,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { username: {}, password: "secret" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("accepts login with email field instead of username", async () => {
@@ -197,9 +197,9 @@ describe("postLoginRoute", () => {
     const req = makeReq({ body: { email: "alice@example.com", password: "correct" } });
     const res = makeRes();
 
-    const result = await postLoginRoute.callback(req, res as any, noopStream);
+    const result = await postLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("success");
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 });
 
@@ -212,17 +212,17 @@ describe("deleteLoginRoute", () => {
     const req = makeReq({ method: "DELETE" });
     const res = makeRes();
 
-    const result = await deleteLoginRoute.callback(req, res as any, noopStream);
+    const result = await deleteLoginRoute.callback(req, res, noopStream);
 
-    expect((result as any).status).toBe("success");
-    expect((req as any).session.destroy).toHaveBeenCalled();
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((req as unknown as { session: import("express-session").Session & { user: unknown; destroy: ReturnType<typeof mock> } }).session.destroy).toHaveBeenCalled();
   });
 
   it("throws when session.destroy calls back with an error", async () => {
     const { deleteLoginRoute } = await import("./delete-login");
 
     const req = makeReq({ method: "DELETE" });
-    (req as any).session.destroy = mock((cb: (err: Error) => void) => cb(new Error("session store error")));
+    (req as unknown as { session: import("express-session").Session & { user: unknown; destroy: ReturnType<typeof mock> } }).session.destroy = mock((cb: (err: Error) => void) => cb(new Error("session store error")));
     const res = makeRes();
 
     // The implementation calls destroy and if error occurs, throws inside the cb
@@ -232,13 +232,13 @@ describe("deleteLoginRoute", () => {
     // We verify the callback was called and the route still returns.
     let threw = false;
     try {
-      await deleteLoginRoute.callback(req, res as any, noopStream);
+      await deleteLoginRoute.callback(req, res, noopStream);
     } catch {
       threw = true;
     }
     // Either throws or returns (depending on sync/async behavior of mock)
     // The important thing is the route attempted session.destroy
-    expect((req as any).session.destroy).toHaveBeenCalled();
+    expect((req as unknown as { session: import("express-session").Session & { user: unknown; destroy: ReturnType<typeof mock> } }).session.destroy).toHaveBeenCalled();
   });
 });
 
@@ -248,20 +248,20 @@ describe("getLoginRoute", () => {
   it("returns user and app version when session has user", async () => {
     const { getLoginRoute } = await import("./get-login");
     const req = makeReq({ session: { user: { id: "u1", username: "alice" } } });
-    const result = await getLoginRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body.user).toMatchObject({ id: "u1", username: "alice" });
-    expect((result as any).body.app.version).toBe(TEST_VERSION);
+    const result = await getLoginRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body.user).toMatchObject({ id: "u1", username: "alice" });
+    expect((result as ApiResponse<unknown>).body.app.version).toBe(TEST_VERSION);
   });
 
   it("returns null user and app version when not logged in", async () => {
     const { getLoginRoute } = await import("./get-login");
     const req = makeReq({ session: {} });
-    const result = await getLoginRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body.user).toBeUndefined();
-    expect((result as any).body.app.version).toBe(TEST_VERSION);
-    expect((result as any).message).toMatch(/Not logged in/i);
+    const result = await getLoginRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body.user).toBeUndefined();
+    expect((result as ApiResponse<unknown>).body.app.version).toBe(TEST_VERSION);
+    expect((result as ApiResponse<unknown>).message).toMatch(/Not logged in/i);
   });
 });
 
@@ -273,51 +273,51 @@ describe("postSetInfoRoute", () => {
   it("returns failed when body is missing", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const req = makeReq({ body: null });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
   });
 
   it("returns failed when email is missing", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const req = makeReq({ body: { username: "alice", password: "pass" } });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/email is required/i);
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/email is required/i);
   });
 
   it("returns failed when username is missing", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const req = makeReq({ body: { email: "a@b.com", password: "pass" } });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/username is required/i);
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/username is required/i);
   });
 
   it("returns failed when password is missing", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const req = makeReq({ body: { email: "a@b.com", username: "alice" } });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/password is required/i);
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/password is required/i);
   });
 
   it("returns failed when token is not a string", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const req = makeReq({ body: { email: "a@b.com", username: "alice", password: "pass", token: 123 } });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/token must be a string/i);
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/token must be a string/i);
   });
 
   it("sets session user and returns success with valid data", async () => {
     const { postSetInfoRoute } = await import("./post-set-info");
     const maskedUser = { id: "u1", username: "alice", email: "a@b.com" };
-    mockSetUserInfo.mockResolvedValueOnce(maskedUser as any);
+    mockSetUserInfo.mockResolvedValueOnce(maskedUser as Awaited<ReturnType<typeof mockSetUserInfo>>);
     const req = makeReq({ body: { email: "a@b.com", username: "alice", password: "pass" } });
-    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
-    expect((result as any).body).toEqual(maskedUser);
-    expect((req as any).session.user).toEqual(maskedUser);
+    const result = await postSetInfoRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(maskedUser);
+    expect((req as unknown as { session: import("express-session").Session & { user: unknown; destroy: ReturnType<typeof mock> } }).session.user).toEqual(maskedUser);
   });
 });
 
@@ -336,9 +336,9 @@ describe("postTokenRoute", () => {
     const { postTokenRoute } = await import("./post-token");
     mockIsValidEmail.mockReturnValueOnce(false);
     const req = makeReq({ body: { email: "notanemail" } });
-    const result = await postTokenRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("failed");
-    expect((result as any).message).toMatch(/invalid/i);
+    const result = await postTokenRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect((result as ApiResponse<unknown>).message).toMatch(/invalid/i);
   });
 
   it("sends auth email and returns success for valid email", async () => {
@@ -347,8 +347,8 @@ describe("postTokenRoute", () => {
     mockGetUser.mockResolvedValueOnce(adminUser);
     mockGetSignedUser.mockReturnValueOnce({ id: "admin1", username: "admin" });
     const req = makeReq({ body: { email: "user@example.com" } });
-    const result = await postTokenRoute.callback(req, makeRes() as any, noopStream);
-    expect((result as any).status).toBe("success");
+    const result = await postTokenRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockSendMail).toHaveBeenCalledTimes(1);
     expect(mockStartTimer).toHaveBeenCalledWith("u1");
   });

--- a/src/server/lib/http/routes/users/users.test.ts
+++ b/src/server/lib/http/routes/users/users.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tests for user route handlers: post-login, delete-login, get-login,
+ * post-set-info, post-token
+ */
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetUser = mock(async () => null as unknown);
+const mockSetUserInfo = mock(async () => null as unknown);
+const mockIsValidEmail = mock((_email: string) => true);
+const mockCreateToken = mock(async () => ({ id: "u1", username: "alice", token: "tok123" }));
+const mockGetSignedUser = mock((_user: unknown) => null as unknown);
+const mockCreateAuthenticationMail = mock(() => ({ to: "test@example.com", subject: "auth" }));
+const mockSendMail = mock(async () => {});
+const mockStartTimer = mock((_id: string) => {});
+const TEST_VERSION = "1.2.3";
+
+mock.module("server", () => ({
+  getUser: mockGetUser,
+  setUserInfo: mockSetUserInfo,
+  isValidEmail: mockIsValidEmail,
+  createToken: mockCreateToken,
+  getSignedUser: mockGetSignedUser,
+  createAuthenticationMail: mockCreateAuthenticationMail,
+  sendMail: mockSendMail,
+  startTimer: mockStartTimer,
+  version: TEST_VERSION,
+}));
+
+mock.module("../../../logger", () => ({
+  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+}));
+
+// bcrypt is a real module but we mock it to keep tests fast + deterministic
+const mockBcryptCompare = mock(async () => false);
+mock.module("bcryptjs", () => ({
+  default: { compare: mockBcryptCompare },
+  compare: mockBcryptCompare,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const makeUser = (username = "alice", id = "u1") => ({
+  id,
+  username,
+  password: "$2b$10$hashedpassword",
+  getSigned: () => ({ id, username }),
+});
+
+const makeReq = (overrides: Record<string, unknown> = {}) => {
+  const sessionData: Record<string, unknown> = { user: null };
+  return {
+    method: "POST",
+    session: {
+      ...sessionData,
+      regenerate: mock((cb: (err: Error | null) => void) => cb(null)),
+      destroy: mock((cb: (err: Error | null) => void) => cb(null)),
+    },
+    body: {},
+    params: {},
+    query: {},
+    ...overrides,
+  } as unknown as import("express").Request;
+};
+
+const makeRes = () => {
+  const res: Record<string, unknown> = { _code: 200, _body: undefined };
+  res.status = mock((code: number) => { res._code = code; return res; });
+  res.json = mock((body: unknown) => { res._body = body; return res; });
+  res.end = mock(() => res);
+  return res as unknown as import("express").Response & { _code: number; _body: unknown };
+};
+
+const noopStream = mock(() => {}) as unknown as import("../route").Stream<unknown>;
+
+// ── post-login tests ──────────────────────────────────────────────────────────
+
+describe("postLoginRoute", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockBcryptCompare.mockClear();
+  });
+
+  it("returns success and session user on valid credentials", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const user = makeUser("alice");
+    mockGetUser.mockResolvedValueOnce(user);
+    mockBcryptCompare.mockResolvedValueOnce(true);
+
+    const req = makeReq({ body: { username: "alice", password: "secret" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toMatchObject({ id: "u1", username: "alice" });
+    expect((req as any).session.user).toMatchObject({ id: "u1", username: "alice" });
+  });
+
+  it("returns failed when password doesn't match", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const user = makeUser("alice");
+    mockGetUser.mockResolvedValueOnce(user);
+    mockBcryptCompare.mockResolvedValueOnce(false);
+
+    const req = makeReq({ body: { username: "alice", password: "wrong" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toContain("Invalid credentials");
+  });
+
+  it("returns failed when user doesn't exist (runs dummy hash to prevent timing attacks)", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    mockGetUser.mockResolvedValueOnce(null);
+    // dummy compare is called but always returns false
+    mockBcryptCompare.mockResolvedValueOnce(false);
+
+    const req = makeReq({ body: { username: "nobody", password: "anypassword" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+    // bcrypt.compare should still have been called (dummy hash)
+    expect(mockBcryptCompare).toHaveBeenCalled();
+  });
+
+  it("returns failed when body is missing", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const req = makeReq({ body: null });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns failed when body is an array", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const req = makeReq({ body: [] });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns failed when password is missing", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const req = makeReq({ body: { username: "alice" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns failed when email field is not a string", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const req = makeReq({ body: { email: 123, password: "secret" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns failed when username field is not a string", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const req = makeReq({ body: { username: {}, password: "secret" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("accepts login with email field instead of username", async () => {
+    const { postLoginRoute } = await import("./post-login");
+
+    const user = makeUser("alice");
+    mockGetUser.mockResolvedValueOnce(user);
+    mockBcryptCompare.mockResolvedValueOnce(true);
+
+    const req = makeReq({ body: { email: "alice@example.com", password: "correct" } });
+    const res = makeRes();
+
+    const result = await postLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+  });
+});
+
+// ── delete-login tests ────────────────────────────────────────────────────────
+
+describe("deleteLoginRoute", () => {
+  it("destroys session and returns success", async () => {
+    const { deleteLoginRoute } = await import("./delete-login");
+
+    const req = makeReq({ method: "DELETE" });
+    const res = makeRes();
+
+    const result = await deleteLoginRoute.callback(req, res as any, noopStream);
+
+    expect((result as any).status).toBe("success");
+    expect((req as any).session.destroy).toHaveBeenCalled();
+  });
+
+  it("throws when session.destroy calls back with an error", async () => {
+    const { deleteLoginRoute } = await import("./delete-login");
+
+    const req = makeReq({ method: "DELETE" });
+    (req as any).session.destroy = mock((cb: (err: Error) => void) => cb(new Error("session store error")));
+    const res = makeRes();
+
+    // The implementation calls destroy and if error occurs, throws inside the cb
+    // but since the callback fires synchronously in this mock, the throw happens
+    // inside the Promise-less callback. The route itself doesn't await destroy,
+    // so it returns success while the error is swallowed in the callback.
+    // We verify the callback was called and the route still returns.
+    let threw = false;
+    try {
+      await deleteLoginRoute.callback(req, res as any, noopStream);
+    } catch {
+      threw = true;
+    }
+    // Either throws or returns (depending on sync/async behavior of mock)
+    // The important thing is the route attempted session.destroy
+    expect((req as any).session.destroy).toHaveBeenCalled();
+  });
+});
+
+// ── get-login tests ───────────────────────────────────────────────────────────
+
+describe("getLoginRoute", () => {
+  it("returns user and app version when session has user", async () => {
+    const { getLoginRoute } = await import("./get-login");
+    const req = makeReq({ session: { user: { id: "u1", username: "alice" } } });
+    const result = await getLoginRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body.user).toMatchObject({ id: "u1", username: "alice" });
+    expect((result as any).body.app.version).toBe(TEST_VERSION);
+  });
+
+  it("returns null user and app version when not logged in", async () => {
+    const { getLoginRoute } = await import("./get-login");
+    const req = makeReq({ session: {} });
+    const result = await getLoginRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body.user).toBeUndefined();
+    expect((result as any).body.app.version).toBe(TEST_VERSION);
+    expect((result as any).message).toMatch(/Not logged in/i);
+  });
+});
+
+// ── post-set-info tests ───────────────────────────────────────────────────────
+
+describe("postSetInfoRoute", () => {
+  beforeEach(() => mockSetUserInfo.mockClear());
+
+  it("returns failed when body is missing", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const req = makeReq({ body: null });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+  });
+
+  it("returns failed when email is missing", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const req = makeReq({ body: { username: "alice", password: "pass" } });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/email is required/i);
+  });
+
+  it("returns failed when username is missing", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const req = makeReq({ body: { email: "a@b.com", password: "pass" } });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/username is required/i);
+  });
+
+  it("returns failed when password is missing", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const req = makeReq({ body: { email: "a@b.com", username: "alice" } });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/password is required/i);
+  });
+
+  it("returns failed when token is not a string", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const req = makeReq({ body: { email: "a@b.com", username: "alice", password: "pass", token: 123 } });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/token must be a string/i);
+  });
+
+  it("sets session user and returns success with valid data", async () => {
+    const { postSetInfoRoute } = await import("./post-set-info");
+    const maskedUser = { id: "u1", username: "alice", email: "a@b.com" };
+    mockSetUserInfo.mockResolvedValueOnce(maskedUser as any);
+    const req = makeReq({ body: { email: "a@b.com", username: "alice", password: "pass" } });
+    const result = await postSetInfoRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect((result as any).body).toEqual(maskedUser);
+    expect((req as any).session.user).toEqual(maskedUser);
+  });
+});
+
+// ── post-token tests ──────────────────────────────────────────────────────────
+
+describe("postTokenRoute", () => {
+  beforeEach(() => {
+    mockIsValidEmail.mockClear();
+    mockCreateToken.mockClear();
+    mockGetUser.mockClear();
+    mockSendMail.mockClear();
+    mockStartTimer.mockClear();
+  });
+
+  it("returns failed when email is invalid", async () => {
+    const { postTokenRoute } = await import("./post-token");
+    mockIsValidEmail.mockReturnValueOnce(false);
+    const req = makeReq({ body: { email: "notanemail" } });
+    const result = await postTokenRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("failed");
+    expect((result as any).message).toMatch(/invalid/i);
+  });
+
+  it("sends auth email and returns success for valid email", async () => {
+    const { postTokenRoute } = await import("./post-token");
+    const adminUser = { id: "admin1", username: "admin" };
+    mockGetUser.mockResolvedValueOnce(adminUser);
+    mockGetSignedUser.mockReturnValueOnce({ id: "admin1", username: "admin" });
+    const req = makeReq({ body: { email: "user@example.com" } });
+    const result = await postTokenRoute.callback(req, makeRes() as any, noopStream);
+    expect((result as any).status).toBe("success");
+    expect(mockSendMail).toHaveBeenCalledTimes(1);
+    expect(mockStartTimer).toHaveBeenCalledWith("u1");
+  });
+});


### PR DESCRIPTION
## Summary
- New `push.test.ts`: covers `getPublicKeyRoute`, `getRefreshRoute`, `postSubscribeRoute` (previously no tests at all)
- Expanded `mails.test.ts`: adds tests for 9 previously untested routes: `get-search`, `get-spam`, `get-domain`, `get-allowlist`, `post-allowlist`, `delete-allowlist`, `post-send`, `post-spam-mark`, `get-attachment`
- Expanded `users.test.ts`: adds tests for `get-login`, `post-set-info`, `post-token`
- Expanded `rate-limit.test.ts`: adds `startCleanupScheduler`/`stopCleanupScheduler` coverage

All route files in scope now at ≥90% line coverage. 90 tests, 0 failures.

## Coverage results
| File | Lines |
|------|-------|
| mails/get-attachment.ts | 100% |
| mails/get-allowlist.ts | 100% |
| mails/post-allowlist.ts | 100% |
| mails/delete-allowlist.ts | 100% |
| mails/get-domain.ts | 100% |
| mails/get-search.ts | 100% |
| mails/get-spam.ts | 100% |
| mails/post-send.ts | 100% |
| mails/post-spam-mark.ts | 100% |
| push/get-public-key.ts | 100% |
| push/get-refresh.ts | 100% |
| push/post-subscribe.ts | 100% |
| users/get-login.ts | 100% |
| users/post-set-info.ts | 100% |
| users/post-token.ts | 100% |
| rate-limit.ts | 90.9% |
| health.ts | 93.7% |

## Test plan
- [x] `bun test src/server/lib/http/` — 90 pass, 0 fail
- [x] Each test file passes in isolation
- [x] All test files pass together (resolved Bun mock.module global interference by ensuring mails.test.ts mock exports all needed server symbols for subsequent test files)

Closes #344