### PR TITLE
fix(imap): IDLE terminates on split/pipelined DONE, no dropped command (#546)

### DIFF
--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Tests for IMAP IDLE termination — handler.ts + session.ts (#546).
+ *
+ * Regression coverage: DONE must be detected by the handler's main line
+ * buffer (which reassembles split TCP chunks and \r\n-delimited lines), not a
+ * separate raw-socket listener that only matched when an entire chunk equalled
+ * "DONE". The old listener left the session stranded in IDLE forever when:
+ *   1. DONE was split across TCP chunks ("DO" then "NE\r\n"), or
+ *   2. DONE was pipelined with the next command ("DONE\r\nA4 NOOP\r\n") — and
+ *      the pipelined command was silently dropped.
+ */
+
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { EventEmitter } from "events";
+
+const mockAddIdleSession = mock(() => {});
+const mockRemoveIdleSession = mock(() => {});
+mock.module("./idle-manager", () => ({
+  idleManager: {
+    addIdleSession: mockAddIdleSession,
+    removeIdleSession: mockRemoveIdleSession,
+  },
+}));
+
+import { ImapRequestHandler } from "./handler";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 15));
+
+function makeMockSocket() {
+  const socket = new EventEmitter() as EventEmitter & {
+    writes: string[];
+    writable: boolean;
+    destroyed: boolean;
+    write: (data: string) => boolean;
+    setTimeout: () => void;
+    destroy: () => void;
+    end: () => void;
+  };
+  socket.writes = [];
+  socket.writable = true;
+  socket.destroyed = false;
+  socket.write = (data: string) => {
+    socket.writes.push(data);
+    return true;
+  };
+  socket.setTimeout = () => {};
+  socket.destroy = () => {
+    socket.destroyed = true;
+  };
+  socket.end = () => {};
+  return socket;
+}
+
+interface TestSession {
+  authenticated: boolean;
+  selectedMailbox: string | null;
+  store: unknown;
+  startIdle: (tag: string) => Promise<unknown>;
+  isInIdleMode: () => boolean;
+  endIdle: () => void;
+}
+
+async function makeIdlingSession() {
+  const handler = new ImapRequestHandler();
+  const socket = makeMockSocket();
+  // setSocket expects a net.Socket; the mock implements the surface it uses.
+  handler.setSocket(socket as never);
+  const session = (handler as unknown as { session: TestSession }).session;
+  // Drive the session straight into IDLE without a real DB-backed login.
+  session.authenticated = true;
+  session.selectedMailbox = "INBOX";
+  session.store = {
+    getUser: () => ({ id: "u1", username: "admin" }),
+    countMessages: async () => null,
+  };
+  await session.startIdle("a3");
+  return { handler, socket, session };
+}
+
+describe("IMAP IDLE DONE handling (#546)", () => {
+  beforeEach(() => {
+    mockAddIdleSession.mockClear();
+    mockRemoveIdleSession.mockClear();
+  });
+
+  it("starts IDLE and emits the continuation response", async () => {
+    const { socket, session } = await makeIdlingSession();
+    expect(session.isInIdleMode()).toBe(true);
+    expect(socket.writes.join("")).toContain("+ idling\r\n");
+  });
+
+  it("terminates IDLE on a single-write DONE (control case)", async () => {
+    const { socket, session } = await makeIdlingSession();
+    socket.emit("data", Buffer.from("DONE\r\n"));
+    await flush();
+    expect(session.isInIdleMode()).toBe(false);
+    expect(socket.writes.join("")).toContain("a3 OK IDLE terminated\r\n");
+  });
+
+  it("terminates IDLE when DONE is split across TCP chunks", async () => {
+    const { socket, session } = await makeIdlingSession();
+    socket.emit("data", Buffer.from("DO"));
+    socket.emit("data", Buffer.from("NE\r\n"));
+    await flush();
+    expect(session.isInIdleMode()).toBe(false);
+    expect(socket.writes.join("")).toContain("a3 OK IDLE terminated\r\n");
+  });
+
+  it("terminates IDLE and processes a command pipelined after DONE", async () => {
+    const { socket, session } = await makeIdlingSession();
+    socket.emit("data", Buffer.from("DONE\r\na4 NOOP\r\n"));
+    await flush();
+    expect(session.isInIdleMode()).toBe(false);
+    const out = socket.writes.join("");
+    expect(out).toContain("a3 OK IDLE terminated\r\n");
+    // The pipelined NOOP must not be dropped — it gets a tagged response.
+    expect(out).toContain("a4 OK NOOP completed\r\n");
+  });
+
+  it("ignores non-DONE input during IDLE without terminating", async () => {
+    const { socket, session } = await makeIdlingSession();
+    socket.emit("data", Buffer.from("a5 NOOP\r\n"));
+    await flush();
+    expect(session.isInIdleMode()).toBe(true);
+    expect(socket.writes.join("")).not.toContain("a5 OK NOOP completed");
+  });
+});

