### PR TITLE
test(infra): add test-preload + restoreLeaves helper (#557 step 1)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,10 @@
 [test]
+# Preload runs once before any test file. Snapshots real `pg` / `web-push`
+# exports onto `globalThis.__REAL_*` so `scripts/test-helpers.ts#restoreLeaves`
+# can re-mock leaf deps back to their real exports in test files'
+# `afterAll`. Mirrors budget's pattern.
+preload = ["./scripts/test-preload.ts"]
+
 # Exclude test files themselves from the coverage report
 coverageSkipTestFiles = true
 

--- a/scripts/test-helpers.ts
+++ b/scripts/test-helpers.ts
@@ -1,0 +1,58 @@
+/**
+ * Test-side mock helpers. Tests import these and use them in
+ * `beforeAll` / `afterAll` to install + restore process-global
+ * `mock.module(...)` overrides cleanly.
+ *
+ * Why restore: bun's `mock.module()` is process-global and has no
+ * `unmock` API — once a file mocks `"pg"` with a FakePool, every
+ * subsequent file in the same `bun test` process sees the mock unless
+ * it's explicitly re-mocked back to real. `restoreLeaves()` re-mocks
+ * each leaf to the snapshot the preload captured (`globalThis.__REAL_*`)
+ * before any test file ran, so the next file starts from a known
+ * baseline.
+ *
+ * Usage pattern:
+ *
+ *   import { restoreLeaves } from "test-helpers";
+ *   import { afterAll, mock } from "bun:test";
+ *
+ *   mock.module("pg", () => ({ Pool: FakePool, ... }));
+ *
+ *   afterAll(restoreLeaves);
+ *
+ * Note: `pg`'s lazy-pool getter that lets a test file's `mock.module`
+ * actually rebind the cached `Pool` reference is not yet in `client.ts`
+ * — that's a separate PR (tracked by inbox#557 step 2). Until then,
+ * this helper restores the SPEC binding on `pg` so a subsequent file's
+ * fresh `import { Pool } from "pg"` resolves to the real Pool; tests
+ * that depend on per-file pool isolation should hold until lazy-pool
+ * lands.
+ */
+import { mock } from "bun:test";
+
+interface RealLeaves {
+  __REAL_PG: Record<string, unknown> & { default: unknown };
+  __REAL_WEB_PUSH: Record<string, unknown> & { default: unknown };
+}
+
+const realLeaves = (): RealLeaves => {
+  const g = globalThis as unknown as Partial<RealLeaves>;
+  if (!g.__REAL_PG || !g.__REAL_WEB_PUSH) {
+    throw new Error(
+      "test-helpers: real leaf snapshots missing on globalThis. " +
+        "Run tests via `bun test` (which preloads `scripts/test-preload.ts`).",
+    );
+  }
+  return g as RealLeaves;
+};
+
+/**
+ * Re-mock the standard set of leaf deps (`pg`, `web-push`) back to the
+ * real module exports captured by the preload. Pass directly to
+ * `afterAll(restoreLeaves)`.
+ */
+export const restoreLeaves = (): void => {
+  const { __REAL_PG, __REAL_WEB_PUSH } = realLeaves();
+  mock.module("pg", () => __REAL_PG);
+  mock.module("web-push", () => __REAL_WEB_PUSH);
+};

--- a/scripts/test-preload.ts
+++ b/scripts/test-preload.ts
@@ -1,0 +1,35 @@
+/**
+ * Test preload — runs ONCE before any test file in `bun test`.
+ *
+ * Captures real exports of leaf node-modules that tests commonly mock
+ * (`pg`, `web-push`) onto `globalThis.__REAL_*` so test files can
+ * `afterAll`-restore via `scripts/test-helpers.ts#restoreLeaves` and
+ * not leak per-file `mock.module(...)` overrides into the next file.
+ *
+ * `mock.module(...)` in Bun is process-wide and has no `unmock` API —
+ * once test A mocks `"pg"` with a FakePool, every subsequent test file
+ * sees the mock unless explicitly re-mocked back to real. The snapshots
+ * captured here are the "real" baseline.
+ *
+ * The snapshots are taken at preload time — BEFORE any test file has
+ * a chance to call `mock.module(...)` — so they're guaranteed to be
+ * the real module exports.
+ *
+ * We spread the full namespace (not just a hand-picked subset) because
+ * these libs' methods reference each other through `module.exports` at
+ * runtime — e.g. `web-push.sendNotification` internally references
+ * `module.exports.getVapidHeaders`. A partial-restore snapshot crashes
+ * the next file's web-push call when an internal reference is missing.
+ */
+
+const realPg = require("pg");
+const realWebPush = require("web-push");
+
+(globalThis as Record<string, unknown>).__REAL_PG = {
+  ...realPg,
+  default: realPg.default ?? realPg,
+};
+(globalThis as Record<string, unknown>).__REAL_WEB_PUSH = {
+  ...realWebPush,
+  default: realWebPush.default ?? realWebPush,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
       "server": ["./server"],
       "server/*": ["./server/*"],
       "common": ["./common"],
-      "common/*": ["./common/*"]
+      "common/*": ["./common/*"],
+      "test-helpers": ["../scripts/test-helpers.ts"]
     },
     "types": ["bun-types"]
   },


