### PR TITLE
fix(ci): Dockerfile copies scripts/ + bunfig.toml so bun test can resolve test-helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ WORKDIR /app
 COPY package.json bun.lockb* ./
 COPY tsconfig.json tsconfig.node.json ./
 COPY vite.config.ts ./
+COPY bunfig.toml ./
 COPY src src
+COPY scripts scripts
 COPY public public
 COPY index.html ./
 


### PR DESCRIPTION
## Problem

Recent CD runs on `main` fail at the `RUN bun test` step in the Dockerfile:

```
error: Cannot find package 'test-helpers' from '/app/src/server/lib/users.test.ts'
```

PR #495 (merged earlier today, 2026-06-07) added `import { restoreLeaves } from "test-helpers"` to `src/server/lib/users.test.ts`. The `test-helpers` path alias resolves via tsconfig.json:

```json
"test-helpers": ["../scripts/test-helpers.ts"]
```

— a file at the repo root `scripts/test-helpers.ts`. Local `bun test` works because the file exists in the worktree. **In the Docker build, it doesn't**: the Dockerfile only copies `src/`, `public/`, `package.json`, `tsconfig.json`, `tsconfig.node.json`, `vite.config.ts`, and `index.html`. `scripts/` was never in the build context, so `bun test` can't resolve the import.

## Fix

Add two COPYs:

- `COPY bunfig.toml ./` — Bun reads this at test time; it preloads `scripts/test-preload.ts` (the sibling that snapshots real `pg`/`web-push` exports onto globalThis for `restoreLeaves` to restore).
- `COPY scripts scripts` — brings both `test-preload.ts` and `test-helpers.ts` into the build context.

The two have to ship together: preload populates the snapshots that `restoreLeaves` reads.

## Why this was latent

`test-helpers` has been referenced in a doc comment in `src/server/lib/postgres/client.ts:46` since the test infra landed (#558), but no test file actually *imported* the helper until #495 today. The preload was also silently a no-op in Docker — but that doesn't matter for tests that don't call `restoreLeaves`. PR #495's import is the first hard dependency on the file from inside the Docker build context.

## Test plan

- [x] Local `bun test src/server/lib/users.test.ts` — 49/49 pass
- [ ] CD on this PR passes (build will run `bun test` inside Docker with the new COPYs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)