### PR TITLE
fix(search): remove redundant decodeURIComponent that rejects percent chars

### DIFF
--- a/src/server/lib/http/routes/mails/get-search.ts
+++ b/src/server/lib/http/routes/mails/get-search.ts
@@ -10,7 +10,7 @@ export const getSearchRoute = new Route<SearchGetResponse>(
   async (req) => {
     const user = req.session.user!;
 
-    const value = decodeURIComponent(req.params.value);
+    const value = req.params.value;
     const field = req.query.field as unknown as string | undefined;
     const result = await searchMail(user, value, field);
 

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -477,6 +477,21 @@ describe("getSearchRoute", () => {
       "subject"
     );
   });
+
+  it("handles percent characters without throwing URIError", async () => {
+    const { getSearchRoute } = await import("./get-search");
+    mockSearchMail.mockResolvedValueOnce([]);
+
+    const req = makeReq({ params: { value: "100% off" }, query: {} });
+    const result = await getSearchRoute.callback(req, makeRes(), noopStream);
+
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect(mockSearchMail).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "u1" }),
+      "100% off",
+      undefined
+    );
+  });
 });
 
 // ── get-spam route ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Remove redundant `decodeURIComponent` in `get-search.ts` — Express already URL-decodes `req.params` values, so the extra decode throws `URIError` on literal `%` characters (e.g. searching "100% off"), returning HTTP 500 and burning a global alarm-cooldown slot
- Add test covering percent-character search terms

## E2E

- Started dev server, logged in as admin
- `GET /api/mails/search/100%25%20off` → 200 success (was 500 before fix)
- `GET /api/mails/search/50%25` → 200 success
- `GET /api/mails/search/hello` → 200 success (regression check)
- `bun test src/server/lib/http/routes/mails/mails.test.ts` — 42 pass, 0 fail

## Note

`delete-allowlist.ts` has the same `decodeURIComponent(req.params.pattern)` pattern — same class of bug. Not fixed here to keep scope narrow; tracked as a known issue.

Closes #523