### PR DESCRIPTION
## Summary

Step 1 of 4+ for #557 — bring inbox in line with budget's [PR #467](https://github.com/hoiekim/budget/pull/467) test isolation pattern so we can retire all DI seams (`createPush(webPushImpl)` factory, `checkSpam(…, deps)` parameter) per:

- Hoie 2026-05-31 (DM): *"Consistency is very important in my org. Remove all monkey patch and DI completely."*
- Hoie 2026-06-03 on #495: *"I don't like DI. Budget repo recently figured out how to avoid DI by restoring mocks in `afterAll`. Do the same thing here."*

This PR is **infrastructure scaffolding ONLY** — no source changes, no test changes. Subsequent PRs against #557 will rewrite tests and remove DI seams on top of this foundation.

## Diff

- `scripts/test-preload.ts` — captures real `pg` + `web-push` exports onto `globalThis.__REAL_*` before any test file runs. Spreads the full namespace (not a hand-picked subset) so internal cross-references in these libs (e.g. `web-push.sendNotification` calling `module.exports.getVapidHeaders`) don't crash after restore.
- `scripts/test-helpers.ts` — exports `restoreLeaves()` that re-mocks each leaf spec back to the preload snapshot. Tests will call `afterAll(restoreLeaves)` once they're rewritten.
- `bunfig.toml` `[test] preload = […]` — registers the preload so `bun test src/path/to/x.test.ts` works without an explicit `--preload` flag.
- `tsconfig.json` — adds `test-helpers` path alias.

## Why infra-only

Hoie 2026-05-30: *"Sounds good. Apply this testing framework and open a PR. Make sure to make zero changes to the source code files to prevent regression."* Same bar applied here — the lazy-pool Proxy refactor in `postgres/client.ts` that lets per-file `mock.module("pg", FakePool)` rebind the cached Pool reference is intentionally NOT in this PR. That's a load-bearing source change with its own regression-audit + tests + sandbox E2E (mirroring budget #467's pattern), and lands as **step 2**.

## Verification

- `bun test src` → **837 pass / 0 fail** (no behaviour change — preload only captures globals).
- `bun run typecheck` clean.
- `bun run lint` clean (17 pre-existing warnings unchanged).

## Sandbox

Test-infra change with no functional surface — `bun run dev` not exercised. Skipping sandbox per the non-functional skip rule.

## Plan (tracked in #557)

1. **This PR** — infra scaffolding.
2. Lazy-pool Proxy in `postgres/client.ts` + `resetPool` wired into `restoreLeaves` (source change; full regression audit).
3. Retire `createPush(webPushImpl)` DI factory in `push.ts`; rewrite `push.test.ts` to `mock.module("web-push", …)` + `afterAll(restoreLeaves)`.
4. Retire `checkSpam(…, deps: CheckSpamDeps)` in `spam/service.ts`; same pattern for `spam/service.test.ts`.
5. Sweep remaining test files using `mock.module` without restoration (one PR per logical group; bundling rule applies — multiple files of the same kind in one PR).

Closes part 1 of #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)