### PR TITLE
test: add coverage for src/server/lib/util.ts (partial #345)

### DIFF
--- a/src/server/lib/util.test.ts
+++ b/src/server/lib/util.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { getDomain, getUserDomain } from "./util";
+
+describe("getDomain", () => {
+  const originalEnv = process.env.EMAIL_DOMAIN;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.EMAIL_DOMAIN = originalEnv;
+    } else {
+      delete process.env.EMAIL_DOMAIN;
+    }
+  });
+
+  it("returns EMAIL_DOMAIN env var when set", () => {
+    process.env.EMAIL_DOMAIN = "example.com";
+    expect(getDomain()).toBe("example.com");
+  });
+
+  it("returns 'mydomain' as default when EMAIL_DOMAIN is unset", () => {
+    delete process.env.EMAIL_DOMAIN;
+    expect(getDomain()).toBe("mydomain");
+  });
+});
+
+describe("getUserDomain", () => {
+  const originalEnv = process.env.EMAIL_DOMAIN;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.EMAIL_DOMAIN = originalEnv;
+    } else {
+      delete process.env.EMAIL_DOMAIN;
+    }
+  });
+
+  it("returns base domain for admin user", () => {
+    process.env.EMAIL_DOMAIN = "example.com";
+    expect(getUserDomain("admin")).toBe("example.com");
+  });
+
+  it("returns subdomain for regular user", () => {
+    process.env.EMAIL_DOMAIN = "example.com";
+    expect(getUserDomain("alice")).toBe("alice.example.com");
+  });
+
+  it("uses default domain when EMAIL_DOMAIN is unset", () => {
+    delete process.env.EMAIL_DOMAIN;
+    expect(getUserDomain("bob")).toBe("bob.mydomain");
+  });
+});


### PR DESCRIPTION
## Summary
- New \`src/server/lib/util.test.ts\` covering \`getDomain\` and \`getUserDomain\`
- \`util.ts\` reaches 100% line and 100% function coverage
- 5 tests, 0 failures

## Why this PR is small
Issue #345 lists 5 files: \`users.ts\`, \`smtp.ts\`, \`push.ts\`, \`session.ts\`, \`util.ts\`. Coverage check from \`main\`:

| File | Functions | Lines |
|------|-----------|-------|
| session.ts (pure re-export, no behavior) | 100% | 100% |
| util.ts (before this PR) | 100% | 0% |
| util.ts (after this PR) | 100% | 100% |
| push.ts | 77.78% | 40.54% |
| smtp.ts | 73.33% | 46.49% |
| users.ts | 0% | 10.20% |

Remaining work for \`push.ts\`, \`users.ts\`, and \`smtp.ts\` will land in separate PRs — those modules pull in the \`server\` barrel transitively (idle-manager, mail repos, etc.), so each one needs a comprehensive mock surface to avoid Bun's "Export named X not found" ESM linkage errors. Splitting them keeps review scope tight and avoids one large mock-heavy PR.

## Test plan
- [x] \`bun test src/server/lib/util.test.ts\` — 5 pass, 0 fail
- [x] \`bun test src/server/lib/util.test.ts --coverage\` — 100% lines / 100% functions on \`util.ts\`
- [x] \`bunx eslint src/server/lib/util.test.ts\` — clean (no \`any\`)
- [x] \`bun run typecheck\` — clean

Refs #345