### PR TITLE
chore(env): document LOG_LEVEL override in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,7 @@ SSL_CERTIFICATE_KEY=
 # SMTP_SUBMISSION_PORT=587
 # IMAP_PORT=143
 # IMAP_TLS_PORT=993
+
+# Optional: log verbosity. One of debug | info | warn | error.
+# Default: info (or error when NODE_ENV=test). See src/server/lib/logger.ts.
+# LOG_LEVEL=info


### PR DESCRIPTION
## Summary

`process.env.LOG_LEVEL` is read in \`src/server/lib/logger.ts:44\` (default \`info\`; \`error\` when \`NODE_ENV=test\`) and again at \`logger.ts:89\` to gate stack-trace inclusion. It's documented at the top of `logger.ts` (line 6) but **missing from `.env.example`** — devs cloning the repo see no hint the knob exists.

This mirrors the recently-merged budget #360 (LOG_LEVEL) and inbox #488 (SMTP/IMAP ports). Comment-only block, no behavior change.

## Diff

```
+# Optional: log verbosity. One of debug | info | warn | error.
+# Default: info (or error when NODE_ENV=test). See src/server/lib/logger.ts.
+# LOG_LEVEL=info
```

## Test plan

- [x] Source default verified (logger.ts:44-48): \`LOG_LEVEL\` env wins; else \`error\` when \`NODE_ENV === 'test'\`; else \`info\`. Comment matches exactly.
- [x] No new env-var introduced — pure documentation of an existing one.
- [x] Diff is comment-only; no source file touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)