### PR TITLE
fix(routing): exact method+path registration so wildcards don't shadow specific paths

### DIFF
--- a/src/server/lib/http/routes/route.test.ts
+++ b/src/server/lib/http/routes/route.test.ts
@@ -59,20 +59,6 @@ describe("StreamingStatus", () => {
 // ── Route.handler ─────────────────────────────────────────────────────────────
 
 describe("Route.handler", () => {
-  it("calls next() when method does not match", async () => {
-    const cb = mock(async () => ({ status: "success" as const }));
-    const route = new Route("POST", "/test", cb);
-
-    const req = makeReq({ method: "GET" });
-    const res = makeRes();
-    const next = makeNext();
-
-    await route.handler(req, res, next);
-
-    expect(cb).not.toHaveBeenCalled();
-    expect(next).toHaveBeenCalled();
-  });
-
   it("responds with json result when method matches", async () => {
     const route = new Route("GET", "/test", async () => ({ status: "success" as const, body: { hello: "world" } }));
 
@@ -174,6 +160,47 @@ describe("Route.handler", () => {
 
     expect((res as unknown as { _body: unknown })._body).toMatchObject({ status: "error", message: "Internal server error" });
     process.env.NODE_ENV = origEnv;
+  });
+});
+
+// ── Route.register ────────────────────────────────────────────────────────────
+
+describe("Route.register", () => {
+  it("binds to the verb-specific router method (not router.use)", () => {
+    const calls: Array<[string, string]> = [];
+    const fakeRouter = {
+      get: (p: string) => calls.push(["get", p]),
+      post: (p: string) => calls.push(["post", p]),
+      delete: (p: string) => calls.push(["delete", p]),
+      use: (p: string) => calls.push(["use", p]),
+    } as unknown as import("express").Router;
+
+    new Route("GET", "/g", async () => undefined).register(fakeRouter);
+    new Route("POST", "/p", async () => undefined).register(fakeRouter);
+    new Route("DELETE", "/d", async () => undefined).register(fakeRouter);
+
+    expect(calls).toEqual([
+      ["get", "/g"],
+      ["post", "/p"],
+      ["delete", "/d"],
+    ]);
+  });
+
+  it("does not fall back to router.use (which would mount-match — the #505 cause)", () => {
+    const useCalls: string[] = [];
+    const verbCalls: string[] = [];
+    const fakeRouter = {
+      get: (p: string) => verbCalls.push(`get ${p}`),
+      post: (p: string) => verbCalls.push(`post ${p}`),
+      delete: (p: string) => verbCalls.push(`delete ${p}`),
+      use: (p: string) => useCalls.push(`use ${p}`),
+    } as unknown as import("express").Router;
+
+    new Route("DELETE", "/:id", async () => undefined).register(fakeRouter);
+    new Route("DELETE", "/spam-allowlist/:pattern", async () => undefined).register(fakeRouter);
+
+    expect(useCalls).toEqual([]);
+    expect(verbCalls).toEqual(["delete /:id", "delete /spam-allowlist/:pattern"]);
   });
 });
 

--- a/src/server/lib/http/routes/route.ts
+++ b/src/server/lib/http/routes/route.ts
@@ -46,38 +46,38 @@ export class Route<T> {
     this.callback = callback;
   }
 
-  handler: RequestHandler = async (req, res, next) => {
-    if (req.method === this.method) {
-      try {
-        const stream: Stream<T> = (response) => {
-          if (Buffer.isBuffer(response)) res.write(response);
-          else res.write(JSON.stringify(response) + "\n");
-        };
-        const result = await this.callback(req, res, stream);
-        if (Buffer.isBuffer(result)) res.send(result);
-        else if (result) res.json(result);
-        else res.end();
-        return;
-      } catch (error: unknown) {
-        logger.error("Route handler error", { method: this.method, path: this.path }, error);
-        sendAlarm(
-          `Route Error: ${this.method} ${this.path}`,
-          `**Error:** ${error instanceof Error ? error.message : String(error)}`
-        ).catch(() => undefined);
-        const message =
-          process.env.NODE_ENV === "production"
-            ? "Internal server error"
-            : error instanceof Error
-              ? error.message
-              : String(error);
-        res.status(500).json({ status: "error", message });
-      }
+  handler: RequestHandler = async (req, res, _next) => {
+    try {
+      const stream: Stream<T> = (response) => {
+        if (Buffer.isBuffer(response)) res.write(response);
+        else res.write(JSON.stringify(response) + "\n");
+      };
+      const result = await this.callback(req, res, stream);
+      if (Buffer.isBuffer(result)) res.send(result);
+      else if (result) res.json(result);
+      else res.end();
+    } catch (error: unknown) {
+      logger.error("Route handler error", { method: this.method, path: this.path }, error);
+      sendAlarm(
+        `Route Error: ${this.method} ${this.path}`,
+        `**Error:** ${error instanceof Error ? error.message : String(error)}`
+      ).catch(() => undefined);
+      const message =
+        process.env.NODE_ENV === "production"
+          ? "Internal server error"
+          : error instanceof Error
+            ? error.message
+            : String(error);
+      res.status(500).json({ status: "error", message });
     }
-    next();
   };
 
   register = (router: Router) => {
-    router.use(this.path, this.handler);
+    // Bind to the exact method + path. Using `router.use(path, handler)` would
+    // mount-match (prefix match) and let a wildcard like `/:id` shadow more
+    // specific paths registered after it (#505).
+    const method = this.method.toLowerCase() as "get" | "post" | "delete";
+    router[method](this.path, this.handler);
   };
 }
 


### PR DESCRIPTION
Closes #505

## Summary

`Route.register` used `router.use(this.path, this.handler)`. `router.use` is **mount-point** (prefix) matching, not exact-method routing — the `Route.handler` itself gated on `req.method`. That meant a wildcard registered earlier (e.g. `DELETE /:id`) shadowed any specific path with the same method registered later (e.g. `DELETE /spam-allowlist/:pattern`): Express's `router.use` captures `:id = "spam-allowlist"`, the method matches, and the more specific handler is never reached.

Switch to `router[method.toLowerCase()](path, handler)` so registration is exact on both verb and path. Express's path-priority routing now guarantees a specific path is preferred over a wildcard regardless of registration order. The redundant `if (req.method === this.method)` gate in the handler becomes unreachable and is removed.

## What changed

- `src/server/lib/http/routes/route.ts` — `register` binds via verb-specific router method; `handler` no longer needs to gate on method (the router does it).
- `src/server/lib/http/routes/route.test.ts` — drop the now-obsolete "calls next() on method mismatch" handler test (the handler is only reached when the method matches), add a `Route.register` describe block that verifies the verb-specific router method is called and `router.use` is never invoked (regression guard for #505).

## Test plan

- [x] `bun test src/server/lib/http/routes/route.test.ts` — 14/0 pass
- [x] `bun test src/server` — 823/0 pass (no regressions in mails/users/push tests)
- [x] `bun x tsc --noEmit` — clean
- [x] E2E against `bun run dev` on a fresh DB (admin/inbox):
  - `DELETE /api/mails/spam-allowlist/test505%40inbox.app` → `{"status":"success"}`, entry actually removed from list (count went 2 → 1)
  - `DELETE /api/mails/<uuid>` (no such mail) → `"Invalid request. You may not manipulate other users' email"` (wildcard still works for the documented case)
  - `DELETE /api/mails/spam-allowlist/never-existed%40inbox.app` → `"Entry not found"` (specific handler's own error message — was previously unreachable, now reachable)
  - `GET /api/mails/spam-allowlist` → success (unaffected sibling)