### PR TITLE
fix(receive): expand group addresses, split concatenated ones, drop empties in convertAddressValue

### DIFF
--- a/src/server/lib/mails/receive.test.ts
+++ b/src/server/lib/mails/receive.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, afterAll, beforeAll } from "bun:test";
 
 import type { IncomingMail, IncomingMailAddress } from "common";
-import { validateIncomingMail, addressToUsername, convertMailAddress } from "./receive";
+import {
+  validateIncomingMail,
+  addressToUsername,
+  convertMailAddress,
+  convertAddressValue,
+} from "./receive";
 
 const makeMail = (envelopeTo: { address: string }[]): IncomingMail =>
   ({ envelopeTo } as unknown as IncomingMail);
@@ -177,5 +182,66 @@ describe("convertMailAddress (spam EmailContext source, #528)", () => {
       fromName: undefined,
       replyToAddress: undefined,
     });
+  });
+});
+
+describe("convertAddressValue", () => {
+  it("returns undefined for empty / nullish input", () => {
+    expect(convertAddressValue(undefined)).toBeUndefined();
+    expect(convertAddressValue([])).toBeUndefined();
+  });
+
+  it("lowercases and keeps a simple address", () => {
+    expect(convertAddressValue({ address: "Alice@Example.COM", name: "Alice" })).toEqual([
+      { address: "alice@example.com", name: "Alice" },
+    ]);
+  });
+
+  it("drops empty / whitespace-only addresses instead of storing { address: '' } (#535)", () => {
+    expect(convertAddressValue({ address: "" })).toBeUndefined();
+    expect(convertAddressValue({ address: "   ", name: "Nobody" })).toBeUndefined();
+    expect(
+      convertAddressValue([{ address: "" }, { address: "bob@example.com" }])
+    ).toEqual([{ address: "bob@example.com", name: undefined }]);
+  });
+
+  it("expands RFC 2822 group members instead of dropping them (#535)", () => {
+    const grouped = {
+      address: "",
+      name: "Team",
+      group: [
+        { address: "Alice@Example.com", name: "Alice" },
+        { address: "bob@example.com", name: "Bob" },
+      ],
+    };
+    expect(convertAddressValue(grouped)).toEqual([
+      { address: "alice@example.com", name: "Alice" },
+      { address: "bob@example.com", name: "Bob" },
+    ]);
+  });
+
+  it("expands a single (non-array) group member", () => {
+    expect(
+      convertAddressValue({ address: "", group: { address: "solo@example.com", name: "Solo" } })
+    ).toEqual([{ address: "solo@example.com", name: "Solo" }]);
+  });
+
+  it("splits comma-concatenated addresses into separate rows (#535)", () => {
+    expect(
+      convertAddressValue({
+        address: "annie@bratko.net, presidential@hoie.kim",
+        name: "Both",
+      })
+    ).toEqual([
+      { address: "annie@bratko.net", name: "Both" },
+      { address: "presidential@hoie.kim", name: "Both" },
+    ]);
+  });
+
+  it("drops empty fragments produced by a trailing comma", () => {
+    expect(convertAddressValue({ address: "a@x.com, , b@x.com" })).toEqual([
+      { address: "a@x.com", name: undefined },
+      { address: "b@x.com", name: undefined },
+    ]);
   });
 });

