### PR TITLE
docs(DEVELOPMENT): document envelope_to + CC/BCC in received-mail filtering

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -289,18 +289,19 @@ Base capabilities advertised: `IMAP4rev1 LITERAL+ SASL-IR LOGIN-REFERRALS ID ENA
 
 Sent mail is detected by **address matching**, not a boolean `sent` flag:
 
-- A mail appears in "Received" if the recipient's address matches the account
+- A mail appears in "Received" if any of `to_address`, `cc_address`, `bcc_address`, or `envelope_to` matches the account
 - A mail appears in "Sent" if the sender's `from_address` matches the account
 - Self-sent emails (same from and to) appear in **both** views correctly
 
 This was changed in PR #199 from the previous `sent` column approach. The address-based method handles edge cases better:
 - Self-email: one DB row, visible in both views
-- Multi-recipient: each user's copy is scoped correctly
+- Multi-recipient: each user's copy is scoped correctly (CC and BCC recipients land in the received view)
+- Listserv / sub-addressed delivery: `envelope_to` (the SMTP-level RCPT TO) often differs from MIME `to_address` for GitHub notifications and mailing-list relays — including it ensures the actual delivery target surfaces (PRs #525, #526)
 - No ambiguity about what "sent" means for forwarded or relayed mail
 
 Key functions:
-- `getMailHeaders()` — filters by `from_address` or `to_address` based on view
-- `getAccountStats()` — counts using address matching (not `sent` flag)
+- `getMailHeaders()` — for received view, filters on `to_address`, `cc_address`, `bcc_address`, and `envelope_to`; for sent view, filters on `from_address`
+- `getAccountStats()` — counts using the same address-column set (not `sent` flag)
 
 **Self-email:** When a user sends mail to themselves, the sent-mail copy is saved with the sender's address as `from_address` and the recipient's address (same address) as `to_address`. It appears in the Sent view because `from_address` matches the user, and in the Received view because `to_address` matches the user — no special-casing required.
 


### PR DESCRIPTION
## Summary

After PRs #525 (`getAccountStats`) and #526 (`getMailHeaders`), the received-branch address filter is the union of `to_address`, `cc_address`, `bcc_address`, and `envelope_to`. The "Sent Mail Detection" section in `DEVELOPMENT.md` still described the filter as just "recipient's address matches the account" with `getMailHeaders()` shown as filtering by `to_address` only.

This PR updates three bullets in that section to match post-#525/#526 reality:

1. **"Received" criterion** — lists all four address columns instead of the single ambiguous "recipient's address."
2. **Edge-cases list** — adds a "Listserv / sub-addressed delivery" bullet pointing to `envelope_to` (the SMTP-level RCPT TO) as the carrier for cases like GitHub notification sub-addresses where MIME `to_address` is the list address, not the user's actual delivery target.
3. **Key functions** — `getMailHeaders()` now lists all four received-view columns; `getAccountStats()` follows the same column set.

Found via Sweep 7 (docs drift, side) against the daily ops protocol — the code changes shipped 2026-05-23/24 but the docs hadn't caught up.

## Test plan

- [x] Verified diff is markdown-only (`DEVELOPMENT.md` only, +5/-4)
- [x] Cross-checked each claim against the current SQL in `src/server/lib/postgres/repositories/mails.ts`:
  - `getMailHeaders` `addressCondition` at line 273-275: `(${TO_ADDRESS} @> $2 OR cc_address @> $2 OR bcc_address @> $2 OR envelope_to @> $2)`
  - `getAccountStats` `addressExpansion` at line 445-452: `to_address || cc_address || bcc_address || envelope_to`
- [x] PR #199 reference preserved (this is an update, not a replacement, of the originating PR's context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)