### PR TITLE
feat(client): IndexedDB cache for mail list views (Phase 1 of #432)

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -28,6 +28,7 @@ import {
   useLocalStorage,
   QueryCache,
   call,
+  idbClear,
   onKeyboardActivate
 } from "client";
 import { MailsSynchronizer } from "client/Box";
@@ -387,6 +388,8 @@ const Accounts = ({
         "originalMessage",
         "isCcOpen"
       ].forEach((key) => localStorage.removeItem(key));
+      // Same reason: drop the persisted IDB query cache (mail headers, accounts list).
+      void idbClear();
       setUserInfo(undefined);
       setSelectedAccount("");
     };

--- a/src/client/lib/idbStore.ts
+++ b/src/client/lib/idbStore.ts
@@ -1,0 +1,132 @@
+import type { QueryClient, QueryKey } from "react-query";
+
+const DB_NAME = "inbox";
+const STORE = "queries";
+const DB_VERSION = 1;
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+const openDB = (): Promise<IDBDatabase> => {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB not available"));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  }).catch((e) => {
+    dbPromise = null;
+    throw e;
+  });
+  return dbPromise;
+};
+
+const withStore = async <T>(
+  mode: IDBTransactionMode,
+  op: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T | undefined> => {
+  try {
+    const db = await openDB();
+    return await new Promise<T>((resolve, reject) => {
+      const store = db.transaction(STORE, mode).objectStore(STORE);
+      const req = op(store);
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return undefined;
+  }
+};
+
+export const idbGet = <T = unknown>(key: string): Promise<T | undefined> =>
+  withStore<T>("readonly", (s) => s.get(key) as IDBRequest<T>);
+
+export const idbSet = (key: string, value: unknown): Promise<unknown> =>
+  withStore("readwrite", (s) => s.put(value, key));
+
+export const idbDelete = (key: string): Promise<unknown> =>
+  withStore("readwrite", (s) => s.delete(key));
+
+export const idbClear = (): Promise<unknown> =>
+  withStore("readwrite", (s) => s.clear());
+
+const idbGetAll = async (): Promise<Map<string, unknown>> => {
+  try {
+    const db = await openDB();
+    return await new Promise<Map<string, unknown>>((resolve, reject) => {
+      const map = new Map<string, unknown>();
+      const store = db.transaction(STORE, "readonly").objectStore(STORE);
+      const req = store.openCursor();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          map.set(String(cursor.key), cursor.value);
+          cursor.continue();
+        } else {
+          resolve(map);
+        }
+      };
+      req.onerror = () => reject(req.error);
+    });
+  } catch {
+    return new Map();
+  }
+};
+
+// Only persist queries whose keys match these patterns. Search results and
+// transient/static fetches are intentionally excluded — they would either
+// leak across users or never benefit from persistence.
+const PERSIST_PATTERNS: RegExp[] = [
+  /^\/api\/mails\/accounts$/,
+  /^\/api\/mails\/headers\//
+];
+
+const keyToString = (key: QueryKey): string =>
+  typeof key === "string" ? key : Array.isArray(key) ? String(key[0]) : String(key);
+
+const shouldPersist = (key: string): boolean =>
+  PERSIST_PATTERNS.some((p) => p.test(key));
+
+/**
+ * Populates the queryClient cache with last-known data from IndexedDB.
+ * Call once during app boot before rendering, so the first paint shows
+ * cached data immediately instead of a skeleton.
+ */
+export const hydrateQueryClient = async (queryClient: QueryClient): Promise<void> => {
+  const all = await idbGetAll();
+  for (const [key, value] of all) {
+    if (!shouldPersist(key)) continue;
+    queryClient.setQueryData(key, value);
+  }
+};
+
+/**
+ * Subscribes to queryClient cache mutations and mirrors persistable
+ * queries into IndexedDB. Returns an unsubscribe function.
+ *
+ * Should be called AFTER hydrateQueryClient so the initial setQueryData
+ * calls during hydration do not cause a write-back loop.
+ */
+export const attachIDBPersistence = (queryClient: QueryClient): (() => void) => {
+  const cache = queryClient.getQueryCache();
+  return cache.subscribe((event) => {
+    if (!event) return;
+    if (event.type !== "queryUpdated" && event.type !== "queryAdded") return;
+    const query = event.query;
+    if (!query) return;
+    const key = keyToString(query.queryKey);
+    if (!shouldPersist(key)) return;
+    const data = query.state.data;
+    if (data === undefined) {
+      void idbDelete(key);
+    } else {
+      void idbSet(key, data);
+    }
+  });
+};

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -7,3 +7,4 @@ export * from "./call";
 export * from "./user";
 export * from "./queryClient";
 export * from "./a11y";
+export * from "./idbStore";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { App, callUser } from "client";
+import {
+  App,
+  attachIDBPersistence,
+  callUser,
+  hydrateQueryClient,
+  queryClient
+} from "client";
 
 import "./index.scss";
 
@@ -27,7 +33,8 @@ window.addEventListener("unhandledrejection", (event) => {
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
 const mountApp = async () => {
-  const user = await callUser();
+  const [user] = await Promise.all([callUser(), hydrateQueryClient(queryClient)]);
+  attachIDBPersistence(queryClient);
   root.render(
     <StrictMode>
       <App user={user} />


### PR DESCRIPTION
## Summary
- Adds `src/client/lib/idbStore.ts` — a thin promise-based wrapper around `indexedDB` (one DB `inbox`, one object store `queries`, no extra deps).
- Hydrates `queryClient` from IDB during `mountApp()` before `root.render()` so first paint shows last-known accounts and mail-headers data instead of skeletons.
- Subscribes to `queryClient.getQueryCache()` after hydration to mirror `queryUpdated` / `queryAdded` events back into IDB. Subscription is attached **after** hydration so the initial `setQueryData` calls don't write back into IDB redundantly.
- Restricted by an explicit `PERSIST_PATTERNS` regex list (`/api/mails/accounts`, `/api/mails/headers/...`) — search results and static text fetches are skipped.
- Logout (`Accounts/index.tsx`) calls `idbClear()` alongside the existing `localStorage` clear, so a previous user's mail metadata cannot leak to the next user on the same browser.

## Scope
This is **Phase 1 only** of the implementation plan posted on #432 — read-only mirror of mail list views, no offline writes, no body cache, no search index, no service worker. Hoie greenlit "skip design doc and go directly to implementation" on 2026-05-03.

## Test plan
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (18 pre-existing warnings unchanged)
- [x] `bun test` — 720 pass / 0 fail
- [x] `bun run build-client` — production bundle builds successfully
- [x] `bun run dev-server` + `bun run dev-client` start cleanly; vite serves the new module at `/src/client/lib/idbStore.ts` and the new imports appear in the transformed `index.tsx`.
- [ ] **Browser E2E not run from this cron context** — no headless-browser tool available. The actual IDB read/write/hydrate flow needs to be verified manually in a browser:
   1. First load (clean IDB) → confirm skeleton then data, then DevTools → Application → IndexedDB → `inbox` → `queries` shows entries for `/api/mails/accounts` and the active `/api/mails/headers/...` URL.
   2. Reload → confirm first paint shows the cached account list / mail headers immediately (no skeleton).
   3. Click logout → confirm the `inbox` IDB store is empty afterwards.

## Notes / follow-ups
- `Accounts` keeps `refetchOnWindowFocus: "always"` and `refetchInterval: 10min`, so hydrated stale data still revalidates on focus or interval — SWR semantics preserved.
- `MailsSynchronizer` continues to detect count drift between hydrated accounts and hydrated mail headers and triggers `refetchMails()`, so the existing freshness guarantee is unchanged.
- Phases 2 (offline mutations + replay queue) and 3 (search index) remain open in #432.

Closes nothing yet — leaves #432 open for follow-up phases.