### PR TITLE
docs: fix stale env var names and commands in CONTRIBUTING and docs/

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,14 +31,14 @@ bun test
 If a module requires secrets at import time, refactor to lazy initialization:
 
 ```typescript
-// ❌ Bad: Fails if VAPID_KEY is missing
-const vapidKey = process.env.VAPID_KEY!;
+// ❌ Bad: Fails if PUSH_VAPID_PRIVATE_KEY is missing
+const vapidKey = process.env.PUSH_VAPID_PRIVATE_KEY!;
 export const push = webpush.setVapidDetails(...);
 
 // ✅ Good: Only fails when actually used
 export const getPushService = () => {
-  const vapidKey = process.env.VAPID_KEY;
-  if (!vapidKey) throw new Error("VAPID_KEY required for push notifications");
+  const vapidKey = process.env.PUSH_VAPID_PRIVATE_KEY;
+  if (!vapidKey) throw new Error("PUSH_VAPID_PRIVATE_KEY required for push notifications");
   return webpush.setVapidDetails(...);
 };
 ```
@@ -53,7 +53,7 @@ const mockApiKey = "test_key_not_real_do_not_use";
 const mockToken = "fake-jwt-token-for-testing";
 
 // ✅ Use test utilities
-const mockEnv = { VAPID_KEY: "TEST_VAPID_KEY_PLACEHOLDER" };
+const mockEnv = { PUSH_VAPID_PRIVATE_KEY: "TEST_VAPID_KEY_PLACEHOLDER" };
 ```
 
 ### Pre-Commit Checklist
@@ -69,7 +69,7 @@ Before committing, verify:
 
 - TypeScript for all new code
 - Use existing patterns in the codebase
-- Run `bun run build` to verify no type errors
+- Run `bun run typecheck` to verify no type errors
 
 ## Pull Requests
 
@@ -81,11 +81,14 @@ Before committing, verify:
 ## Environment Variables
 
 Required for full functionality:
-- `DATABASE_URL` — PostgreSQL connection string
-- `SESSION_SECRET` — Express session secret
+- `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DATABASE` — PostgreSQL connection
+- `SECRET` — Express session secret
+- `EMAIL_DOMAIN` — Domain used for `*@EMAIL_DOMAIN` mail addresses
+- `ADMIN_PASSWORD` — Password for the built-in `admin` user
 
 Optional:
-- `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` — For push notifications
-- `MAILGUN_API_KEY`, `MAILGUN_DOMAIN` — For outbound email
+- `APP_HOSTNAME` — Server hostname for IMAP/SMTP TLS (falls back to `EMAIL_DOMAIN`)
+- `PUSH_VAPID_PUBLIC_KEY`, `PUSH_VAPID_PRIVATE_KEY` — For push notifications
+- `MAILGUN_KEY` — For outbound email via Mailgun
 
 See `.env.example` for the full list.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -5,9 +5,10 @@
   - `src/server`: All component modules that powers backend server
     - `src/server/lib/http`: Express server, middleware and API route handlers (`src/server/lib/http/routes`).
     - `src/server/lib/imap`: IMAP server implementation.
-    - `src/server/lib/smtp`: SMTP server implementation.
     - `src/server/lib/mails`: Mail processing and Mailgun integration.
     - `src/server/lib/postgres`: Database layer (client, models, repositories).
+    - `src/server/lib/spam`: Spam classification.
+    - `src/server/lib/smtp.ts`: SMTP server (single file).
 - `public`: Static assets served by the client build.
 
 # CLI scripts

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1,16 +1,21 @@
 # Directory structure
 
-- `src`: React build source code
+- `src`: Source code
   - `src/client`: React components. Subdirectories follow mounting order.
   - `src/server`: All component modules that powers backend server
-    - `src/server/routes`: Routing modules that determines API paths and entrypoints.
-    - `src/server/lib`: Lower level modules that functions in between routers and database.
-- `public`: React public files
+    - `src/server/lib/http`: Express server, middleware and API route handlers (`src/server/lib/http/routes`).
+    - `src/server/lib/imap`: IMAP server implementation.
+    - `src/server/lib/smtp`: SMTP server implementation.
+    - `src/server/lib/mails`: Mail processing and Mailgun integration.
+    - `src/server/lib/postgres`: Database layer (client, models, repositories).
+- `public`: Static assets served by the client build.
 
 # CLI scripts
 
-- `npm start`: Builds and runs (production mode)
-- `npm build`: Builds server & client
-- `npm run dev`: Runs server & client separately without building (development mode)
-- `npm run dev-server`: Runs backend server only in development mode
-- `npm run dev-clientfront`: Runs frontend server only in development mode
+- `bun start`: Builds and runs (production mode)
+- `bun run build`: Builds server & client
+- `bun run dev`: Runs server & client separately without building (development mode)
+- `bun run dev-server`: Runs backend server only in development mode
+- `bun run dev-client`: Runs frontend server only in development mode
+- `bun run typecheck`: Type-check the codebase without emitting
+- `bun test`: Run the test suite

--- a/docs/how_to_setup.md
+++ b/docs/how_to_setup.md
@@ -15,7 +15,7 @@ For detailed instruction, please keep reading this document.
 
 1. Clone this git repository
    ```
