### PR TITLE
fix(routing): unmatched /api/* requests return 404 JSON instead of SPA HTML

### DIFF
--- a/src/server/lib/http/routes/index.ts
+++ b/src/server/lib/http/routes/index.ts
@@ -37,6 +37,15 @@ apiRouter.use("/users", usersRouter);
 apiRouter.use("/mails", mailsRouter);
 apiRouter.use("/push", pushRouter);
 
+// Unmatched /api/* requests get a JSON 404 rather than falling through to the
+// SPA index.html catch-all in http/index.ts. Without this, an authenticated
+// GET to e.g. /api/mails/unknown-route returns 200 + text/html, which silently
+// breaks any client that parses the body as JSON.
+apiRouter.use((_req, res) => {
+  if (res.headersSent) return;
+  res.status(404).json({ status: "failed", message: "Not found" });
+});
+
 // Global 5xx error handler — catches unhandled errors thrown inside route handlers
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 apiRouter.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {


### PR DESCRIPTION
Closes #516

## Summary
Unmatched `/api/*` GETs were falling through to the SPA `index.html` catch-all in `src/server/lib/http/index.ts`, returning `200 + text/html` instead of `404 + application/json`. Clients doing `.then(r => r.json())` got an unrelated parse error rather than the actual "endpoint does not exist" signal. POST/PUT/DELETE on unknown `/api/*` paths fell through to Express's default HTML 404 page.

## Fix
One file changed: `src/server/lib/http/routes/index.ts`. Adds a JSON 404 middleware at the end of `apiRouter`, before the 5xx error handler:

\`\`\`ts
apiRouter.use((_req, res) => {
  if (res.headersSent) return;
  res.status(404).json({ status: "failed", message: "Not found" });
});
\`\`\`

This is the cleaner of the two fix options the issue proposed — `apiRouter` now closes itself, so the SPA catch-all in `http/index.ts` doesn't need to know about `/api/*`. All HTTP verbs get consistent JSON 404s.

## E2E (live dev server on :3004 with this branch)

| Request | Before | After |
|---|---|---|
| `GET /api/unknown-path` (unauth) | `200 text/html` (SPA) | `404 application/json {"status":"failed","message":"Not found"}` |
| `GET /api/mails/no-such-path` (unauth) | `401 application/json` | `401 application/json` (unchanged — `mailsRouter.use(authRequired)` runs first) |
| `GET /api/mails/no-such-path` (auth) | `200 text/html` (SPA) | `404 application/json` |
| `GET /api/unknown-path` (auth) | `200 text/html` (SPA) | `404 application/json` |
| `POST /api/unknown-path` | `404 text/html` (Express default) | `404 application/json` |
| `DELETE /api/unknown-path` | `404 text/html` (Express default) | `404 application/json` |

Positive cases verified unchanged:
- `GET /api/health` → 200 application/json ✓
- `GET /api/users/login` (auth) → 200 application/json ✓
- Login flow (`POST /api/users/login` with admin creds) → 200 ✓

## Tests
No new test file. The fix is a 4-line HTTP-level behavior change; the existing test infra here (no supertest, deep mocking required to spin up `apiRouter` in-process) would add far more LOC of plumbing than the fix itself. E2E coverage above exercises the real production path.

## Notes
- The eslint warning on line 50 (unused `eslint-disable` directive) is pre-existing on `upstream/main` — confirmed via `git stash; bun --bun eslint`. Not touched per the "no unrelated changes" rule.
- Related to but distinct from #501 (stale `/assets/*` chunk filenames); that path is covered by the SW cache landed in #502. This issue only ever needed the `/api/*` server-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)