### PR TITLE
fix(spam-classifier): DI seams instead of mock.module to stabilize CD

### DIFF
--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -16,8 +16,6 @@
 
 import { describe, it, expect } from "bun:test";
 
-process.env.CLASSIFIER_DEBUG = "1";
-
 import { tokenize, extractTokens, trainWithEmail, classifyEmail } from "./classifier";
 
 type DocCounts = { spamDocs: number; hamDocs: number };
@@ -207,31 +205,14 @@ describe("classifyEmail", () => {
       ["prize", { spamCount: 16, hamCount: 1 }],
       ["free", { spamCount: 15, hamCount: 1 }],
     ]);
-    let docCountsHits = 0;
-    let wordCountsHits = 0;
     const result = await classifyEmail(
       "user1",
       { subject: "Win a free prize today" },
       {
-        getClassifierDocCounts: async () => {
-          docCountsHits++;
-          return { spamDocs: 20, hamDocs: 20 };
-        },
-        getWordCounts: async () => {
-          wordCountsHits++;
-          return wordCounts;
-        },
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 20, hamDocs: 20 }),
+        getWordCounts: stubWordCounts(wordCounts),
       },
     );
-    // Diagnostic — if CI ever fails this, the failure message tells us
-    // exactly which side of the math broke (DI plumbing vs. score calc).
-    if (result.score <= 50) {
-      // eslint-disable-next-line no-console
-      console.error("[diagnostic] result=", JSON.stringify(result), {
-        docCountsHits,
-        wordCountsHits,
-      });
-    }
     expect(result.score).toBeGreaterThan(50);
     expect(result.reason).not.toBeNull();
   });

--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -6,33 +6,23 @@
  * Bun and was the root cause of intermittent CI failures of the
  * "high score to spam-like email" case (Hoie 2026-05-17). Same DI
  * pattern as `backfill-snapshots.ts`.
+ *
+ * Test stubs are plain async functions rather than `mock()` instances
+ * + `mockResolvedValueOnce` queues — the queue-based pattern proved
+ * flaky in CI (Bun 1.3.14 on ubuntu-latest) where the once-value did
+ * not always survive across `beforeEach` mock resets. Plain functions
+ * are simpler and deterministic.
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect } from "bun:test";
 
 import { tokenize, extractTokens, trainWithEmail, classifyEmail } from "./classifier";
 
-const mockTrainClassifier = mock(
-  async (_userId: string, _words: string[], _isSpam: boolean): Promise<void> => {},
-);
-const mockGetClassifierDocCounts = mock(
-  async (_userId: string): Promise<{ spamDocs: number; hamDocs: number }> => ({
-    spamDocs: 0,
-    hamDocs: 0,
-  }),
-);
-const mockGetWordCounts = mock(
-  async (
-    _userId: string,
-    _words: string[],
-  ): Promise<Map<string, { spamCount: number; hamCount: number }>> => new Map(),
-);
+type DocCounts = { spamDocs: number; hamDocs: number };
+type WordCounts = Map<string, { spamCount: number; hamCount: number }>;
 
