### PR TITLE
fix(badge): exclude drafts from getUnreadNotifications

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -214,3 +214,39 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456)
     expect(updateWhereCount).toBe(2);
   });
 });
+
+// Source-text scan for #507: getUnreadNotifications must exclude drafts
+// so the push-payload badge_count matches the FE-polling badge count
+// (getAccountStats excludes draft = FALSE via its expanded_mails CTE).
+// Drift between the two queries inflated the iOS badge above the
+// FE-shown unread count and produced a +1-per-new-mail symptom.
+describe("getUnreadNotifications SQL filter", () => {
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(
+      /export const getUnreadNotifications[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getUnreadNotifications not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("excludes drafts (draft = FALSE) so badge matches FE polling (#507)", () => {
+    expect(fnSource).toMatch(/draft\s*=\s*FALSE/);
+  });
+
+  it("preserves existing exclusions for sent + expunged", () => {
+    expect(fnSource).toMatch(/sent\s*=\s*FALSE/);
+    expect(fnSource).toMatch(/expunged\s*=\s*FALSE/);
+  });
+
+  it("counts only unread rows (read = FALSE) in the FILTER", () => {
+    expect(fnSource).toMatch(/COUNT\(\*\)\s+FILTER\s*\(WHERE\s+read\s*=\s*FALSE\)/);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1020,13 +1020,23 @@ export const getUnreadNotifications = async (
     if (user_ids.length === 0) return new Map();
 
     const placeholders = user_ids.map((_, i) => `$${i + 1}`).join(", ");
+    // Mirror getAccountStats' exclusions (draft + expunged): drafts have
+    // `draft=TRUE AND read=FALSE` in the Drafts folder, which the FE
+    // polling (getAccountStats) excludes via `draft = FALSE`. Without
+    // the same filter here, the push-payload badge_count would include
+    // drafts while the FE-driven badge_count wouldn't — drift caused
+    // the symptom Hoie reported 2026-05-20 ("badge says 15 even though
+    // 0 unread; +1 on new mail").
     const sql = `
-      SELECT 
+      SELECT
         user_id,
         COUNT(*) FILTER (WHERE read = FALSE) as unread_count,
         MAX(date) as latest
-      FROM mails 
-      WHERE user_id IN (${placeholders}) AND sent = FALSE AND expunged = FALSE
+      FROM mails
+      WHERE user_id IN (${placeholders})
+        AND sent = FALSE
+        AND expunged = FALSE
+        AND draft = FALSE
       GROUP BY user_id
     `;
 


### PR DESCRIPTION
Closes #507.

## Summary

`getUnreadNotifications` (`src/server/lib/postgres/repositories/mails.ts:1016`) drives the push-payload `badge_count`. It filtered `read=FALSE AND sent=FALSE AND expunged=FALSE` but **didn't exclude drafts**. The FE-polling counterpart `getAccountStats` does (`AND draft = FALSE` in its expanded_mails CTE). Drift inflated the iOS badge by exactly the number of read=FALSE drafts.

Add `AND draft = FALSE`. Source-grep regression tests in `mails.test.ts` so the two queries stay aligned.

## Why this is the cause of #507's symptoms

- **"Badge says 15 even though there's 0 unread"** → 15 drafts marked `read=FALSE` in DB. Push-side count returns 15; FE polling returns 0. iOS badge sticks at whichever update fired last.
- **"Open and close the app, badge sometimes disappears"** → FE polling on focus updates `newMailsTotal = 0` → `setAppBadge(0)` → badge clears. Sometimes iOS PWA misses the set-to-zero, so it sticks.
- **"Get a new mail → suddenly 16"** → push fires, `getUnreadNotifications` returns 15+1 = 16 (drafts + the new one), SW does `setAppBadge(16)`. Exact +1 pattern reported.

## decrementBadgeCount

`decrementBadgeCount` (`push.ts:167`) calls `getNotifications` → `getUnreadNotifications`, so it picks up this fix transitively. No separate change.

## Test plan

- [x] `bun test src/server/lib/postgres/repositories/mails.test.ts` — 17 pass (3 new for the SQL filter)
- [x] `bun test` (full suite) — 825 pass, 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run lint` — 0 errors (19 pre-existing warnings unrelated)
- [ ] Sandbox E2E — verify push payload from `notifyNewMails` shows `badge_count` matching the FE-polling unread count when the user has draft rows