### PR TITLE
refactor(client): lazy Pool Proxy for per-test-file mock isolation (#557 step 2)

### DIFF
--- a/src/server/lib/postgres/client.test.ts
+++ b/src/server/lib/postgres/client.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, mock, beforeAll, afterAll } from "bun:test";
+
+// Capture real pg before mocking so we can restore at end-of-file.
+const realPg = { ...(await import("pg")) };
+
+const ctorCalls = mock(() => {});
+
+class FakePool {
+  ending = false;
+  _clients: string[] = ["c1", "c2", "c3"];
+  config: unknown;
+  // EventEmitter-style mutation field — set trap regression test.
+  listeners: Array<(err: Error) => void> = [];
+  constructor(config: unknown) {
+    this.config = config;
+    ctorCalls();
+  }
+  end() {
+    this.ending = true;
+    this._clients = this._clients.filter((c) => c !== "c2");
+    return Promise.resolve();
+  }
+  query() {
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  }
+  connect() {
+    return Promise.resolve({ query: () => {}, release: () => {} });
+  }
+  on(_event: string, handler: (err: Error) => void) {
+    this.listeners.push(handler);
+  }
+}
+
+mock.module("pg", () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+}));
+
+const { pool, resetPool } = await import("./client");
+
+afterAll(() => {
+  // Restore pg so subsequent test files don't see FakePool.
+  mock.module("pg", () => realPg);
+  resetPool();
+});
+
+describe("lazy pool Proxy", () => {
+  beforeAll(() => {
+    resetPool();
+    ctorCalls.mockClear();
+  });
+
+  test("first property access instantiates exactly one Pool", () => {
+    resetPool();
+    ctorCalls.mockClear();
+    void pool.ending;
+    void pool.connect;
+    void pool.query;
+    expect(ctorCalls).toHaveBeenCalledTimes(1);
+  });
+
+  test("assignments forward to the underlying Pool (regression: pg.Pool methods do `this.ending = true`)", async () => {
+    resetPool();
+    expect(pool.ending).toBe(false);
+    await pool.end();
+    expect(pool.ending).toBe(true);
+  });
+
+  test("methods that mutate via `this.prop = filtered(this.prop)` land on the real Pool", async () => {
+    resetPool();
+    expect(pool._clients).toEqual(["c1", "c2", "c3"]);
+    await pool.end();
+    expect(pool._clients).toEqual(["c1", "c3"]);
+  });
+
+  test("`in` operator and key enumeration forward to the underlying Pool", () => {
+    resetPool();
+    expect("ending" in pool).toBe(true);
+    expect("nonexistent" in pool).toBe(false);
+    expect(Object.keys(pool)).toContain("ending");
+  });
+
+  test("prototype chain forwards — instanceof works against the wrapped class", () => {
+    resetPool();
+    void pool.ending;
+    expect(Object.getPrototypeOf(pool)).toBe(FakePool.prototype);
+  });
+
+  test("resetPool drops the cached instance so the next access rebuilds", () => {
+    resetPool();
+    void pool.ending;
+    const before = ctorCalls.mock.calls.length;
+    resetPool();
+    void pool.ending;
+    expect(ctorCalls.mock.calls.length).toBe(before + 1);
+  });
+});

--- a/src/server/lib/postgres/client.ts
+++ b/src/server/lib/postgres/client.ts
@@ -35,7 +35,54 @@ const config: PoolConfig = {
   },
 };
 
