### PR TITLE
chore(env): remove dead OPENAI_KEY entry from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,6 @@ APP_HOSTNAME=inbox.app
 SECRET=inbox
 ADMIN_PASSWORD=inbox
 
-OPENAI_KEY=
-
 # Mailgun API key for email sending
 MAILGUN_KEY=
 


### PR DESCRIPTION
## Summary
- `.env.example` still lists `OPENAI_KEY=` even though the OpenAI/AI-insight feature it powered was removed in PR #168 (chore: remove openai library and AI insight feature).
- No source code under `src/` reads `OPENAI_KEY` or `OPENAI_API_KEY` — verified with `rg 'OPENAI'` (no matches).
- Removes the dead entry so it doesn't mislead new developers into hunting for what it configures.

## Test plan
- [x] `rg 'OPENAI' src/` returns no matches (the env var is truly unused).
- [x] No app behavior change — `.env.example` is documentation only.
- [x] Visual diff: 2-line removal, no other entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)