### PR TITLE
fix(sanitize): scrub javascript:/data: in SVG xlink:href and button formaction

### DIFF
--- a/src/client/lib/html.ts
+++ b/src/client/lib/html.ts
@@ -23,17 +23,33 @@ const sanitizeEmailHtml = (html: string): string => {
   const DANGEROUS_ATTR = /^on/i; // onclick, onerror, onload, ...
   const SCRIPT_URI = /^\s*(javascript|vbscript):/i;
   const HREF_DATA_URI = /^\s*data:/i; // dangerous in href/action (HTML data: can run JS); harmless as <img src>
+  // SVG <a xlink:href> is the XML-namespaced equivalent of HTML href, and
+  // <button formaction> is the action equivalent for form submission. Both
+  // accept the same URI schemes as href/action and need the same scrubbing.
+  const SCRIPT_URI_ATTRS = new Set([
+    "href",
+    "src",
+    "action",
+    "xlink:href",
+    "formaction",
+  ]);
+  const DATA_URI_ATTRS = new Set([
+    "href",
+    "action",
+    "xlink:href",
+    "formaction",
+  ]);
   doc.querySelectorAll("*").forEach((el) => {
     Array.from(el.attributes).forEach((attr) => {
       if (DANGEROUS_ATTR.test(attr.name)) {
         el.removeAttribute(attr.name);
       } else if (
-        (attr.name === "href" || attr.name === "src" || attr.name === "action") &&
+        SCRIPT_URI_ATTRS.has(attr.name) &&
         SCRIPT_URI.test(attr.value)
       ) {
         el.removeAttribute(attr.name);
       } else if (
-        (attr.name === "href" || attr.name === "action") &&
+        DATA_URI_ATTRS.has(attr.name) &&
         HREF_DATA_URI.test(attr.value)
       ) {
         el.removeAttribute(attr.name);


### PR DESCRIPTION
## Summary
- Closes #473
- The defense-in-depth email body sanitizer in `src/client/lib/html.ts` only checked the literal attribute names `href`, `src`, and `action` when scrubbing dangerous URI schemes. `xlink:href` (SVG `<a>`) and `formaction` (`<button>` / `<input type="submit">`) carry the same URI semantics and were missed — `javascript:`, `vbscript:`, and `data:` URIs survived sanitization on those attributes.
- Promote the attribute-name lists to `Set<string>` that include `xlink:href` and `formaction`. Same scrubbing semantics, just covers the namespaced/per-button URL-bearing equivalents.

The email iframe sandbox in `MailBody.tsx` (`allow-same-origin allow-popups allow-popups-to-escape-sandbox` — no `allow-scripts`) and modern browsers' top-level `data:` blocking gate this from being a working exploit today. But the sanitizer's documented purpose is defense-in-depth, and these gaps weaken that layer for no reason.

## Test plan
- [x] `bun --bun tsc --noEmit` clean
- [x] `bun lint` clean (no new warnings)
- [x] `bun test` 746/746 pass
- [x] **E2E** in a real Chromium via Playwright (`page.evaluate` running the in-tree sanitizer):
  - Pre-fix repro confirmed: `xlink:href javascript: BYPASS`, `xlink:href data: BYPASS`, `formaction javascript: BYPASS`, `<form action="javascript:...">` correctly stripped (already covered).
  - Post-fix verification: every `javascript:`/`vbscript:`/`data:` URI stripped from `xlink:href` and `formaction`. Safe `https:` URIs preserved on the same attrs (`<a xlink:href="https://safe.example/page">` → kept; `<button formaction="https://safe.example/y">` → kept).
  - Regression check: existing behaviors unchanged — `<a href="javascript:...">` still stripped, `<a href="data:...">` still stripped, `<a href="https://...">` still kept, `<img src="https://...">` and `<img src="data:image/...">` still kept with `referrerpolicy="no-referrer"` + `loading="lazy"` (PR #469 mitigations preserved).
  - Re-rendered the Plaid welcome mail (17 https `<img>`) end-to-end through an iframe in the running app: 17/17 images loaded with the new sanitizer (regression check for the change shipped in #469).

🤖 Generated with [Claude Code](https://claude.com/claude-code)