### PR TITLE
fix(accounts): dedupe address rows so badge counts match mail list (Closes #442)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -444,17 +444,20 @@ export const getAccountStats = async (
       ? `AND address ILIKE '%@' || $2`
       : "";
 
+    // DISTINCT collapses rows where the same address appears more than once in
+    // a single mail's recipient/sender list (e.g. LinkedIn duplicates the To
+    // header), so each mail contributes once per address it actually involves.
     const sql = `
       WITH expanded_mails AS (
-        SELECT 
+        SELECT DISTINCT
           mail_id, read, saved, date,
           ${addressExpansion}
-        FROM mails 
+        FROM mails
         WHERE user_id = $1
           AND expunged = FALSE
           AND ${addressNotNull}
       )
-      SELECT 
+      SELECT
         address,
         COUNT(*) as count,
         SUM(CASE WHEN read = FALSE THEN 1 ELSE 0 END) as unread,


### PR DESCRIPTION
## Summary
- Fixes #442. Adds `SELECT DISTINCT` to the inner CTE in `getAccountStats` so rows where the same address appears multiple times in a single mail's `to/cc/bcc` (or `from`) JSONB array collapse to one before aggregation.
- Real-world trigger: LinkedIn duplicates the To address in its notification mail, so each such mail was counted twice in the per-account badge while the per-account list (`GET /headers/:account`) — which uses `@>` set-membership — counted it once. `unread` and `saved` aggregates had the same latent overcount.

## Why DISTINCT is safe
`mail_id, read, saved, date` are mail-level columns (functionally dependent on `mail_id`), so deduping on the full row is equivalent to deduping on `(mail_id, address)`. No information is lost.

## Test plan
- [x] `bun test` → 581 pass, 0 fail
- [x] `bun run typecheck` → clean
- [x] Live API on local dev with prod-snapshot DB — verified all four affected accounts now match between `/api/mails/accounts` badge and `/api/mails/headers/:account`:
  - `linkedin@hoie.kim`: badge 503 → 499 (matches headers list of 499)
  - `wayfair@hoie.kim`: badge 48 → 46 (matches 46)
  - `junk@hoie.kim`: badge 4 → 3 (matches 3)
  - `stanford@hoie.kim`: badge 3 → 2 (matches 2)
- [x] Total received account count unchanged (384), sent unchanged (65) — only inflated counts dropped to their true value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)