### PR TITLE
refactor(imap): extract resolveBox helper in Store class (Closes #485)

### DIFF
--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -48,6 +48,21 @@ export class Store {
     return this.user;
   }
 
+  /**
+   * Resolve an IMAP mailbox name into the (accountName, isSent) pair used by
+   * the mail repository. `INBOX` and the unified `Sent Messages` folder both
+   * map to `accountName=null` (no account scoping); everything else maps to
+   * the per-account address derived from the box name.
+   */
+  private resolveBox(box: string): { accountName: string | null; isSent: boolean } {
+    const isDomainInbox = box === "INBOX";
+    const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
+    const isSent = isSentBox(box);
+    const accountName =
+      isDomainInbox || isUnifiedSent ? null : boxToAccount(this.user.username, box);
+    return { accountName, isSent };
+  }
+
   listMailboxes = async (): Promise<string[]> => {
     try {
       // Match HTTP /api/mails/accounts: filter by user's domain so we only
@@ -122,13 +137,7 @@ export class Store {
     box: string
   ): Promise<{ total: number; unread: number; maxUid: number } | null> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
-
+      const { accountName, isSent } = this.resolveBox(box);
       return await countMessages(this.user.id, accountName, isSent);
     } catch (error) {
       logger.error("Error counting messages", { component: "imap.store", box }, error);
@@ -142,13 +151,7 @@ export class Store {
    */
   getAllUids = async (box: string): Promise<number[]> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
-
+      const { accountName, isSent } = this.resolveBox(box);
       return await pgGetAllUids(this.user.id, accountName, isSent);
     } catch (error) {
       logger.error("Error getting all UIDs", { component: "imap.store", box }, error);
@@ -164,13 +167,7 @@ export class Store {
     useUid: boolean = false
   ): Promise<Map<string, Partial<Mail>>> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
-
+      const { accountName, isSent } = this.resolveBox(box);
       const mailModels = await getMailsByRange(
         this.user.id,
         accountName,
@@ -276,13 +273,7 @@ export class Store {
     operation: StoreOperationType = "FLAGS"
   ): Promise<UpdatedMailFlags[]> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
-
+      const { accountName, isSent } = this.resolveBox(box);
       return await setMailFlags(
         this.user.id,
         accountName,
@@ -305,13 +296,7 @@ export class Store {
    */
   expunge = async (box: string): Promise<number[]> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
-
+      const { accountName, isSent } = this.resolveBox(box);
       return await expungeDeletedMails(this.user.id, accountName, isSent);
     } catch (error) {
       logger.error("Error expunging messages", { component: "imap.store", box }, error);
@@ -324,12 +309,7 @@ export class Store {
     criteria: SearchCriterion[]
   ): Promise<number[]> => {
     try {
-      const isDomainInbox = box === "INBOX";
-      const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
-      const isSent = isSentBox(box);
-      const accountName = (isDomainInbox || isUnifiedSent)
-        ? null
-        : boxToAccount(this.user.username, box);
+      const { accountName, isSent } = this.resolveBox(box);
 
       // Convert criteria to a simpler flat format for searchMailsByUid
       const simplifiedCriteria: { type: string; value?: unknown }[] = [];


### PR DESCRIPTION
## Summary

Closes #485.

Six `Store` methods (`countMessages`, `getAllUids`, `getMessages`, `setFlags`, `expunge`, `search`) each open with the same 4-line `(accountName, isSent)` derivation:

```ts
const isDomainInbox = box === "INBOX";
const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
const isSent = isSentBox(box);
const accountName = (isDomainInbox || isUnifiedSent)
  ? null
  : boxToAccount(this.user.username, box);
```

Drift risk: a new sentinel (e.g. `SHARED INBOX`) would require touching six callsites; the single conceptual question "is this box account-scoped, and if so what's the account name?" belongs in one place.

## Changes

Single-file refactor in `src/server/lib/imap/store.ts`:

- Added a private `resolveBox(box: string): { accountName: string | null; isSent: boolean }` helper.
- Each of the six methods now opens with `const { accountName, isSent } = this.resolveBox(box);`.

Diff: **+21 / -41**. No behavioural change. No repository, type, route, or test edits.

Per the issue body: `Store.search`'s ~140-line criterion-translation switch is **out of scope** here — that's a separate readability problem (typed-criterion-visitor pattern) and isn't reachable with this kind of one-line helper.

## Test plan

- [x] `bun x tsc --noEmit` — clean
- [x] `bun test src/server/lib/imap/` — 359/359 pass (full IMAP suite exercises every refactored method end-to-end)
- [x] `bun test src/server` — 804/804 pass

E2E not separately run because every refactored method is covered by the existing IMAP integration tests; no behaviour changes between this PR and main per a static read of the diff (the helper computes the exact same triple in the exact same order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)