### PR TITLE
docs(DEVELOPMENT): include xlink:href + formaction in sanitizer attribute list

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -537,7 +537,7 @@ const sanitize = (html: string) =>
 See `src/client/Box/components/Mails/index.tsx` for the implementation (PR #174).
 
 Additional defense layers:
-- **HTML sanitization** — `sanitizeEmailHtml()` in `src/client/lib/html.ts` runs before email HTML reaches the iframe. It strips `<script>`/`<iframe>`/`<object>`/`<embed>`/`<applet>`/`<base>` elements, `on*` event-handler attributes, `javascript:`/`vbscript:` URIs in `href`/`src`/`action`, and `data:` URIs in `href`/`action` (kept in `<img src>` since inline data images are harmless). It also adds `referrerpolicy="no-referrer"` and `loading="lazy"` to every `<img>` so external images load without leaking the inbox origin and only when scrolled into view.
+- **HTML sanitization** — `sanitizeEmailHtml()` in `src/client/lib/html.ts` runs before email HTML reaches the iframe. It strips `<script>`/`<iframe>`/`<object>`/`<embed>`/`<applet>`/`<base>` elements, `on*` event-handler attributes, `javascript:`/`vbscript:` URIs in URL-bearing attributes (`href`, `src`, `action`, `xlink:href`, `formaction`), and `data:` URIs in the same set minus `src` (kept on `<img src>` since inline data images are harmless). It also adds `referrerpolicy="no-referrer"` and `loading="lazy"` to every `<img>` so external images load without leaking the inbox origin and only when scrolled into view.
 - **CSP headers** — set in `src/server/lib/http/index.ts`. `img-src 'self' data: blob: https:` allows external email images while blocking plain `http:` to avoid mixed content. `script-src 'self'`, `object-src 'none'`, `base-uri 'self'`, and `frame-src 'self'` (combined with the email-iframe `sandbox`) keep emails from executing code or framing hostile content.
 
 ### Data Deletion Strategy


### PR DESCRIPTION
## Summary

PR #474 expanded `SCRIPT_URI_ATTRS` and `DATA_URI_ATTRS` in `src/client/lib/html.ts` to also scrub `xlink:href` (SVG `<a>`) and `formaction` (`<button>` / `<input type="submit">`). The defense-in-depth bullet in `DEVELOPMENT.md:540` (added in #475) still listed the pre-#474 attribute set, which is now stale.

Update the bullet to:
- list the URL-bearing attributes scrubbed for `javascript:`/`vbscript:` URIs as `href`, `src`, `action`, `xlink:href`, `formaction`
- note that `data:` URIs are stripped from the same set minus `src` (still kept on `<img src>` since inline data images are harmless)

Pure markdown — single line in `DEVELOPMENT.md`.

## Test plan

- [x] Verified attribute lists against `src/client/lib/html.ts:29-41` at `upstream/main` HEAD (`af90f95`):
  - `SCRIPT_URI_ATTRS = {href, src, action, xlink:href, formaction}` — matches new wording.
  - `DATA_URI_ATTRS = {href, action, xlink:href, formaction}` — matches "same set minus `src`".
- [x] No source files touched. `git diff --stat` = `DEVELOPMENT.md | 2 +-`.
- [x] No other inbox docs reference the sanitizer attribute set (grepped `xlink|formaction|sanitizeEmailHtml|html\.ts` across all `*.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)