### PR TITLE
fix(imap): re-apply user-domain filter to LIST mailbox stats (Closes #437)

### DIFF
--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for store.ts — IMAP Store class.
+ *
+ * Regression coverage for: listMailboxes must filter getAccountStats by the
+ * user's domain so external CC/BCC/recipient addresses on stored mails do
+ * not leak into the IMAP mailbox listing. PR #310 originally added this
+ * filter; PR #196 (CREATE/DELETE/RENAME mailboxes) inadvertently removed it.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { SignedUser } from "common";
+
+const mockGetAccountStats = mock(() => Promise.resolve([]));
+const mockCountMessages = mock(() => Promise.resolve({ total: 0, unread: 0, maxUid: 0 }));
+const mockGetMailsByRange = mock(() => Promise.resolve(new Map()));
+const mockSetMailFlags = mock(() => Promise.resolve());
+const mockSearchMailsByUid = mock(() => Promise.resolve([]));
+const mockSaveMail = mock(() => Promise.resolve({ _id: "x" }));
+const mockExpunge = mock(() => Promise.resolve(0));
+const mockGetAllUids = mock(() => Promise.resolve([]));
+
+mock.module("../postgres/repositories/mails", () => ({
+  getAccountStats: mockGetAccountStats,
+  countMessages: mockCountMessages,
+  getMailsByRange: mockGetMailsByRange,
+  setMailFlags: mockSetMailFlags,
+  searchMailsByUid: mockSearchMailsByUid,
+  saveMail: mockSaveMail,
+  expungeDeletedMails: mockExpunge,
+  getAllUids: mockGetAllUids,
+}));
+
+const mockGetMailboxesByUser = mock(() => Promise.resolve([]));
+mock.module("../postgres/repositories/mailboxes", () => ({
+  getMailboxesByUser: mockGetMailboxesByUser,
+}));
+
+mock.module("server", () => ({
+  logger: { warn: mock(() => {}), error: mock(() => {}), info: mock(() => {}), debug: mock(() => {}) },
+  getUserDomain: (username: string) =>
+    username === "admin" ? "example.com" : `${username}.example.com`,
+}));
+
+import { Store } from "./store";
+
+const makeUser = (overrides: Partial<{ id: string; username: string; email: string }> = {}) =>
+  new SignedUser({
+    id: "user-123",
+    username: "alice",
+    email: "alice@alice.example.com",
+    ...overrides,
+  });
+
+describe("Store.listMailboxes", () => {
+  beforeEach(() => {
+    mockGetAccountStats.mockClear();
+    mockGetMailboxesByUser.mockClear();
+    mockGetAccountStats.mockResolvedValue([]);
+    mockGetMailboxesByUser.mockResolvedValue([]);
+  });
+
+  it("passes the user's domain as the third arg to both getAccountStats calls (regression PR #310 / #196)", async () => {
+    const store = new Store(makeUser());
+    await store.listMailboxes();
+
+    expect(mockGetAccountStats).toHaveBeenCalledTimes(2);
+    expect(mockGetAccountStats).toHaveBeenCalledWith("user-123", false, "alice.example.com");
+    expect(mockGetAccountStats).toHaveBeenCalledWith("user-123", true, "alice.example.com");
+  });
+
+  it("uses the bare EMAIL_DOMAIN for the admin user, not 'admin.<domain>'", async () => {
+    const store = new Store(
+      makeUser({ id: "admin-1", username: "admin", email: "admin@example.com" })
+    );
+    await store.listMailboxes();
+
+    expect(mockGetAccountStats).toHaveBeenCalledWith("admin-1", false, "example.com");
+    expect(mockGetAccountStats).toHaveBeenCalledWith("admin-1", true, "example.com");
+  });
+
+  it("returns ['INBOX'] when no accounts and no user mailboxes exist", async () => {
+    const store = new Store(makeUser());
+    const result = await store.listMailboxes();
+    expect(result).toEqual(["INBOX"]);
+  });
+});

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -56,9 +56,13 @@ export class Store {
 
   listMailboxes = async (): Promise<string[]> => {
     try {
+      // Match HTTP /api/mails/accounts: filter by user's domain so we only
+      // expose addresses that belong to this server, not every external
+      // CC/BCC/recipient address found on stored mails.
+      const userDomain = getUserDomain(this.user.username);
       const [receivedStats, sentStats, userMailboxes] = await Promise.all([
-        getAccountStats(this.user.id, false),
-        getAccountStats(this.user.id, true),
+        getAccountStats(this.user.id, false, userDomain),
+        getAccountStats(this.user.id, true, userDomain),
         getMailboxesByUser(this.user.id),
       ]);
 


### PR DESCRIPTION
## Summary
- Re-introduce the \`userDomain\` argument on both \`getAccountStats\` calls in \`Store.listMailboxes\` so IMAP \`LIST\` output matches the HTTP \`/api/mails/accounts\` endpoint and stops exposing external recipient addresses as fake mailboxes.
- Add \`src/server/lib/imap/store.test.ts\` with a regression assertion that both stats calls receive the domain argument, so the next refactor of this \`Promise.all\` can't silently drop it again.

## Background
PR #310 (Mar 16) originally added the filter; PR #196 (Mar 22, CREATE/DELETE/RENAME mailboxes) rewrote the \`Promise.all\` to include \`getMailboxesByUser\` and dropped the third argument from both \`getAccountStats(this.user.id, …)\` calls in the process.

Full repro and root-cause writeup: #437.

## Diff (essence)
\`\`\`diff
+      // Match HTTP /api/mails/accounts: filter by user's domain so we only
+      // expose addresses that belong to this server, not every external
+      // CC/BCC/recipient address found on stored mails.
+      const userDomain = getUserDomain(this.user.username);
       const [receivedStats, sentStats, userMailboxes] = await Promise.all([
-        getAccountStats(this.user.id, false),
-        getAccountStats(this.user.id, true),
+        getAccountStats(this.user.id, false, userDomain),
+        getAccountStats(this.user.id, true, userDomain),
         getMailboxesByUser(this.user.id),
       ]);
\`\`\`

## Test plan
- [x] New test file \`src/server/lib/imap/store.test.ts\` — 3 tests, all pass.
- [x] Verified the new tests **fail** on \`upstream/main\` (without the fix): the two \`toHaveBeenCalledWith(\"...\", false|true, \"<domain>\")\` assertions report only two-argument call shapes — i.e. the test catches the regression.
- [x] \`bun test src/server/lib/imap/ src/server/lib/mails/accounts.test.ts\` → 358 pass, 0 fail.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` reports no new warnings on changed files.
- [ ] End-to-end IMAP repro deferred — would require sending a real outbound mail to an external address through Mailgun, which the dev environment isn't set up for. Code path inspection + unit test is the verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)