--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -13,13 +13,13 @@
 import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
 import { EventEmitter } from "events";
 
-// Capture the real `./idle-manager` exports BEFORE the `mock.module`
-// override below so `afterAll` can re-mock them back. `mock.module` is
+// Capture the real `./idle-manager` module BEFORE the `mock.module`
+// override below so `afterAll` can restore it. `mock.module` is
 // process-global; without the restore, a subsequent test file in the
 // same `bun test` process that imports `./idle-manager` (notably the
 // IDLE-heartbeat manager suite landing in this same directory) sees the
-// stubbed `{ idleManager }` shape only and loses access to the real
-// `IdleManager` class + the `IDLE_*_MS` constants.
+// stubbed two-method `{ idleManager }` shape and loses the real
+// `idleManager` singleton (the module's only export).
 const realIdleManagerModule = await import("./idle-manager");
 
 const mockAddIdleSession = mock(() => {});

--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -10,8 +10,17 @@
  *      the pipelined command was silently dropped.
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
 import { EventEmitter } from "events";
+
+// Capture the real `./idle-manager` exports BEFORE the `mock.module`
+// override below so `afterAll` can re-mock them back. `mock.module` is
+// process-global; without the restore, a subsequent test file in the
+// same `bun test` process that imports `./idle-manager` (notably the
+// IDLE-heartbeat manager suite landing in this same directory) sees the
+// stubbed `{ idleManager }` shape only and loses access to the real
+// `IdleManager` class + the `IDLE_*_MS` constants.
+const realIdleManagerModule = await import("./idle-manager");
 
 const mockAddIdleSession = mock(() => {});
 const mockRemoveIdleSession = mock(() => {});
@@ -21,6 +30,10 @@ mock.module("./idle-manager", () => ({
     removeIdleSession: mockRemoveIdleSession,
   },
 }));
+
+afterAll(() => {
+  mock.module("./idle-manager", () => ({ ...realIdleManagerModule }));
+});
 
 import { ImapRequestHandler } from "./handler";
 

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -102,9 +102,16 @@ export class ImapRequestHandler {
           }
 
           if (line.trim()) {
-            // When session is in IDLE mode, skip normal command processing —
-            // the IDLE data handler on session.ts handles DONE exclusively.
+            // The only valid client input during IDLE is "DONE". This line
+            // buffer already reassembles split TCP chunks and pipelined input,
+            // so handle DONE here: terminate IDLE and fall through so any
+            // command pipelined after DONE (e.g. "DONE\r\nA4 NOOP\r\n") is
+            // processed on the next loop iteration. Non-DONE input during IDLE
+            // is ignored per RFC 2177.
             if (session.isInIdleMode()) {
+              if (line.trim().toUpperCase() === "DONE") {
+                session.endIdle();
+              }
               continue;
             }
 

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -431,24 +431,18 @@ export class ImapSession {
     );
 
     this.write("+ idling\r\n");
-    this.socket.on("data", this.handleIdleData);
+    // DONE is detected by the handler's main line buffer (handler.ts), which
+    // reassembles split TCP chunks and \r\n-delimited lines. A separate raw
+    // socket "data" listener here used to miss split ("DO" + "NE\r\n") and
+    // pipelined ("DONE\r\nA4 NOOP\r\n") DONEs, stranding the session in IDLE.
   };
 
