### PR TITLE
chore: rephrase Hoie-attributed comments as design choices

### DIFF
--- a/src/server/lib/spam/classifier.test.ts
+++ b/src/server/lib/spam/classifier.test.ts
@@ -4,8 +4,7 @@
  * Uses dependency injection (positional `deps` arg on `trainWithEmail` /
  * `classifyEmail`) instead of `mock.module`, which is process-wide in
  * Bun and was the root cause of intermittent CI failures of the
- * "high score to spam-like email" case (Hoie 2026-05-17). Same DI
- * pattern as `backfill-snapshots.ts`.
+ * "high score to spam-like email" case.
  *
  * Test stubs are plain async functions rather than `mock()` instances
  * + `mockResolvedValueOnce` queues — the queue-based pattern proved

--- a/src/server/lib/spam/classifier.ts
+++ b/src/server/lib/spam/classifier.ts
@@ -27,7 +27,7 @@ import { EmailContext } from "./types";
 // DI seams — production callers pass nothing and get the real DB
 // implementations. Tests pass mocks via positional args instead of
 // `mock.module`, which is process-wide in Bun and leaks across sibling
-// test files. Same factoring as `backfill-snapshots.ts` (Hoie 2026-05-14).
+// test files.
 type TrainClassifierFn = typeof realTrainClassifier;
 type GetClassifierDocCountsFn = typeof realGetClassifierDocCounts;
 type GetWordCountsFn = typeof realGetWordCounts;


### PR DESCRIPTION
## Summary
Mirrors the directive surfaced on the budget repo (PR #352 / #383): *\"Don't document with my name in the code. Don't document quoting canonical instructions. Phrase them as design choices.\"*

Two comments in inbox carried the pattern, both on the spam-classifier surface:

| File | Comment |
|------|---------|
| \`src/server/lib/spam/classifier.ts\` | DI seam factoring header attributed the choice to the reviewer |
| \`src/server/lib/spam/classifier.test.ts\` | Test-header rationale cited the reviewer + date for the CI-failure incident that motivated DI |

Both are rephrased to assert the design directly. No behaviour change — comment-only diff.

## Test plan
- [x] \`rg 'Hoie 2026|Per Hoie' src/\` returns 0 hits after this PR.
- [x] \`bun run typecheck\` clean.
- [x] \`bun run lint\` clean (pre-existing warnings unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)