### PR TITLE
fix(imap): FETCH FLAGS now returns \Answered

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for fetch-helpers.ts — getRequestedFields column mapping.
+ * Covers inbox #542: FETCH FLAGS must request the `answered` column so the
+ * \Answered flag round-trips (STORE writes it, FETCH must read it back).
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+
+// fetch-helpers imports `logger` from "server"; stub it.
+mock.module("server", () => ({
+  logger: {
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    info: mock(() => {}),
+    debug: mock(() => {})
+  }
+}));
+
+import { getRequestedFields } from "./fetch-helpers";
+
+describe("getRequestedFields", () => {
+  describe("FLAGS", () => {
+    it("requests every flag-backing column, including answered", () => {
+      const fields = getRequestedFields([{ type: "FLAGS" }]);
+      // \Seen, \Flagged, \Deleted, \Draft, \Answered all need their column.
+      expect(fields.has("read")).toBe(true);
+      expect(fields.has("saved")).toBe(true);
+      expect(fields.has("deleted")).toBe(true);
+      expect(fields.has("draft")).toBe(true);
+      expect(fields.has("answered")).toBe(true);
+    });
+  });
+
+  describe("ENVELOPE", () => {
+    it("requests envelope header columns", () => {
+      const fields = getRequestedFields([{ type: "ENVELOPE" }]);
+      expect(fields.has("subject")).toBe(true);
+      expect(fields.has("from")).toBe(true);
+      expect(fields.has("messageId")).toBe(true);
+    });
+  });
+
+  it("always includes uid", () => {
+    expect(getRequestedFields([]).has("uid")).toBe(true);
+  });
+
+  it("unions columns across multiple data items", () => {
+    const fields = getRequestedFields([{ type: "FLAGS" }, { type: "INTERNALDATE" }]);
+    expect(fields.has("answered")).toBe(true);
+    expect(fields.has("date")).toBe(true);
+  });
+});

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -139,6 +139,7 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<keyof MailTy
         fields.add("saved");
         fields.add("deleted");
         fields.add("draft");
+        fields.add("answered");
         break;
 
       case "BODYSTRUCTURE":


### PR DESCRIPTION
## Problem

`getRequestedFields` (`src/server/lib/imap/fetch-helpers.ts`) mapped the `FLAGS` data item to `read`/`saved`/`deleted`/`draft` but **omitted `answered`**. Because that set drives the SQL SELECT column list (`store.getMessages` → `getMailsByRange` → `PartialMailModel`), `model.answered` was always `undefined`, and `formatFlags` (which *does* check `mail.answered`) never emitted `\Answered`.

Result: an asymmetry where STORE writes `\Answered` (and echoes it in its own untagged response), `SEARCH ANSWERED` honors it (fixed in #539), but `FETCH FLAGS` never returns it — so IMAP clients (Thunderbird, Apple Mail, etc.) see every mail as un-answered.

## Fix

One line — add `fields.add("answered")` to the `FLAGS` case. The rest of the chain already supports it: `store.getMessages` maps `model.answered → mail.answered` (`store.ts:195`) and `formatFlags` already checks `mail.answered` (`util.ts:241`).

## Testing

- New `fetch-helpers.test.ts` pins the requested-column set for `FLAGS` (now includes `answered`), `ENVELOPE`, the implicit `uid`, and multi-item unioning.
- Full imap suite green: **363 pass / 0 fail**.
- `bun run typecheck` clean.

The downstream link — `formatFlags` emitting `\Answered` when `answered=true` — is already covered in `util.test.ts`. A wire-level FETCH E2E isn't reachable: the imap test suite is unit-level with no live IMAP client+server harness, so I verified the exact regression point (the missing requested column) plus the existing downstream coverage rather than standing up a full IMAP client.

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)