### PR TITLE
fix(imap): notifyNewMail honours the mailboxes filter again (#549)

### DIFF
--- a/src/server/lib/imap/idle-manager.test.ts
+++ b/src/server/lib/imap/idle-manager.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for idle-manager.ts — IdleManager.notifyNewMail mailbox filtering.
+ *
+ * Regression coverage for #549: PR #373 added a per-mailbox filter so an IDLE
+ * session is only notified when it watches one of the target mailboxes (with an
+ * INBOX catch-all). PR #331's async refactor constructed `mailboxSet` but never
+ * consulted it, so every session for the user got EXISTS regardless of mailbox.
+ */
+
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
+// idle-manager ↔ push ↔ server-barrel form a runtime import cycle: idle-manager
+// imports the `server` barrel (for `logger`), which re-exports push.ts, whose
+// top-level `createPush(realIdleManager)` needs the idleManager singleton. When
+// idle-manager is the test entry the barrel reaches push before the singleton is
+// constructed. Importing push first forces the graph to initialize in the order
+// the production server uses, so the singleton is ready.
+import "../push";
+import { idleManager } from "./idle-manager";
+import type { ImapSession } from "./session";
+
+const makeSession = () => {
+  const write = mock(() => {});
+  const countMailboxMessages = mock(() =>
+    Promise.resolve({ total: 3, unread: 1, maxUid: 3 })
+  );
+  const session = { write, countMailboxMessages } as unknown as ImapSession;
+  return { session, write, countMailboxMessages };
+};
+
+describe("IdleManager.notifyNewMail mailbox filtering", () => {
+  let inbox: ReturnType<typeof makeSession>;
+  let usps: ReturnType<typeof makeSession>;
+  let drafts: ReturnType<typeof makeSession>;
+
+  beforeEach(() => {
+    // shutdown() clears any sessions a prior test registered on the singleton.
+    idleManager.shutdown();
+    inbox = makeSession();
+    usps = makeSession();
+    drafts = makeSession();
+    idleManager.addIdleSession("s-inbox", inbox.session, "t1", "INBOX", "alice");
+    idleManager.addIdleSession("s-usps", usps.session, "t2", "usps@hoie.kim", "alice");
+    idleManager.addIdleSession("s-drafts", drafts.session, "t3", "Drafts", "alice");
+  });
+
+  afterAll(() => {
+    idleManager.shutdown();
+  });
+
+  it("notifies only the matching mailbox and the INBOX catch-all", async () => {
+    await idleManager.notifyNewMail(["alice"], ["usps@hoie.kim"]);
+
+    // INBOX is the aggregate view — always notified.
+    expect(inbox.countMailboxMessages).toHaveBeenCalledTimes(1);
+    expect(inbox.write).toHaveBeenCalled();
+    // The targeted per-account mailbox is notified.
+    expect(usps.countMailboxMessages).toHaveBeenCalledTimes(1);
+    expect(usps.write).toHaveBeenCalled();
+    // A session watching an unrelated mailbox is NOT notified.
+    expect(drafts.countMailboxMessages).not.toHaveBeenCalled();
+    expect(drafts.write).not.toHaveBeenCalled();
+  });
+
+  it("notifies every session for the user when no mailbox filter is given", async () => {
+    await idleManager.notifyNewMail(["alice"]);
+
+    expect(inbox.write).toHaveBeenCalled();
+    expect(usps.write).toHaveBeenCalled();
+    expect(drafts.write).toHaveBeenCalled();
+  });
+
+  it("does not notify sessions belonging to a different user", async () => {
+    const bob = makeSession();
+    idleManager.addIdleSession("s-bob", bob.session, "t4", "INBOX", "bob");
+
+    await idleManager.notifyNewMail(["alice"], ["usps@hoie.kim"]);
+
+    expect(bob.write).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/lib/imap/idle-manager.ts
+++ b/src/server/lib/imap/idle-manager.ts
@@ -68,9 +68,14 @@ class IdleManager {
 
     const notifications: Array<{ sessionId: string; idleSession: IdleSession }> = [];
     this.idleSessions.forEach((idleSession, sessionId) => {
-      if (usernameSet.has(idleSession.username)) {
-        notifications.push({ sessionId, idleSession });
+      if (!usernameSet.has(idleSession.username)) return;
+      if (mailboxSet !== null) {
+        const watching = idleSession.mailbox;
+        // INBOX is the aggregate view showing every account's mail, so it is
+        // always notified; other sessions only when watching a target mailbox.
+        if (watching !== "INBOX" && !mailboxSet.has(watching)) return;
       }
+      notifications.push({ sessionId, idleSession });
     });
 
     await Promise.all(


### PR DESCRIPTION
## Closes #549

### The bug
`IdleManager.notifyNewMail(usernames, mailboxes?)` built `mailboxSet` from the `mailboxes` argument but then only checked `usernameSet` when collecting sessions to notify — `mailboxSet` was dead. Every IDLE session for the matching user received `* {n} EXISTS` regardless of which mailbox it was watching.

PR #373 had added the per-mailbox filter (skip sessions whose `mailbox` isn't in the target set, with an INBOX catch-all). PR #331's async refactor — which queries `countMailboxMessages` before emitting EXISTS — moved the loop into a `notifications.push(...)` step and silently dropped the filter. The caller (`receive.ts` → `push.notifyNewMails(usernames, mailboxes)` with mailboxes derived from the envelope recipients) still passes the mailboxes expecting them to be honoured.

### The fix
Restore the filter inside the notifications-collection step:

```ts
this.idleSessions.forEach((idleSession, sessionId) => {
  if (!usernameSet.has(idleSession.username)) return;
  if (mailboxSet !== null) {
    const watching = idleSession.mailbox;
    if (watching !== "INBOX" && !mailboxSet.has(watching)) return;
  }
  notifications.push({ sessionId, idleSession });
});
```

The INBOX catch-all is kept: INBOX is the aggregate view that surfaces every account's mail, so a new mail to any per-account box should still notify an INBOX-watching session. When no `mailboxes` argument is given (`mailboxSet === null`) the behaviour is unchanged — every session for the user is notified.

### Tests
New `src/server/lib/imap/idle-manager.test.ts` (3 cases):
- **notifies only the matching mailbox and the INBOX catch-all** — two clients on `INBOX` and `usps@hoie.kim` are notified, a third on `Drafts` is not.
- **notifies every session when no mailbox filter is given** — back-compat path.
- **does not notify sessions belonging to a different user** — username gate still holds.

Verified the first case **fails** on the pre-fix source (the `Drafts` session gets an EXISTS) and **passes** after the fix.

The test file imports `../push` before `./idle-manager` to force the `idle-manager ↔ push ↔ server-barrel` runtime cycle to initialize in the same order the production server uses (otherwise the barrel reaches `push.ts`'s top-level `createPush(realIdleManager)` before the singleton exists). Documented inline.

### Verification
- `bun test src/server/lib/imap/idle-manager.test.ts` → 3 pass
- `bun test src/server` (full server suite) → **923 pass / 0 fail** (no `mock.module` bleed — the test mocks nothing shared)
- `bun run typecheck` → clean

E2E note: this is server-internal IMAP IDLE protocol behaviour with no browser surface; it's exercised by the unit tests driving the real `IdleManager` singleton with mock sessions, which is the meaningful test path here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
