### PR TITLE
fix(mails): include envelope_to in account-stats address expansion

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -214,3 +214,73 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456)
     expect(updateWhereCount).toBe(2);
   });
 });
+
+describe("getAccountStats — envelope_to inclusion in received address expansion", () => {
+  // Mails sent via listserv-style routing (e.g. GitHub notifications) carry
+  // a MIME `to` header that points at the list address (e.g.
+  // `<budget@noreply.github.com>`) and an SMTP-level `envelope_to` that
+  // points at the actual recipient sub-address (e.g. `<x@hoie.kim>`). If
+  // the received-side address expansion ignores envelope_to, those mails
+  // never surface in the per-account view — but the push badge counts
+  // them via the broader `getUnreadNotifications` query, so the FE shows
+  // 0 unread while the iOS badge shows N. Verified against prod on
+  // 2026-05-23: admin had badge=26 / FE=0 because 26 GitHub notification
+  // mails carried envelope_to=claoie@hoie.kim but MIME to=noreply.github.
+  let mailsSource: string;
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(
+      /export const getAccountStats[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getAccountStats not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("received-branch address expansion unions envelope_to with to/cc/bcc", () => {
+    // Locate the addressExpansion ternary's received branch — everything
+    // between `addressExpansion = sent ? <sent SQL>` and the final `;`,
+    // dropping the sent SQL portion via the backtick boundary.
+    const exprMatch = fnSource.match(
+      /const\s+addressExpansion\s*=\s*sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+    );
+    if (!exprMatch) throw new Error("addressExpansion ternary not found");
+    const receivedSql = exprMatch[1];
+    expect(receivedSql).toContain("to_address");
+    expect(receivedSql).toContain("cc_address");
+    expect(receivedSql).toContain("bcc_address");
+    expect(receivedSql).toContain("envelope_to");
+  });
+
+  it("received-branch null-check includes envelope_to", () => {
+    // Otherwise rows with only envelope_to populated (no MIME recipient
+    // headers, which happens for some listserv-style senders) would be
+    // filtered out before the address expansion even fires.
+    const exprMatch = fnSource.match(
+      /const\s+addressNotNull\s*=\s*sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+    );
+    if (!exprMatch) throw new Error("addressNotNull ternary not found");
+    const receivedSql = exprMatch[1];
+    expect(receivedSql).toContain("to_address IS NOT NULL");
+    expect(receivedSql).toContain("envelope_to IS NOT NULL");
+  });
+
+  it("sent-branch address expansion remains from_address only", () => {
+    // Don't accidentally widen the sent view — envelope_from has its own
+    // semantics (bounce path) and isn't symmetric with envelope_to here.
+    const exprMatch = fnSource.match(
+      /const\s+addressExpansion\s*=\s*sent\s*\?\s*`([^`]*)`/
+    );
+    if (!exprMatch) throw new Error("sent branch not found");
+    const sentSql = exprMatch[1];
+    expect(sentSql).toContain("from_address");
+    expect(sentSql).not.toContain("envelope_to");
+    expect(sentSql).not.toContain("envelope_from");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -426,19 +426,28 @@ export const getAccountStats = async (
   }[]
 > => {
   try {
-    // For sent mails, only look at from_address
-    // For received mails, look at to_address, cc_address, and bcc_address
+    // For sent mails, only look at from_address.
+    // For received mails, union to_address + cc_address + bcc_address AND
+    // envelope_to. `envelope_to` is the SMTP-level delivery address, which
+    // can differ from MIME to/cc/bcc when a sender uses listserv-style
+    // routing (e.g. GitHub notifications: MIME `to_text` =
+    // `"hoiekim/budget" <budget@noreply.github.com>`, envelope_to =
+    // `<sub-addr>@hoie.kim`). Without including envelope_to, mails
+    // delivered via sub-addressing don't surface in the per-account
+    // received view at all — but the push badge counts them, causing
+    // FE shows 0 / badge shows N.
     const addressExpansion = sent
       ? `jsonb_array_elements(from_address)->>'address' as address`
       : `jsonb_array_elements(
-          COALESCE(to_address, '[]'::jsonb) || 
-          COALESCE(cc_address, '[]'::jsonb) || 
-          COALESCE(bcc_address, '[]'::jsonb)
+          COALESCE(to_address, '[]'::jsonb) ||
+          COALESCE(cc_address, '[]'::jsonb) ||
+          COALESCE(bcc_address, '[]'::jsonb) ||
+          COALESCE(envelope_to, '[]'::jsonb)
         )->>'address' as address`;
 
     const addressNotNull = sent
       ? `from_address IS NOT NULL`
-      : `(to_address IS NOT NULL OR cc_address IS NOT NULL OR bcc_address IS NOT NULL)`;
+      : `(to_address IS NOT NULL OR cc_address IS NOT NULL OR bcc_address IS NOT NULL OR envelope_to IS NOT NULL)`;
 
     // Use address matching (from_address for sent, to/cc/bcc for received) rather
     // than the `sent` boolean flag, so self-emails appear in both views correctly.


### PR DESCRIPTION
Reported by Hoie 2026-05-23: *\"right now i see 26 in the badge. Verify if your theory is correct. If so open a PR.\"*

Verified the envelope_to / domain-filter mismatch is the real cause; the earlier PR #482→#512 revert was orthogonal and didn't fix the user-visible bug.

## Data (prod inbox DB, just now)

```
getUnreadNotifications (badge query — no domain, no draft filter):     26
getAccountStats with @hoie.kim domain filter (FE inbox unread count):   0
```

All 26 mails the badge counts are GitHub list notifications:

| field        | value                                              |
|--------------|---------------------------------------------------|
| from         | `\"claoie\" <notifications@github.com>`             |
| MIME to      | `\"hoiekim/budget\" <budget@noreply.github.com>` *or* `\"hoiekim/inbox\" <inbox@noreply.github.com>` — **outside @hoie.kim** |
| envelope_to  | `claoie@hoie.kim` — **inside @hoie.kim** |
| draft / spam / deleted | all FALSE |

So the SMTP-level envelope_to addresses a sub-address in the user's domain, but the MIME `to` header points at a listserv-style address. `getAccountStats`'s received-side address expansion (`src/server/lib/postgres/repositories/mails.ts:431-441`) only unions `to_address || cc_address || bcc_address` — it doesn't know about `envelope_to`. So these mails never surface in the per-account view at all. The push badge counts them via the much-broader `getUnreadNotifications` query → FE shows 0 / badge shows 26.

## Fix

Union `envelope_to` into the received-branch address expansion, and add `envelope_to IS NOT NULL` to the addressNotNull check so mails with ONLY envelope_to populated still survive the expansion. Sent branch unchanged (envelope_from has different semantics — bounce path, not symmetric with envelope_to here).

After this change: the 26 mails surface under a `claoie@hoie.kim` account row in the received list. Badge=26 and FE unread under `claoie@hoie.kim`=26 converge.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (no new warnings on mails.ts)
- [x] Full server tests: **825/825** pass
- [x] 3 new tests added (source-text scan pattern, consistent with existing `expungeDeletedMails` regression tests in the same file):
  - Received branch unions `envelope_to` alongside `to`/`cc`/`bcc`.
  - Received-branch null-check includes `envelope_to`.
  - Sent branch unchanged — `from_address` only, no `envelope_*`.
- [x] Verified regression-catch: removed the envelope_to additions, ran tests → 2/3 new tests fail. Restored → 17/17 pass.

Will spin sandbox next.