### PR TITLE
fix(test): add debug to logger mocks to unbreak CD on main

### DIFF
--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -76,7 +76,7 @@ mock.module("server", () => ({
 
 // Mock logger used directly in post-mark
 mock.module("../../../logger", () => ({
-  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+  logger: { debug: mock(() => {}), info: mock(() => {}), warn: mock(() => {}), error: mock(() => {}) },
 }));
 
 // ── Helper factories ──────────────────────────────────────────────────────────

--- a/src/server/lib/http/routes/route.test.ts
+++ b/src/server/lib/http/routes/route.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock } from "bun:test";
 
 mock.module("../../logger", () => ({
-  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+  logger: { debug: mock(() => {}), info: mock(() => {}), warn: mock(() => {}), error: mock(() => {}) },
 }));
 mock.module("../../alarm", () => ({
   sendAlarm: mock(async () => {}),

--- a/src/server/lib/http/routes/users/users.test.ts
+++ b/src/server/lib/http/routes/users/users.test.ts
@@ -29,7 +29,7 @@ mock.module("server", () => ({
 }));
 
 mock.module("../../../logger", () => ({
-  logger: { error: mock(() => {}), info: mock(() => {}), warn: mock(() => {}) },
+  logger: { debug: mock(() => {}), info: mock(() => {}), warn: mock(() => {}), error: mock(() => {}) },
 }));
 
 // bcrypt is a real module but we mock it to keep tests fast + deterministic


### PR DESCRIPTION
## Summary
- Closes #444
- Three logger mocks added in PR #435 omit `debug`. `mailbox-parsers.ts:27` calls `logger.debug` on parse-failure, so when bun's process-global `mock.module` swaps in the bare `{error, info, warn}` shape, any later `parseList` call throws `TypeError: logger.debug is not a function`.
- Fix is one-line in each of the three test files: add `debug: mock(() => {})` so the mock matches the real logger shape.

## Why this is CI-only
Bun's `mock.module` is process-wide and persists once a test file loads. Local file-system load order happens to load `mailbox-parsers.ts`/`security.test.ts` before any of the http-route mocks run; CI's Docker layer orders files differently and the mock leaks across, hitting the parser when the "should fail on missing reference" test runs.

## Verification
- 667 tests, 0 fail locally on `fix/logger-mock-missing-debug` (rebased on `upstream/main` @ 096bcf7)
- Diff is +3 / -3, scoped to mock definitions only

## Test plan
- [ ] CD passes on this PR (the one job that's been failing on main since 096bcf7)
- [ ] After merge, `bun test` succeeds in Docker for follow-up commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)