--- a/src/server/lib/mails/receive.ts
+++ b/src/server/lib/mails/receive.ts
@@ -178,9 +178,10 @@ export const convertMail = async (
   const replyTo = convertMailAddress(incoming.replyTo);
 
   const envelopeFrom = convertAddressValue(incoming.envelopeFrom);
-  const envelopeTo = convertAddressValue(
-    incoming.envelopeTo
-  ) as MailAddressValueType[];
+  // convertAddressValue returns undefined when no usable address survives
+  // (empty input, or every entry filtered out). envelopeTo is dereferenced
+  // below and passed to Mail as a non-null array, so default to [].
+  const envelopeTo = convertAddressValue(incoming.envelopeTo) ?? [];
 
   const attachments = await convertAttachments(incoming.attachments);
 
@@ -244,20 +245,42 @@ export const convertMailAddress = (
   return { value, text };
 };
 
-const convertAddressValue = (
+// Exported for direct unit coverage of the group-expansion / address-split /
+// empty-filter logic — the corruption fixed in #535 is entirely inside here.
+export const convertAddressValue = (
   incoming?: IncomingMailAddressValue | IncomingMailAddressValue[]
 ) => {
   if (!incoming) return undefined;
   const array: MailAddressValueType[] = [];
-  const push = ({ address, name }: IncomingMailAddressValue) => {
-    const value = { address: address?.toLowerCase(), name };
-    array.push(value);
+  const push = (entry: IncomingMailAddressValue) => {
+    // RFC 2822 group addresses (`"Team": a@x.com, b@x.com;`) arrive with the
+    // members on `entry.group` and an empty top-level `address`. Recurse into
+    // the members so they aren't dropped as `{ address: "" }`.
+    if (entry.group) {
+      const members = Array.isArray(entry.group) ? entry.group : [entry.group];
+      members.forEach(push);
+      return;
+    }
+    const address = entry.address?.toLowerCase().trim();
+    if (!address) return; // drop empty/whitespace-only addresses
+    // Some parsed entries arrive comma-concatenated in a single `address`
+    // string (`"alice@x.com, bob@x.com"`). A valid address never contains a
+    // comma, so split into separate rows rather than storing a phantom one.
+    if (address.includes(",")) {
+      address
+        .split(",")
+        .map((a) => a.trim())
+        .filter(Boolean)
+        .forEach((a) => array.push({ address: a, name: entry.name }));
+      return;
+    }
+    array.push({ address, name: entry.name });
   };
   if (Array.isArray(incoming)) {
     if (incoming.length) incoming.forEach(push);
     else return undefined;
-  } else if (incoming) push(incoming);
-  return array;
+  } else push(incoming);
+  return array.length ? array : undefined;
 };
 
 const convertAttachments = async (


### PR DESCRIPTION
Closes #535

## Problem

`convertAddressValue` (`src/server/lib/mails/receive.ts`) destructured only `{ address, name }` from each incoming entry and ignored the `group` field. This corrupted incoming mail two ways:

1. **Group members dropped.** RFC 2822 group addresses (`"Team": a@x.com, b@x.com;`) arrive with an empty top-level `address` and the members on `entry.group`. The old code stored just `{ address: "" }` and lost the members — 170+ CC entries in the prod snapshot are empty as a result. Reply-all then silently skips those recipients.
2. **Concatenated addresses stored verbatim.** Some entries arrive with `address: "alice@x.com, bob@x.com"` (a single comma-joined string). These were stored as-is, producing phantom account rows like `annie@bratko.net, presidential@hoie.kim` in the accounts list.

## Fix

In `convertAddressValue`'s `push`:
- If `entry.group` is set, recurse into its members (array or single) instead of pushing the empty wrapper.
- If the trimmed `address` contains a comma, split it into one row per address (a valid email address never contains a comma) — the shared `name` is carried onto each.
- Drop entries whose address is empty/whitespace-only rather than storing `{ address: "" }`.
- Return `undefined` when nothing survives (consistent with the existing empty-array contract).

## Tests

`convertAddressValue` is now exported and covered by a new `receive.test.ts` (7 tests, driven with the issue's real corrupted samples):
- lowercases + keeps a simple address
- drops empty / whitespace-only addresses, including mixed arrays
- expands array-form and single-form group members
- splits comma-concatenated addresses (`annie@bratko.net, presidential@hoie.kim`)
- drops empty fragments from a trailing comma

```
receive.test.ts: 7 pass, 0 fail
src/server/lib/mails/ (full suite): 135 pass, 0 fail
bun run typecheck: clean
```

## Verification note

This is the server-side mail-ingest path; it's only reachable by an actual inbound SMTP/mailgun delivery, which a browser E2E can't drive. `convertAddressValue` is the entire bug surface, so the unit tests exercise it directly with the exact group/concatenated/empty inputs from the issue's reproduction — that is the functional verification here. The 185 already-corrupted rows in the snapshot are not backfilled (out of scope; this fix prevents new corruption going forward).

🤖 Generated with [Claude Code](https://claude.com/claude-code)