### PR TITLE
fix(mails): render external images in email bodies with privacy mitigations (Closes #455)

### DIFF
--- a/src/client/lib/html.ts
+++ b/src/client/lib/html.ts
@@ -21,18 +21,31 @@ const sanitizeEmailHtml = (html: string): string => {
 
   // Strip dangerous attributes on every element
   const DANGEROUS_ATTR = /^on/i; // onclick, onerror, onload, ...
-  const DANGEROUS_URI = /^\s*(javascript|vbscript|data):/i;
+  const SCRIPT_URI = /^\s*(javascript|vbscript):/i;
+  const HREF_DATA_URI = /^\s*data:/i; // dangerous in href/action (HTML data: can run JS); harmless as <img src>
   doc.querySelectorAll("*").forEach((el) => {
     Array.from(el.attributes).forEach((attr) => {
       if (DANGEROUS_ATTR.test(attr.name)) {
         el.removeAttribute(attr.name);
       } else if (
         (attr.name === "href" || attr.name === "src" || attr.name === "action") &&
-        DANGEROUS_URI.test(attr.value)
+        SCRIPT_URI.test(attr.value)
+      ) {
+        el.removeAttribute(attr.name);
+      } else if (
+        (attr.name === "href" || attr.name === "action") &&
+        HREF_DATA_URI.test(attr.value)
       ) {
         el.removeAttribute(attr.name);
       }
     });
+  });
+
+  // Add tracking-mitigation attributes to all <img> tags so external images load
+  // without leaking the inbox origin as referrer and only when scrolled into view.
+  doc.querySelectorAll("img").forEach((img) => {
+    img.setAttribute("referrerpolicy", "no-referrer");
+    if (!img.hasAttribute("loading")) img.setAttribute("loading", "lazy");
   });
 
   return doc.documentElement.outerHTML;

--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -56,13 +56,16 @@ export const initializeHttp = async () => {
   app.use((_req, res, next) => {
     // Restrict resource origins. 'unsafe-inline' for styles is required by React.
     // 'blob:' in img-src allows inline email images loaded as object URLs.
+    // 'https:' in img-src allows external images in email bodies (the sanitizer
+    // adds referrerpolicy="no-referrer" + loading="lazy" to mitigate tracking).
+    // Plain http: is intentionally omitted to avoid mixed-content on prod.
     res.setHeader(
       "Content-Security-Policy",
       [
         "default-src 'self'",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data: blob:",
+        "img-src 'self' data: blob: https:",
         "connect-src 'self'",
         // sandbox attribute on email iframes restricts their content;
         // frame-src 'self' allows those sandboxed iframes to be embedded.


### PR DESCRIPTION
Closes #455

## Summary

External-URL images weren't rendering in email bodies because the CSP `img-src` directive was set to `'self' data: blob:` only — every `https://` image silently failed to load. This PR relaxes the guardrail so external images render, while adding two privacy-preserving mitigations so removing the guardrail doesn't fully expose the user to remote tracking.

## What changed

### 1. Relax CSP `img-src`
`src/server/lib/http/index.ts`

```diff
- "img-src 'self' data: blob:",
+ "img-src 'self' data: blob: https:",
```

`https:` covers all modern email senders. Plain `http:` is intentionally omitted to avoid mixed-content on the production HTTPS deployment.

### 2. Add tracking-mitigation attributes to all `<img>` tags
`src/client/lib/html.ts` (`sanitizeEmailHtml`)

After the dangerous-attribute pass, the sanitizer now sets:

- `referrerpolicy="no-referrer"` — browser will not send the inbox origin as referrer when fetching tracking pixels (reduces what spammers learn from a single image load).
- `loading="lazy"` (only when the email author hasn't already set `loading=`) — images load only when scrolled into view, so unread emails do not silently fire tracking-pixel requests during list-view rendering.

### 3. Stop stripping `data:` URIs from `<img src>`
`src/client/lib/html.ts`

The previous regex `^\s*(javascript|vbscript|data):` blocked all three URI schemes uniformly across `href`/`src`/`action`. For `<img src>`, `data:` URIs are harmless (they only display an image — no script execution), and stripping them was blocking legitimate inline base64 images. The fix splits the rule:

- `javascript:` / `vbscript:` are still stripped from any of `href`/`src`/`action` (XSS guard intact).
- `data:` is now only stripped from `href` and `action` (where data: can deliver HTML/JS), not from `src`.

The CSP already permitted `data:` in `img-src`, so this aligns the sanitizer with the CSP intent.

## Why this is a "middle ground"

- ✅ External images render — the user-facing UX problem is fixed.
- ✅ External images don't leak the inbox origin as referrer (`referrerpolicy="no-referrer"`).
- ✅ Tracking pixels in unread emails don't fire until the user scrolls them into view (`loading="lazy"`).
- ✅ XSS surface unchanged: scripts still blocked by both the iframe sandbox (no `allow-scripts`) and CSP `script-src 'self'`. `javascript:` URIs still stripped by the sanitizer.
- ⚠️ Senders can still embed pixel-tracking once the user opens the email — fully privacy-preserving image loading would require a server-side image proxy (separate, larger effort). This PR is the targeted "remove the guardrail and add lightweight mitigations" fix Hoie asked for in #455.

## Test plan

- [x] **Branched from `upstream/main`** (`ba5ce56`).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors, 18 warnings (all pre-existing, unchanged).
- [x] `bun test` — **741 / 0 fail** (no regressions vs. upstream/main's 741).
- [x] **Browser E2E (Playwright, headless chromium against `bun run dev`)** — 9 / 9 assertions pass:
  - CSP header on `/` includes the new `img-src 'self' data: blob: https:`.
  - `processHtmlForViewer('<img src="https://example.com/x.png">')` → src preserved, `referrerpolicy="no-referrer"` + `loading="lazy"` added.
  - `processHtmlForViewer('<img src="data:image/png;base64,...">')` → src preserved (was stripped pre-fix).
  - `processHtmlForViewer('<img src="javascript:alert(1)">')` → src stripped (XSS guard intact).
  - `processHtmlForViewer('<a href="javascript:...">')` → href stripped (regression).
  - `processHtmlForViewer('<a href="data:text/html,...">')` → href stripped (regression — data: in href can run JS).
  - `<img loading="eager">` from sender preserved (sanitizer doesn't overwrite explicit author intent).
  - Live in-browser load of an external `https://upload.wikimedia.org/...png` returns `naturalWidth=120` — CSP genuinely allows it.
- [x] Logged in as admin during the E2E.

## Files

- `src/server/lib/http/index.ts` — relaxed CSP `img-src`.
- `src/client/lib/html.ts` — split URI-scheme rule, added per-`<img>` referrerpolicy + loading attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)