### PR TITLE
fix(push): iOS badge no longer +1 over actual unread count (Closes #471)

### DIFF
--- a/src/server/lib/push.test.ts
+++ b/src/server/lib/push.test.ts
@@ -257,7 +257,10 @@ describe("notifyNewMails", () => {
     expect(sendArgs[0]).toBe(subscription);
     const payload = JSON.parse(sendArgs[1] as string);
     expect(payload.title).toBe("You have a new mail");
-    expect(payload.badge_count).toBe(2);
+    // `count: 1` already includes the just-arrived mail (saveMailHandler awaits
+    // the insert before notifyNewMails runs), so the badge must equal the DB
+    // count — no +1 (#471).
+    expect(payload.badge_count).toBe(1);
     expect(payload.push_subscription_id).toBe("sub-1");
     expect(m.repo.updateLastNotified).toHaveBeenCalledTimes(1);
     expect(m.repo.updateLastNotified.mock.calls[0]).toEqual(["sub-1"] as never);
@@ -279,8 +282,10 @@ describe("notifyNewMails", () => {
 
     const sendArgs = m.sendNotification.mock.calls[0] as unknown as unknown[];
     const payload = JSON.parse(sendArgs[1] as string);
-    expect(payload.title).toBe("You have 5 new mails");
-    expect(payload.badge_count).toBe(5);
+    // Both message and badge reflect the actual unread count (4 in DB → 4 in
+    // the message/badge), not 5 — see #471.
+    expect(payload.title).toBe("You have 4 new mails");
+    expect(payload.badge_count).toBe(4);
   });
 
   it("skips notification when no fresh unread mail (latest <= lastNotified)", async () => {

--- a/src/server/lib/push.ts
+++ b/src/server/lib/push.ts
@@ -115,19 +115,22 @@ export const createPush = (
         if (!notification) return;
         const badgeCount = notification.count || 0;
         const badgeLatest = notification.latest;
-        const incrementedBadgeCount = badgeCount + 1;
 
         if (badgeLatest && badgeLatest <= lastNotified) return;
 
+        // `badgeCount` is the current unread count from the DB. By the time
+        // notifyNewMails runs, saveMailHandler has already awaited the insert
+        // (see receive.ts), so the new mail is already part of `badgeCount` —
+        // do NOT add 1 again or the iOS badge ends up off-by-one (Closes #471).
         const message =
           badgeCount > 1
-            ? `You have ${incrementedBadgeCount} new mails`
+            ? `You have ${badgeCount} new mails`
             : "You have a new mail";
 
         const notificationPayload = {
           title: message,
           icon: "/icons/logo192.png",
-          badge_count: incrementedBadgeCount,
+          badge_count: badgeCount,
           push_subscription_id,
         };
 


### PR DESCRIPTION
## Summary

Hoie reported: *"When added to homescreen in iOS the badge icon for new mails doesn't match with actual new mails count. It's always +1."*

Root cause: `notifyNewMails` in `src/server/lib/push.ts:118` computed `badgeCount + 1` and sent that as the push payload's `badge_count`. The +1 dates back to commit `6c44bb0` (Oct 2025) and reflects a stale assumption that `getNotifications` returns the unread count *before* the just-arrived mail was inserted.

The timing today is the opposite — in `src/server/lib/mails/receive.ts:56-62`:

```ts
await Promise.all(
  usernames.map((u) => saveIncomingMail(u, validData, { remoteAddress: options.remoteAddress }))
);
…
await push.notifyNewMails(usernames, mailboxes);
```

`saveIncomingMail` writes the row with `read = FALSE` and `notifyNewMails` is `await`-ed after it returns. `getUnreadNotifications` (`src/server/lib/postgres/repositories/mails.ts:1016`) then runs `COUNT(*) FILTER (WHERE read = FALSE)` and naturally includes the just-arrived mail. So the DB count is already correct — adding 1 produces +1 too many.

The same +1 was also bleeding into the notification title (e.g. `"You have 5 new mails"` when only 4 were actually unread). Both fields now use the DB count directly.

## Fix

`src/server/lib/push.ts` — drop `incrementedBadgeCount`; use `badgeCount` for both `title` and `badge_count`. Inline comment explains the timing relationship that makes the +1 unnecessary.

```diff
-        const incrementedBadgeCount = badgeCount + 1;
-
-        if (badgeLatest && badgeLatest <= lastNotified) return;
+        if (badgeLatest && badgeLatest <= lastNotified) return;

         const message =
           badgeCount > 1
-            ? `You have ${incrementedBadgeCount} new mails`
+            ? `You have ${badgeCount} new mails`
             : "You have a new mail";

         const notificationPayload = {
           title: message,
           icon: "/icons/logo192.png",
-          badge_count: incrementedBadgeCount,
+          badge_count: badgeCount,
           push_subscription_id,
         };
```

## decrementBadgeCount is unchanged

The symmetric `decrementBadgeCount` (`push.ts:174`) does `Math.max(badgeCount - 1, 0)`. That's correct, because `post-mark.ts:37-39` fires `push.decrementBadgeCount([user]).catch(…)` *before* it `await`s `markRead`. The decrement anticipates the imminent `read = TRUE` write, mirror-image of `notifyNewMails`'s post-write timing.

## Test plan

- [x] `bun test src/server/lib/push.test.ts` — 24/24 pass after updating the two `count → badge_count` expectations (count=1 → badge=1, count=4 → "You have 4 new mails" + badge=4).
- [x] `bun test` — full suite **804/804 pass**, no regressions.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean for changed files (19 pre-existing warnings on unrelated files, no new).
- [x] Hand-traced flow: `saveMailHandler` (`receive.ts:39`) → `await saveIncomingMail` → DB row with `read=FALSE` → `push.notifyNewMails` → `getNotifications` reads DB → `count` includes new mail → badge value now matches actual unread count.
- [ ] iOS device E2E — requires a real APNs-bridged WebPush + home-screen install path that isn't reachable from this cron environment. The unit test assertions document the corrected payload shape (`badge_count == count` instead of `count + 1`), which is what the service worker (`public/service-worker.js:14-18`) hands to `navigator.setAppBadge`.

## Out of scope

- The latent race in `decrementBadgeCount` (no `await` before `markRead`) — separate concern, would land its own focused PR.
- The `unread_doc_count` polling badge in `src/client/App.tsx:158` (`noti.setBadge(newMailsTotal)`) — uses a different code path (HTTP `/api/mails/accounts`, no +1 in the chain), already matches the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)