### PR TITLE
fix(spam): url-shortener rule matches host segments only, not substrings (Closes #477)

### DIFF
--- a/src/server/lib/spam/rules.test.ts
+++ b/src/server/lib/spam/rules.test.ts
@@ -90,6 +90,49 @@ describe("Spam Rules", () => {
       const result = evaluateRules(email);
       expect(result.matchedRules.some(r => r.id === "url-shortener")).toBe(false);
     });
+
+    it.each([
+      ["wealthfront.com (contains 't.co')", "https://email.wealthfront.com/ls/click?upn=abc"],
+      ["marriott.com (contains 't.co')", "https://www.marriott.com/hotels/reservation"],
+      ["att.com (contains 't.co')", "Sign in: https://www.att.com/myaccount"],
+      ["scott.com (contains 't.co')", "Check https://scott.com/orders"],
+      ["abbott.com (contains 't.co')", "https://abbott.com/labs"],
+      ["elliot.com (contains 't.co')", "https://elliot.com/products"],
+    ])("should NOT flag legit URL with shortener substring inside host: %s", (_label, text) => {
+      const email: EmailContext = {
+        fromAddress: "no-reply@em.wealthfront.com",
+        subject: "Account update",
+        text,
+      };
+      const result = evaluateRules(email);
+      expect(result.matchedRules.some(r => r.id === "url-shortener")).toBe(false);
+    });
+
+    it.each([
+      ["t.co", "https://t.co/abc123"],
+      ["goo.gl", "Map: https://goo.gl/maps/xyz"],
+      ["tinyurl.com", "https://tinyurl.com/foobar"],
+      ["bare bit.ly without protocol", "Click bit.ly/scam now"],
+      ["ow.ly with surrounding punctuation", "Link (https://ow.ly/abc)."],
+    ])("should flag actual shortener: %s", (_label, text) => {
+      const email: EmailContext = {
+        fromAddress: "test@example.com",
+        subject: "Check this out",
+        text,
+      };
+      const result = evaluateRules(email);
+      expect(result.matchedRules.some(r => r.id === "url-shortener")).toBe(true);
+    });
+
+    it("should flag when shortener and legit URL coexist", () => {
+      const email: EmailContext = {
+        fromAddress: "test@example.com",
+        subject: "Update",
+        text: "Visit https://wealthfront.com or https://bit.ly/foo",
+      };
+      const result = evaluateRules(email);
+      expect(result.matchedRules.some(r => r.id === "url-shortener")).toBe(true);
+    });
   });
 
   describe("marketing-no-unsubscribe rule", () => {

--- a/src/server/lib/spam/rules.ts
+++ b/src/server/lib/spam/rules.ts
@@ -45,10 +45,22 @@ function hasExcessiveUppercase(text: string): boolean {
 
 /**
  * Check if text contains URL shorteners.
+ *
+ * Matches a shortener only when it appears as a complete host segment.
+ * Naive `includes()` on the raw text substring-matches `t.co` inside
+ * legitimate hosts like `wealthfront.com`, `marriott.com`, `att.com`,
+ * `scott.com` (any `<letter>t.co` sequence inside a domain trips it).
+ *
+ * Preceding char must not be a letter/digit/dot/hyphen (host continuation),
+ * and trailing char must not be a letter/digit/hyphen (subdomain continuation).
  */
 function containsUrlShortener(text: string): boolean {
-  const lowerText = text.toLowerCase();
-  return URL_SHORTENERS.some(domain => lowerText.includes(domain));
+  const lower = text.toLowerCase();
+  return URL_SHORTENERS.some(shortener => {
+    const escaped = shortener.replace(/\./g, "\\.");
+    const re = new RegExp(`(?:^|[^a-z0-9.-])${escaped}(?![a-z0-9-])`);
+    return re.test(lower);
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- `URL_SHORTENERS.some(d => lowerText.includes(d))` substring-matched `"t.co"` inside legit hostnames `wealthfront.com`, `marriott.com`, `att.com`, `scott.com`, `abbott.com`, `elliot.com` — any host with `<letter>t.co` (e.g. `nt.co` in `wealthfront.com`, `tt.co` in `marriott.com`/`scott.com`/`att.com`) tripped it and added **+25** to `totalScore`. Same shape as #463 (Spamhaus open-resolver warning false positive): a layer-2 contributor pushing legit mail past the 50-point threshold.
- Fix: require the shortener to appear as a complete host segment — preceded by a non-host-continuation char (not letter/digit/`.`/`-`), followed by a non-host-continuation char (not letter/digit/`-`). Still catches `https://bit.ly/abc`, bare `bit.ly/scam`, `https://t.co/abc`, `(https://ow.ly/abc)`. Rejects `https://email.wealthfront.com/x`, `https://att.com/x`, `https://marriott.com/x`, etc.

## Impact on local prod-snapshot DB
24 stored mails currently flagged with `spam_reasons @> ["URL shorteners in body"]`. Re-evaluating the `containsUrlShortener` predicate against their bodies:

| Mode | Rule fires |
| --- | --- |
| Pre-fix (substring) | **21 / 24** |
| Post-fix (host-segment) | **0 / 24** |

All 21 fires were `"t.co"` matching inside hostnames in plain-text URLs:
- `no-reply@em.wealthfront.com` — *Your monthly Green Dot statement is available…*
- `connect-notification@online.procaresoftware.com` — Procare daycare daily summaries (Wesley Bratko)
- `no-reply@lyftmail.com` — Lyft ride receipts
- `donotreply@lge.com` — LG account verification
- `uspostalservice@usps.com` — USPS account-recovery
- `no-reply@leetcode.com` — LeetCode Weekly Digest

The 3 mails (24 − 21) that didn't fire under either logic on re-evaluation had their `goo.gl` link only in HTML `<a href>` attribute values; `getTextContent(email)` strips tags before the rule runs, so those URLs never reached the rule. Same blind spot pre-fix → no regression.

(Most of the 24 are also flagged with `Listed in Spamhaus ZEN` — that contributor was fixed in #464. This PR retires the next-most-impactful layer-2 false positive in the snapshot.)

## Test plan
- [x] New `it.each` covering 6 legit hosts that contain a shortener substring (`wealthfront.com`, `marriott.com`, `att.com`, `scott.com`, `abbott.com`, `elliot.com`) → rule must NOT fire.
- [x] New `it.each` covering 5 real-shortener shapes (`https://t.co/...`, `https://goo.gl/...`, `https://tinyurl.com/...`, bare `bit.ly/scam`, parenthesized `(https://ow.ly/abc).`) → rule MUST fire.
- [x] New "composite" test: legit URL + real shortener in same body → rule fires.
- [x] Existing rule tests still pass (`should flag emails with bit.ly links`, `should not flag normal URLs`, score-accumulation).
- [x] `bun test` — **782/782 pass** (+5 new assertions in this rule, 0 regressions).
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean (18 pre-existing warnings on unrelated files, no new).
- [x] E2E against local prod-snapshot DB: 21/24 → 0/24 false-fire elimination; no real-shortener fires lost.