### PR TITLE
fix(search): preserve `sent` field through searchMail mapping

### DIFF
--- a/src/server/lib/mails/search.test.ts
+++ b/src/server/lib/mails/search.test.ts
@@ -163,6 +163,21 @@ describe("searchMail", () => {
     expect(results[0].insight).toEqual(insight);
   });
 
+  it("should preserve the sent field from the model (regression for #497)", async () => {
+    // Before the fix, searchMail dropped `sent` and the MailHeaderData
+    // constructor defaulted it to false — so every search hit looked received.
+    const models = [
+      { mail_id: "s1", subject: "Sent", date: "2024-01-01", from_address: null, from_text: null, to_address: null, to_text: null, cc_address: null, cc_text: null, bcc_address: null, bcc_text: null, read: true, saved: false, sent: true, insight: null, highlight: undefined },
+      { mail_id: "r1", subject: "Received", date: "2024-01-02", from_address: null, from_text: null, to_address: null, to_text: null, cc_address: null, cc_text: null, bcc_address: null, bcc_text: null, read: false, saved: false, sent: false, insight: null, highlight: undefined },
+    ];
+    mockSearchMails.mockResolvedValue(models);
+
+    const results = await searchMail(mockUser, "mixed");
+    expect(results).toHaveLength(2);
+    expect(results[0].sent).toBe(true);
+    expect(results[1].sent).toBe(false);
+  });
+
   it("should return multiple results", async () => {
     const models = [
       { mail_id: "m1", subject: "First", date: "2024-01-01", from_address: null, from_text: null, to_address: null, to_text: null, cc_address: null, cc_text: null, bcc_address: null, bcc_text: null, read: false, saved: false, insight: null, highlight: undefined },

--- a/src/server/lib/mails/search.ts
+++ b/src/server/lib/mails/search.ts
@@ -31,6 +31,7 @@ export const searchMail = async (
         : undefined,
       read: m.read,
       saved: m.saved,
+      sent: m.sent,
       insight: m.insight as Insight | undefined,
       cc: m.cc_address
         ? { value: m.cc_address as MailAddressValueType[], text: m.cc_text || "" }


### PR DESCRIPTION
Closes #497.

## Summary

`searchMail` in `src/server/lib/mails/search.ts` built `MailHeaderData` objects from `SearchMailModel` rows but never read `m.sent`. `MailHeaderData`'s constructor defaults `sent = false` when omitted (`src/common/models/mails/MailData.ts:56`), so every result coming out of `GET /api/mails/search/:value` reported `sent: false` regardless of whether the mail was actually sent.

Same shape as PR #356 (Mar 27 2026), which added `saved` / `insight` / `cc` / `bcc` to this mapping but missed `sent`. The sibling mapper `getMailHeaders` (`src/server/lib/mails/headers.ts:45-67`) already forwards `sent: m.sent` — this brings search into parity.

## One-line fix

```diff
       read: m.read,
       saved: m.saved,
+      sent: m.sent,
       insight: m.insight as Insight | undefined,
```

`SearchMailModel extends MailModel` already carries `sent: boolean` — no schema, type, or downstream change needed.

## Test plan

- [x] `bun run tsc --noEmit` clean
- [x] New regression test `should preserve the sent field from the model (regression for #497)` in `search.test.ts` — asserts both `sent: true` and `sent: false` propagate to the result.
- [x] `bun test src/server/lib/mails/search.test.ts` — **16 pass, 0 fail** (+1 vs baseline)
- [x] `bun test` (full suite) — **819 pass, 0 fail** (same delta)
- [ ] Sandbox E2E: load `/api/mails/search/<query>`, confirm `sent: true` is returned for hits that are sent mails in the DB (reproduction in issue body cross-checked 3 mail IDs against `SELECT sent FROM mails WHERE mail_id IN (...)`).

## Why this matters

Per the issue body:
1. Reply composer (`onClickReply` in `src/client/Box/components/Mails/index.tsx:140-146`) assumes `from` = sender and `to` = self. For a sent mail returned by search this is reversed → clicking Reply opens a composer addressed to *yourself*.
2. Type contract violated: `MailHeaderDataType.sent` is non-optional `boolean`. Half the search results are silently wrong.
3. Any future client code that surfaces sent/received state from search hits gets the wrong answer.

## Out of scope

- `searchMails` doesn't filter on `is_spam = FALSE` or `draft = FALSE` either — flagged in the issue body's "Adjacent" section, best landed alongside the spam-folder UI in #460.
- The broader `sent`-column-removal effort (#430) is still gated on the UID-uniqueness decision; until that lands, today's `sent` column behavior is authoritative and this fix is the right one for now. When #430 ships, this mapping will follow it (along with all other `m.sent` callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)