-   git clone https://github.com/garageScript/inbox.git
+   git clone https://github.com/hoiekim/inbox.git
    ```
 2. Copy `.env.example` file and name it `.env.local` then determine environment variables in `.env.local` file as following.
 
@@ -24,7 +24,7 @@ For detailed instruction, please keep reading this document.
    APP_HOSTNAME             // Domain name that hosts inbox web app.
 
    SECRET                   // Encoding secret for session data. Any value works.
-   ADMIN_PW                 // Password to login to Inbox as admin user.
+   ADMIN_PASSWORD           // Password to login to Inbox as admin user.
 
    MAILGUN_KEY              // (optional) API key issued by Mailgun. Used to send emails.
 
@@ -81,8 +81,8 @@ If you want to use this app only for receiving mails, skip this step.
    Then run app using this command
 
    ```
-   npm i
-   npm run dev
+   bun install
+   bun run dev
    ```
 
 ### Environment Variables
@@ -95,4 +95,4 @@ Default port number is 3004. So you can connect to Inbox at http://(your-server-
 
 For development mode, use port number 3000 instead.
 
-Admin username is `admin`, password is equal to the value of environment variable called `ADMIN_PW`
+Admin username is `admin`, password is equal to the value of environment variable called `ADMIN_PASSWORD`


### PR DESCRIPTION
## Summary

Three docs files (`CONTRIBUTING.md`, `docs/how_to_setup.md`, `docs/dev_guide.md`) were added back in March (commit for #210) and have never been audited against the current `.env.example` / `package.json` / source layout. Daily ops review caught multiple staleness items.

### What changed

**`CONTRIBUTING.md`**
- "Environment Variables" listed env vars that **do not exist in the code**: `DATABASE_URL`, `SESSION_SECRET`, `VAPID_PUBLIC_KEY`/`VAPID_PRIVATE_KEY`, `MAILGUN_API_KEY`/`MAILGUN_DOMAIN`. Replaced with the real names (`POSTGRES_*`, `SECRET`, `PUSH_VAPID_*`, `MAILGUN_KEY`) plus the always-required `EMAIL_DOMAIN` and `ADMIN_PASSWORD`.
- Lazy-init TS example used `process.env.VAPID_KEY` (3 spots). Renamed to `PUSH_VAPID_PRIVATE_KEY` to match `src/server/lib/push.ts:20`.
- "Code Style" said run `bun run build` to verify type errors → `bun run typecheck` (the dedicated script).

**`docs/how_to_setup.md`**
- `git clone https://github.com/garageScript/inbox.git` → `hoiekim/inbox.git`.
- `ADMIN_PW` (twice — env table + step 5) → `ADMIN_PASSWORD` (matches `src/server/lib/postgres/initialize.ts:143`).
- Dev run commands `npm i` / `npm run dev` → `bun install` / `bun run dev` to match the `bun`-prefixed scripts in `package.json` and the rest of CONTRIBUTING.md.

**`docs/dev_guide.md`**
- Listed `src/server/routes` — routes actually live under `src/server/lib/http/routes`. Replaced the directory listing with the real `src/server/lib/{http,imap,smtp,mails,postgres}` layout (matches `DEVELOPMENT.md`).
- CLI scripts used `npm` and referenced `npm run dev-clientfront` — the real script is `dev-client`. Switched to `bun` and added `typecheck` / `test` for parity with `package.json`.

### Verified against
- `.env.example` (env var names)
- `src/server/lib/postgres/client.ts:4` (`POSTGRES_HOST`)
- `src/server/lib/http/index.ts:42` (`process.env.SECRET`)
- `src/server/lib/push.ts:20` (`PUSH_VAPID_PUBLIC_KEY`/`PUSH_VAPID_PRIVATE_KEY`)
- `src/server/lib/mails/mailgun.ts:11` (`MAILGUN_KEY`)
- `src/server/lib/postgres/initialize.ts:143` (`ADMIN_PASSWORD`)
- `package.json` (script names: `dev-client`, `typecheck`, etc.)

`grep` for the deleted names (`SESSION_SECRET`, `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, `ADMIN_PW`, `VAPID_KEY`) returns zero source hits — confirms they never existed.

## Test plan
- [x] Docs-only change; no source files touched.
- [x] Each replacement value cross-checked against the cited source location.
- [x] `git diff --cached` scanned — no secrets, no unrelated files.