### PR TITLE
docs(DEVELOPMENT): document shipped HTML sanitizer and CSP defenses

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -537,8 +537,8 @@ const sanitize = (html: string) =>
 See `src/client/Box/components/Mails/index.tsx` for the implementation (PR #174).
 
 Additional defense layers:
-- HTML sanitization (planned: #124)
-- CSP headers (planned: #151)
+- **HTML sanitization** — `sanitizeEmailHtml()` in `src/client/lib/html.ts` runs before email HTML reaches the iframe. It strips `<script>`/`<iframe>`/`<object>`/`<embed>`/`<applet>`/`<base>` elements, `on*` event-handler attributes, `javascript:`/`vbscript:` URIs in `href`/`src`/`action`, and `data:` URIs in `href`/`action` (kept in `<img src>` since inline data images are harmless). It also adds `referrerpolicy="no-referrer"` and `loading="lazy"` to every `<img>` so external images load without leaking the inbox origin and only when scrolled into view.
+- **CSP headers** — set in `src/server/lib/http/index.ts`. `img-src 'self' data: blob: https:` allows external email images while blocking plain `http:` to avoid mixed content. `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, and `frame-src 'self'` (combined with the email-iframe `sandbox`) keep emails from executing code or framing hostile content.
 
 ### Data Deletion Strategy
 


### PR DESCRIPTION
## Summary

`DEVELOPMENT.md` "Email Display Security -> Additional defense layers" still labeled both items as planned, but each was implemented and shipped weeks ago, and PR #469 (today) enhanced both further. Replace the two `(planned: #N)` bullets with concrete descriptions tied to source locations.

| Bullet | Was | Now |
|---|---|---|
| HTML sanitization | `(planned: #124)` -- issue closed 2026-03-25 | Describes `sanitizeEmailHtml()` in `src/client/lib/html.ts:12` (script/iframe/object/embed/applet/base stripping, on* + URI-scheme attribute filtering, plus PR #469's `referrerpolicy="no-referrer"` + `loading="lazy"` on `<img>`) |
| CSP headers | `(planned: #151)` -- issue closed 2026-03-21 | Describes the `Content-Security-Policy` set in `src/server/lib/http/index.ts:63-77`, including PR #469's `img-src` `https:` addition (with rationale for blocking `http:`) |

## Verification

- `src/client/lib/html.ts:12` -- `sanitizeEmailHtml` exists, called from `processHtmlForViewer` (line 110)
- `src/server/lib/http/index.ts:63-77` -- `Content-Security-Policy` header is set on every response
- `gh issue view 124` -> CLOSED 2026-03-25
- `gh issue view 151` -> CLOSED 2026-03-21
- `git grep -n "planned" *.md docs/ CONTRIBUTING.md` after the change -> no matches (these were the only two)

Pure documentation change, no source touched.

## Test plan
- [x] `git diff` reviewed -- only DEVELOPMENT.md, only the two bullets
- [x] All claims about source locations verified by reading the files
- [x] Both referenced issues confirmed CLOSED

Generated with Claude Code