### PR TITLE
fix(mails): include envelope_to in getMailHeaders received-branch filter

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -284,3 +284,54 @@ describe("getAccountStats — envelope_to inclusion in received address expansio
     expect(sentSql).not.toContain("envelope_from");
   });
 });
+
+describe("getMailHeaders — envelope_to in received-branch address condition", () => {
+  // Companion to the getAccountStats change in PR #525. That PR surfaced
+  // the per-account row keyed on envelope_to in the accounts list, but
+  // clicking through still rendered an empty mail list because this
+  // function — which backs the per-account mail list view — only
+  // matched on MIME to/cc/bcc. Hoie 2026-05-23 on PR #525 sandbox:
+  // "the github emails are not included in mail list".
+  let mailsSource: string;
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(
+      /export const getMailHeaders[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeaders not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("received branch's addressCondition unions envelope_to with to/cc/bcc", () => {
+    // Source uses `${TO_ADDRESS}` template-literal substitution that
+    // expands to "to_address" at runtime; the static text contains the
+    // token, so the test asserts on the template tokens directly.
+    const exprMatch = fnSource.match(
+      /addressCondition\s*=\s*options\.sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+    );
+    if (!exprMatch) throw new Error("addressCondition ternary not found");
+    const receivedSql = exprMatch[1];
+    expect(receivedSql).toContain("${TO_ADDRESS}");
+    expect(receivedSql).toContain("cc_address @>");
+    expect(receivedSql).toContain("bcc_address @>");
+    expect(receivedSql).toContain("envelope_to @>");
+  });
+
+  it("sent branch's addressCondition remains from_address only", () => {
+    const exprMatch = fnSource.match(
+      /addressCondition\s*=\s*options\.sent\s*\?\s*`([^`]*)`/
+    );
+    if (!exprMatch) throw new Error("sent branch not found");
+    const sentSql = exprMatch[1];
+    expect(sentSql).toContain("${FROM_ADDRESS}");
+    expect(sentSql).not.toContain("envelope_to");
+    expect(sentSql).not.toContain("envelope_from");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -262,11 +262,17 @@ export const getMailHeaders = async (
     const addressJson = JSON.stringify([{ address }]);
     // Detect sent/received by address matching, not the `sent` flag.
     // For sent mails, check from_address only.
-    // For received mails, check to_address, cc_address, and bcc_address.
-    // This ensures self-emails appear in both Sent and Inbox views correctly.
+    // For received mails, check to_address, cc_address, bcc_address AND
+    // envelope_to. `envelope_to` is the SMTP-level delivery address that
+    // can differ from MIME to/cc/bcc when a sender uses listserv-style
+    // routing (e.g. GitHub notifications: MIME `to` = list address,
+    // envelope_to = the actual recipient sub-address). Mirrors the
+    // received-branch address expansion in `getAccountStats` (PR #525)
+    // so that an account row surfaced by envelope_to still resolves to
+    // its mails when the user clicks through.
     const addressCondition = options.sent
       ? `${FROM_ADDRESS} @> $2::jsonb`
-      : `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb)`;
+      : `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
     // Select only columns needed for mail headers — excludes html/text/attachments
     // to avoid loading full email bodies into memory for every concurrent request.
     const headerColumns = [


### PR DESCRIPTION
Companion to **PR #525** (merged 2026-05-23 18:04 UTC).

PR #525 fixed \`getAccountStats\` so envelope_to-only mails surface as a per-account row in the accounts list — but the per-account **mail list view** backed by \`getMailHeaders\` still filtered on MIME to/cc/bcc only. Result: the new \`claoie@hoie.kim\` account row appeared with N unread, but clicking through showed an empty list. Hoie on the PR #525 sandbox:

> the github emails are not included in mail list

(This fix was queued in PR #525's amended commit, force-pushed after the merge landed the first commit — so it didn't make it onto main. This PR re-applies it cleanly from current main.)

## Change

\`getMailHeaders\` (`src/server/lib/postgres/repositories/mails.ts`) — received-branch \`addressCondition\` adds \`envelope_to @> \$2::jsonb\` alongside to/cc/bcc. Sent branch unchanged. Mirrors PR #525's address-expansion shape so the list backing query agrees with the accounts-list query.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun run lint\` clean (no new warnings on mails.ts)
- [x] Full server tests: 827/827 pass
- [x] 2 new source-text scan tests in mails.test.ts (consistent with PR #525's pattern):
  - Received branch unions \`envelope_to\` alongside to/cc/bcc.
  - Sent branch remains from_address only.
- [x] Regression-catch verified: deleted the envelope_to addition → 1/2 new tests fail. Restored → 19/19 pass.

Sandbox spinning next.