### PR TITLE
fix(a11y): keyboard support for primary clickable divs (Closes #229)

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -22,7 +22,14 @@ import {
 
 import { Account } from "common";
 import { AccountsGetResponse, LoginDeleteResponse } from "server";
-import { Context, Category, useLocalStorage, QueryCache, call } from "client";
+import {
+  Context,
+  Category,
+  useLocalStorage,
+  QueryCache,
+  call,
+  onKeyboardActivate
+} from "client";
 import { MailsSynchronizer } from "client/Box";
 
 import "./index.scss";
@@ -196,7 +203,13 @@ const Accounts = ({
 
       return (
         <div key={i}>
-          <div className={classes.join(" ")} onClick={onClickAccount}>
+          <div
+            className={classes.join(" ")}
+            role="button"
+            tabIndex={0}
+            onClick={onClickAccount}
+            onKeyDown={onKeyboardActivate(onClickAccount)}
+          >
             <span>{accountName?.split("@")[0] || "Unknown"}</span>
             {unreadNo && selectedCategory !== Category.SavedMails ? (
               <div className="numberBall">{unreadNo}</div>
@@ -276,7 +289,15 @@ const Accounts = ({
       if (e === Category.Search) classes.push("flex");
 
       return (
-        <div key={i} className={classes.join(" ")} onClick={onClickCategory}>
+        <div
+          key={i}
+          className={classes.join(" ")}
+          role="tab"
+          tabIndex={0}
+          aria-selected={selectedCategory === e}
+          onClick={onClickCategory}
+          onKeyDown={onKeyboardActivate(onClickCategory)}
+        >
           {e === Category.Search ? (
             <SearchIcon />
           ) : (

--- a/src/client/Box/components/Mails/components/MailHeader.tsx
+++ b/src/client/Box/components/Mails/components/MailHeader.tsx
@@ -1,10 +1,11 @@
 import { ComponentProps, useContext } from "react";
-import { Context, getDateForMailHeader } from "client";
+import { Context, getDateForMailHeader, onKeyboardActivate } from "client";
 import { MailAddressValueType, MailHeaderData } from "common";
 
-export interface MailHeaderProps extends ComponentProps<"div"> {
+export interface MailHeaderProps extends Omit<ComponentProps<"div">, "onClick"> {
   mail: MailHeaderData;
   isActive: boolean;
+  onClick?: () => void;
 }
 
 const MailHeader = (props: MailHeaderProps) => {
@@ -27,7 +28,10 @@ const MailHeader = (props: MailHeaderProps) => {
   return (
     <div
       className="header cursor"
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={onClick ? onKeyboardActivate(onClick) : undefined}
       onMouseLeave={onMouseLeave}
     >
       <div className="mailcard-small content">{duration}</div>

--- a/src/client/Header/components/LeftMenu/index.tsx
+++ b/src/client/Header/components/LeftMenu/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Context } from "client";
+import { Context, onKeyboardActivate } from "client";
 import HamburgerIcon from "./components/HamburgerIcon";
 
 const LeftMenu = () => {
@@ -19,7 +19,15 @@ const LeftMenu = () => {
   };
 
   return (
-    <div className="menu left cursor" onClick={onClickHamburger}>
+    <div
+      className="menu left cursor"
+      role="button"
+      tabIndex={0}
+      aria-label="Toggle accounts panel"
+      aria-expanded={isAccountsOpen}
+      onClick={onClickHamburger}
+      onKeyDown={onKeyboardActivate(onClickHamburger)}
+    >
       <div id="hamburger" className="iconBox">
         <div>
           <HamburgerIcon />

--- a/src/client/Header/components/RightMenu/index.tsx
+++ b/src/client/Header/components/RightMenu/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { Context } from "client";
+import { Context, onKeyboardActivate } from "client";
 import WriteIcon from "./components/WriteIcon";
 
 const RightMenu = () => {
@@ -10,7 +10,14 @@ const RightMenu = () => {
   };
 
   return (
-    <div className="menu right cursor" onClick={onClickWriter}>
+    <div
+      className="menu right cursor"
+      role="button"
+      tabIndex={0}
+      aria-label={isWriterOpen ? "Close compose" : "Compose new mail"}
+      onClick={onClickWriter}
+      onKeyDown={onKeyboardActivate(onClickWriter)}
+    >
       <div id="write" className="iconBox">
         <WriteIcon />
       </div>

--- a/src/client/lib/a11y.ts
+++ b/src/client/lib/a11y.ts
@@ -1,0 +1,14 @@
+import { KeyboardEvent } from "react";
+
+/**
+ * Wrap a click-style handler so it also fires on Enter/Space when focused.
+ * Use with `role="button"` and `tabIndex={0}` on non-button elements that
+ * have `onClick`.
+ */
+export const onKeyboardActivate =
+  (handler: () => void) => (e: KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handler();
+    }
+  };

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -6,3 +6,4 @@ export * from "./html";
 export * from "./call";
 export * from "./user";
 export * from "./queryClient";
+export * from "./a11y";


### PR DESCRIPTION
## Summary

Addresses priority items 1–3 from #229 — adds keyboard activation (Enter/Space) and ARIA roles to the **primary** non-button clickable divs:

| Element | File | Change |
|---|---|---|
| Mail card header | `Mails/components/MailHeader.tsx` | `role=\"button\"`, `tabIndex={0}`, `onKeyDown` |
| Account row | `Accounts/index.tsx:199` | `role=\"button\"`, `tabIndex={0}`, `onKeyDown` |
| Category tab | `Accounts/index.tsx:279` | `role=\"tab\"`, `tabIndex={0}`, `aria-selected`, `onKeyDown` |
| Hamburger menu | `Header/LeftMenu/index.tsx` | `role=\"button\"`, `aria-label`, `aria-expanded`, `onKeyDown` |
| Compose menu | `Header/RightMenu/index.tsx` | `role=\"button\"`, dynamic `aria-label`, `onKeyDown` |

New shared helper `src/client/lib/a11y.ts` → `onKeyboardActivate(handler)` wraps a click-style callback so it also fires on Enter/Space. Single 7-line helper used at all five sites.

## Scope

The issue lists 6 sites (priority 1–3) plus form labels and skip-to-content (priorities 4+). This PR covers priority 1–3 only — the highest-traffic interactive elements. Form labels, skip-to-content, and focus management when switching between mail list/body views are intentionally **not** in this PR and can land as follow-ups so review stays focused.

The mail-card sub-actions (`star`, `reply`, `share`, `trash`, `kebab` icon boxes inside `Mails/index.tsx`) are also deferred — they're inside the mail card and need a small CSS pass to keep the focus ring visually contained, which is more cleanly addressed separately.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings on changed files (16 pre-existing warnings elsewhere unchanged)
- [x] `bun test` — 581 pass, 0 fail
- [x] `bun run build-client` — builds cleanly (existing dynamic-import warnings unchanged)
- [x] Vite dev server starts; HMR-served `RightMenu` module verified to contain `tabIndex: 0`, `role: \"button\"`, `aria-label`, and `onKeyDown: onKeyboardActivate(...)` in the transformed source
- [ ] **Manual browser keyboard test deferred** — actual Tab/Enter/Space interaction needs a logged-in browser session against the running app. Code path is mechanical (the helper just calls the existing onClick on the matching key) and unit-test-equivalent verification is the served-source check above. Hoie, please confirm tab order feels right when you pick this up, especially the category-tab `role=\"tab\"` (debated `role=\"button\"` vs `role=\"tab\"` here — went with `tab` because they're a single-selection group).

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)