### PR TITLE
fix(spam-allowlist): add UNIQUE(user_id, pattern) so ON CONFLICT works (Closes #483)

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -75,28 +75,6 @@ export const initializePostgres = async (): Promise<void> => {
       tables.map((t) => ({ name: t.name, schema: t.schema }))
     );
 
-    // One-off constraint backfill: spam_allowlist (user_id, pattern) UNIQUE was
-    // declared after the table shipped, so `CREATE TABLE IF NOT EXISTS` is a
-    // no-op for pre-existing deployments. addEntry's ON CONFLICT depends on it.
-    await pool.query(`
-      DO $$
-      BEGIN
-        IF NOT EXISTS (
-          SELECT 1 FROM pg_constraint
-          WHERE conrelid = 'spam_allowlist'::regclass
-            AND conname = 'spam_allowlist_user_id_pattern_key'
-        ) THEN
-          DELETE FROM spam_allowlist a
-          USING spam_allowlist b
-          WHERE a.ctid < b.ctid
-            AND a.user_id = b.user_id
-            AND a.pattern = b.pattern;
-          ALTER TABLE spam_allowlist
-            ADD CONSTRAINT spam_allowlist_user_id_pattern_key UNIQUE (user_id, pattern);
-        END IF;
-      END $$;
-    `);
-
     // Create indexes after migrations ensure all columns exist
     for (const table of tables) {
       for (const idx of table.indexes) {

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -75,6 +75,28 @@ export const initializePostgres = async (): Promise<void> => {
       tables.map((t) => ({ name: t.name, schema: t.schema }))
     );
 
+    // One-off constraint backfill: spam_allowlist (user_id, pattern) UNIQUE was
+    // declared after the table shipped, so `CREATE TABLE IF NOT EXISTS` is a
+    // no-op for pre-existing deployments. addEntry's ON CONFLICT depends on it.
+    await pool.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conrelid = 'spam_allowlist'::regclass
+            AND conname = 'spam_allowlist_user_id_pattern_key'
+        ) THEN
+          DELETE FROM spam_allowlist a
+          USING spam_allowlist b
+          WHERE a.ctid < b.ctid
+            AND a.user_id = b.user_id
+            AND a.pattern = b.pattern;
+          ALTER TABLE spam_allowlist
+            ADD CONSTRAINT spam_allowlist_user_id_pattern_key UNIQUE (user_id, pattern);
+        END IF;
+      END $$;
+    `);
+
     // Create indexes after migrations ensure all columns exist
     for (const table of tables) {
       for (const idx of table.indexes) {

--- a/src/server/lib/postgres/models/spam_allowlist.test.ts
+++ b/src/server/lib/postgres/models/spam_allowlist.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for SpamAllowlistTable methods.
+ *
+ * Verifies the SQL string + parameter normalization layer that wraps the DB.
+ * Pool is mocked — no live PostgreSQL needed.
+ *
+ * Specifically covers the regression from #483: addEntry's ON CONFLICT clause
+ * references (user_id, pattern) and must match the table's UNIQUE constraint.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+type Captured = { sql: string; params: unknown[] };
+const captured: Captured[] = [];
+let nextRows: unknown[] = [];
+let nextRowCount: number | null = null;
+
+const mockPoolQuery = mock(async (sql: string, params?: unknown[]) => {
+  captured.push({ sql, params: params ?? [] });
+  const rows = nextRows;
+  const rowCount = nextRowCount;
+  // Reset so each call's plant is one-shot.
+  nextRows = [];
+  nextRowCount = null;
+  return { rows, rowCount };
+});
+
+mock.module("../client", () => ({ pool: { query: mockPoolQuery } }));
+
+// Import only AFTER the pool mock is in place so the module resolves to it.
+import {
+  spamAllowlistTable,
+  SpamAllowlistModel,
+  PATTERN,
+} from "./spam_allowlist";
+import { USER_ID } from "./common";
+
+beforeEach(() => {
+  captured.length = 0;
+  nextRows = [];
+  nextRowCount = null;
+});
+
+describe("SpamAllowlistTable constraint declaration", () => {
+  it("declares UNIQUE(user_id, pattern) — must match addEntry's ON CONFLICT clause", () => {
+    expect(spamAllowlistTable.constraints).toContain(`UNIQUE(${USER_ID}, ${PATTERN})`);
+  });
+});
+
+describe("SpamAllowlistTable.addEntry", () => {
+  const userId = "11111111-1111-1111-1111-111111111111";
+
+  it("issues an INSERT … ON CONFLICT (user_id, pattern) DO NOTHING", async () => {
+    nextRows = [
+      {
+        allowlist_id: "aaaa",
+        user_id: userId,
+        pattern: "alice@example.com",
+        created_at: "2026-05-14T00:00:00Z",
+      },
+    ];
+    const result = await spamAllowlistTable.addEntry(userId, "alice@example.com");
+    expect(result).toBeInstanceOf(SpamAllowlistModel);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].sql).toContain("INSERT INTO spam_allowlist");
+    expect(captured[0].sql).toContain(`ON CONFLICT (${USER_ID}, ${PATTERN})`);
+    expect(captured[0].sql).toContain("DO NOTHING");
+    expect(captured[0].sql).toContain("RETURNING *");
+  });
+
+  it("lowercases the pattern before insertion", async () => {
+    nextRows = [
+      {
+        allowlist_id: "bbbb",
+        user_id: userId,
+        pattern: "alice@example.com",
+        created_at: "2026-05-14T00:00:00Z",
+      },
+    ];
+    await spamAllowlistTable.addEntry(userId, "ALICE@Example.COM");
+    expect(captured[0].params).toEqual([userId, "alice@example.com"]);
+  });
+
+  it("returns null when no row is returned (duplicate hit)", async () => {
+    nextRows = [];
+    const result = await spamAllowlistTable.addEntry(userId, "alice@example.com");
+    expect(result).toBeNull();
+  });
+});
+
+describe("SpamAllowlistTable.isAllowlisted", () => {
+  const userId = "22222222-2222-2222-2222-222222222222";
+
+  it("queries with both exact and *@domain forms (lowercased)", async () => {
+    nextRows = [{ count: "1" }];
+    const result = await spamAllowlistTable.isAllowlisted(userId, "BOB@Example.COM");
+    expect(result).toBe(true);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].sql).toContain("COUNT(*) AS count");
+    expect(captured[0].params).toEqual([userId, "bob@example.com", "*@example.com"]);
+  });
+
+  it("returns false when the COUNT is zero", async () => {
+    nextRows = [{ count: "0" }];
+    const result = await spamAllowlistTable.isAllowlisted(userId, "stranger@unknown.com");
+    expect(result).toBe(false);
+  });
+
+  it("returns false when the COUNT row is missing", async () => {
+    nextRows = [];
+    const result = await spamAllowlistTable.isAllowlisted(userId, "x@y.com");
+    expect(result).toBe(false);
+  });
+});
+
+describe("SpamAllowlistTable.removeByPattern", () => {
+  const userId = "33333333-3333-3333-3333-333333333333";
+
+  it("issues a DELETE filtered by user_id and LOWER(pattern), lowercases input", async () => {
+    nextRowCount = 1;
+    const ok = await spamAllowlistTable.removeByPattern(userId, "Alice@Example.com");
+    expect(ok).toBe(true);
+    expect(captured[0].sql).toContain("DELETE FROM spam_allowlist");
+    expect(captured[0].sql).toContain(`LOWER(${PATTERN}) = $2`);
+    expect(captured[0].params).toEqual([userId, "alice@example.com"]);
+  });
+
+  it("returns false when no row matched (rowCount === 0)", async () => {
+    nextRowCount = 0;
+    const ok = await spamAllowlistTable.removeByPattern(userId, "ghost@example.com");
+    expect(ok).toBe(false);
+  });
+
+  it("treats missing rowCount as zero (returns false)", async () => {
+    nextRowCount = null;
+    const ok = await spamAllowlistTable.removeByPattern(userId, "ghost@example.com");
+    expect(ok).toBe(false);
+  });
+});
+
+describe("SpamAllowlistTable.removeById", () => {
+  const userId = "44444444-4444-4444-4444-444444444444";
+  const allowlistId = "55555555-5555-5555-5555-555555555555";
+
+  it("scopes the DELETE by both user_id and allowlist_id to prevent cross-user delete", async () => {
+    nextRowCount = 1;
+    const ok = await spamAllowlistTable.removeById(userId, allowlistId);
+    expect(ok).toBe(true);
+    expect(captured[0].sql).toContain("DELETE FROM spam_allowlist");
+    expect(captured[0].sql).toContain(`${USER_ID} = $1`);
+    expect(captured[0].sql).toContain("allowlist_id = $2");
+    expect(captured[0].params).toEqual([userId, allowlistId]);
+  });
+
+  it("returns false when no row matched", async () => {
+    nextRowCount = 0;
+    const ok = await spamAllowlistTable.removeById(userId, allowlistId);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("SpamAllowlistTable.getAllForUser", () => {
+  const userId = "66666666-6666-6666-6666-666666666666";
+
+  it("returns SELECT * filtered by user_id, newest first", async () => {
+    nextRows = [
+      {
+        allowlist_id: "z",
+        user_id: userId,
+        pattern: "p1",
+        created_at: "2026-05-14T00:00:00Z",
+      },
+      {
+        allowlist_id: "y",
+        user_id: userId,
+        pattern: "p2",
+        created_at: "2026-05-13T00:00:00Z",
+      },
+    ];
+    const result = await spamAllowlistTable.getAllForUser(userId);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBeInstanceOf(SpamAllowlistModel);
+    expect(captured[0].sql).toContain("SELECT * FROM spam_allowlist");
+    expect(captured[0].sql).toContain(`${USER_ID} = $1`);
+    expect(captured[0].sql).toContain("ORDER BY created_at DESC");
+    expect(captured[0].params).toEqual([userId]);
+  });
+
+  it("returns an empty array when the user has no entries", async () => {
+    nextRows = [];
+    const result = await spamAllowlistTable.getAllForUser(userId);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/server/lib/postgres/models/spam_allowlist.ts
+++ b/src/server/lib/postgres/models/spam_allowlist.ts
@@ -64,7 +64,7 @@ class SpamAllowlistTable extends Table<SpamAllowlistJSON, SpamAllowlistSchema, S
   readonly name = SPAM_ALLOWLIST;
   readonly primaryKey = ALLOWLIST_ID;
   readonly schema = spamAllowlistSchema;
-  readonly constraints: Constraints = [];
+  readonly constraints: Constraints = [`UNIQUE(${USER_ID}, ${PATTERN})`];
   readonly indexes = [{ column: USER_ID }];
   readonly ModelClass = SpamAllowlistModel;
   readonly supportsSoftDelete = false;


### PR DESCRIPTION
## Summary

Closes #483.

`POST /api/mails/spam-allowlist` has returned HTTP 500 on every call since PR #73 (Spam Filter Phase 1, March 6, 2026) because `SpamAllowlistTable.addEntry` runs `ON CONFLICT (user_id, pattern) DO NOTHING` but the table never had a matching unique constraint. The route is only latent today because no client UI calls it; open issue #462 would have shipped a UI on top of this broken backend.

## Changes

### `src/server/lib/postgres/models/spam_allowlist.ts`

Declare the missing UNIQUE constraint:

```ts
readonly constraints: Constraints = [`UNIQUE(${USER_ID}, ${PATTERN})`];
```

Matches `spam_training.ts:75` (the working comparison case noted in the issue). Fresh deployments will pick up the constraint via `CREATE TABLE IF NOT EXISTS` at startup.

### `src/server/lib/postgres/models/spam_allowlist.test.ts` (new)

14 mock-pool tests covering:
- `addEntry` — SQL contains `ON CONFLICT (user_id, pattern) DO NOTHING` + `RETURNING *`; pattern is lowercased before insertion; returns null when no row returned (duplicate hit).
- `isAllowlisted` — queries both exact and `*@domain` forms (lowercased); returns false on COUNT=0 and on empty row.
- `removeByPattern` — DELETE filtered by `user_id` and `LOWER(pattern)`; lowercases input; returns false on rowCount=0 and rowCount=null.
- `removeById` — DELETE scoped by both `user_id` AND `allowlist_id` (prevents cross-user delete); returns false when no row matched.
- `getAllForUser` — SELECT * filtered by `user_id` with `ORDER BY created_at DESC`; returns empty array when no entries.
- `SpamAllowlistTable.constraints` declaration — sentinel test asserting the constraint string matches `addEntry`'s ON CONFLICT clause so future schema/SQL drift breaks the suite, not production.

Repo convention is to mock `pool.query` for SQL-layer tests (see `health.test.ts`, `classifier.test.ts`) — a real-DB integration test would require a live PostgreSQL connection which isn't set up in the test harness.

## Existing-deployment backfill

Pre-existing DBs do not have the constraint, and `CREATE TABLE IF NOT EXISTS` won't add it. The backfill is intentionally **not** committed here — Hoie will run it manually outside the app startup path. For reference, the operation needed against an existing DB is:

```sql
DELETE FROM spam_allowlist a USING spam_allowlist b
  WHERE a.ctid < b.ctid AND a.user_id = b.user_id AND a.pattern = b.pattern;
ALTER TABLE spam_allowlist
  ADD CONSTRAINT spam_allowlist_user_id_pattern_key UNIQUE (user_id, pattern);
```

A timestamped migration-script system would let this kind of one-off live in-repo; that's a separate scope.

## Test plan

- [x] `bun test src/server/lib/postgres/models/spam_allowlist.test.ts` — 14/14 pass
- [x] `bun test src/server` — 818/818 pass
- [x] `bun x tsc --noEmit` — clean
- [x] E2E on local dev server (admin login):
  - `POST /api/mails/spam-allowlist {"pattern":"test1@example.com"}` → HTTP 200, row returned (was HTTP 500 pre-fix with `there is no unique or exclusion constraint matching the ON CONFLICT specification`)
  - `POST` same pattern again → HTTP 200 `{"status":"failed","message":"Entry already exists"}` (route maps `addEntry`'s null return)
  - `POST "TEST1@Example.COM"` (case variation) → HTTP 200 `"Entry already exists"` (lowercase normalization dedup confirmed)
  - `GET /api/mails/spam-allowlist` → single row, no duplicates

## Notes

- The fix is forward-compatible with #462 (allowlist management UI) — once the UI ships, every "Add to allowlist" click will succeed instead of 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
