### PR TITLE
fix(reply): derive sent/received from sender address (#510)

### DIFF
--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -31,7 +31,7 @@ import {
   RobotIcon
 } from "./components";
 
-import { Context, Category, QueryCache, call } from "client";
+import { Context, Category, QueryCache, call, isSentMail } from "client";
 import { AccountsCache } from "client/Box/components/Accounts";
 
 import "./index.scss";
@@ -88,6 +88,7 @@ interface RenderedMailProps {
   setReplyData: Dispatch<SetStateAction<ReplyData>>;
   requestDeleteMail: (mail: MailHeaderData) => Promise<ApiResponse<MailDeleteResponse>>;
   selectedAccount: string;
+  domainName: string;
   accountsCache: AccountsCache;
   selectedCategory: Category;
   removeAccountFromQueryData: () => void;
@@ -108,6 +109,7 @@ const RenderedMail = ({
   setReplyData,
   requestDeleteMail,
   selectedAccount,
+  domainName,
   accountsCache,
   selectedCategory,
   removeAccountFromQueryData,
@@ -142,7 +144,17 @@ const RenderedMail = ({
       const clonedActiveMailId = { ...activeMailId, [mail.id]: true };
       setActiveMailId(clonedActiveMailId);
     }
-    setReplyData({ ...mail, to: { address: selectedAccount } });
+    // The Writer derives the composer's "From" from `replyData.to.address`
+    // and the composer's "To" from `replyData.from.value[0].address`. For
+    // received mail that lines up naturally; for sent mail surfaced via
+    // search (or Sent Mails), we swap `from`/`to` so Reply addresses the
+    // original recipient — not the user themselves. See #510.
+    if (isSentMail(mail, domainName)) {
+      const ownAddress = mail.from?.value?.[0]?.address || selectedAccount;
+      setReplyData({ ...mail, from: mail.to, to: { address: ownAddress } });
+    } else {
+      setReplyData({ ...mail, to: { address: selectedAccount } });
+    }
   };
 
   const onClickShare = () => {
@@ -356,7 +368,8 @@ const RenderedMails = ({ page }: { page: number }) => {
     isWriterOpen,
     setReplyData,
     selectedAccount,
-    selectedCategory
+    selectedCategory,
+    domainName
   } = useContext(Context);
 
   const [activeMailId, setActiveMailId] = useState<ActiveMailMap>({});
@@ -538,6 +551,7 @@ const RenderedMails = ({ page }: { page: number }) => {
           setReplyData={setReplyData}
           requestDeleteMail={requestDeleteMail}
           selectedAccount={selectedAccount}
+          domainName={domainName}
           accountsCache={accountsCache}
           selectedCategory={selectedCategory}
           removeAccountFromQueryData={removeAccountFromQueryData}

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -7,3 +7,4 @@ export * from "./call";
 export * from "./user";
 export * from "./queryClient";
 export * from "./a11y";
+export * from "./mails";

--- a/src/client/lib/mails.test.ts
+++ b/src/client/lib/mails.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { MailHeaderData } from "common";
+import { isSentMail } from "./mails";
+
+const makeMail = (fromAddress: string | undefined) =>
+  new MailHeaderData({
+    from: fromAddress ? { value: [{ address: fromAddress }], text: fromAddress } : undefined,
+  });
+
+describe("isSentMail", () => {
+  it("returns true when sender address ends with @<userDomain>", () => {
+    expect(isSentMail(makeMail("hoie@hoie.kim"), "hoie.kim")).toBe(true);
+    expect(isSentMail(makeMail("career@hoie.kim"), "hoie.kim")).toBe(true);
+  });
+
+  it("returns false when sender address is on a different domain", () => {
+    expect(isSentMail(makeMail("eric.cole@salesforce.com"), "hoie.kim")).toBe(false);
+    expect(isSentMail(makeMail("noreply@github.com"), "hoie.kim")).toBe(false);
+  });
+
+  it("is case-insensitive on both sender address and domain", () => {
+    expect(isSentMail(makeMail("Hoie@Hoie.Kim"), "hoie.kim")).toBe(true);
+    expect(isSentMail(makeMail("hoie@hoie.kim"), "HOIE.KIM")).toBe(true);
+  });
+
+  it("does not substring-match a domain that merely contains the user domain", () => {
+    // e.g. user domain "hoie.kim" must not match "hoie.kim.attacker.com"
+    expect(isSentMail(makeMail("phish@hoie.kim.attacker.com"), "hoie.kim")).toBe(false);
+    // …and must not match "fakehoie.kim" (no @ boundary)
+    expect(isSentMail(makeMail("phish@fakehoie.kim"), "hoie.kim")).toBe(false);
+  });
+
+  it("returns false when from address or user domain is missing", () => {
+    expect(isSentMail(makeMail(undefined), "hoie.kim")).toBe(false);
+    expect(isSentMail(makeMail("hoie@hoie.kim"), "")).toBe(false);
+    expect(isSentMail({ from: { value: [], text: "" } }, "hoie.kim")).toBe(false);
+  });
+});

--- a/src/client/lib/mails.ts
+++ b/src/client/lib/mails.ts
@@ -1,0 +1,17 @@
+import { MailHeaderData } from "common";
+
+/**
+ * Detects whether `mail` was sent by the user, by comparing the sender
+ * address against the user's domain. This is the canonical way to derive
+ * sent/received state — see #430 / #509 for the rationale (the `sent`
+ * column on the `mails` table is deprecated; do not branch on `mail.sent`).
+ */
+export const isSentMail = (
+  mail: Pick<MailHeaderData, "from">,
+  userDomain: string
+): boolean => {
+  if (!userDomain) return false;
+  const fromAddress = mail.from?.value?.[0]?.address;
+  if (!fromAddress) return false;
+  return fromAddress.toLowerCase().endsWith(`@${userDomain.toLowerCase()}`);
+};


### PR DESCRIPTION
Closes #510

## Summary

When the Reply icon was clicked on a sent mail (e.g. via Sent Mails or Search), the composer was opened addressed to the user themselves. The old `onClickReply` always set `replyData.to = { address: selectedAccount }` and left `replyData.from = mail.from`. The Writer derives `sender = replyData.to.address.split("@")[0]` and `to = replyData.from.value[0].address`, which lines up for received mail but reverses for sent mail (where `mail.from` is the user's own address → composer addresses the user).

Fix per Hoie's direction in closed PR #498 and the deprecation note added by PR #509: detect sent/received by comparing the sender address against the user's domain (`domainName` context, populated from `/api/mails/domain`), then swap the from/to pair for sent mail so Reply targets the original recipient.

## Changes

- New `src/client/lib/mails.ts` with `isSentMail(mail, userDomain)` helper
- `onClickReply` (Mails/index.tsx) swaps from/to for sent mails; received-mail behavior unchanged
- `domainName` plumbed from `Context` down to `RenderedMail` props
- Unit tests in `mails.test.ts`: domain match, case-insensitivity, rejects substring/host-suffix attacks (`hoie.kim` vs `fakehoie.kim` / `hoie.kim.attacker.com`), missing-field handling

## Test plan

`bun test src/client/lib/mails.test.ts` → 5 pass / 0 fail
`bun run typecheck` → clean

E2E (Playwright against local prod-snapshot DB, admin user, domain hoie.kim):

- Scenario 1 — Sent > `test` account: top mail from=test@hoie.kim, to=<external@redacted>, sent=true → composer To after Reply = `<external@redacted>` (original recipient ✓). Without the fix, To would have been the user's own address.
- Scenario 2 — All > `amazon` account: received mail → composer To after Reply = `amazondls@…services.hr.a2z.com` (external sender, NOT the user's own domain ✓). Received behavior preserved.

## Out of scope

- `getMailHeaders` still forwards `sent: m.sent` (`headers.ts:64`); the deprecation note implies a follow-up cleanup, but it's not blocking the user-visible reply bug fixed here. Tracked alongside #430.
- `onClickShare` (forward) is untouched — forward already sets `to: { address: "" }` so the user types the recipient; no detection needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*[Edited 2026-05-24: redacted external email address from E2E test scenario per daily security review §2a — real Gmail addresses must not appear in PR bodies.]*