### PR TITLE
fix(spa): cache /assets/* in service worker, register on every load

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -94,27 +94,48 @@ self.addEventListener("fetch", (event) => {
 });
 
 self.addEventListener("push", (event) => {
-  if (!event.data) return;
+  // Gate the entire handler on the user actually being opted in. Since
+  // the SW is now registered for everyone (so the /assets/* cache tier
+  // can help users who never enabled push), a push that arrives for a
+  // user who has revoked notification permission or whose
+  // pushManager.subscription was unsubscribed would otherwise throw on
+  // showNotification (permission denied) and on the /api/push/refresh
+  // call with a stale subscription_id (server 4xx). Bail out cleanly
+  // when there's no active subscription or no notification permission.
+  const handler = async () => {
+    if (!event.data) return;
+    if (self.Notification && self.Notification.permission !== "granted") return;
+    const sub = await self.registration.pushManager.getSubscription();
+    if (!sub) return;
 
-  const notification = event.data.json();
-  if (!notification) return;
+    let notification;
+    try {
+      notification = event.data.json();
+    } catch {
+      return;
+    }
+    if (!notification) return;
 
-  const { push_subscription_id, title, icon, badge_count } = notification;
+    const { push_subscription_id, title, icon, badge_count } = notification;
 
-  const showNotification = async () => {
-    if (!title) return;
-    return self.registration.showNotification(title, { icon });
+    const jobs = [];
+    if (title) {
+      jobs.push(self.registration.showNotification(title, { icon }).catch(() => {}));
+    }
+    if (badge_count !== undefined && self.navigator) {
+      if (badge_count === 0 && self.navigator.clearAppBadge) {
+        jobs.push(self.navigator.clearAppBadge().catch(() => {}));
+      } else if (self.navigator.setAppBadge) {
+        jobs.push(self.navigator.setAppBadge(badge_count).catch(() => {}));
+      }
+    }
+    if (push_subscription_id) {
+      jobs.push(
+        fetch("/api/push/refresh/" + push_subscription_id).catch(() => {}),
+      );
+    }
+    await Promise.all(jobs);
   };
 
-  const setBadge = async () => {
-    if (badge_count === undefined) return;
-    if (badge_count === 0) return self.navigator.clearAppBadge();
-    else return self.navigator.setAppBadge(badge_count);
-  };
-
-  const refresh = () => fetch("/api/push/refresh/" + push_subscription_id);
-
-  const jobs = Promise.all([showNotification(), setBadge(), refresh()]);
-
-  event.waitUntil(jobs);
+  event.waitUntil(handler());
 });

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,3 +1,98 @@
+// Inbox service worker
+//
+// Two responsibilities:
+//   1. Push notifications (badge + system notification + server-side refresh
+//      ping). Pre-existing; logic unchanged.
+//   2. Cache-first for hashed assets (`/assets/*`). After every deploy,
+//      Vite rewrites the content-hashed chunk filenames in `index.html`,
+//      so users with stale tabs holding old chunk URLs were getting
+//      `'text/html' is not a valid JavaScript MIME type.` because the SPA
+//      catch-all served `index.html` for missing chunks (#501). With the
+//      cache-first /assets/* tier here, the old chunks are served from
+//      cache and the app keeps working until the user reloads. Mirrors
+//      `budget/src/client/sw.ts` lines 63–79 (Hoie 2026-05-19).
+
+const CACHE_NAME = "inbox-v1";
+
+self.addEventListener("install", (event) => {
+  // Precache the SPA shell so it's available offline.
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.add("/"))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  // Drop old cache versions on a new SW activation.
+  event.waitUntil(
+    caches
+      .keys()
+      .then((names) =>
+        Promise.all(names.filter((n) => n !== CACHE_NAME).map((n) => caches.delete(n))),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method !== "GET" || url.origin !== self.location.origin) return;
+
+  // Never intercept API calls.
+  if (url.pathname.startsWith("/api")) return;
+
+  // Cache-first for hashed assets (JS, CSS under /assets/).
+  // Vite embeds a content hash in every filename, so the URL itself
+  // changes when the content changes — no stale data is ever served.
+  // The cache holds whatever URLs were valid the last time the user
+  // loaded; if a deploy invalidates them, the cached copies keep the
+  // open tab working until the user reloads onto fresh HTML.
+  if (url.pathname.startsWith("/assets/")) {
+    event.respondWith(
+      caches.open(CACHE_NAME).then((cache) =>
+        cache.match(request).then((cached) => {
+          if (cached) return cached;
+          return fetch(request).then((response) => {
+            if (response.ok) cache.put(request, response.clone());
+            return response;
+          });
+        }),
+      ),
+    );
+    return;
+  }
+
+  // Network-first for HTML navigation so fresh index.html is always used.
+  // Always store under "/" so the SPA shell is found regardless of which
+  // path the user was on when they last had network access.
+  if (request.mode === "navigate") {
+    const responsePromise = fetch(request);
+
+    event.waitUntil(
+      responsePromise
+        .then((response) => {
+          if (response.ok) {
+            return caches
+              .open(CACHE_NAME)
+              .then((cache) => cache.put("/", response.clone()));
+          }
+        })
+        .catch(() => {}),
+    );
+
+    event.respondWith(
+      responsePromise.catch(async () => {
+        const cached = await caches.match("/");
+        return cached ?? new Response("Offline", { status: 503 });
+      }),
+    );
+  }
+});
+
 self.addEventListener("push", (event) => {
   if (!event.data) return;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -24,6 +24,20 @@ window.addEventListener("unhandledrejection", (event) => {
   navigator.sendBeacon("/api/client-error", new Blob([body], { type: "application/json" }));
 });
 
+// Register the service worker on every page load so the cache-first
+// /assets/* tier inside service-worker.js is always active — keeps the
+// app working on stale tabs after a deploy rewrites the hashed chunk
+// filenames in index.html (#501). The push-notification subscribe flow
+// in client/lib/notification.ts no-ops `register()` after the first
+// call, so this doesn't change anything for already-subscribed users.
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js").catch((error) => {
+      console.error("Service worker registration failed:", error);
+    });
+  });
+}
+
 const root = createRoot(document.getElementById("root") as HTMLElement);
 
 const mountApp = async () => {


### PR DESCRIPTION
Closes #501.

## Summary

Original #501 proposed tightening the SPA catch-all to 404 for asset paths + client-side reload on chunk-load failures. Per Hoie 2026-05-19: prefer the **service-worker caching approach** that budget already implements (`budget/src/client/sw.ts` L63–79). Old chunks get served from cache after a deploy, so stale tabs keep working until the user reloads onto fresh HTML.

## Changes

1. **`public/service-worker.js`** — extend the existing push-only worker with caching:
   - `install`: precache `/`, `skipWaiting`
   - `activate`: drop old cache versions, `clients.claim`
   - `fetch`:
     - skip non-GET / cross-origin
     - skip `/api/*` (never intercept the API)
     - **cache-first for `/assets/*`** — mirrors budget L63–79. Hashed filenames mean no stale data is ever served (URL encodes content hash).
     - network-first for navigate, caching the HTML under `/` so offline reloads find the SPA shell

2. **`src/index.tsx`** — register `/service-worker.js` on every page load, not just when the user subscribes to push notifications. The push subscribe flow in `client/lib/notification.ts` already called `register()`, which is now redundant but harmless (returns the existing registration).

3. **`public/service-worker.js` push handler hardening** (follow-up commit, Hoie 2026-05-19) — since the SW now registers for every user, a push delivered to a client whose notification permission was revoked or whose `pushManager` subscription is gone would otherwise blow up. The push handler now:
   - skips when `Notification.permission !== "granted"`
   - skips when `pushManager.getSubscription()` returns null
   - wraps `event.data.json()` in try/catch (non-JSON payload)
   - per-job `.catch(() => {})` on `showNotification` / `setAppBadge` / `refresh` so a single failure doesn't reject the whole `waitUntil`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 818 pass
- [x] `bun run lint` — 0 errors (19 pre-existing warnings, unrelated)
- [ ] Sandbox E2E — load the app once to seed the cache, then redeploy with new hashed chunk URLs and verify the stale tab continues working without the MIME error
- [ ] Verify push notifications still fire for opted-in users; verify no console errors for opted-out users after a push delivery
