### PR TITLE
fix(allowlist): remove redundant decodeURIComponent in DELETE route

### DIFF
--- a/src/server/lib/http/routes/mails/delete-allowlist.ts
+++ b/src/server/lib/http/routes/mails/delete-allowlist.ts
@@ -12,7 +12,7 @@ export const deleteSpamAllowlistRoute = new Route<AllowlistDeleteResponse>(
   async (req) => {
     const user = req.session.user!;
 
-    const pattern = decodeURIComponent(req.params.pattern);
+    const pattern = req.params.pattern;
     const removed = await removeAllowlistEntry(user.id, pattern);
 
     if (!removed) {

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -622,7 +622,7 @@ describe("deleteSpamAllowlistRoute", () => {
   it("returns failed when entry not found", async () => {
     const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
     mockRemoveAllowlistEntry.mockResolvedValueOnce(false);
-    const req = makeReq({ params: { pattern: "*%40spam.com" } });
+    const req = makeReq({ params: { pattern: "*@spam.com" } });
     const result = await deleteSpamAllowlistRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("failed");
     expect((result as ApiResponse<unknown>).message).toMatch(/not found/i);
@@ -631,7 +631,15 @@ describe("deleteSpamAllowlistRoute", () => {
   it("returns success when entry removed", async () => {
     const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
     mockRemoveAllowlistEntry.mockResolvedValueOnce(true);
-    const req = makeReq({ params: { pattern: "*%40spam.com" } });
+    const req = makeReq({ params: { pattern: "*@spam.com" } });
+    const result = await deleteSpamAllowlistRoute.callback(req, makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+  });
+
+  it("handles patterns containing percent chars without throwing", async () => {
+    const { deleteSpamAllowlistRoute } = await import("./delete-allowlist");
+    mockRemoveAllowlistEntry.mockResolvedValueOnce(true);
+    const req = makeReq({ params: { pattern: "100%match@spam.com" } });
     const result = await deleteSpamAllowlistRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
   });


### PR DESCRIPTION
## Summary

- Removes the redundant `decodeURIComponent()` call in `delete-allowlist.ts` — Express already URL-decodes `req.params` values, so the extra decode throws `URIError` on patterns containing literal `%` chars
- Same root cause as #523 (fixed in PR #530), applied to the delete-allowlist route
- Updated existing test mocks to pass decoded params (matching Express behavior) and added a regression test for percent-containing patterns

Closes #531

## E2E verification

Unit tests: all 42 route tests pass (`bun test mails.test.ts`), including the new percent-char regression test.

Live E2E: the DELETE route is currently shadowed by the `DELETE /api/mails/:id` wildcard (tracked in #505, fix in PR #515), so the endpoint is unreachable via HTTP until that fix merges. The `decodeURIComponent` removal is confirmed correct by the unit test and by code inspection — it matches the identical fix in PR #530 for the search route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)