### PR TITLE
fix(accounts): exclude drafts from per-account badge counts (Closes #446)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -447,6 +447,9 @@ export const getAccountStats = async (
     // DISTINCT collapses rows where the same address appears more than once in
     // a single mail's recipient/sender list (e.g. LinkedIn duplicates the To
     // header), so each mail contributes once per address it actually involves.
+    // The draft filter mirrors getMailHeaders so per-account badge counts match
+    // the headers list view (drafts belong to the IMAP Drafts folder, not to
+    // the per-account inbox view).
     const sql = `
       WITH expanded_mails AS (
         SELECT DISTINCT
@@ -455,6 +458,7 @@ export const getAccountStats = async (
         FROM mails
         WHERE user_id = $1
           AND expunged = FALSE
+          AND draft = FALSE
           AND ${addressNotNull}
       )
       SELECT


### PR DESCRIPTION
## Summary
- Add `AND draft = FALSE` to the `expanded_mails` CTE in `getAccountStats` so the per-account badge counts only the mails the headers list actually surfaces.
- Mirrors the filter `getMailHeaders` already applies on the same table — drafts belong to the IMAP Drafts folder, not to the per-account inbox view.

## Why
`getMailHeaders` filters `expunged = FALSE AND draft = FALSE`; `getAccountStats` was missing the `draft` half. Any draft (`\Draft` IMAP flag) addressed to an account inflates that account's badge by exactly one without ever appearing in the list view — a count > visible-mails discrepancy in the same shape as #442 / PR #443, just driven by a different SQL omission.

Full repro and root-cause writeup in #446.

## Diff (essence)
```diff
+    // Exclude drafts so per-account badge counts match the headers list view,
+    // which already filters them (drafts belong to the IMAP Drafts folder, not
+    // to the per-account inbox view).
     const sql = `
       WITH expanded_mails AS (
         SELECT
           mail_id, read, saved, date,
           ${addressExpansion}
         FROM mails
         WHERE user_id = $1
           AND expunged = FALSE
+          AND draft = FALSE
           AND ${addressNotNull}
       )
```

## Composes cleanly with #443
PR #443 adds `DISTINCT` to the same `SELECT`; this PR adds `AND draft = FALSE` to the same `WHERE`. They touch different lines in the same CTE — both fixes belong, and the textual conflict is trivial.

## Test plan
- [x] `bun test src/server/lib/postgres/repositories/mails.test.ts src/server/lib/mails/accounts.test.ts` → 19 pass, 0 fail.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` reports no new warnings on changed files.
- [x] **End-to-end on local prod-snapshot DB** with `EMAIL_DOMAIN=hoie.kim`:
  - Pre-fix (transaction-scoped): set `draft=TRUE` on one mail addressed to `daycare@hoie.kim` → `accounts` API showed **34**, `headers` API showed **33** (1-mail inflation).
  - Post-fix on the live server: same `UPDATE`, then `accounts` API shows **33**, `headers` API shows **33** (matching).
  - With no draft (default snapshot state): both endpoints continue to return **34** for `daycare@hoie.kim`, plus identical counts for moltboie/bilt/apple/amazon/google/polygon/wellsfargo (verified earlier in the session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)