-const trainDeps = { trainClassifier: mockTrainClassifier };
-const classifyDeps = {
-  getClassifierDocCounts: mockGetClassifierDocCounts,
-  getWordCounts: mockGetWordCounts,
-};
+const stubDocCounts = (counts: DocCounts) => async (_userId: string) => counts;
+const stubWordCounts = (counts: WordCounts) => async (_u: string, _w: string[]) => counts;
 
 // --- tokenize() ---
 describe("tokenize", () => {
@@ -54,9 +44,7 @@ describe("tokenize", () => {
 
   it("filters out words shorter than 3 characters", () => {
     const result = tokenize("hi me it go the to");
-    // All 2-char words should be absent (min length is 3)
     expect(result.every((w) => w.length >= 3)).toBe(true);
-    // "the" is 3 chars — should be included
     expect(result).toContain("the");
   });
 
@@ -73,7 +61,6 @@ describe("tokenize", () => {
     expect(result).toContain("call");
     expect(result).toContain("spam");
     expect(result).toContain("today");
-    // Numbers alone should not appear
     expect(result).not.toContain("800");
     expect(result).not.toContain("50");
   });
@@ -119,14 +106,21 @@ describe("extractTokens", () => {
 
 // --- trainWithEmail() ---
 describe("trainWithEmail", () => {
-  beforeEach(() => {
-    mockTrainClassifier.mockClear();
-  });
-
   it("calls trainClassifier with extracted tokens", async () => {
-    await trainWithEmail("user1", { subject: "Buy cheap meds", text: "Click here now" }, true, trainDeps);
-    expect(mockTrainClassifier).toHaveBeenCalledTimes(1);
-    const [userId, words, isSpam] = mockTrainClassifier.mock.calls[0] as [string, string[], boolean];
+    const calls: Array<[string, string[], boolean]> = [];
+    const trainClassifier = async (userId: string, words: string[], isSpam: boolean) => {
+      calls.push([userId, words, isSpam]);
+    };
+
+    await trainWithEmail(
+      "user1",
+      { subject: "Buy cheap meds", text: "Click here now" },
+      true,
+      { trainClassifier },
+    );
+
+    expect(calls.length).toBe(1);
+    const [userId, words, isSpam] = calls[0];
     expect(userId).toBe("user1");
     expect(isSpam).toBe(true);
     expect(words).toContain("cheap");
@@ -134,104 +128,137 @@ describe("trainWithEmail", () => {
   });
 
   it("skips training when no tokens can be extracted", async () => {
-    await trainWithEmail("user1", {}, false, trainDeps);
-    expect(mockTrainClassifier).not.toHaveBeenCalled();
+    let called = false;
+    const trainClassifier = async () => {
+      called = true;
+    };
+    await trainWithEmail("user1", {}, false, { trainClassifier });
+    expect(called).toBe(false);
   });
 
   it("trains as ham when isSpam=false", async () => {
-    await trainWithEmail("user2", { subject: "Team standup tomorrow" }, false, trainDeps);
-    const [, , isSpam] = mockTrainClassifier.mock.calls[0] as [string, string[], boolean];
-    expect(isSpam).toBe(false);
+    const calls: Array<[string, string[], boolean]> = [];
+    const trainClassifier = async (u: string, w: string[], s: boolean) => {
+      calls.push([u, w, s]);
+    };
+    await trainWithEmail("user2", { subject: "Team standup tomorrow" }, false, {
+      trainClassifier,
+    });
+    expect(calls[0]?.[2]).toBe(false);
   });
 });
 
 // --- classifyEmail() ---
 describe("classifyEmail", () => {
-  beforeEach(() => {
-    mockGetClassifierDocCounts.mockClear();
-    mockGetWordCounts.mockClear();
-    // Reset to the default zero-docs implementation so prior tests'
-    // `mockResolvedValueOnce` queues don't bleed across cases.
-    mockGetClassifierDocCounts.mockImplementation(async () => ({ spamDocs: 0, hamDocs: 0 }));
-    mockGetWordCounts.mockImplementation(async () => new Map());
-  });
-
   it("returns score=0 when not enough training data (below MIN_TRAINING_DOCS=5)", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 2, hamDocs: 1 });
-    const result = await classifyEmail("user1", { subject: "Win a prize" }, classifyDeps);
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Win a prize" },
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 2, hamDocs: 1 }),
+        getWordCounts: stubWordCounts(new Map()),
+      },
+    );
     expect(result.score).toBe(0);
     expect(result.reason).toBeNull();
   });
 
   it("returns score=0 when no spam docs trained", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 0, hamDocs: 10 });
-    const result = await classifyEmail("user1", { subject: "Win a prize" }, classifyDeps);
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Win a prize" },
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 0, hamDocs: 10 }),
+        getWordCounts: stubWordCounts(new Map()),
+      },
+    );
     expect(result.score).toBe(0);
   });
 
   it("returns score=0 when no ham docs trained", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 0 });
-    const result = await classifyEmail("user1", { subject: "Hello team" }, classifyDeps);
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Hello team" },
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 10, hamDocs: 0 }),
+        getWordCounts: stubWordCounts(new Map()),
+      },
+    );
     expect(result.score).toBe(0);
   });
 
   it("returns score=0 when email has no extractable tokens", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 10 });
-    const result = await classifyEmail("user1", {}, classifyDeps);
+    const result = await classifyEmail(
+      "user1",
+      {},
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 10, hamDocs: 10 }),
+        getWordCounts: stubWordCounts(new Map()),
+      },
+    );
     expect(result.score).toBe(0);
   });
 
   it("assigns high score to spam-like email with sufficient training", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 20, hamDocs: 20 });
-    // The word "win" seen 18/20 times in spam, 1/20 in ham → strongly spam
-    mockGetWordCounts.mockResolvedValueOnce(
-      new Map([
-        ["win", { spamCount: 18, hamCount: 1 }],
-        ["prize", { spamCount: 16, hamCount: 1 }],
-        ["free", { spamCount: 15, hamCount: 1 }],
-      ]),
-    );
+    const wordCounts: WordCounts = new Map([
+      ["win", { spamCount: 18, hamCount: 1 }],
+      ["prize", { spamCount: 16, hamCount: 1 }],
+      ["free", { spamCount: 15, hamCount: 1 }],
+    ]);
     const result = await classifyEmail(
       "user1",
       { subject: "Win a free prize today" },
-      classifyDeps,
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 20, hamDocs: 20 }),
+        getWordCounts: stubWordCounts(wordCounts),
+      },
     );
     expect(result.score).toBeGreaterThan(50);
     expect(result.reason).not.toBeNull();
   });
 
   it("assigns low score to ham-like email with sufficient training", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 20, hamDocs: 20 });
