### PR TITLE
chore(env): document SMTP/IMAP port overrides in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,11 @@ AWS_USER_SECRET_KEY=
 
 SSL_CERTIFICATE=
 SSL_CERTIFICATE_KEY=
+
+# Optional: override default mail-server ports (useful in sandbox/dev where
+# the privileged ports are already taken). When unset, the defaults below apply.
+# SMTP_PORT=25
+# SMTPS_PORT=465
+# SMTP_SUBMISSION_PORT=587
+# IMAP_PORT=143
+# IMAP_TLS_PORT=993


### PR DESCRIPTION
## Summary

The five mail-server port env vars (`SMTP_PORT`, `SMTPS_PORT`, `SMTP_SUBMISSION_PORT`, `IMAP_PORT`, `IMAP_TLS_PORT`) are read in:
- `src/server/lib/smtp.ts:227,238,248`
- `src/server/lib/imap/index.ts:22-23`
- `src/server/lib/http/routes/health.ts:76,82,93-95`

…but were missing from `.env.example`. `DEVELOPMENT.md` already documents them as overrides (added in PR #470 on 2026-05-08), but `.env.example` is the canonical surface devs copy into `.env.local`. Adding them as commented-out defaults makes the override mechanism discoverable without changing default behaviour for any existing deployment (the underlying source-side defaults are unchanged).

Found via daily-ops Sweep 6 (env-var/source vs `.env.example` reconciliation).

## Test plan

- [x] Source-side defaults unchanged — every comment value matches the literal default in source (`25`, `465`, `587`, `143`, `993`).
- [x] No CI-relevant files changed (only `.env.example`); `bun typecheck`/`lint` not applicable.
- [x] Manually confirmed by reading `.env.example` after edit — file ends with newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