-  private handleIdleData = (data: Buffer) => {
-    if (!this.isIdling) return;
-    const command = data.toString().trim().toUpperCase();
-    if (command === "DONE") {
-      this.endIdle();
-    }
-  };
-
-  private endIdle = () => {
+  endIdle = () => {
     if (!this.isIdling || !this.idleTag) return;
     this.isIdling = false;
     const tag = this.idleTag;
     this.idleTag = null;
     idleManager.removeIdleSession(this.sessionId);
-    this.socket.off("data", this.handleIdleData);
     this.write(`${tag} OK IDLE terminated\r\n`);
   };
 
@@ -463,7 +457,6 @@ export class ImapSession {
   cleanup = () => {
     if (this.isIdling) {
       idleManager.removeIdleSession(this.sessionId);
-      this.socket.off("data", this.handleIdleData);
       this.isIdling = false;
       this.idleTag = null;
       logger.debug("IDLE session cleaned up on socket close", {


### PR DESCRIPTION
## Summary

IMAP IDLE could get stuck **forever**. Termination relied on a second `socket.on("data")` listener (`handleIdleData`) that fired `endIdle()` only when an *entire* raw TCP chunk trimmed to exactly `"DONE"`. Two common client behaviours broke it:

1. **Split DONE** — TCP delivers `"DO"` then `"NE\r\n"`. Each chunk is evaluated alone; neither equals `DONE`. IDLE never ends.
2. **Pipelined DONE + next command** — client writes `"DONE\r\nA4 NOOP\r\n"` in one buffer. The whole chunk trims to `"DONE\r\nA4 NOOP"` ≠ `DONE`, so IDLE never ends — **and** handler.ts's parallel line buffer discarded the trailing `A4 NOOP` under its `isInIdleMode()` short-circuit, silently dropping the client's command (no response ever sent).

Root cause: two `socket.on("data")` listeners coexisted (handler.ts's buffered line parser + session.ts's raw `handleIdleData`), racing over the same bytes.

## Fix

`handler.ts` already reassembles split TCP chunks into `\r\n`-delimited lines. Detect `DONE` there instead:

- On a `DONE` line during IDLE → `session.endIdle()`, then **fall through** so a command pipelined after DONE is processed on the next loop iteration.
- Non-DONE input during IDLE is ignored per RFC 2177.
- The redundant raw-socket `handleIdleData` listener is **removed entirely** — eliminating the dual-listener race that was the root cause. `endIdle` is now public and called by the handler; its listener-removal line and the matching one in `cleanup()` are gone.

Net: `session.ts` loses the raw listener + its teardown; `handler.ts` gains the DONE check.

## Test plan

Server-side protocol change — verified with a new test (`handler-idle.test.ts`) that drives the **real** `ImapRequestHandler` + `ImapSession` over a mock socket (`EventEmitter`), emitting raw `data` events exactly as TCP would. Only `idle-manager` is mocked (inert singleton); the actual line-buffering + DONE-detection + command-dispatch path runs unmodified. (A live IMAP socket E2E would require auth against the real `inbox` Postgres DB.)

5 tests:
- starts IDLE and emits `+ idling`
- single-write `DONE\r\n` terminates (control)
- **split** `"DO"` + `"NE\r\n"` terminates
- **pipelined** `"DONE\r\nA4 NOOP\r\n"` terminates **and** the `A4 NOOP` gets `a4 OK NOOP completed` (not dropped)
- non-DONE input during IDLE is ignored, session stays idling

**Regression guard confirmed:** running the new test against the pre-fix code fails exactly the split-DONE and pipelined-DONE cases (the two reported bugs); the fix turns them green.

```
bun test src/server/lib/imap/   →  364 pass, 0 fail (14 files)
bun x tsc --noEmit              →  exit 0
```

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
