### PR TITLE
fix(spam): DI seam in service.ts to unblock classifier.test.ts on CI

### DIFF
--- a/src/server/lib/spam/service.test.ts
+++ b/src/server/lib/spam/service.test.ts
@@ -6,12 +6,14 @@ const mockClassifyEmail = mock(async (_uid: string, _email: unknown) => ({
 }));
 const mockIsAllowlisted = mock(async (_uid: string, _addr: string) => false);
 
-mock.module("./classifier", () => ({ classifyEmail: mockClassifyEmail }));
+// Don't mock.module("./classifier", ...) — Bun's mock.module is process-wide
+// and would clobber classifier.test.ts. Use the service's DI seam instead.
 mock.module("../postgres/repositories/spam_allowlists", () => ({
   isAllowlisted: mockIsAllowlisted,
 }));
 
-const { checkSpam } = await import("./service");
+const { checkSpam, setSpamServiceDependencies } = await import("./service");
+setSpamServiceDependencies({ classifyEmail: mockClassifyEmail });
 
 // Email crafted so two minor rules fire (reply-to-mismatch + html-only-no-text = 20 pts).
 // remoteAddress is omitted so the DNSBL layer is skipped (no network calls in tests).

--- a/src/server/lib/spam/service.ts
+++ b/src/server/lib/spam/service.ts
@@ -13,7 +13,17 @@ import { checkDnsbls, DEFAULT_DNSBLS } from "./dnsbl";
 import { logger } from "../logger";
 import { evaluateRules, DEFAULT_RULES } from "./rules";
 import { isAllowlisted } from "../postgres/repositories/spam_allowlists";
-import { classifyEmail } from "./classifier";
+import { classifyEmail as realClassifyEmail } from "./classifier";
+
+// Dependency injection seam. Don't `mock.module("./classifier", ...)` in tests —
+// it's hoisted process-wide and clobbers classifier.test.ts. Tests override
+// classifyEmail via setSpamServiceDependencies({ classifyEmail }) instead.
+const deps = {
+  classifyEmail: realClassifyEmail,
+};
+
+export const setSpamServiceDependencies = (overrides: Partial<typeof deps>) =>
+  Object.assign(deps, overrides);
 
 /**
  * Default spam filter configuration.
@@ -90,7 +100,7 @@ export async function checkSpam(
 
   // Layer 3: Naive Bayes classifier (user-trained, per-user model)
   try {
-    const { score: classifierScore, reason: classifierReason } = await classifyEmail(userId, email);
+    const { score: classifierScore, reason: classifierReason } = await deps.classifyEmail(userId, email);
     // classifyEmail returns P(spam) * 100 in [0, 100], where < 50 is a HAM verdict
     // and >= 50 is a SPAM verdict (the classifier sets reason to non-null only at >= 50).
     // Only contribute to totalScore when the verdict leans spam — otherwise a


### PR DESCRIPTION
## Why

`bun test --coverage` was failing on CI (consistent, not flaky) in `src/server/lib/spam/classifier.test.ts`:

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 50
Received: 0
  at .../classifier.test.ts:177:26
(fail) classifyEmail > assigns high score to spam-like email with sufficient training
```

The classifier was scoring **0** instead of >50 for an email with 18/20 spam-doc tokens. Cause: `src/server/lib/spam/service.test.ts:9` (pre-existing) calls

```ts
mock.module("./classifier", () => ({ classifyEmail: mockClassifyEmail }));
```

Bun's `mock.module` is hoisted **process-wide** across the whole `bun test` run — see `reference_bun_mock_module_global_hoisting.md` (memory). Whichever file's mock-call evaluates last wins for the entire process. On macOS the filesystem-traversal order leaves the real classifier module in place when classifier.test.ts runs; on CI's Linux runner the order is different and classifier.test.ts ends up calling the mock, which always returns `{score: 0, reason: null}`.

This bites whenever a fresh PR rebases — see inbox/#491 (CI red on the same failure, completely unrelated to its diff).

## Fix

Apply the same pattern `push.ts` already uses (see `5146ca8`):

```ts
// service.ts
import { classifyEmail as realClassifyEmail } from "./classifier";

const deps = { classifyEmail: realClassifyEmail };

export const setSpamServiceDependencies = (overrides: Partial<typeof deps>) =>
  Object.assign(deps, overrides);
```

`checkSpam` calls `deps.classifyEmail(...)` instead of the direct import. `service.test.ts` overrides via `setSpamServiceDependencies({ classifyEmail: mockClassifyEmail })` and **drops** the `mock.module("./classifier", ...)` call entirely. The classifier module binding is never touched by tests, so classifier.test.ts always sees the real implementation regardless of test-file order.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` — same 19 pre-existing warnings, 0 errors (no new)
- [x] `bun test src/server/lib/spam` → 65 pass / 0 fail
- [x] `bun test` (full) → 818 pass / 0 fail
- [ ] CI green on this PR (will verify after push)
- [ ] Once merged, rebase #491 onto main — its CI should turn green automatically

## E2E

**Skipped — justified by the change.** This PR adds an internal DI seam (`deps`/setter) and rewires one call site (`classifyEmail(…)` → `deps.classifyEmail(…)`). The runtime call path is identical: `realClassifyEmail` is wired up via the default `deps` value, so production behavior is unchanged. The only behavioral diff is in `service.test.ts` (which is test-only). Unit tests verify both the rules-only and classifier-contribution paths still produce the same `checkSpam` outputs.