### PR TITLE
fix(spam): classifier HAM verdict no longer inflates total spam score (Closes #451)

### DIFF
--- a/src/server/lib/spam/service.test.ts
+++ b/src/server/lib/spam/service.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const mockClassifyEmail = mock(async (_uid: string, _email: unknown) => ({
+  score: 0,
+  reason: null as string | null,
+}));
+const mockIsAllowlisted = mock(async (_uid: string, _addr: string) => false);
+
+mock.module("./classifier", () => ({ classifyEmail: mockClassifyEmail }));
+mock.module("../postgres/repositories/spam_allowlists", () => ({
+  isAllowlisted: mockIsAllowlisted,
+}));
+
+const { checkSpam } = await import("./service");
+
+// Email crafted so two minor rules fire (reply-to-mismatch + html-only-no-text = 20 pts).
+// remoteAddress is omitted so the DNSBL layer is skipped (no network calls in tests).
+const subtleHamEmail = {
+  fromAddress: "newsletter@company.com",
+  replyToAddress: "marketing@othercompany.com",
+  fromName: "Newsletter",
+  subject: "Weekly newsletter",
+  html: "<p>Read our weekly update. To unsubscribe click here.</p>",
+};
+
+describe("checkSpam — classifier scoring gate", () => {
+  beforeEach(() => {
+    mockClassifyEmail.mockClear();
+    mockIsAllowlisted.mockClear();
+  });
+
+  it("ignores classifier score < 50 (HAM verdict) so it does not inflate totalScore", async () => {
+    mockClassifyEmail.mockResolvedValueOnce({ score: 49, reason: null });
+    const result = await checkSpam("user1", subtleHamEmail);
+    // Rules contribute 20 (reply-to mismatch + html-only). Classifier verdict is HAM
+    // (score 49 < 50, reason null) and must contribute 0 — pre-fix it added 49 → 69.
+    expect(result.score).toBe(20);
+    expect(result.isSpam).toBe(false);
+    expect(result.flaggedBy).toBeUndefined();
+  });
+
+  it("adds classifier score >= 50 (SPAM verdict) to totalScore", async () => {
+    mockClassifyEmail.mockResolvedValueOnce({
+      score: 75,
+      reason: "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)",
+    });
+    const result = await checkSpam("user1", subtleHamEmail);
+    // Rules 20 + classifier 75 = 95.
+    expect(result.score).toBe(95);
+    expect(result.isSpam).toBe(true);
+    expect(result.reasons).toContain(
+      "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)"
+    );
+  });
+
+  it("adds classifier score = 50 (boundary SPAM verdict) to totalScore", async () => {
+    mockClassifyEmail.mockResolvedValueOnce({
+      score: 50,
+      reason: "Bayesian classifier: 50% spam probability (10 spam / 10 ham documents trained)",
+    });
+    const cleanEmail = {
+      fromAddress: "x@y.com",
+      subject: "Hello there",
+      text: "Hi friend, hope you are well.",
+    };
+    const result = await checkSpam("user1", cleanEmail);
+    expect(result.score).toBe(50);
+    expect(result.isSpam).toBe(true);
+    expect(result.flaggedBy).toBe("classifier");
+  });
+
+  it("treats classifier score = 0 as untrained (no contribution, no reason)", async () => {
+    mockClassifyEmail.mockResolvedValueOnce({ score: 0, reason: null });
+    const result = await checkSpam("user1", subtleHamEmail);
+    expect(result.score).toBe(20);
+    expect(result.isSpam).toBe(false);
+  });
+
+  it("does not set flaggedBy='classifier' when verdict is HAM", async () => {
+    mockClassifyEmail.mockResolvedValueOnce({ score: 30, reason: null });
+    const result = await checkSpam("user1", {
+      fromAddress: "x@y.com",
+      subject: "Hello there",
+      text: "hello there",
+    });
+    expect(result.flaggedBy).toBeUndefined();
+  });
+});

--- a/src/server/lib/spam/service.ts
+++ b/src/server/lib/spam/service.ts
@@ -91,9 +91,14 @@ export async function checkSpam(
   // Layer 3: Naive Bayes classifier (user-trained, per-user model)
   try {
     const { score: classifierScore, reason: classifierReason } = await classifyEmail(userId, email);
-    if (classifierScore > 0) {
+    // classifyEmail returns P(spam) * 100 in [0, 100], where < 50 is a HAM verdict
+    // and >= 50 is a SPAM verdict (the classifier sets reason to non-null only at >= 50).
+    // Only contribute to totalScore when the verdict leans spam — otherwise a
+    // ham-leaning score (e.g. 49) would still inflate totalScore past spamThreshold
+    // when combined with other layers, flipping legitimate mail to spam.
+    if (classifierReason !== null) {
       totalScore += classifierScore;
-      if (classifierReason) reasons.push(classifierReason);
+      reasons.push(classifierReason);
       if (!flaggedBy) flaggedBy = "classifier";
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

The Layer-3 Naive Bayes classifier returns `P(spam) * 100` in `[0, 100]`, where `< 50` is a **HAM** verdict. Pre-fix, `service.ts` added the raw `classifierScore` to `totalScore` whenever it was `> 0`, so a ham-leaning score (e.g. `49`) still contributed 49 spam points. Combined with two minor rules — `reply-to-mismatch` (15) + `html-only-no-text` (5) = 20 — total = 69 ≥ 50 → flagged as spam, even though the classifier said ham.

Gate the classifier's contribution on `classifierReason !== null`, which `classifyEmail` already sets to non-null exactly when `score >= 50`. Below the boundary the classifier no longer contributes; at or above it the full score is added as before.

## Fix

```diff
-    if (classifierScore > 0) {
+    if (classifierReason !== null) {
       totalScore += classifierScore;
-      if (classifierReason) reasons.push(classifierReason);
+      reasons.push(classifierReason);
       if (!flaggedBy) flaggedBy = "classifier";
     }
```

## Test plan

- [x] **New regression test** `src/server/lib/spam/service.test.ts` — 5 cases:
  - HAM verdict (score 49, reason null): contributes 0, total = 20, isSpam = false
  - SPAM verdict (score 75, reason set): contributes 75, total = 95, isSpam = true
  - Boundary SPAM verdict (score 50, reason set): contributes 50, total = 50, isSpam = true, flaggedBy = `classifier`
  - Untrained (score 0, reason null): contributes 0
  - HAM verdict does not set `flaggedBy = 'classifier'`
- [x] **Pre-fix verification**: stashed the fix, ran the new test on `upstream/main` — first case fails with `Received: 69, Expected: 20` (matches the bug).
- [x] **Post-fix verification**: re-applied the fix — all 5 new tests pass.
- [x] `bun test` — **725/725 pass**, 0 fail (was 720/720 + 5 new = 725 total).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors, 18 warnings (all pre-existing, unchanged).
- [x] **E2E**: bun run dev started cleanly (server :3004 + client :3000 both 200). Full E2E of the classifier path is gated on training data (`MIN_TRAINING_DOCS = 5` per class), and local prod-snapshot DB has 0 rows in `spam_training`, so the regression test is the highest-fidelity verification this bug never re-emerges.

## Impact

Latent in production until a user marks ≥ 5 ham + ≥ 5 spam (the `MIN_TRAINING_DOCS` gate). Bug shipped in PR #423 (Phase 2). Catching it before training data accumulates avoids any user-visible misclassification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)