-    // Words only seen in ham
-    mockGetWordCounts.mockResolvedValueOnce(
-      new Map([
-        ["standup", { spamCount: 0, hamCount: 15 }],
-        ["meeting", { spamCount: 1, hamCount: 18 }],
-        ["tomorrow", { spamCount: 0, hamCount: 17 }],
-      ]),
-    );
+    const wordCounts: WordCounts = new Map([
+      ["standup", { spamCount: 0, hamCount: 15 }],
+      ["meeting", { spamCount: 1, hamCount: 18 }],
+      ["tomorrow", { spamCount: 0, hamCount: 17 }],
+    ]);
     const result = await classifyEmail(
       "user1",
       { subject: "Team standup meeting tomorrow" },
-      classifyDeps,
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 20, hamDocs: 20 }),
+        getWordCounts: stubWordCounts(wordCounts),
+      },
     );
     expect(result.score).toBeLessThan(50);
     expect(result.reason).toBeNull();
   });
 
   it("returns score=0 and no error when DB throws", async () => {
-    mockGetClassifierDocCounts.mockRejectedValueOnce(new Error("DB error"));
-    const result = await classifyEmail("user1", { subject: "Hello there" }, classifyDeps);
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Hello there" },
+      {
+        getClassifierDocCounts: async () => {
+          throw new Error("DB error");
+        },
+        getWordCounts: stubWordCounts(new Map()),
+      },
+    );
     expect(result.score).toBe(0);
     expect(result.reason).toBeNull();
   });
 
   it("returns a score in [0, 100]", async () => {
-    mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 10 });
-    mockGetWordCounts.mockResolvedValueOnce(
-      new Map([["click", { spamCount: 8, hamCount: 2 }]]),
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Click here" },
+      {
+        getClassifierDocCounts: stubDocCounts({ spamDocs: 10, hamDocs: 10 }),
+        getWordCounts: stubWordCounts(new Map([["click", { spamCount: 8, hamCount: 2 }]])),
+      },
     );
-    const result = await classifyEmail("user1", { subject: "Click here" }, classifyDeps);
     expect(result.score).toBeGreaterThanOrEqual(0);
     expect(result.score).toBeLessThanOrEqual(100);
   });

--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -16,6 +16,8 @@
 
 import { describe, it, expect } from "bun:test";
 
+process.env.CLASSIFIER_DEBUG = "1";
+
 import { tokenize, extractTokens, trainWithEmail, classifyEmail } from "./classifier";
 
 type DocCounts = { spamDocs: number; hamDocs: number };

--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -1,24 +1,38 @@
 /**
  * Unit tests for the Naive Bayes spam classifier.
  *
- * Uses mock implementations for the database layer so no real DB is needed.
+ * Uses dependency injection (positional `deps` arg on `trainWithEmail` /
+ * `classifyEmail`) instead of `mock.module`, which is process-wide in
+ * Bun and was the root cause of intermittent CI failures of the
+ * "high score to spam-like email" case (Hoie 2026-05-17). Same DI
+ * pattern as `backfill-snapshots.ts`.
  */
 
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
-// --- Mock the database repositories ---
-// We mock the entire module so the classifier never touches a real DB.
-const mockTrainClassifier = mock(async (_userId: string, _words: string[], _isSpam: boolean) => {});
-const mockGetClassifierDocCounts = mock(async (_userId: string) => ({ spamDocs: 0, hamDocs: 0 }));
-const mockGetWordCounts = mock(async (_userId: string, _words: string[]) => new Map<string, { spamCount: number; hamCount: number }>());
+import { tokenize, extractTokens, trainWithEmail, classifyEmail } from "./classifier";
 
