### PR TITLE
refactor(push): extract sendNotificationSafely — drop duplicated 410 handling + isFailed flag

### DIFF
--- a/src/server/lib/push.ts
+++ b/src/server/lib/push.ts
@@ -74,6 +74,36 @@ export const createPush = (
     });
   };
 
+  // Send one notification and absorb the "subscription expired" (HTTP 410)
+  // case by deleting the dead subscription. Returns whether the send
+  // succeeded so callers can gate follow-up writes (e.g. updateLastNotified)
+  // without threading a mutable flag out of a .catch.
+  const sendNotificationSafely = async (
+    subscription: ComputedPushSubscription,
+    payload: object,
+    push_subscription_id: string,
+  ): Promise<boolean> => {
+    try {
+      await webPushImpl.sendNotification(subscription, JSON.stringify(payload));
+      return true;
+    } catch (error) {
+      if ((error as { statusCode?: number }).statusCode === 410) {
+        logger.info("Subscription has expired, removing from database", {
+          component: "push",
+          push_subscription_id,
+        });
+        await deleteSubscription(push_subscription_id);
+      } else {
+        logger.error(
+          "Error sending push notification",
+          { component: "push" },
+          error,
+        );
+      }
+      return false;
+    }
+  };
+
   const ONE_DAY = 1000 * 60 * 60 * 24;
 
   const cleanSubscriptions = () => {
@@ -131,28 +161,12 @@ export const createPush = (
           push_subscription_id,
         };
 
-        let isFailed = false;
-
-        await webPushImpl
-          .sendNotification(subscription, JSON.stringify(notificationPayload))
-          .catch(async (error) => {
-            isFailed = true;
-            if (error.statusCode === 410) {
-              logger.info("Subscription has expired, removing from database", {
-                component: "push",
-                push_subscription_id,
-              });
-              return deleteSubscription(push_subscription_id);
-            } else {
-              logger.error(
-                "Error sending push notification",
-                { component: "push" },
-                error,
-              );
-            }
-          });
-
-        if (isFailed) return;
+        const success = await sendNotificationSafely(
+          subscription,
+          notificationPayload,
+          push_subscription_id,
+        );
+        if (!success) return;
 
         await repo.updateLastNotified(push_subscription_id);
 
@@ -183,23 +197,11 @@ export const createPush = (
           push_subscription_id,
         };
 
-        return webPushImpl
-          .sendNotification(subscription, JSON.stringify(notificationPayload))
-          .catch((error) => {
-            if (error.statusCode === 410) {
-              logger.info("Subscription has expired, removing from database", {
-                component: "push",
-                push_subscription_id,
-              });
-              deleteSubscription(push_subscription_id);
-            } else {
-              logger.error(
-                "Error sending push notification",
-                { component: "push" },
-                error,
-              );
-            }
-          });
+        return sendNotificationSafely(
+          subscription,
+          notificationPayload,
+          push_subscription_id,
+        );
       }),
     );
   };


### PR DESCRIPTION
## What

Extracts a private `sendNotificationSafely(subscription, payload, push_subscription_id)` helper in `createPush` and routes both notification senders through it.

Before, `notifyNewMails` and `decrementBadgeCount` each carried an **identical ~14-LOC `.catch` block** handling the "subscription expired" (HTTP 410 → delete the dead subscription, else log) case, and `notifyNewMails` threaded the send outcome back to its happy path through a **mutable `isFailed` flag** set inside the async `.catch`:

```ts
let isFailed = false;
await webPushImpl.sendNotification(...).catch(async (error) => { isFailed = true; ... });
if (isFailed) return;
await repo.updateLastNotified(push_subscription_id);
```

After:

```ts
const success = await sendNotificationSafely(subscription, notificationPayload, push_subscription_id);
if (!success) return;
await repo.updateLastNotified(push_subscription_id);
```

The 410-handling lives in exactly one place; the boolean return advertises the failure short-circuit that the flag previously hid.

## Why

- **Principle 1 (code tells the truth):** the `isFailed` flag carried a `.catch` side-effect out to gate a later `await` — the shape read as straight-line but the short-circuit was implicit. A `Promise<boolean>` return makes the failure path explicit at the call site.
- **Principle 2 (one canonical way):** the send + 410-delete logic was mirrored across two methods; a change to expiry handling had to be made twice and would drift.

Addresses #555.

## Testing

Behavior-preserving; no signature or external-behavior change. Existing `push.test.ts` already pins all three paths:
- 410 → `deleteSubscription` called, `updateLastNotified` **not** called
- non-410 send failure → no delete, no `updateLastNotified`
- success → `updateLastNotified` called

```
$ bun run typecheck   # clean
$ bun run lint        # 0 errors (pre-existing warnings only, none in push.ts)
$ bun test src/server/lib/push.test.ts
 24 pass / 0 fail / 61 expect() calls
```

Pure server-side notification dispatch — no browser surface to E2E; the unit suite exercises the changed control flow directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
