### PR TITLE
docs(DEVELOPMENT): note IMAP/SMTP port env overrides; fix CAPABILITY-by-TLS-mode wording

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,14 +46,16 @@ src/
 
 Inbox runs multiple services:
 
-| Service | Port | Description |
-|---------|------|-------------|
-| HTTP/API | 3000 | Web UI + REST API |
-| IMAP | 143 | IMAP server (STARTTLS) |
-| IMAP/TLS | 993 | IMAP server (Implicit TLS) |
-| SMTP | 25 | SMTP server (plain) |
-| SMTP/TLS | 465 | SMTP server (Implicit TLS) |
-| SMTP/STARTTLS | 587 | SMTP server (STARTTLS) |
+| Service | Default Port | Override Env | Description |
+|---------|--------------|--------------|-------------|
+| HTTP/API | 3000 | — | Web UI + REST API |
+| IMAP | 143 | `IMAP_PORT` | IMAP server (STARTTLS) |
+| IMAP/TLS | 993 | `IMAP_TLS_PORT` | IMAP server (Implicit TLS) |
+| SMTP | 25 | `SMTP_PORT` | SMTP server (plain) |
+| SMTP/TLS | 465 | `SMTPS_PORT` | SMTP server (Implicit TLS) |
+| SMTP/STARTTLS | 587 | `SMTP_SUBMISSION_PORT` | SMTP server (STARTTLS) |
+
+The IMAP/SMTP port env vars exist primarily to let non-root sandboxes bind high ports (143/25 require root). Production deployments typically leave them unset.
 
 ## Key Environment Variables
 
@@ -379,7 +381,7 @@ The IMAP server targets compatibility with standard mail clients (Apple Mail, iO
 
 - **BODYSTRUCTURE must match BODY[] encoding**: If BODYSTRUCTURE declares `base64`, the corresponding `BODY[n]` fetch must return base64-encoded content (not raw UTF-8)
 - **RFC822.SIZE must account for encoding**: Size should reflect the encoded (wire-format) message size
-- **CAPABILITY response must match port**: Port 993 (implicit TLS) must NOT advertise STARTTLS; port 143 must advertise it
+- **CAPABILITY response must match TLS mode**: Implicit-TLS connections must NOT advertise STARTTLS; plain connections must advertise it. (`getCapabilities(isTls)` in `src/server/lib/imap/capabilities.ts`.)
 - **AUTHENTICATE PLAIN**: Support both inline initial response and challenge-response flow (some clients omit the initial response)
 - **Supported extensions**: NAMESPACE (RFC 2342), ENABLE (RFC 5161), UNSELECT (RFC 3691); GETQUOTAROOT returns NO (not supported)
 - **Flags on sub-mailboxes**: Per-account mailboxes should NOT have `\Noselect` — clients need to be able to select them


### PR DESCRIPTION
## Summary

Reflects PR #467 (`IMAP_PORT`) and documents the long-standing but undocumented `SMTP_PORT` / `SMTPS_PORT` / `SMTP_SUBMISSION_PORT` env vars.

1. **Services table** — added an \"Override Env\" column so contributors know which env vars override each IMAP/SMTP port. New trailing note explains the primary use case (non-root sandboxes — 143/25 require root).
2. **IMAP Client Compatibility** — the bullet \"CAPABILITY response must match port: Port 993 must NOT advertise STARTTLS; port 143 must advertise it\" was conceptually outdated after PR #467 routed the gate through `isTls` rather than the port number. Reworded to \"must match TLS mode\" with a pointer to `getCapabilities(isTls)`. Default-port behavior is unchanged.

## Verification

- `src/server/lib/imap/index.ts:22-23` — `getImapPort()` reads `IMAP_PORT`, `getImapTlsPort()` reads `IMAP_TLS_PORT`.
- `src/server/lib/smtp.ts:228, 238, 249` — three SMTP listeners read `SMTP_PORT`, `SMTPS_PORT`, `SMTP_SUBMISSION_PORT`.
- `src/server/lib/imap/capabilities.ts` — `getCapabilities(isTls)` is the post-PR-#467 signature.

No source code touched; pure docs PR.

## Test plan

- [ ] CI green (markdown only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)