### PR TITLE
fix(security): validateIncomingMail uses suffix check (not substring) for domain match

### DIFF
--- a/src/server/lib/mails/receive.test.ts
+++ b/src/server/lib/mails/receive.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterAll, beforeAll } from "bun:test";
+
+import type { IncomingMail } from "common";
+import { validateIncomingMail, addressToUsername } from "./receive";
+
+const makeMail = (envelopeTo: { address: string }[]): IncomingMail =>
+  ({ envelopeTo } as unknown as IncomingMail);
+
+describe("validateIncomingMail (envelope-to gate via isValidAddress)", () => {
+  it("accepts an exact-match domain recipient", () => {
+    const mail = makeMail([{ address: "alice@hoie.kim" }]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBe(mail);
+  });
+
+  it("accepts a subdomain recipient", () => {
+    const mail = makeMail([{ address: "alice@support.hoie.kim" }]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBe(mail);
+  });
+
+  it("rejects an unrelated domain", () => {
+    const mail = makeMail([{ address: "alice@other.com" }]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBeUndefined();
+  });
+
+  it("rejects a confusable domain that only embeds the target as a substring (regression: PR #478-class bug)", () => {
+    // "evil-hoie.kim-attack.com" includes the substring "hoie.kim" but is not
+    // a subdomain — the prior `.includes()` check accepted it, the suffix
+    // check must reject it.
+    const mail = makeMail([{ address: "victim@evil-hoie.kim-attack.com" }]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBeUndefined();
+  });
+
+  it("rejects a domain that prepends the target without a dot separator", () => {
+    const mail = makeMail([{ address: "victim@notthehoie.kim" }]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBeUndefined();
+  });
+
+  it("is case-insensitive on both sides", () => {
+    const mail = makeMail([{ address: "Alice@SUPPORT.Hoie.Kim" }]);
+    expect(validateIncomingMail(mail, "HOIE.KIM")).toBe(mail);
+  });
+
+  it("returns undefined when envelopeTo is missing", () => {
+    expect(validateIncomingMail({} as IncomingMail, "hoie.kim")).toBeUndefined();
+  });
+
+  it("returns undefined when domainName is missing", () => {
+    const mail = makeMail([{ address: "alice@hoie.kim" }]);
+    expect(validateIncomingMail(mail, undefined)).toBeUndefined();
+  });
+
+  it("accepts the mail when at least one recipient matches", () => {
+    const mail = makeMail([
+      { address: "victim@evil-hoie.kim-attack.com" },
+      { address: "alice@hoie.kim" },
+    ]);
+    expect(validateIncomingMail(mail, "hoie.kim")).toBe(mail);
+  });
+});
+
+describe("addressToUsername", () => {
+  const originalEnv = process.env.EMAIL_DOMAIN;
+
+  beforeAll(() => {
+    process.env.EMAIL_DOMAIN = "hoie.kim";
+  });
+
+  afterAll(() => {
+    if (originalEnv !== undefined) {
+      process.env.EMAIL_DOMAIN = originalEnv;
+    } else {
+      delete process.env.EMAIL_DOMAIN;
+    }
+  });
+
+  it("returns the subdomain as the username", () => {
+    expect(addressToUsername("anything@bob.hoie.kim")).toBe("bob");
+  });
+
+  it("returns 'admin' when the address is at the base domain", () => {
+    expect(addressToUsername("hi@hoie.kim")).toBe("admin");
+  });
+});

--- a/src/server/lib/mails/receive.ts
+++ b/src/server/lib/mails/receive.ts
@@ -361,8 +361,9 @@ const getMailboxesFromIncomingMail = (data: IncomingMail): string[] => {
 
 const isValidAddress = (address: string, domain: string) => {
   const parsedAddress = address.split("@");
-  const domainInData = parsedAddress[parsedAddress.length - 1];
-  return domainInData.toLowerCase().includes(domain.toLowerCase());
+  const domainInData = parsedAddress[parsedAddress.length - 1].toLowerCase();
+  const target = domain.toLowerCase();
+  return domainInData === target || domainInData.endsWith(`.${target}`);
 };
 
 export const validateIncomingMail = (


### PR DESCRIPTION
## Summary

- `isValidAddress` in `src/server/lib/mails/receive.ts:362-366` used `.includes(domain)` to match the recipient domain, accepting confusable hostnames that merely contain the target as a substring (e.g. `victim@evil-hoie.kim-attack.com` for `EMAIL_DOMAIN=hoie.kim`).
- Replace with the exact-or-subdomain suffix check that `smtp.ts:106` (`addr.address.endsWith(\`@${EMAIL_DOMAIN}\`)`) already uses for the primary SMTP gate.
- Add `receive.test.ts` covering the confusable-domain regression, exact/subdomain accepts, case-insensitivity, and `addressToUsername` admin/subdomain split (8 tests for `validateIncomingMail`, 2 for `addressToUsername`).

In the current call graph this is defense-in-depth — `saveMailHandler` is invoked from `smtp.ts:149` after the strict envelope-to filter at `smtp.ts:106`, so the loose check in `receive.ts` is gated upstream. The fix tightens the boundary so any future ingress that wires through `validateIncomingMail` (Mailgun webhook, internal API, future SMTP code path) inherits the same domain check.

Same class of bug as PR #478 fixed in spam rules (substring match against \`t.co\` matched inside \`marriott.com\` / \`wealthfront.com\`).

## Test plan

- [x] \`bun test src/server/lib/mails/ src/server/lib/smtp.test.ts\` → 166/166 pass
- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean (warnings pre-existing on `spam_allowlists.ts` and `start.ts` are unchanged)
- [x] Branch based on \`upstream/main\` 8a6eb72

🤖 Generated with [Claude Code](https://claude.com/claude-code)