-mock.module("../postgres/repositories/spam_training", () => ({
-  trainClassifier: mockTrainClassifier,
+const mockTrainClassifier = mock(
+  async (_userId: string, _words: string[], _isSpam: boolean): Promise<void> => {},
+);
+const mockGetClassifierDocCounts = mock(
+  async (_userId: string): Promise<{ spamDocs: number; hamDocs: number }> => ({
+    spamDocs: 0,
+    hamDocs: 0,
+  }),
+);
+const mockGetWordCounts = mock(
+  async (
+    _userId: string,
+    _words: string[],
+  ): Promise<Map<string, { spamCount: number; hamCount: number }>> => new Map(),
+);
+
+const trainDeps = { trainClassifier: mockTrainClassifier };
+const classifyDeps = {
   getClassifierDocCounts: mockGetClassifierDocCounts,
   getWordCounts: mockGetWordCounts,
-}));
-
-import { tokenize, extractTokens, trainWithEmail, classifyEmail } from "./classifier";
+};
 
 // --- tokenize() ---
 describe("tokenize", () => {
@@ -110,7 +124,7 @@ describe("trainWithEmail", () => {
   });
 
   it("calls trainClassifier with extracted tokens", async () => {
-    await trainWithEmail("user1", { subject: "Buy cheap meds", text: "Click here now" }, true);
+    await trainWithEmail("user1", { subject: "Buy cheap meds", text: "Click here now" }, true, trainDeps);
     expect(mockTrainClassifier).toHaveBeenCalledTimes(1);
     const [userId, words, isSpam] = mockTrainClassifier.mock.calls[0] as [string, string[], boolean];
     expect(userId).toBe("user1");
@@ -120,12 +134,12 @@ describe("trainWithEmail", () => {
   });
 
   it("skips training when no tokens can be extracted", async () => {
-    await trainWithEmail("user1", {}, false);
+    await trainWithEmail("user1", {}, false, trainDeps);
     expect(mockTrainClassifier).not.toHaveBeenCalled();
   });
 
   it("trains as ham when isSpam=false", async () => {
-    await trainWithEmail("user2", { subject: "Team standup tomorrow" }, false);
+    await trainWithEmail("user2", { subject: "Team standup tomorrow" }, false, trainDeps);
     const [, , isSpam] = mockTrainClassifier.mock.calls[0] as [string, string[], boolean];
     expect(isSpam).toBe(false);
   });
@@ -136,30 +150,34 @@ describe("classifyEmail", () => {
   beforeEach(() => {
     mockGetClassifierDocCounts.mockClear();
     mockGetWordCounts.mockClear();
+    // Reset to the default zero-docs implementation so prior tests'
+    // `mockResolvedValueOnce` queues don't bleed across cases.
+    mockGetClassifierDocCounts.mockImplementation(async () => ({ spamDocs: 0, hamDocs: 0 }));
+    mockGetWordCounts.mockImplementation(async () => new Map());
   });
 
   it("returns score=0 when not enough training data (below MIN_TRAINING_DOCS=5)", async () => {
     mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 2, hamDocs: 1 });
-    const result = await classifyEmail("user1", { subject: "Win a prize" });
+    const result = await classifyEmail("user1", { subject: "Win a prize" }, classifyDeps);
     expect(result.score).toBe(0);
     expect(result.reason).toBeNull();
   });
 
   it("returns score=0 when no spam docs trained", async () => {
     mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 0, hamDocs: 10 });
-    const result = await classifyEmail("user1", { subject: "Win a prize" });
+    const result = await classifyEmail("user1", { subject: "Win a prize" }, classifyDeps);
     expect(result.score).toBe(0);
   });
 
   it("returns score=0 when no ham docs trained", async () => {
     mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 0 });
-    const result = await classifyEmail("user1", { subject: "Hello team" });
+    const result = await classifyEmail("user1", { subject: "Hello team" }, classifyDeps);
     expect(result.score).toBe(0);
   });
 
   it("returns score=0 when email has no extractable tokens", async () => {
     mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 10 });
-    const result = await classifyEmail("user1", {});
+    const result = await classifyEmail("user1", {}, classifyDeps);
     expect(result.score).toBe(0);
   });
 
@@ -171,9 +189,13 @@ describe("classifyEmail", () => {
         ["win", { spamCount: 18, hamCount: 1 }],
         ["prize", { spamCount: 16, hamCount: 1 }],
         ["free", { spamCount: 15, hamCount: 1 }],
-      ])
+      ]),
     );
-    const result = await classifyEmail("user1", { subject: "Win a free prize today" });
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Win a free prize today" },
+      classifyDeps,
+    );
     expect(result.score).toBeGreaterThan(50);
     expect(result.reason).not.toBeNull();
   });
@@ -186,16 +208,20 @@ describe("classifyEmail", () => {
         ["standup", { spamCount: 0, hamCount: 15 }],
         ["meeting", { spamCount: 1, hamCount: 18 }],
         ["tomorrow", { spamCount: 0, hamCount: 17 }],
-      ])
+      ]),
     );
-    const result = await classifyEmail("user1", { subject: "Team standup meeting tomorrow" });
+    const result = await classifyEmail(
+      "user1",
+      { subject: "Team standup meeting tomorrow" },
+      classifyDeps,
+    );
     expect(result.score).toBeLessThan(50);
     expect(result.reason).toBeNull();
   });
 
   it("returns score=0 and no error when DB throws", async () => {
     mockGetClassifierDocCounts.mockRejectedValueOnce(new Error("DB error"));
-    const result = await classifyEmail("user1", { subject: "Hello there" });
+    const result = await classifyEmail("user1", { subject: "Hello there" }, classifyDeps);
     expect(result.score).toBe(0);
     expect(result.reason).toBeNull();
   });
