### PR TITLE
fix(client): tolerate non-array attachments in mail body (#561)

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -120,7 +120,10 @@ const MailBody = ({ mailId }: Props) => {
   const data = query.data;
 
   if (query.isSuccess && data) {
-    const attachments: JSX.Element[] | undefined = data.attachments?.map(
+    const attachmentList = Array.isArray(data.attachments)
+      ? data.attachments
+      : [];
+    const attachments: JSX.Element[] = attachmentList.map(
       (attachment: AttachmentType, i: number) => {
         const onClickAttachment = () => {
           call
@@ -225,7 +228,7 @@ const MailBody = ({ mailId }: Props) => {
         <div className="loading_message">
           {isLoadingIframe ? loadingMessage : null}
         </div>
-        {attachments && attachments.length ? (
+        {attachments.length ? (
           <div className="attachmentBox">{attachments}</div>
         ) : (
           <></>

--- a/src/server/lib/mails/body.test.ts
+++ b/src/server/lib/mails/body.test.ts
@@ -60,6 +60,23 @@ describe("getMailBody", () => {
     expect(result!.attachments).toEqual(attachments);
   });
 
+  it("should normalize a non-array attachments value to undefined", async () => {
+    // A legacy row can store attachments as a JSON object ({}) rather than an
+    // array; the response must expose only a valid array-or-undefined shape.
+    const mockModel = {
+      mail_id: "mail-005",
+      html: "<p>Legacy mail</p>",
+      attachments: {},
+      message_id: "<msg-005@example.com>",
+      insight: null,
+    };
+    mockGetMailById.mockResolvedValue(mockModel);
+
+    const result = await getMailBody("user-123", "mail-005");
+    expect(result).toBeDefined();
+    expect(result!.attachments).toBeUndefined();
+  });
+
   it("should map insight when present", async () => {
     const insight = { category: "invoice", summary: "Invoice #123" };
     const mockModel = {

--- a/src/server/lib/mails/body.ts
+++ b/src/server/lib/mails/body.ts
@@ -12,7 +12,9 @@ export const getMailBody = async (
   return new MailBodyData({
     id: mailModel.mail_id,
     html: mailModel.html,
-    attachments: mailModel.attachments as AttachmentType[] | undefined,
+    attachments: Array.isArray(mailModel.attachments)
+      ? (mailModel.attachments as AttachmentType[])
+      : undefined,
     messageId: mailModel.message_id,
     insight: mailModel.insight as Insight | undefined,
   });


### PR DESCRIPTION
## Summary

Opening a mail whose `attachments` is a non-array JSON object (e.g. `{}`) crashed the `MailBody` render: `?.` guards `null`/`undefined` but not a non-array object, so `.map` threw. Because the only `ErrorBoundary` wraps the whole app (`App.tsx`), this blanked the entire inbox UI behind "Something went wrong" — and the crashing mail is reachable via normal **search**, so it's a live, user-triggerable full-app crash.

Per #561 this is a read-path defect, not a data problem (the trigger is one legacy 2023 row; all others store proper arrays), so the fix is read-path hardening, not a migration.

## Changes

- **`server/lib/mails/body.ts`** — normalize a non-array `attachments` value to `undefined`, so the response actually honors its declared `AttachmentType[] | undefined` shape instead of passing a blind cast through (boundary tells the truth).
- **`client/.../MailBody.tsx`** — guard the map with `Array.isArray`; the now-non-nullable `attachments` array also lets the vacuous `attachments &&` render guard drop to `attachments.length`.
- **`server/lib/mails/body.test.ts`** — added a case asserting a non-array (`{}`) attachments value normalizes to `undefined`.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (17 pre-existing warnings in untouched files)
- [x] `bun test` — 883 pass / 0 fail (incl. the new non-array normalization case in `body.test.ts`)
- [x] **UI E2E** — Playwright, sandbox `fix` (PR #565) vs `baseline` (`upstream/main`), logged in as admin, against the **real malformed row from the issue** (`8d44a8a9-f473-409a-97b4-cb93b95b44d3`, "Re: Inquiry about invoice", `attachments = {}` — the only non-array row in the dataset). Driven via the documented repro: Search category → query "inquiry invoice" → open result #5 (the malformed mail).
  - **API layer** — `GET /api/mails/body/8d44a8a9…`: baseline returns `attachments: {}` (raw non-array); fix returns `attachments: undefined` (normalized).
  - **Baseline (`upstream/main`)** — opening the mail throws `TypeError: …map is not a function`, the top-level `ErrorBoundary` catches, and the **entire app** is replaced by "Something went wrong / Try Again / Reload Page" (mail list wiped to 0 rows). Screenshot: `/tmp/pr-565-baseline.png`.
  - **Fix (this PR)** — same mail, same path: mail body **renders** (iframe present), the search list stays intact (13 rows), no console error, no ErrorBoundary. Screenshot: `/tmp/pr-565-fix.png`.

Closes #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)