### PR TITLE
docs(DEVELOPMENT): fix POSTGRES_DB env var and project tree

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,9 +33,10 @@ src/
 │   │   ├── http/     # Express server + API routes
 │   │   │   └── routes/ # API endpoints
 │   │   ├── imap/     # IMAP server implementation
-│   │   ├── smtp/     # SMTP server implementation
 │   │   ├── mails/    # Mail processing utilities
-│   │   └── postgres/ # Database layer
+│   │   ├── postgres/ # Database layer
+│   │   ├── spam/     # Spam classification (rules + Naive Bayes)
+│   │   └── smtp.ts   # SMTP server (single file)
 │   └── start.ts      # Server entry point
 └── common/           # Shared code
     └── models/       # Data models
@@ -420,7 +421,7 @@ Configure via environment variables:
 - `POSTGRES_PORT` (default: 5432)
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
-- `POSTGRES_DB`
+- `POSTGRES_DATABASE`
 
 ### Repository Pattern
 


### PR DESCRIPTION
## Summary

Two code-verifiable staleness fixes in `DEVELOPMENT.md`:

1. **`POSTGRES_DB` → `POSTGRES_DATABASE`** (line 423). The app's pg client destructures `POSTGRES_DATABASE` from `process.env` (`src/server/lib/postgres/client.ts:8`). `CONTRIBUTING.md`, `docs/how_to_setup.md`, and `.env.example` all use the correct name; only `DEVELOPMENT.md` had the old `POSTGRES_DB` (which is the official `postgres` Docker image's init var, not what the inbox app reads).

2. **Project tree: `smtp/` → `smtp.ts`** (line 36). The SMTP server is implemented in a single `src/server/lib/smtp.ts` file, not a directory. `docs/dev_guide.md` already describes it as `(single file)`. While editing the tree I also added the `spam/` directory that's been on disk since PR #423 (Naive Bayes classifier).

## Verification

- `grep` for `POSTGRES_DB` and `POSTGRES_DATABASE` in repo — only `docker-compose.yml` (correctly using both: `POSTGRES_DATABASE` for the inbox container, `POSTGRES_DB` for the postgres container init) and now-corrected docs.
- `ls src/server/lib/` confirms `smtp.ts` is a file and `spam/` is a directory.
- No source-code changes; only `DEVELOPMENT.md` (4 insertions, 3 deletions).

## Test plan

- [x] Type check / lint / tests not affected (docs-only change)
- [x] CI green