### PR TITLE
chore(imap): remove unreachable duplicate date-criterion cases in Store.search

### DIFF
--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -34,12 +34,6 @@ import {
 import {
   SearchCriterion,
   UidCriterion,
-  BeforeCriterion,
-  OnCriterion,
-  SinceCriterion,
-  SentBeforeCriterion,
-  SentOnCriterion,
-  SentSinceCriterion,
 } from "./types";
 import { logger, getUserDomain } from "server";
 
@@ -428,25 +422,6 @@ export class Store {
             }
             break;
           }
-
-          case "BEFORE":
-            simplifiedCriteria.push({ type: "BEFORE", value: (criterion as BeforeCriterion).date });
-            break;
-          case "ON":
-            simplifiedCriteria.push({ type: "ON", value: (criterion as OnCriterion).date });
-            break;
-          case "SINCE":
-            simplifiedCriteria.push({ type: "SINCE", value: (criterion as SinceCriterion).date });
-            break;
-          case "SENTBEFORE":
-            simplifiedCriteria.push({ type: "SENTBEFORE", value: (criterion as SentBeforeCriterion).date });
-            break;
-          case "SENTON":
-            simplifiedCriteria.push({ type: "SENTON", value: (criterion as SentOnCriterion).date });
-            break;
-          case "SENTSINCE":
-            simplifiedCriteria.push({ type: "SENTSINCE", value: (criterion as SentSinceCriterion).date });
-            break;
 
           default:
             logger.warn("Unsupported search criterion", { component: "imap.store", type });


### PR DESCRIPTION
## Summary

`Store.search` in `src/server/lib/imap/store.ts` had two blocks of cases for the six date search-criteria types (`BEFORE`, `ON`, `SINCE`, `SENTBEFORE`, `SENTON`, `SENTSINCE`) inside the same `switch (type)`. The first block (above `case "UID"`) handles all six with a single `simplifiedCriteria.push({ type, value: dateCriterion.date })`. The second block at the bottom of the switch did the same thing but with the named type aliases — and was structurally unreachable: a `switch` only enters one matching case, and the first block already breaks out for every value it matches.

## Fix

- Delete the duplicate block (25 lines).
- Drop the six type-alias imports (`BeforeCriterion` / `OnCriterion` / `SinceCriterion` / `SentBeforeCriterion` / `SentOnCriterion` / `SentSinceCriterion`) — only the dead block referenced them; the live block does the cast inline as `{ type: string; date: Date }`.

Net: −25 lines, no behaviour change. Same `simplifiedCriteria` items reach `searchMailsByUid` for date predicates as before.

## Verification

- ` bun run typecheck` — clean (no errors after the import trim).
- `bun run lint` — 19 pre-existing warnings on unrelated files, no new.
- `bun test src/server/lib/imap/` — **359/359 pass** (797 expect calls). No imap-side regressions.

E2E not required — this is dead-code removal in a switch statement; the live path was already covered by IMAP search tests, which all still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)