-export const pool = new Pool(config);
+// Lazy pool: the Proxy defers `new Pool(config)` to first property
+// access. `Pool` here is a LIVE ESM binding to `pg.Pool` — bun's
+// `mock.module("pg", () => ({ Pool: FakePool, … }))` from a test file
+// re-points it, so the first method call during that file's tests
+// instantiates the test's FakePool.
+//
+// `resetPool()` clears the cached instance so the NEXT first-access
+// rebuilds against whatever `Pool` resolves to at that moment. Tests
+// call this from `afterAll(restoreLeaves)` (`scripts/test-helpers.ts`,
+// landing alongside the test infra in #557 step 1) so file B's run
+// doesn't inherit file A's FakePool. Production never calls
+// `resetPool()` — the cached real Pool stays for the process lifetime.
+//
+// The traps below all forward to `_pool`. `set`/`deleteProperty`/`has`
+// are required (not just `get`) because pg's own Pool methods do
+// `this.ending = true`, `this._clients = filtered`, etc. — the default
+// Proxy `set` would write to the empty target, leaving `_pool` stale.
+let _pool: Pool | null = null;
+const getPool = (): Pool => {
+  if (!_pool) _pool = new Pool(config);
+  return _pool;
+};
+export const resetPool = (): void => {
+  _pool = null;
+};
+export const pool: Pool = new Proxy({} as Pool, {
+  get(_target, prop) {
+    return Reflect.get(getPool(), prop, getPool());
+  },
+  set(_target, prop, value) {
+    return Reflect.set(getPool(), prop, value, getPool());
+  },
+  has(_target, prop) {
+    return Reflect.has(getPool(), prop);
+  },
+  deleteProperty(_target, prop) {
+    return Reflect.deleteProperty(getPool(), prop);
+  },
+  ownKeys() {
+    return Reflect.ownKeys(getPool());
+  },
+  getOwnPropertyDescriptor(_target, prop) {
+    return Reflect.getOwnPropertyDescriptor(getPool(), prop);
+  },
+  getPrototypeOf() {
+    return Reflect.getPrototypeOf(getPool());
+  },
+});
 
 // Log unexpected pool-level errors so they appear in server logs and are not silently swallowed.
 // Without this, a background idle client error would surface as an unhandled rejection.


### PR DESCRIPTION
## Summary

Step 2 of #557 — mirrors budget's [PR #467](https://github.com/hoiekim/budget/pull/467) lazy-pool refactor so per-test-file `mock.module(\"pg\", FakePool)` can actually rebind the cached Pool instance.

Replaces eager `export const pool = new Pool(config)` with a `Proxy({} as Pool, {...})` that defers `new Pool(config)` to first property access and reads a **live ESM binding** to `pg.Pool`. When a test mocks pg, the proxy's first access in that file instantiates the test's FakePool. `resetPool()` clears the cache between files.

## Why all the proxy traps (not just `get`)

The traps forward `get` / `set` / `has` / `deleteProperty` / `ownKeys` / `getOwnPropertyDescriptor` / `getPrototypeOf` to `_pool`. **Critical: forward `set`, not just `get`.** pg's own Pool methods mutate `this` (verified in `node_modules/pg-pool/index.js`):

- `this.ending = true` inside `end()` (line 458)
- `this._clients = this._clients.filter(...)` (lines 171, 260)
- `this._endCallback = ...` (line 460)

The default Proxy `set` trap writes to the **empty target object**, not `_pool`. Without forwarding `set`, the first `pool.end()` leaves `_pool.ending === false` and pg's `if (this.ending) return` guards misbehave silently. Same regression for `EventEmitter.on/emit/removeListener` mutations (`this._events.error = ...`, `this._eventsCount++`).

This was the bug that almost shipped in budget #467 before the `set`-trap follow-up — caught only when Hoie asked \"Any regression risk due to source file changes?\" inbox gets the fix upfront.

## Regression coverage

New `src/server/lib/postgres/client.test.ts` pins the contract (6 cases):
- first property access creates exactly one Pool instance
- assignments forward to `_pool` (`this.ending = true`)
- mutation-via-reassign (`this._clients = this._clients.filter(...)`)
- `in` operator and Object.keys enumeration forward
- `Object.getPrototypeOf(pool) === FakePool.prototype`
- `resetPool` drops the cached instance so the next access rebuilds

## Verification

- `bun test src` → **843 pass / 0 fail** (837 prior + 6 new).
- `bun run typecheck` clean.
- `bun run lint` clean (17 pre-existing warnings unchanged).
- **E2E:** `PORT=3014 bun src/server/start.ts` boots cleanly. `/api/health` returns `{healthy:true,checks:{database:\"ok\",http:\"ok\",smtp:25:\"ok\",imap:143:\"ok\",...}}` — pool exercised through real pg → real Postgres → real query.

## What this PR does NOT do

- Doesn't wire `resetPool` into `restoreLeaves` — that's a one-line follow-up after both this PR and #558 (test infra) merge.
- Doesn't retire any DI seams yet (`createPush`, `CheckSpamDeps`) — those are steps 3 and 4 of #557.
- Doesn't change any test file using DI — those rewrite later.

Step 2 of #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)