### PR TITLE
fix(spam): skip classifier training when /spam/mark is a no-op

### DIFF
--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -27,7 +27,7 @@ const mockGetAllowlistForUser = mock(async () => []);
 const mockAddAllowlistEntry = mock(async () => null as unknown);
 const mockRemoveAllowlistEntry = mock(async () => false as unknown);
 const mockSendMail = mock(async () => {});
-const mockMarkSpam = mock(async () => false as unknown);
+const mockMarkSpam = mock(async () => ({ found: false, changed: false }) as unknown);
 const mockGetAttachment = mock(() => undefined as unknown);
 const mockMailsTableQueryOne = mock(async () => null as unknown);
 const AUTH_ERROR_MESSAGE = "Authentication required";
@@ -620,7 +620,7 @@ describe("postMarkSpamMailRoute", () => {
 
   it("returns failed when mail not found or no permission", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
-    mockMarkSpam.mockResolvedValueOnce(null);
+    mockMarkSpam.mockResolvedValueOnce({ found: false, changed: false });
     const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("failed");
@@ -629,7 +629,7 @@ describe("postMarkSpamMailRoute", () => {
 
   it("returns success when spam marked", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
-    mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
+    mockMarkSpam.mockResolvedValueOnce({ found: true, changed: true });
     const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
@@ -637,8 +637,16 @@ describe("postMarkSpamMailRoute", () => {
 
   it("returns success when spam unmarked (is_spam false)", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
-    mockMarkSpam.mockResolvedValueOnce({ id: "m1" });
+    mockMarkSpam.mockResolvedValueOnce({ found: true, changed: true });
     const req = makeReq({ body: { mail_id: "m1", is_spam: false } });
+    const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+  });
+
+  it("returns success but skips training when re-marking with the same value", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    mockMarkSpam.mockResolvedValueOnce({ found: true, changed: false });
+    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
   });

--- a/src/server/lib/http/routes/mails/post-spam-mark.ts
+++ b/src/server/lib/http/routes/mails/post-spam-mark.ts
@@ -33,33 +33,36 @@ export const postMarkSpamMailRoute = new Route<SpamMarkPostResponse>(
       return { status: "failed", message: "is_spam must be a boolean" };
     }
 
-    const updated = await markSpam(user.id, mail_id, is_spam);
+    const { found, changed } = await markSpam(user.id, mail_id, is_spam);
 
-    if (!updated) {
+    if (!found) {
       return {
         status: "failed",
         message: "Mail not found or you don't have permission"
       };
     }
 
-    // Train the Naive Bayes classifier with this feedback.
-    // Fire-and-forget: classifier training failure must not break the user action.
-    getMailById(user.id, mail_id)
-      .then((mail) => {
-        if (!mail) return;
-        const emailContext = {
-          subject: mail.subject ?? undefined,
-          text: mail.text ?? undefined,
-          html: mail.html ?? undefined,
-          fromAddress: Array.isArray(mail.from_address) && mail.from_address.length > 0
-            ? (mail.from_address[0] as { address?: string }).address
-            : undefined,
-        };
-        return trainWithEmail(user.id, emailContext, is_spam);
-      })
-      .catch((error) => {
-        logger.warn("[SpamFilter] Classifier training failed for feedback", { mail_id }, error);
-      });
+    // Only train when is_spam actually flipped. Re-marking with the same value
+    // (idempotent click / retry / fat-finger toggle) must not re-train — one
+    // training sample per user action per mail, not one per HTTP call.
+    if (changed) {
+      getMailById(user.id, mail_id)
+        .then((mail) => {
+          if (!mail) return;
+          const emailContext = {
+            subject: mail.subject ?? undefined,
+            text: mail.text ?? undefined,
+            html: mail.html ?? undefined,
+            fromAddress: Array.isArray(mail.from_address) && mail.from_address.length > 0
+              ? (mail.from_address[0] as { address?: string }).address
+              : undefined,
+          };
+          return trainWithEmail(user.id, emailContext, is_spam);
+        })
+        .catch((error) => {
+          logger.warn("[SpamFilter] Classifier training failed for feedback", { mail_id }, error);
+        });
+    }
 
     return { status: "success" };
   }

--- a/src/server/lib/http/routes/push/push.test.ts
+++ b/src/server/lib/http/routes/push/push.test.ts
@@ -39,7 +39,7 @@ mock.module("server", () => ({
   getAllowlistForUser: mock(async () => []),
   addAllowlistEntry: mock(async () => null),
   removeAllowlistEntry: mock(async () => false),
-  markSpam: mock(async () => false),
+  markSpam: mock(async () => ({ found: false, changed: false })),
   getAttachment: mock(() => undefined),
   AUTH_ERROR_MESSAGE: "Authentication required",
   MailValidationError: class extends Error {},

--- a/src/server/lib/mails/spam.test.ts
+++ b/src/server/lib/mails/spam.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 const mockGetSpamMails = mock(() => Promise.resolve([]));
-const mockMarkMailSpam = mock(() => Promise.resolve(true));
+const mockMarkMailSpam = mock(() =>
+  Promise.resolve({ found: true, changed: true })
+);
 
 mock.module("../postgres/repositories/mails", () => ({
   getSpamMails: mockGetSpamMails,
@@ -163,16 +165,22 @@ describe("markSpam", () => {
     expect(mockMarkMailSpam).toHaveBeenCalledWith("user-123", "mail-abc", false);
   });
 
-  it("should return true when successful", async () => {
-    mockMarkMailSpam.mockResolvedValue(true);
+  it("returns found+changed when the row's is_spam actually flipped", async () => {
+    mockMarkMailSpam.mockResolvedValue({ found: true, changed: true });
     const result = await markSpam("user-123", "mail-abc", true);
-    expect(result).toBe(true);
+    expect(result).toEqual({ found: true, changed: true });
   });
 
-  it("should return false when operation fails", async () => {
-    mockMarkMailSpam.mockResolvedValue(false);
+  it("returns found-without-change for an idempotent re-mark", async () => {
+    mockMarkMailSpam.mockResolvedValue({ found: true, changed: false });
     const result = await markSpam("user-123", "mail-abc", true);
-    expect(result).toBe(false);
+    expect(result).toEqual({ found: true, changed: false });
+  });
+
+  it("returns not-found when the (user, mail) pair does not exist", async () => {
+    mockMarkMailSpam.mockResolvedValue({ found: false, changed: false });
+    const result = await markSpam("user-123", "mail-abc", true);
+    expect(result).toEqual({ found: false, changed: false });
   });
 
   it("should propagate errors from markMailSpam", async () => {

--- a/src/server/lib/mails/spam.ts
+++ b/src/server/lib/mails/spam.ts
@@ -47,6 +47,6 @@ export const markSpam = async (
   user_id: string,
   mail_id: string,
   is_spam: boolean
-): Promise<boolean> => {
+): Promise<{ found: boolean; changed: boolean }> => {
   return markMailSpam(user_id, mail_id, is_spam);
 };

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1167,20 +1167,34 @@ export const getSpamMails = async (user_id: string): Promise<MailModel[]> => {
 
 /**
  * Mark or unmark a mail as spam.
+ *
+ * Returns:
+ *   - `found`: true if the (user, mail) pair exists, regardless of current is_spam value
+ *   - `changed`: true if the row's is_spam value was actually flipped
+ *
+ * Distinguishing "no change" from "not found" lets the caller skip classifier
+ * training on idempotent re-marks while still surfacing real auth failures.
  */
 export const markMailSpam = async (
   user_id: string,
   mail_id: string,
   is_spam: boolean
-): Promise<boolean> => {
+): Promise<{ found: boolean; changed: boolean }> => {
   try {
     const result = await pool.query(
-      `UPDATE mails SET is_spam = $1, updated = NOW() WHERE mail_id = $2 AND user_id = $3`,
+      `UPDATE mails SET is_spam = $1, updated = NOW()
+         WHERE mail_id = $2 AND user_id = $3 AND is_spam IS DISTINCT FROM $1
+         RETURNING mail_id`,
       [is_spam, mail_id, user_id]
     );
-    return (result.rowCount ?? 0) > 0;
+    if ((result.rowCount ?? 0) > 0) return { found: true, changed: true };
+    const exists = await pool.query(
+      `SELECT 1 FROM mails WHERE mail_id = $1 AND user_id = $2 LIMIT 1`,
+      [mail_id, user_id]
+    );
+    return { found: (exists.rowCount ?? 0) > 0, changed: false };
   } catch (error) {
     logger.error("Failed to mark mail as spam", {}, error);
-    return false;
+    return { found: false, changed: false };
   }
 };


### PR DESCRIPTION
Closes #489

## Summary

`POST /api/mails/spam/mark` retrained the per-user Naive Bayes classifier on every call — even when the call didn't actually change `is_spam`. Per the issue body, three identical mark-as-spam calls on a single mail produced `__total__ = (spam_count = 3, ham_count = 0)` instead of `1/0`; a mark→unmark→mark→unmark toggle ended at `2/2`, putting the same vocabulary into both classes at equal weight and effectively poisoning per-word probabilities.

## Root cause

`markMailSpam` issued `UPDATE mails SET is_spam = $1 …` unconditionally and treated `rowCount > 0` as "success" — which is true whenever the user owns the mail, regardless of whether the boolean was actually flipping. The route (`post-spam-mark.ts`) then unconditionally fired `trainWithEmail` whenever `markSpam` returned truthy.

## Fix

1. `markMailSpam` now adds `AND is_spam IS DISTINCT FROM $1` to the `UPDATE`, and on a 0-row update issues a follow-up `SELECT 1 WHERE mail_id = ? AND user_id = ?` to distinguish "no-op (row exists, value already matched)" from "not found (row missing / wrong user)". It returns `{ found, changed }`.
2. `markSpam` (the lib wrapper) passes through the new shape.
3. `post-spam-mark.ts` returns `{ status: "failed", message: "Mail not found …" }` only when `found === false`. On `found === true && changed === false`, it returns `{ status: "success" }` (idempotent no-op) **without** queueing classifier training. Training fires only when `changed === true`.

## Test plan

- [x] `bun run tsc --noEmit` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only)
- [x] `bun test` — `820 pass / 0 fail` (full suite)
- [x] Unit: `markSpam` returns `{ found: true, changed: true }` on flip, `{ found: true, changed: false }` on idempotent re-mark, `{ found: false, changed: false }` when the (user, mail) pair doesn't exist
- [x] Unit: `postMarkSpamMailRoute` returns `success` for both real-flip and idempotent re-mark, `failed` only when `found === false`
- [ ] E2E reproduction from the issue body (three identical mark-as-spam calls → `spam_count = 1`, toggle scenario → `spam_count = 1, ham_count = 1`). Will exercise once a sandbox is available.

## Caller impact

`markSpam` / `markMailSpam` callers updated:
- `post-spam-mark.ts` — destructures `{ found, changed }`
- Existing tests (`mails.test.ts`, `push.test.ts`, `spam.test.ts`) updated to mock the new return shape; the old `{ id: … } | null` / `boolean` returns are gone.

## Out of scope (flagged in issue, not addressed here)

- `classifier.ts:107` doc-vs-impl mismatch on `MIN_TRAINING_DOCS` per-class gate — separate issue.
- `getMailHeaders` / `getAccountStats` not filtering `is_spam = FALSE` — best landed alongside #460.