@@ -203,9 +229,9 @@ describe("classifyEmail", () => {
   it("returns a score in [0, 100]", async () => {
     mockGetClassifierDocCounts.mockResolvedValueOnce({ spamDocs: 10, hamDocs: 10 });
     mockGetWordCounts.mockResolvedValueOnce(
-      new Map([["click", { spamCount: 8, hamCount: 2 }]])
+      new Map([["click", { spamCount: 8, hamCount: 2 }]]),
     );
-    const result = await classifyEmail("user1", { subject: "Click here" });
+    const result = await classifyEmail("user1", { subject: "Click here" }, classifyDeps);
     expect(result.score).toBeGreaterThanOrEqual(0);
     expect(result.score).toBeLessThanOrEqual(100);
   });

--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -205,14 +205,31 @@ describe("classifyEmail", () => {
       ["prize", { spamCount: 16, hamCount: 1 }],
       ["free", { spamCount: 15, hamCount: 1 }],
     ]);
+    let docCountsHits = 0;
+    let wordCountsHits = 0;
     const result = await classifyEmail(
       "user1",
       { subject: "Win a free prize today" },
       {
-        getClassifierDocCounts: stubDocCounts({ spamDocs: 20, hamDocs: 20 }),
-        getWordCounts: stubWordCounts(wordCounts),
+        getClassifierDocCounts: async () => {
+          docCountsHits++;
+          return { spamDocs: 20, hamDocs: 20 };
+        },
+        getWordCounts: async () => {
+          wordCountsHits++;
+          return wordCounts;
+        },
       },
     );
+    // Diagnostic — if CI ever fails this, the failure message tells us
+    // exactly which side of the math broke (DI plumbing vs. score calc).
+    if (result.score <= 50) {
+      // eslint-disable-next-line no-console
+      console.error("[diagnostic] result=", JSON.stringify(result), {
+        docCountsHits,
+        wordCountsHits,
+      });
+    }
     expect(result.score).toBeGreaterThan(50);
     expect(result.reason).not.toBeNull();
   });

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -114,16 +114,11 @@ export async function classifyEmail(
     getWordCounts?: GetWordCountsFn;
   } = {},
 ): Promise<{ score: number; reason: string | null }> {
-  // DIAGNOSTIC (Hoie 2026-05-17, remove before merge) — unconditional
-  // log so we can see what deps the function sees in CI.
-  // eslint-disable-next-line no-console
-  console.error("[classifyEmail enter]", {
-    userId,
-    hasDocCountsDep: typeof deps.getClassifierDocCounts,
-    hasWordCountsDep: typeof deps.getWordCounts,
-    depsKeys: Object.keys(deps),
-    realDocCountsType: typeof realGetClassifierDocCounts,
-  });
+  // DIAGNOSTIC (Hoie 2026-05-17, remove before merge) — write to stderr
+  // directly to bypass Bun's test-runner stdout buffering on passing tests.
+  process.stderr.write(
+    `[classifyEmail enter] userId=${userId} hasDocs=${typeof deps.getClassifierDocCounts} hasWords=${typeof deps.getWordCounts} depsKeys=${Object.keys(deps).join(",")}\n`,
+  );
   const getClassifierDocCounts = deps.getClassifierDocCounts ?? realGetClassifierDocCounts;
   const getWordCounts = deps.getWordCounts ?? realGetWordCounts;
   try {

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -114,17 +114,16 @@ export async function classifyEmail(
     getWordCounts?: GetWordCountsFn;
   } = {},
 ): Promise<{ score: number; reason: string | null }> {
-  // DIAGNOSTIC (Hoie 2026-05-17): log deps signature so a CI failure of
-  // classifier.test.ts shows whether the DI plumbing is actually firing.
+  // DIAGNOSTIC (Hoie 2026-05-17, remove before merge) — unconditional
+  // log so we can see what deps the function sees in CI.
   // eslint-disable-next-line no-console
-  if (process.env.CLASSIFIER_DEBUG === "1") {
-    console.error("[classifyEmail enter]", {
-      userId,
-      hasDocCountsDep: typeof deps.getClassifierDocCounts,
-      hasWordCountsDep: typeof deps.getWordCounts,
-      depsKeys: Object.keys(deps),
-    });
-  }
+  console.error("[classifyEmail enter]", {
+    userId,
+    hasDocCountsDep: typeof deps.getClassifierDocCounts,
+    hasWordCountsDep: typeof deps.getWordCounts,
+    depsKeys: Object.keys(deps),
+    realDocCountsType: typeof realGetClassifierDocCounts,
+  });
   const getClassifierDocCounts = deps.getClassifierDocCounts ?? realGetClassifierDocCounts;
   const getWordCounts = deps.getWordCounts ?? realGetWordCounts;
   try {

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -18,11 +18,19 @@
 
 import { logger } from "../logger";
 import {
-  trainClassifier,
-  getClassifierDocCounts,
-  getWordCounts,
+  trainClassifier as realTrainClassifier,
+  getClassifierDocCounts as realGetClassifierDocCounts,
+  getWordCounts as realGetWordCounts,
 } from "../postgres/repositories/spam_training";
 import { EmailContext } from "./types";
+
+// DI seams — production callers pass nothing and get the real DB
+// implementations. Tests pass mocks via positional args instead of
+// `mock.module`, which is process-wide in Bun and leaks across sibling
+// test files. Same factoring as `backfill-snapshots.ts` (Hoie 2026-05-14).
+type TrainClassifierFn = typeof realTrainClassifier;
+type GetClassifierDocCountsFn = typeof realGetClassifierDocCounts;
+type GetWordCountsFn = typeof realGetWordCounts;
 
 /** Minimum number of spam + ham documents before the classifier will score. */
 const MIN_TRAINING_DOCS = 5;
@@ -71,8 +79,10 @@ export function extractTokens(email: EmailContext): string[] {
 export async function trainWithEmail(
   userId: string,
   email: EmailContext,
-  isSpam: boolean
+  isSpam: boolean,
+  deps: { trainClassifier?: TrainClassifierFn } = {},
 ): Promise<void> {
+  const trainClassifier = deps.trainClassifier ?? realTrainClassifier;
   const words = extractTokens(email);
   if (words.length === 0) {
     logger.warn("[Classifier] No tokens extracted from email — skipping training", { userId });
@@ -98,8 +108,14 @@ export async function trainWithEmail(
  */
 export async function classifyEmail(
   userId: string,
-  email: EmailContext
+  email: EmailContext,
+  deps: {
+    getClassifierDocCounts?: GetClassifierDocCountsFn;
+    getWordCounts?: GetWordCountsFn;
+  } = {},
 ): Promise<{ score: number; reason: string | null }> {
+  const getClassifierDocCounts = deps.getClassifierDocCounts ?? realGetClassifierDocCounts;
+  const getWordCounts = deps.getWordCounts ?? realGetWordCounts;
   try {
     const { spamDocs, hamDocs } = await getClassifierDocCounts(userId);
     const totalDocs = spamDocs + hamDocs;

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -114,11 +114,6 @@ export async function classifyEmail(
     getWordCounts?: GetWordCountsFn;
   } = {},
 ): Promise<{ score: number; reason: string | null }> {
-  // DIAGNOSTIC (Hoie 2026-05-17, remove before merge) — write to stderr
-  // directly to bypass Bun's test-runner stdout buffering on passing tests.
-  process.stderr.write(
-    `[classifyEmail enter] userId=${userId} hasDocs=${typeof deps.getClassifierDocCounts} hasWords=${typeof deps.getWordCounts} depsKeys=${Object.keys(deps).join(",")}\n`,
-  );
   const getClassifierDocCounts = deps.getClassifierDocCounts ?? realGetClassifierDocCounts;
   const getWordCounts = deps.getWordCounts ?? realGetWordCounts;
   try {

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -114,6 +114,17 @@ export async function classifyEmail(
     getWordCounts?: GetWordCountsFn;
   } = {},
 ): Promise<{ score: number; reason: string | null }> {
+  // DIAGNOSTIC (Hoie 2026-05-17): log deps signature so a CI failure of
+  // classifier.test.ts shows whether the DI plumbing is actually firing.
+  // eslint-disable-next-line no-console
+  if (process.env.CLASSIFIER_DEBUG === "1") {
+    console.error("[classifyEmail enter]", {
+      userId,
+      hasDocCountsDep: typeof deps.getClassifierDocCounts,
+      hasWordCountsDep: typeof deps.getWordCounts,
+      depsKeys: Object.keys(deps),
+    });
+  }
   const getClassifierDocCounts = deps.getClassifierDocCounts ?? realGetClassifierDocCounts;
   const getWordCounts = deps.getWordCounts ?? realGetWordCounts;
   try {

--- a/src/server/lib/spam/service.test.ts
+++ b/src/server/lib/spam/service.test.ts
@@ -1,17 +1,28 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+/**
+ * Unit tests for `checkSpam` — verifies the classifier scoring gate
+ * within the 4-layer spam pipeline.
+ *
+ * Uses dependency injection via `checkSpam(... , deps)` instead of
+ * `mock.module`. The latter is process-wide in Bun and silently
+ * replaced classifier.test.ts's imported `classifyEmail` with this
+ * file's mock, causing the CD flake on 2026-05-17 (Hoie).
+ */
 
-const mockClassifyEmail = mock(async (_uid: string, _email: unknown) => ({
-  score: 0,
-  reason: null as string | null,
-}));
-const mockIsAllowlisted = mock(async (_uid: string, _addr: string) => false);
+import { describe, it, expect } from "bun:test";
+import { checkSpam, CheckSpamDeps } from "./service";
 
-mock.module("./classifier", () => ({ classifyEmail: mockClassifyEmail }));
-mock.module("../postgres/repositories/spam_allowlists", () => ({
-  isAllowlisted: mockIsAllowlisted,
-}));
+const stubClassifier = (
+  result: { score: number; reason: string | null },
+): CheckSpamDeps["classifyEmail"] =>
+  async () => result;
 
-const { checkSpam } = await import("./service");
+const stubAllowlist = (allowed: boolean): CheckSpamDeps["isAllowlisted"] =>
+  async () => allowed;
+
+const baseDeps = (score: number, reason: string | null): CheckSpamDeps => ({
+  isAllowlisted: stubAllowlist(false),
+  classifyEmail: stubClassifier({ score, reason }),
+});
 
 // Email crafted so two minor rules fire (reply-to-mismatch + html-only-no-text = 20 pts).
 // remoteAddress is omitted so the DNSBL layer is skipped (no network calls in tests).
@@ -24,14 +35,8 @@ const subtleHamEmail = {
 };
 
 describe("checkSpam — classifier scoring gate", () => {
-  beforeEach(() => {
-    mockClassifyEmail.mockClear();
-    mockIsAllowlisted.mockClear();
-  });
-
   it("ignores classifier score < 50 (HAM verdict) so it does not inflate totalScore", async () => {
-    mockClassifyEmail.mockResolvedValueOnce({ score: 49, reason: null });
-    const result = await checkSpam("user1", subtleHamEmail);
+    const result = await checkSpam("user1", subtleHamEmail, {}, baseDeps(49, null));
     // Rules contribute 20 (reply-to mismatch + html-only). Classifier verdict is HAM
     // (score 49 < 50, reason null) and must contribute 0 — pre-fix it added 49 → 69.
     expect(result.score).toBe(20);
@@ -40,49 +45,60 @@ describe("checkSpam — classifier scoring gate", () => {
   });
 
   it("adds classifier score >= 50 (SPAM verdict) to totalScore", async () => {
-    mockClassifyEmail.mockResolvedValueOnce({
-      score: 75,
-      reason: "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)",
-    });
-    const result = await checkSpam("user1", subtleHamEmail);
+    const result = await checkSpam(
+      "user1",
+      subtleHamEmail,
+      {},
+      baseDeps(
+        75,
+        "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)",
+      ),
+    );
     // Rules 20 + classifier 75 = 95.
     expect(result.score).toBe(95);
     expect(result.isSpam).toBe(true);
     expect(result.reasons).toContain(
-      "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)"
+      "Bayesian classifier: 75% spam probability (20 spam / 20 ham documents trained)",
     );
   });
 
   it("adds classifier score = 50 (boundary SPAM verdict) to totalScore", async () => {
-    mockClassifyEmail.mockResolvedValueOnce({
-      score: 50,
-      reason: "Bayesian classifier: 50% spam probability (10 spam / 10 ham documents trained)",
-    });
     const cleanEmail = {
       fromAddress: "x@y.com",
       subject: "Hello there",
       text: "Hi friend, hope you are well.",
     };
-    const result = await checkSpam("user1", cleanEmail);
+    const result = await checkSpam(
+      "user1",
+      cleanEmail,
+      {},
+      baseDeps(
+        50,
+        "Bayesian classifier: 50% spam probability (10 spam / 10 ham documents trained)",
+      ),
+    );
     expect(result.score).toBe(50);
     expect(result.isSpam).toBe(true);
     expect(result.flaggedBy).toBe("classifier");
   });
 
   it("treats classifier score = 0 as untrained (no contribution, no reason)", async () => {
-    mockClassifyEmail.mockResolvedValueOnce({ score: 0, reason: null });
-    const result = await checkSpam("user1", subtleHamEmail);
+    const result = await checkSpam("user1", subtleHamEmail, {}, baseDeps(0, null));
     expect(result.score).toBe(20);
     expect(result.isSpam).toBe(false);
   });
 
   it("does not set flaggedBy='classifier' when verdict is HAM", async () => {
-    mockClassifyEmail.mockResolvedValueOnce({ score: 30, reason: null });
-    const result = await checkSpam("user1", {
-      fromAddress: "x@y.com",
-      subject: "Hello there",
-      text: "hello there",
-    });
+    const result = await checkSpam(
+      "user1",
+      {
+        fromAddress: "x@y.com",
+        subject: "Hello there",
+        text: "hello there",
+      },
+      {},
+      baseDeps(30, null),
+    );
     expect(result.flaggedBy).toBeUndefined();
   });
 });

--- a/src/server/lib/spam/service.ts
+++ b/src/server/lib/spam/service.ts
@@ -12,8 +12,20 @@ import { SpamCheckResult, SpamFilterConfig, EmailContext } from "./types";
 import { checkDnsbls, DEFAULT_DNSBLS } from "./dnsbl";
 import { logger } from "../logger";
 import { evaluateRules, DEFAULT_RULES } from "./rules";
-import { isAllowlisted } from "../postgres/repositories/spam_allowlists";
-import { classifyEmail } from "./classifier";
+import { isAllowlisted as realIsAllowlisted } from "../postgres/repositories/spam_allowlists";
+import { classifyEmail as realClassifyEmail } from "./classifier";
+
+// DI seams — production callers pass nothing and get the real
+// implementations. Tests inject stubs through these args instead of
+// `mock.module`, which is process-wide in Bun and leaks across sibling
+// test files (root cause of the classifier.test.ts CD flake on
+// 2026-05-17; same DI factoring as backfill-snapshots.ts).
+type IsAllowlistedFn = typeof realIsAllowlisted;
+type ClassifyEmailFn = typeof realClassifyEmail;
+export interface CheckSpamDeps {
+  isAllowlisted?: IsAllowlistedFn;
+  classifyEmail?: ClassifyEmailFn;
+}
 
 /**
  * Default spam filter configuration.
@@ -37,8 +49,11 @@ const DEFAULT_CONFIG: SpamFilterConfig = {
 export async function checkSpam(
   userId: string,
   email: EmailContext,
-  config: Partial<SpamFilterConfig> = {}
+  config: Partial<SpamFilterConfig> = {},
+  deps: CheckSpamDeps = {},
 ): Promise<SpamCheckResult> {
+  const isAllowlisted = deps.isAllowlisted ?? realIsAllowlisted;
+  const classifyEmail = deps.classifyEmail ?? realClassifyEmail;
   const cfg = { ...DEFAULT_CONFIG, ...config };
   const reasons: string[] = [];
   let totalScore = 0;
@@ -122,8 +137,10 @@ export async function checkSpam(
  */
 export async function isSenderAllowlisted(
   userId: string,
-  fromAddress: string
+  fromAddress: string,
+  deps: { isAllowlisted?: IsAllowlistedFn } = {},
 ): Promise<boolean> {
+  const isAllowlisted = deps.isAllowlisted ?? realIsAllowlisted;
   try {
     return await isAllowlisted(userId, fromAddress);
   } catch (error) {


### PR DESCRIPTION
## Summary

CD has failed 4 runs in a row on the flaky test:

```
(fail) classifyEmail > assigns high score to spam-like email with sufficient training
```

Initial guess was `classifier.test.ts`'s own `mock.module("...spam_training", ...)`. After landing a DI fix there, CI still failed — diagnostic logging showed `docCountsHits=0`, meaning the stub I passed via `deps` was never called even though it was clearly being passed.

**True root cause**: `service.test.ts` does `mock.module("./classifier", () => ({ classifyEmail: mockClassifyEmail }))` at module top level. `mock.module` is process-wide in Bun and `"./classifier"` resolves to the same module path from both test files, so under CI's test-file load order the mock leaks into `classifier.test.ts`'s `import { classifyEmail } from "./classifier"`. The real `classifyEmail` was being silently replaced by `mockClassifyEmail`, which returns `{ score: 0, reason: null }` by default — failing the `score > 50` expectation. Locally on macOS the file-load order happened to be benign.

## Long-term fix

Same DI seam pattern on both modules (mirrors `backfill-snapshots.ts`):

- `classifier.ts`: `trainWithEmail` / `classifyEmail` accept an optional `deps` arg defaulting to the real DB functions
- `service.ts`: `checkSpam` / `isSenderAllowlisted` accept an optional `deps` arg defaulting to `realIsAllowlisted` and `realClassifyEmail`
- Both `service.test.ts` and `classifier.test.ts` inject their stubs through the seams as plain async functions — no `mock.module`, no `mock()` queues, no possibility of cross-file leakage
- Production callers unchanged (`deps` defaults)

## Test plan

- [x] `bun test src/server/lib/spam/` — 65 pass
- [x] `bun test --coverage --coverage-reporter=lcov` (full suite, what CI runs) — 818 pass
- [x] `bun run typecheck` — clean
- [x] CI on this branch — test job green
- [ ] CD goes green on merge to main