### PR TITLE
fix(security): rate-limit /api/client-error and isolate alarm cooldowns by key

### DIFF
--- a/src/server/lib/alarm.test.ts
+++ b/src/server/lib/alarm.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect, beforeEach, mock, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, beforeEach, mock, afterEach, afterAll } from "bun:test";
 
-// Mock fetch before importing alarm
+// Mock fetch only during this file's tests so we don't pollute global state
+// for other test files (e.g. client-error.test.ts opens a real listening
+// server and uses fetch to drive it).
 const mockFetch = mock(() => Promise.resolve({ ok: true } as Response));
-global.fetch = mockFetch as typeof fetch;
+const realFetch = globalThis.fetch;
 
 let alarm: typeof import("./alarm");
+
+beforeAll(() => {
+  globalThis.fetch = mockFetch as typeof fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+});
 
 beforeEach(async () => {
   mockFetch.mockClear();
@@ -32,10 +42,29 @@ describe("sendAlarm", () => {
     expect(options.method).toBe("POST");
   });
 
-  it("respects cooldown — second alarm within 60s is suppressed", async () => {
+  it("respects cooldown — second alarm within 60s on the same key is suppressed", async () => {
     process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
-    await alarm.sendAlarm("Error 1", "detail 1");
-    await alarm.sendAlarm("Error 2", "detail 2");
+    await alarm.sendAlarm("Same Title", "detail 1");
+    await alarm.sendAlarm("Same Title", "detail 2");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates cooldowns by key — different keys do not suppress each other", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    // Simulates the issue #517 scenario: a flood of client-error alarms must
+    // not suppress unrelated server-side alarms.
+    await alarm.sendAlarm("Client JS Error", "detail", "client-error");
+    await alarm.sendAlarm("Unhandled Promise Rejection", "detail");
+    await alarm.sendAlarm("Uncaught Exception", "detail");
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("explicit key uses its own bucket even when title differs", async () => {
+    process.env.DISCORD_ALARM_WEBHOOK = "https://discord.com/api/webhooks/test";
+    // Two calls into the same explicit key bucket → second is suppressed even
+    // though titles differ.
+    await alarm.sendAlarm("First Title", "detail", "shared-bucket");
+    await alarm.sendAlarm("Second Title", "detail", "shared-bucket");
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/lib/alarm.ts
+++ b/src/server/lib/alarm.ts
@@ -2,21 +2,36 @@
  * Discord alarm module for server error notifications.
  *
  * Sends a POST to the DISCORD_ALARM_WEBHOOK URL when errors occur.
- * A 1-minute cooldown prevents noise bursts.
+ * A 1-minute cooldown per alarm key prevents noise bursts without letting
+ * one chatty source (e.g. /api/client-error) starve other sources.
  */
 
 const COOLDOWN_MS = 60_000; // 1 minute
 
-let lastAlarmAt = 0;
+const lastAlarmAt = new Map<string, number>();
 
-/** Send a Discord webhook alarm message. Respects cooldown. */
-export const sendAlarm = async (title: string, detail: string): Promise<void> => {
+/**
+ * Send a Discord webhook alarm message. Respects a per-key cooldown so
+ * that traffic on one key cannot suppress alarms from other sources.
+ *
+ * @param title Embed title (also used as the default cooldown key)
+ * @param detail Embed description
+ * @param key Cooldown bucket. Defaults to `title`. Pass an explicit value for
+ *   sources that may fire frequently (e.g. "client-error") so they get their
+ *   own bucket and cannot starve unrelated alarms.
+ */
+export const sendAlarm = async (
+  title: string,
+  detail: string,
+  key: string = title,
+): Promise<void> => {
   const webhookUrl = process.env.DISCORD_ALARM_WEBHOOK;
   if (!webhookUrl) return;
 
   const now = Date.now();
-  if (now - lastAlarmAt < COOLDOWN_MS) return;
-  lastAlarmAt = now;
+  const last = lastAlarmAt.get(key) ?? 0;
+  if (now - last < COOLDOWN_MS) return;
+  lastAlarmAt.set(key, now);
 
   const body = JSON.stringify({
     embeds: [
@@ -43,5 +58,5 @@ export const sendAlarm = async (title: string, detail: string): Promise<void> =>
 
 /** Reset cooldown state (for testing). */
 export const resetAlarmState = (): void => {
-  lastAlarmAt = 0;
+  lastAlarmAt.clear();
 };

--- a/src/server/lib/http/routes/client-error.test.ts
+++ b/src/server/lib/http/routes/client-error.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach } from "bun:test";
+import express from "express";
+import type { Server } from "http";
+
+// Mock the alarm module so we can observe calls without touching Discord.
+const mockSendAlarm = mock(async () => {});
+mock.module("../../alarm", () => ({
+  sendAlarm: mockSendAlarm,
+}));
+
+let server: Server;
+let baseUrl: string;
+// alarm.test.ts (and possibly others) overrides global.fetch. We need the
+// real fetch to drive HTTP into our listening server.
+const realFetch = globalThis.fetch;
+
+beforeAll(async () => {
+  // Re-import after mocks are in place so the router picks up mockSendAlarm.
+  const clientErrorRouter = (await import("./client-error")).default;
+
+  const app = express();
+  app.use(express.json());
+  app.use("/api/client-error", clientErrorRouter);
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+      }
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+beforeEach(() => {
+  mockSendAlarm.mockClear();
+});
+
+const postClientError = async (ip: string, body: object = { message: "x" }) => {
+  if (!baseUrl) throw new Error(`baseUrl not set (server start failed)`);
+  return realFetch(`${baseUrl}/api/client-error`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-real-ip": ip,
+    },
+    body: JSON.stringify(body),
+  });
+};
+
+describe("POST /api/client-error rate limiting (issue #517)", () => {
+  it("returns 429 after the per-IP cap is exceeded", async () => {
+    const ip = "203.0.113.1"; // RFC 5737 TEST-NET-3, unique per test
+    for (let i = 0; i < 5; i++) {
+      const res = await postClientError(ip);
+      expect(res.status).toBe(200);
+    }
+    const blocked = await postClientError(ip);
+    expect(blocked.status).toBe(429);
+    const body = (await blocked.json()) as { status: string; message: string };
+    expect(body.status).toBe("failed");
+    expect(body.message).toMatch(/too many/i);
+  });
+
+  it("isolates the IP cap — other IPs can still report", async () => {
+    const ipA = "203.0.113.2";
+    const ipB = "203.0.113.3";
+    // Burn ipA's budget.
+    for (let i = 0; i < 6; i++) await postClientError(ipA);
+    // ipB should still get through.
+    const res = await postClientError(ipB);
+    expect(res.status).toBe(200);
+  });
+
+  it("forwards to sendAlarm with the dedicated 'client-error' cooldown key", async () => {
+    const res = await postClientError("203.0.113.4", {
+      message: "boom",
+      stack: "at thing",
+      url: "https://example.com/x",
+    });
+    expect(res.status).toBe(200);
+    expect(mockSendAlarm).toHaveBeenCalledTimes(1);
+    const args = mockSendAlarm.mock.calls[0] as [string, string, string];
+    expect(args[0]).toBe("Client JS Error");
+    expect(args[2]).toBe("client-error");
+  });
+});

--- a/src/server/lib/http/routes/client-error.ts
+++ b/src/server/lib/http/routes/client-error.ts
@@ -1,7 +1,16 @@
 import { Router } from "express";
 import { sendAlarm } from "../../alarm";
+import { createLimiter, getClientIp } from "../rate-limit";
 
 const clientErrorRouter = Router();
+
+// Per-IP cap: frontend beacons only fire on actual JS errors, so a tight cap
+// is plenty for legitimate use. Without this, an unauthenticated attacker can
+// burn the alarm cooldown bucket indefinitely (issue #517).
+const clientErrorLimiter = createLimiter(
+  5,
+  "Too many client error reports, try again later",
+);
 
 type ClientErrorBody = {
   message?: string;
@@ -13,9 +22,16 @@ type ClientErrorBody = {
  * POST /client-error
  *
  * Accepts frontend error reports sent via navigator.sendBeacon.
- * Forwards to Discord alarm. No auth required (beacon fires after page unload).
+ * Forwards to Discord alarm. No auth required (beacon fires after page unload),
+ * but IP-rate-limited to prevent alarm-channel abuse.
  */
-clientErrorRouter.post("/", async (req, res) => {
+clientErrorRouter.post("/", clientErrorLimiter.middleware, async (req, res) => {
+  // Every accepted report consumes one slot in the per-IP quota. Unlike the
+  // auth limiters (which only count failures), there is no success/failure
+  // distinction here — the cap exists to bound report *volume*, so record on
+  // each request that clears the read-only middleware check.
+  clientErrorLimiter.recordFailure(getClientIp(req));
+
   const body = req.body as ClientErrorBody;
 
   const message = typeof body.message === "string" ? body.message : "(no message)";
@@ -32,7 +48,9 @@ clientErrorRouter.post("/", async (req, res) => {
     .filter(Boolean)
     .join("\n");
 
-  await sendAlarm("Client JS Error", detail);
+  // Use a dedicated cooldown bucket so client-error volume cannot suppress
+  // unrelated server-side alarms (route 5xx, unhandledRejection, IMAP/SMTP).
+  await sendAlarm("Client JS Error", detail, "client-error");
 
   res.json({ status: "success" });
 });


### PR DESCRIPTION
Closes #517

## Problem

`POST /api/client-error` is unauthenticated and unthrottled, and calls `sendAlarm()` on every request. Because `sendAlarm` uses a process-wide 1-minute cooldown, an external attacker can:

1. Generate up to one attacker-controlled Discord embed per minute on the alarm channel.
2. **Silently suppress every legitimate server alarm** (unhandled rejection, uncaught exception, route 5xx, IMAP/SMTP errors, Shepherd) for the cooldown window simply by keeping the cooldown bucket burning.

## Fix

Two complementary mitigations:

**(a) Per-IP rate limit on `/api/client-error`.** Reuses `createLimiter` (same pattern as `loginLimiter`/`tokenLimiter`): 5 reports / 15 min / IP. Frontend `navigator.sendBeacon` JS error reports stay well below this cap.

**(b) Keyed cooldown in `sendAlarm`.** `lastAlarmAt` becomes a `Map<key, ts>` so each source has its own bucket. The client-error route now passes `key="client-error"`, so noise on that bucket cannot starve `"Unhandled Promise Rejection"`, `"Uncaught Exception"`, `"Route Error: …"`, etc. Default key is the title (backward-compatible behavior for existing callers).

## Tests

New:
- `client-error.test.ts` — mounts the router on a real express app, drives it with real `fetch`:
  - 5 requests from one IP → 200; 6th → 429 with the expected failure body.
  - Per-IP isolation: a different IP still gets through after the first IP is capped.
  - Asserts `sendAlarm` is called with the dedicated `"client-error"` cooldown key.

Updated:
- `alarm.test.ts` — three new cases:
  - Same key suppression (regression for existing behavior).
  - **Cross-key isolation** (issue #517 scenario): `client-error` flood does not suppress `Unhandled Promise Rejection` or `Uncaught Exception`.
  - Explicit-key bucket suppression independent of title.
- Also wraps the test's `global.fetch` override in `beforeAll`/`afterAll` so it stops leaking into sibling test files (this was breaking `client-error.test.ts` until isolated).

All 827 server tests pass.

## E2E

Started dev server (`bun run dev-server`, port 3004) and ran:

```bash
$ for i in 1 2 3 4 5 6 7; do
    curl -s -X POST -w "req $i: HTTP %{http_code}\n" \
      -H "Content-Type: application/json" \
      -H "x-real-ip: 198.51.100.7" \
      -d '{"message":"test","stack":"","url":"http://attacker.example/x"}' \
      http://localhost:3004/api/client-error -o /dev/null
  done
req 1: HTTP 200
req 2: HTTP 200
req 3: HTTP 200
req 4: HTTP 200
req 5: HTTP 200
req 6: HTTP 429
req 7: HTTP 429
```

Response body on 429: `{"status":"failed","message":"Too many client error reports, try again later"}`. A request from a different `x-real-ip` after the cap still returned `200`.

## Related

- #504 (HTTP rate-limit on auth endpoints) — same `createLimiter` pattern, different endpoint.