### PR TITLE
fix(users): propagate token + expiry through getUser (#496)

### DIFF
--- a/src/server/lib/postgres/models/models.test.ts
+++ b/src/server/lib/postgres/models/models.test.ts
@@ -413,6 +413,24 @@ describe("UserModel.toUser", () => {
     const u = new UserModel(makeUserData({ password: null }));
     expect(() => u.toUser()).toThrow("no password set");
   });
+
+  // #496: token/expiry must round-trip through toUser() so callers like
+  // setUserInfo / startTimer can validate them.
+  it("propagates token + expiry when present", () => {
+    const u = new UserModel(
+      makeUserData({ token: "tok-abc", expiry: "2026-12-31T00:00:00+00:00" }),
+    );
+    const user = u.toUser();
+    expect(user.token).toBe("tok-abc");
+    expect(user.expiry).toBe("2026-12-31T00:00:00+00:00");
+  });
+
+  it("propagates null token/expiry without coercing them away", () => {
+    const u = new UserModel(makeUserData({ token: null, expiry: null }));
+    const user = u.toUser();
+    expect(user.token).toBeNull();
+    expect(user.expiry).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/lib/postgres/models/user.ts
+++ b/src/server/lib/postgres/models/user.ts
@@ -27,7 +27,13 @@ export interface MaskedUser {
   email?: string | null;
 }
 
-export type User = MaskedUser & { password: string };
+export type User = MaskedUser & {
+  password: string;
+  // token/expiry are required to round-trip through `toUser()` so callers like
+  // `setUserInfo` can validate them. `null` when no in-flight signup token.
+  token?: string | null;
+  expiry?: string | null;
+};
 
 const userSchema = {
   [USER_ID]: "UUID PRIMARY KEY DEFAULT gen_random_uuid()",
@@ -85,6 +91,8 @@ export class UserModel extends Model<MaskedUser, UserSchema> {
       username: this.username,
       password: this.password,
       email: this.email,
+      token: this.token,
+      expiry: this.expiry,
     };
   }
 }

--- a/src/server/lib/users.ts
+++ b/src/server/lib/users.ts
@@ -29,7 +29,9 @@ export const getUser = async (
     id: pgUser.user_id,
     username: pgUser.username,
     email: pgUser.email ?? undefined,
-    password: pgUser.password
+    password: pgUser.password,
+    token: pgUser.token ?? undefined,
+    expiry: pgUser.expiry ?? undefined
   });
 };
 


### PR DESCRIPTION
## Summary
- \`getUser\` in \`src/server/lib/users.ts\` dropped \`token\` and \`expiry\` when mapping a pg row into a common \`User\`, making \`setUserInfo\` always throw \`token doesn't match\` and breaking the only known signup completion path.
- Extends the \`User\` type with optional \`token\` / \`expiry\` and includes them in \`UserModel.toUser()\` and \`getUser\`'s mapping.
- 2 new unit tests pin the propagation in \`models.test.ts\`.

Closes #496

## What changed
| File | Change |
|------|--------|
| \`src/server/lib/postgres/models/user.ts\` | Extend \`User\` type with optional \`token?: string \| null\` / \`expiry?: string \| null\`; include them in \`UserModel.toUser()\`. |
| \`src/server/lib/users.ts\` | \`getUser\` passes \`pgUser.token\` / \`pgUser.expiry\` through into the \`new User({...})\` mapping. |
| \`src/server/lib/postgres/models/models.test.ts\` | +2 tests: \`toUser()\` propagates token+expiry when present; propagates \`null\` without coercion. |

## Why this is a thin fix
The issue body proposed the literal mapping change in \`users.ts\` but assumed the postgres \`User\` type already exposed token/expiry. It didn't (\`MaskedUser & { password: string }\`), and \`UserModel.toUser()\` didn't return them. So the fix also widens the type and the model's \`toUser()\` projection. \`MaskedUser\` is unchanged — token/expiry are still server-internal.

## Test plan
- [x] \`bun test src/server\` → 820 pass / 0 fail (no regressions).
- [x] \`bun --bun tsc --noEmit\` clean.
- [ ] **E2E** not exercised here. The fix is a pure data-mapping change (5 LOC across the three files) and is unit-pinned at the model boundary. A live signup E2E (createToken → email → set-info → setUserInfo) requires SMTP / DNS and is out of scope for this PR. Verifying the happy path end-to-end is a follow-up tied to PR #495's test pin.

## Coordination with #495
PR #495 (\`test/users-coverage-345\`) includes a regression test at \`users.test.ts:484-508\` that pins the **buggy** behavior (\`rejects even on matching pg token because getUser strips token from its mapping\`), explicitly intended to force a fix that propagates token to update the assertion. After both PRs land, that test will need to flip to a happy-path assertion. I have not modified \`users.test.ts\` in this PR to keep the diff focused and avoid a merge conflict with #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)