### PR TITLE
Revert "fix(push): iOS badge no longer +1 over actual unread count (#482)"

### DIFF
--- a/src/server/lib/push.test.ts
+++ b/src/server/lib/push.test.ts
@@ -257,10 +257,7 @@ describe("notifyNewMails", () => {
     expect(sendArgs[0]).toBe(subscription);
     const payload = JSON.parse(sendArgs[1] as string);
     expect(payload.title).toBe("You have a new mail");
-    // `count: 1` already includes the just-arrived mail (saveMailHandler awaits
-    // the insert before notifyNewMails runs), so the badge must equal the DB
-    // count — no +1 (#471).
-    expect(payload.badge_count).toBe(1);
+    expect(payload.badge_count).toBe(2);
     expect(payload.push_subscription_id).toBe("sub-1");
     expect(m.repo.updateLastNotified).toHaveBeenCalledTimes(1);
     expect(m.repo.updateLastNotified.mock.calls[0]).toEqual(["sub-1"] as never);
@@ -282,10 +279,8 @@ describe("notifyNewMails", () => {
 
     const sendArgs = m.sendNotification.mock.calls[0] as unknown as unknown[];
     const payload = JSON.parse(sendArgs[1] as string);
-    // Both message and badge reflect the actual unread count (4 in DB → 4 in
-    // the message/badge), not 5 — see #471.
-    expect(payload.title).toBe("You have 4 new mails");
-    expect(payload.badge_count).toBe(4);
+    expect(payload.title).toBe("You have 5 new mails");
+    expect(payload.badge_count).toBe(5);
   });
 
   it("skips notification when no fresh unread mail (latest <= lastNotified)", async () => {

--- a/src/server/lib/push.ts
+++ b/src/server/lib/push.ts
@@ -115,22 +115,19 @@ export const createPush = (
         if (!notification) return;
         const badgeCount = notification.count || 0;
         const badgeLatest = notification.latest;
+        const incrementedBadgeCount = badgeCount + 1;
 
         if (badgeLatest && badgeLatest <= lastNotified) return;
 
-        // `badgeCount` is the current unread count from the DB. By the time
-        // notifyNewMails runs, saveMailHandler has already awaited the insert
-        // (see receive.ts), so the new mail is already part of `badgeCount` —
-        // do NOT add 1 again or the iOS badge ends up off-by-one (Closes #471).
         const message =
           badgeCount > 1
-            ? `You have ${badgeCount} new mails`
+            ? `You have ${incrementedBadgeCount} new mails`
             : "You have a new mail";
 
         const notificationPayload = {
           title: message,
           icon: "/icons/logo192.png",
-          badge_count: badgeCount,
+          badge_count: incrementedBadgeCount,
           push_subscription_id,
         };
 


### PR DESCRIPTION
Revert PR #482.

## Why revert

Hoie 2026-05-20: badge regression "started after we fixed the +1 badge count bug." Reverting restores the pre-#482 behavior so the working-as-Hoie-remembers state is back as quickly as possible, then we can re-diagnose the underlying issue against a known-good baseline.

The original PR #482 removed the `+1` from `notifyNewMails`'s `badge_count` and from the notification title, on the theory that `getUnreadNotifications` already includes the just-arrived mail by the time the push fires (since `saveIncomingMail` is awaited before `notifyNewMails`). That theory may have been wrong about the timing, or there's a separate path where the new mail isn't visible to `getUnreadNotifications` yet — either way, removing the `+1` is correlated with the visible regression and reverting first is the safer move.

## What this restores

`src/server/lib/push.ts`:
- `notifyNewMails`'s `badge_count` is `badgeCount + 1` again.
- Title for `badgeCount > 1` reads `"You have ${badgeCount + 1} new mails"` again.
- Inline comment from PR #482 explaining the (now-disproven) timing assumption is gone.

`src/server/lib/push.test.ts` test expectations reverted to expect `badge_count = count + 1` and `count + 1` in the title.

`decrementBadgeCount` is untouched (it wasn't in PR #482 either).

## Issue #507

Reflecting the redirect: I'll re-frame #507 to track "diagnose the actual cause once the revert restores the pre-#482 baseline" rather than the (incorrect) draft-inclusion or noreply-envelope hypotheses.

## Test plan

- [x] `bun test src/server/lib/push.test.ts` — 24 pass after revert
- [x] `bun run typecheck` clean
- [ ] iOS device E2E — requires home-screen install + real APNs path
- [ ] Trigger a new mail to a hoie.kim address, verify the badge increments to the expected value (which will mean we've confirmed the regression is gone OR replicated the pre-#482 behavior, whichever is true)