### PR TITLE
fix(security): HTTP rate-limit only counts real failures, resets on success

### DIFF
--- a/src/server/lib/http/rate-limit.test.ts
+++ b/src/server/lib/http/rate-limit.test.ts
@@ -1,8 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
-
-// We test the module internals by importing after mocking express types
-// so we can construct fake Request/Response objects.
-const mockNext = mock(() => {});
+import { describe, it, expect, mock } from "bun:test";
 
 const makeReq = (ip: string) =>
   ({
@@ -24,41 +20,76 @@ const makeRes = () => {
   return res as unknown as import("express").Response;
 };
 
-describe("createLimiter", () => {
-  it("allows requests below the limit", async () => {
+describe("createLimiter middleware", () => {
+  it("passes requests through when no failures recorded", async () => {
     const { createLimiter } = await import("./rate-limit");
     const limiter = createLimiter(3, "too many");
     const req = makeReq("1.2.3.4");
     const res = makeRes();
     const next = mock(() => {});
 
-    limiter(req, res, next);
-    limiter(req, res, next);
-    limiter(req, res, next);
+    limiter.middleware(req, res, next);
+    limiter.middleware(req, res, next);
+    limiter.middleware(req, res, next);
 
     expect(next).toHaveBeenCalledTimes(3);
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it("blocks requests over the limit", async () => {
+  it("blocks once recordFailure pushes the counter to the max", async () => {
     const { createLimiter } = await import("./rate-limit");
     const limiter = createLimiter(2, "rate limited");
     const req = makeReq("10.0.0.1");
     const res = makeRes();
     const next = mock(() => {});
 
-    limiter(req, res, next); // 1
-    limiter(req, res, next); // 2
-    limiter(req, res, next); // 3 — should be blocked
+    // Before any failures, requests pass.
+    limiter.middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
 
-    expect(next).toHaveBeenCalledTimes(2);
+    // Record two failures — now at the cap.
+    limiter.recordFailure("10.0.0.1");
+    limiter.recordFailure("10.0.0.1");
+
+    limiter.middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1); // not incremented
     expect(res.status).toHaveBeenCalledWith(429);
+  });
+
+  it("does NOT increment on the middleware path (successes don't burn quota)", async () => {
+    const { createLimiter } = await import("./rate-limit");
+    const limiter = createLimiter(2, "limit");
+    const req = makeReq("10.0.0.2");
+    const res = makeRes();
+    const next = mock(() => {});
+
+    // 10 successful pass-throughs do not consume any slots.
+    for (let i = 0; i < 10; i++) limiter.middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(10);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("reset clears the per-IP counter", async () => {
+    const { createLimiter } = await import("./rate-limit");
+    const limiter = createLimiter(2, "limit");
+    const req = makeReq("10.0.0.3");
+    const res = makeRes();
+    const next = mock(() => {});
+
+    limiter.recordFailure("10.0.0.3");
+    limiter.recordFailure("10.0.0.3");
+    limiter.middleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(429);
+
+    limiter.reset("10.0.0.3");
+    const res2 = makeRes();
+    limiter.middleware(req, res2, next);
+    expect(res2.status).not.toHaveBeenCalled();
   });
 
   it("isolates counters between different limiters (regression for #221)", async () => {
     const { createLimiter } = await import("./rate-limit");
 
-    // limiterA allows 5 attempts; limiterB allows 3
     const limiterA = createLimiter(5, "A limit");
     const limiterB = createLimiter(3, "B limit");
 
@@ -70,20 +101,18 @@ describe("createLimiter", () => {
     const nextA = mock(() => {});
     const nextB = mock(() => {});
 
-    // Exhaust limiterB (3 calls)
-    limiterB(reqB, resB, nextB);
-    limiterB(reqB, resB, nextB);
-    limiterB(reqB, resB, nextB);
-    expect(nextB).toHaveBeenCalledTimes(3);
+    // Exhaust limiterB (3 recorded failures).
+    limiterB.recordFailure(ip);
+    limiterB.recordFailure(ip);
+    limiterB.recordFailure(ip);
 
-    // limiterB is now at its max — next call should be blocked
-    limiterB(reqB, resB, nextB);
-    expect(nextB).toHaveBeenCalledTimes(3); // still 3, not 4
+    limiterB.middleware(reqB, resB, nextB);
+    expect(resB.status).toHaveBeenCalledWith(429);
 
-    // limiterA should be UNAFFECTED — counter is isolated
-    limiterA(reqA, resA, nextA);
-    limiterA(reqA, resA, nextA);
-    limiterA(reqA, resA, nextA);
+    // limiterA should be UNAFFECTED — counter is isolated.
+    limiterA.middleware(reqA, resA, nextA);
+    limiterA.middleware(reqA, resA, nextA);
+    limiterA.middleware(reqA, resA, nextA);
     expect(nextA).toHaveBeenCalledTimes(3);
     expect(resA.status).not.toHaveBeenCalled();
   });
@@ -95,11 +124,7 @@ describe("cleanupExpiredAttempts", () => {
       "./rate-limit"
     );
     const limiter = createLimiter(5, "cleanup test");
-    const req = makeReq("5.5.5.5");
-    const res = makeRes();
-    const next = mock(() => {});
-
-    limiter(req, res, next);
+    limiter.recordFailure("5.5.5.5");
 
     // Manually force expiry by calling cleanup — records haven't expired so
     // cleaned count may be 0, but the call should not throw.
@@ -109,13 +134,13 @@ describe("cleanupExpiredAttempts", () => {
 
 describe("startCleanupScheduler / stopCleanupScheduler", () => {
   it("starts and stops without throwing", async () => {
-    const { startCleanupScheduler, stopCleanupScheduler } = await import("./rate-limit");
+    const { startCleanupScheduler, stopCleanupScheduler } = await import(
+      "./rate-limit"
+    );
 
     expect(() => startCleanupScheduler()).not.toThrow();
-    // Calling again while running should be a no-op (idempotent).
     expect(() => startCleanupScheduler()).not.toThrow();
     expect(() => stopCleanupScheduler()).not.toThrow();
-    // Stopping again when already stopped should be a no-op.
     expect(() => stopCleanupScheduler()).not.toThrow();
   });
 });

--- a/src/server/lib/http/rate-limit.ts
+++ b/src/server/lib/http/rate-limit.ts
@@ -31,38 +31,63 @@ interface AttemptRecord {
 // Tracks all per-limiter attempt Maps so the scheduler can clean them all.
 const allAttemptMaps: Map<string, AttemptRecord>[] = [];
 
+export interface RateLimiter {
+  middleware: (req: Request, res: Response, next: NextFunction) => void;
+  recordFailure: (ip: string) => void;
+  reset: (ip: string) => void;
+}
+
 /**
- * Create a rate limiter middleware.
+ * Create a rate limiter with read-only middleware + explicit record/reset hooks.
+ *
+ * The middleware only checks the limit; route handlers decide which outcomes
+ * count by calling `recordFailure(ip)` on real failures or `reset(ip)` on
+ * success. Mirrors the `auth-rate-limit.ts` shape used by IMAP/SMTP so that
+ * successful logins don't pin the counter and transient 500s don't burn the
+ * per-IP quota.
  *
  * Each call to createLimiter gets its own isolated attempt Map so that
  * separate limiters (e.g. loginLimiter and tokenLimiter) do not share
- * counters. Previously a single shared Map caused token requests to
- * consume login quota and vice versa.
+ * counters.
  *
  * @param maxAttempts Maximum attempts allowed within the window
  * @param message Error message to return when limit is exceeded
  */
-export const createLimiter = (maxAttempts: number, message: string) => {
-  // Per-limiter isolated storage — not shared with any other limiter.
+export const createLimiter = (
+  maxAttempts: number,
+  message: string
+): RateLimiter => {
   const attempts = new Map<string, AttemptRecord>();
   allAttemptMaps.push(attempts);
 
-  return (req: Request, res: Response, next: NextFunction) => {
-    const ip = getClientIp(req);
-    const now = Date.now();
+  const isLimited = (ip: string): boolean => {
     const record = attempts.get(ip);
+    return (
+      !!record && Date.now() < record.resetAt && record.count >= maxAttempts
+    );
+  };
 
-    if (record && now < record.resetAt) {
-      if (record.count >= maxAttempts) {
+  return {
+    middleware: (req: Request, res: Response, next: NextFunction) => {
+      const ip = getClientIp(req);
+      if (isLimited(ip)) {
         res.status(429).json({ status: "failed", message });
         return;
       }
-      record.count++;
-    } else {
-      attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+      next();
+    },
+    recordFailure: (ip: string) => {
+      const now = Date.now();
+      const record = attempts.get(ip);
+      if (record && now < record.resetAt) {
+        record.count++;
+      } else {
+        attempts.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+      }
+    },
+    reset: (ip: string) => {
+      attempts.delete(ip);
     }
-
-    next();
   };
 };
 

--- a/src/server/lib/http/routes/users/index.ts
+++ b/src/server/lib/http/routes/users/index.ts
@@ -19,8 +19,8 @@ const postOnly =
   };
 
 // Apply rate limiters only to POST requests (not GET/DELETE)
-usersRouter.use(postLoginRoute.path, postOnly(loginLimiter));
-usersRouter.use(postTokenRoute.path, postOnly(tokenLimiter));
+usersRouter.use(postLoginRoute.path, postOnly(loginLimiter.middleware));
+usersRouter.use(postTokenRoute.path, postOnly(tokenLimiter.middleware));
 
 const routes = [
   getLoginRoute,

--- a/src/server/lib/http/routes/users/post-login.ts
+++ b/src/server/lib/http/routes/users/post-login.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import { MaskedUser } from "common";
 import { getUser } from "server";
 import { Route } from "../route";
+import { getClientIp, loginLimiter } from "../../rate-limit";
 
 export type LoginPostResponse = MaskedUser;
 
@@ -42,7 +43,10 @@ export const postLoginRoute = new Route<LoginPostResponse>(
       ? await bcrypt.compare(password, user.password as string)
       : await bcrypt.compare(password, DUMMY_HASH).then(() => false);
 
+    const ip = getClientIp(req);
+
     if (!pwMatches || !signedUser) {
+      loginLimiter.recordFailure(ip);
       return { status: "failed", message: "Invalid credentials." };
     }
 
@@ -54,6 +58,7 @@ export const postLoginRoute = new Route<LoginPostResponse>(
     });
     req.session.user = signedUser;
 
+    loginLimiter.reset(ip);
     return { status: "success", body: signedUser };
   }
 );

--- a/src/server/lib/http/routes/users/post-token.ts
+++ b/src/server/lib/http/routes/users/post-token.ts
@@ -9,6 +9,7 @@ import {
   startTimer
 } from "server";
 import { Route } from "../route";
+import { getClientIp, tokenLimiter } from "../../rate-limit";
 
 export type TokenPostResponse = undefined;
 
@@ -16,9 +17,11 @@ export const postTokenRoute = new Route<TokenPostResponse>(
   "POST",
   "/token",
   async (req) => {
+    const ip = getClientIp(req);
     const email = req.body.email as string;
 
     if (!isValidEmail(email)) {
+      tokenLimiter.recordFailure(ip);
       return {
         status: "failed",
         message: "Signup failed because email is invalid."
@@ -44,6 +47,11 @@ export const postTokenRoute = new Route<TokenPostResponse>(
     await sendMail(signedAdminUser, new MailDataToSend(authenticationEamil));
 
     startTimer(id);
+
+    // Each successful magic-link send consumes one slot in the per-IP quota
+    // (the limit exists to prevent mail-sending abuse). Server errors thrown
+    // above don't reach this line, so transient 500s no longer burn the quota.
+    tokenLimiter.recordFailure(ip);
 
     return { status: "success" };
   }

--- a/src/server/lib/http/routes/users/users.test.ts
+++ b/src/server/lib/http/routes/users/users.test.ts
@@ -60,6 +60,8 @@ const makeReq = (overrides: Record<string, unknown> = {}) => {
     body: {},
     params: {},
     query: {},
+    headers: {},
+    ip: "127.0.0.1",
     ...overrides,
   } as unknown as import("express").Request;
 };
@@ -351,5 +353,113 @@ describe("postTokenRoute", () => {
     expect((result as ApiResponse<unknown>).status).toBe("success");
     expect(mockSendMail).toHaveBeenCalledTimes(1);
     expect(mockStartTimer).toHaveBeenCalledWith("u1");
+  });
+});
+
+// ── rate-limit integration with login/token routes (#504) ─────────────────────
+
+describe("postLoginRoute + loginLimiter integration (#504)", () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockBcryptCompare.mockClear();
+  });
+
+  it("records a failure on bad credentials but not on success", async () => {
+    const { postLoginRoute } = await import("./post-login");
+    const rateLimit = await import("../../rate-limit");
+    // Fresh limiter for this IP — reset first.
+    rateLimit.loginLimiter.reset("198.51.100.10");
+
+    const req = (body: Record<string, unknown>) =>
+      makeReq({ body, headers: { "x-real-ip": "198.51.100.10" } });
+
+    // Five consecutive bad-password attempts should all reach the handler
+    // (middleware lets them through; recordFailure bumps the counter).
+    mockGetUser.mockResolvedValue(makeUser("alice"));
+    mockBcryptCompare.mockResolvedValue(false);
+    for (let i = 0; i < 5; i++) {
+      const r = await postLoginRoute.callback(req({ username: "alice", password: "wrong" }), makeRes(), noopStream);
+      expect((r as ApiResponse<unknown>).status).toBe("failed");
+    }
+
+    // Now the middleware should block.
+    const blockRes = makeRes();
+    const next = mock(() => {});
+    rateLimit.loginLimiter.middleware(
+      req({ username: "alice", password: "wrong" }),
+      blockRes,
+      next
+    );
+    expect((blockRes as unknown as { _code: number })._code).toBe(429);
+    expect(next).not.toHaveBeenCalled();
+
+    // A successful login (different IP, fresh counter) resets the counter and
+    // does NOT consume a slot.
+    rateLimit.loginLimiter.reset("198.51.100.11");
+    const successReq = makeReq({
+      body: { username: "alice", password: "right" },
+      headers: { "x-real-ip": "198.51.100.11" }
+    });
+    mockGetUser.mockResolvedValueOnce(makeUser("alice"));
+    mockBcryptCompare.mockResolvedValueOnce(true);
+    const ok = await postLoginRoute.callback(successReq, makeRes(), noopStream);
+    expect((ok as ApiResponse<unknown>).status).toBe("success");
+
+    // Now run 10 more successful logins from the same IP — none should
+    // burn a slot (the bug was that successes counted).
+    for (let i = 0; i < 10; i++) {
+      mockGetUser.mockResolvedValueOnce(makeUser("alice"));
+      mockBcryptCompare.mockResolvedValueOnce(true);
+      const r = await postLoginRoute.callback(successReq, makeRes(), noopStream);
+      expect((r as ApiResponse<unknown>).status).toBe("success");
+    }
+
+    // The 11th success-path middleware check still passes.
+    const finalRes = makeRes();
+    const finalNext = mock(() => {});
+    rateLimit.loginLimiter.middleware(successReq, finalRes, finalNext);
+    expect(finalNext).toHaveBeenCalledTimes(1);
+    expect(finalRes.status).not.toHaveBeenCalled();
+  });
+});
+
+describe("postTokenRoute + tokenLimiter integration (#504)", () => {
+  beforeEach(() => {
+    mockIsValidEmail.mockReset();
+    mockIsValidEmail.mockReturnValue(true);
+    mockCreateToken.mockClear();
+    mockGetUser.mockClear();
+    mockSendMail.mockClear();
+    mockStartTimer.mockClear();
+  });
+
+  it("does not count thrown server errors against the IP quota", async () => {
+    const { postTokenRoute } = await import("./post-token");
+    const rateLimit = await import("../../rate-limit");
+    rateLimit.tokenLimiter.reset("198.51.100.20");
+
+    const req = makeReq({
+      body: { email: "user@example.com" },
+      headers: { "x-real-ip": "198.51.100.20" }
+    });
+
+    // sendMail rejects → callback throws → recordFailure should NOT run.
+    mockGetUser.mockResolvedValue({ id: "admin1", username: "admin" });
+    mockGetSignedUser.mockReturnValue({ id: "admin1", username: "admin" });
+    mockSendMail.mockRejectedValue(new Error("smtp transient"));
+
+    for (let i = 0; i < 5; i++) {
+      await expect(
+        postTokenRoute.callback(req, makeRes(), noopStream)
+      ).rejects.toThrow();
+    }
+
+    // Middleware should still let requests through — server errors did not
+    // burn quota.
+    const res = makeRes();
+    const next = mock(() => {});
+    rateLimit.tokenLimiter.middleware(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #504

## Summary

`createLimiter` middleware incremented the per-IP counter on every request, so:
- 5 successful logins from one IP locked the 6th legit login (HTTP 429 for 15 min).
- Token endpoint (limit 3) burned its quota on transient 500s — one buggy state locked all IPs behind a shared upstream proxy for 15 minutes.
- Successful brute-force attempts didn't reset the counter, so a real user couldn't log back in for the rest of the window.

`src/server/lib/auth-rate-limit.ts` (IMAP/SMTP side) already had the correct shape. This PR mirrors it on the HTTP side.

## What changed

- `createLimiter` returns `{ middleware, recordFailure, reset }`. The middleware only gates; route handlers decide which outcomes count.
- `post-login.ts`: `recordFailure(ip)` on `!pwMatches || !signedUser`, `reset(ip)` on success.
- `post-token.ts`: `recordFailure(ip)` on `!isValidEmail` and on the success path (each magic-link send is the rate-limited resource). Server-thrown 500s no longer record because `recordFailure` lives after the throwing `sendMail` call.
- `users.test.ts` mock req gains `headers: {}` + `ip` (needed by `getClientIp`); two new integration tests cover the bug paths.
- `rate-limit.test.ts` rewritten against the new shape (middleware = gate-only; `recordFailure`/`reset` drive counter).

## Test plan

- [x] `bun test src/server/lib/http/rate-limit.test.ts` — 7/0 pass
- [x] `bun test src/server/lib/http/routes/users/users.test.ts` — 23/0 pass (incl. 2 new integration tests for #504)
- [x] `bun test src/server` — 826/0 pass
- [x] `bun x tsc --noEmit` — clean
- [x] E2E against dev server on a fresh DB (admin/inbox):
  - 7 successful logins from one IP → all 200 (was 200×5 + 429×2)
  - 5 wrong passwords → 5×200, 6th 429 (`Too many login attempts`)
  - 4 wrong + 1 success → counter reset, 6 more successful logins all 200 (was: 6th would 429)
  - Token endpoint: 3 invalid emails → 200×3, 4th 429