### PR TITLE
fix(imap): apply SEARCH NOT/OR criteria instead of silently dropping them

### DIFF
--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -41,7 +41,7 @@ mock.module("server", () => ({
     username === "admin" ? "example.com" : `${username}.example.com`,
 }));
 
-import { Store } from "./store";
+import { Store, simplifyCriterion } from "./store";
 
 const makeUser = (overrides: Partial<{ id: string; username: string; email: string }> = {}) =>
   new SignedUser({
@@ -82,5 +82,69 @@ describe("Store.listMailboxes", () => {
     const store = new Store(makeUser());
     const result = await store.listMailboxes();
     expect(result).toEqual(["INBOX"]);
+  });
+});
+
+describe("simplifyCriterion — NOT/OR operand normalisation (regression for #551)", () => {
+  // The parser emits NOT/OR with RAW inner criteria (.criterion / .left / .right),
+  // and raw text/date/header criteria use heterogeneous field names (.value/.date/.field).
+  // simplifyCriterion must recurse so the SQL builder always sees the flat
+  // { type, value } shape — otherwise nested NOT/OR criteria were mis-read or dropped.
+
+  it("normalises NOT's inner criterion (flag)", () => {
+    expect(
+      simplifyCriterion({ type: "NOT", criterion: { type: "SEEN" } } as never)
+    ).toEqual({ type: "NOT", value: { type: "SEEN" } });
+  });
+
+  it("normalises NOT's inner text criterion onto .value", () => {
+    expect(
+      simplifyCriterion({
+        type: "NOT",
+        criterion: { type: "FROM", value: "spam@x" },
+      } as never)
+    ).toEqual({ type: "NOT", value: { type: "FROM", value: "spam@x" } });
+  });
+
+  it("normalises a NOT BEFORE date from .date to .value", () => {
+    const when = new Date("2026-01-01T00:00:00Z");
+    expect(
+      simplifyCriterion({
+        type: "NOT",
+        criterion: { type: "BEFORE", date: when },
+      } as never)
+    ).toEqual({ type: "NOT", value: { type: "BEFORE", value: when } });
+  });
+
+  it("normalises both OR operands recursively", () => {
+    expect(
+      simplifyCriterion({
+        type: "OR",
+        left: { type: "FROM", value: "alice" },
+        right: { type: "TO", value: "bob" },
+      } as never)
+    ).toEqual({
+      type: "OR",
+      value: {
+        left: { type: "FROM", value: "alice" },
+        right: { type: "TO", value: "bob" },
+      },
+    });
+  });
+
+  it("drops an OR whose operand cannot be expressed as a single value (UID)", () => {
+    expect(
+      simplifyCriterion({
+        type: "OR",
+        left: { type: "FROM", value: "alice" },
+        right: { type: "UID", sequenceSet: { ranges: [{ start: 1 }] } },
+      } as never)
+    ).toBeNull();
+  });
+
+  it("normalises HEADER's field/value into { field, text }", () => {
+    expect(
+      simplifyCriterion({ type: "HEADER", field: "Subject", value: "hi" } as never)
+    ).toEqual({ type: "HEADER", value: { field: "Subject", text: "hi" } });
   });
 });

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -37,6 +37,107 @@ import {
 } from "./types";
 import { logger, getUserDomain } from "server";
 
+type SimplifiedCriterion = { type: string; value?: unknown };
+
+/**
+ * Normalises a parsed SearchCriterion into the flat `{ type, value }` shape that
+ * searchMailsByUid consumes. NOT/OR recurse so their operands are normalised too —
+ * otherwise the SQL builder would read the wrong field off the raw parser shape
+ * (e.g. `.date`/`.field` instead of `.value`) and silently mis-handle the nested
+ * criterion. Returns null when the criterion imposes no constraint or can't be
+ * expressed as a single flat value (UID, which expands to multiple entries, and is
+ * handled by the caller). See #551.
+ */
+export const simplifyCriterion = (
+  criterion: SearchCriterion
+): SimplifiedCriterion | null => {
+  const type = criterion.type.toUpperCase();
+  switch (type) {
+    // Flag-based: no additional value
+    case "ALL":
+    case "UNSEEN":
+    case "SEEN":
+    case "ANSWERED":
+    case "UNANSWERED":
+    case "DELETED":
+    case "UNDELETED":
+    case "FLAGGED":
+    case "UNFLAGGED":
+    case "DRAFT":
+    case "UNDRAFT":
+    case "NEW":
+    case "OLD":
+    case "RECENT":
+      return { type };
+
+    // Text search: value is embedded in the criterion object
+    case "SUBJECT":
+    case "FROM":
+    case "TO":
+    case "CC":
+    case "BCC":
+    case "BODY":
+    case "TEXT": {
+      const textCriterion = criterion as { type: string; value: string };
+      return { type, value: textCriterion.value };
+    }
+
+    // Header search
+    case "HEADER": {
+      const hdr = criterion as { type: string; field: string; value: string };
+      return { type, value: { field: hdr.field, text: hdr.value } };
+    }
+
+    // Date criteria: value is a Date object
+    case "BEFORE":
+    case "ON":
+    case "SINCE":
+    case "SENTBEFORE":
+    case "SENTON":
+    case "SENTSINCE": {
+      const dateCriterion = criterion as { type: string; date: Date };
+      return { type, value: dateCriterion.date };
+    }
+
+    // Size criteria
+    case "LARGER":
+    case "SMALLER": {
+      const sizeCriterion = criterion as { type: string; size: number };
+      return { type, value: sizeCriterion.size };
+    }
+
+    // Logical NOT: negate a single (normalised) criterion
+    case "NOT": {
+      const notCriterion = criterion as { type: string; criterion: SearchCriterion };
+      const inner = simplifyCriterion(notCriterion.criterion);
+      return inner ? { type: "NOT", value: inner } : null;
+    }
+
+    // Logical OR: two (normalised) criteria
+    case "OR": {
+      const orCriterion = criterion as {
+        type: string;
+        left: SearchCriterion;
+        right: SearchCriterion;
+      };
+      const left = simplifyCriterion(orCriterion.left);
+      const right = simplifyCriterion(orCriterion.right);
+      if (left && right) return { type: "OR", value: { left, right } };
+      // An OR with an unconstrained/unsupported side matches everything; drop it
+      // rather than over-narrow to the one expressible side.
+      return null;
+    }
+
+    // UID expands to multiple ranges; cannot collapse to a single value here.
+    case "UID":
+      return null;
+
+    default:
+      logger.warn("Unsupported search criterion", { component: "imap.store", type });
+      return null;
+  }
+};
+
 // class that creates "store" object
 export class Store {
   constructor(private user: SignedUser) {}
@@ -311,101 +412,31 @@ export class Store {
     try {
       const { accountName, isSent } = this.resolveBox(box);
 
-      // Convert criteria to a simpler flat format for searchMailsByUid
-      const simplifiedCriteria: { type: string; value?: unknown }[] = [];
+      // Convert criteria to a simpler flat format for searchMailsByUid.
+      // UID expands to one entry per range; everything else (including nested
+      // NOT/OR operands) normalises via simplifyCriterion.
+      const simplifiedCriteria: SimplifiedCriterion[] = [];
 
       for (const criterion of criteria) {
         const type = criterion.type.toUpperCase();
 
-        switch (type) {
-          // Flag-based: no additional value
-          case "ALL":
-          case "UNSEEN":
-          case "SEEN":
-          case "ANSWERED":
-          case "UNANSWERED":
-          case "DELETED":
-          case "UNDELETED":
-          case "FLAGGED":
-          case "UNFLAGGED":
-          case "DRAFT":
-          case "UNDRAFT":
-          case "NEW":
-          case "OLD":
-          case "RECENT":
-            simplifiedCriteria.push({ type });
-            break;
-
-          // Text search: value is embedded in the criterion object
-          case "SUBJECT":
-          case "FROM":
-          case "TO":
-          case "CC":
-          case "BCC":
-          case "BODY":
-          case "TEXT": {
-            const textCriterion = criterion as { type: string; value: string };
-            simplifiedCriteria.push({ type, value: textCriterion.value });
-            break;
-          }
-
-          // Header search
-          case "HEADER": {
-            const hdr = criterion as { type: string; field: string; value: string };
-            simplifiedCriteria.push({ type, value: { field: hdr.field, text: hdr.value } });
-            break;
-          }
-
-          // Date criteria: value is a Date object
-          case "BEFORE":
-          case "ON":
-          case "SINCE":
-          case "SENTBEFORE":
-          case "SENTON":
-          case "SENTSINCE": {
-            const dateCriterion = criterion as { type: string; date: Date };
-            simplifiedCriteria.push({ type, value: dateCriterion.date });
-            break;
-          }
-
-          // Size criteria
-          case "LARGER":
-          case "SMALLER": {
-            const sizeCriterion = criterion as { type: string; size: number };
-            simplifiedCriteria.push({ type, value: sizeCriterion.size });
-            break;
-          }
-
-          // Logical NOT: negate a single criterion
-          case "NOT": {
-            const notCriterion = criterion as { type: string; criterion: SearchCriterion };
-            simplifiedCriteria.push({ type: "NOT", value: notCriterion.criterion });
-            break;
-          }
-
-          // Logical OR: two criteria
-          case "OR": {
-            const orCriterion = criterion as { type: string; left: SearchCriterion; right: SearchCriterion };
-            simplifiedCriteria.push({ type: "OR", value: { left: orCriterion.left, right: orCriterion.right } });
-            break;
-          }
-
-          // UID ranges
-          case "UID": {
-            const uidCriterion = criterion as UidCriterion;
-            for (const range of uidCriterion.sequenceSet.ranges) {
-              if (range.end === undefined) {
-                simplifiedCriteria.push({ type: "UID_EXACT", value: range.start });
-              } else {
-                simplifiedCriteria.push({ type: "UID_RANGE", value: { start: range.start, end: range.end } });
-              }
+        if (type === "UID") {
+          const uidCriterion = criterion as UidCriterion;
+          for (const range of uidCriterion.sequenceSet.ranges) {
+            if (range.end === undefined) {
+              simplifiedCriteria.push({ type: "UID_EXACT", value: range.start });
+            } else {
+              simplifiedCriteria.push({
+                type: "UID_RANGE",
+                value: { start: range.start, end: range.end },
+              });
             }
-            break;
           }
-
-          default:
-            logger.warn("Unsupported search criterion", { component: "imap.store", type });
+          continue;
         }
+
+        const simplified = simplifyCriterion(criterion);
+        if (simplified) simplifiedCriteria.push(simplified);
       }
 
       return await searchMailsByUid(

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -285,53 +285,52 @@ describe("getAccountStats — envelope_to inclusion in received address expansio
   });
 });
 
-describe("searchMailsByUid — flag criteria use schema columns", () => {
-  let fnSource: string;
+describe("buildCriterionClause — flag criteria use schema columns", () => {
+  // Regression guard (originally on searchMailsByUid's inline switch, retargeted
+  // here when #551 extracted the per-criterion logic into buildCriterionClause):
+  // the answered/deleted/draft flags map to their real boolean columns, never to
+  // a bare "FALSE" match-none sentinel that an earlier draft of this fix used.
+  const clauseFor = async (type: string) => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    return buildCriterionClause({ type }, "uid_account", values as never);
+  };
 
-  beforeAll(async () => {
-    const fs = await import("fs/promises");
-    const path = await import("path");
-    const mailsSource = await fs.readFile(
-      path.join(import.meta.dir, "mails.ts"),
-      "utf8"
-    );
-    const fnMatch = mailsSource.match(
-      /export const searchMailsByUid[\s\S]*?\n};/
-    );
-    if (!fnMatch) throw new Error("searchMailsByUid not found in mails.ts");
-    fnSource = fnMatch[0];
+  it("ANSWERED maps to answered = TRUE", async () => {
+    expect(await clauseFor("ANSWERED")).toBe("answered = TRUE");
   });
 
-  it("ANSWERED pushes answered = TRUE", () => {
-    expect(fnSource).toMatch(/case\s+"ANSWERED":\s*\n\s*conditions\.push\("answered = TRUE"\)/);
+  it("UNANSWERED maps to answered = FALSE", async () => {
+    expect(await clauseFor("UNANSWERED")).toBe("answered = FALSE");
   });
 
-  it("UNANSWERED pushes answered = FALSE", () => {
-    expect(fnSource).toMatch(/case\s+"UNANSWERED":\s*\n\s*conditions\.push\("answered = FALSE"\)/);
+  it("DELETED maps to deleted = TRUE", async () => {
+    expect(await clauseFor("DELETED")).toBe("deleted = TRUE");
   });
 
-  it("DELETED pushes deleted = TRUE", () => {
-    expect(fnSource).toMatch(/case\s+"DELETED":\s*\n\s*conditions\.push\("deleted = TRUE"\)/);
+  it("UNDELETED maps to deleted = FALSE", async () => {
+    expect(await clauseFor("UNDELETED")).toBe("deleted = FALSE");
   });
 
-  it("UNDELETED pushes deleted = FALSE", () => {
-    expect(fnSource).toMatch(/case\s+"UNDELETED":\s*\n\s*conditions\.push\("deleted = FALSE"\)/);
+  it("DRAFT maps to draft = TRUE", async () => {
+    expect(await clauseFor("DRAFT")).toBe("draft = TRUE");
   });
 
-  it("DRAFT pushes draft = TRUE", () => {
-    expect(fnSource).toMatch(/case\s+"DRAFT":\s*\n\s*conditions\.push\("draft = TRUE"\)/);
+  it("UNDRAFT maps to draft = FALSE", async () => {
+    expect(await clauseFor("UNDRAFT")).toBe("draft = FALSE");
   });
 
-  it("UNDRAFT pushes draft = FALSE", () => {
-    expect(fnSource).toMatch(/case\s+"UNDRAFT":\s*\n\s*conditions\.push\("draft = FALSE"\)/);
-  });
-
-  it("does not contain FALSE sentinel for any flag criterion", () => {
-    const flagBlock = fnSource.match(
-      /case "ANSWERED"[\s\S]*?case "UNDRAFT"[\s\S]*?break;/
-    );
-    if (!flagBlock) throw new Error("flag block not found");
-    expect(flagBlock[0]).not.toContain('"FALSE"');
+  it("no flag criterion returns a bare FALSE sentinel", async () => {
+    for (const type of [
+      "ANSWERED",
+      "UNANSWERED",
+      "DELETED",
+      "UNDELETED",
+      "DRAFT",
+      "UNDRAFT",
+    ]) {
+      expect(await clauseFor(type)).not.toBe("FALSE");
+    }
   });
 });
 
@@ -381,5 +380,114 @@ describe("getMailHeaders — envelope_to in received-branch address condition", 
     expect(sentSql).toContain("${FROM_ADDRESS}");
     expect(sentSql).not.toContain("envelope_to");
     expect(sentSql).not.toContain("envelope_from");
+  });
+});
+
+describe("buildCriterionClause — NOT/OR SQL generation (regression for #551)", () => {
+  // buildCriterionClause receives the normalised `{ type, value }` shape that
+  // store.ts's simplifyCriterion produces. It pushes bound params onto `values`
+  // (1-indexed `$N` tracks values.length) and returns the boolean SQL fragment,
+  // or null when the criterion imposes no constraint.
+
+  it("NOT wraps the inner clause instead of dropping it", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "NOT", value: { type: "SEEN" } },
+      "uid_account",
+      values as never
+    );
+    // Pre-fix this case had no `case "NOT"`/default, so the criterion fell
+    // through the switch and contributed NOTHING — the query matched everything.
+    expect(frag).toBe("NOT (read = TRUE)");
+    expect(values).toHaveLength(0);
+  });
+
+  it("OR joins both sides with continuous param numbering", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      {
+        type: "OR",
+        value: {
+          left: { type: "FROM", value: "alice" },
+          right: { type: "FROM", value: "bob" },
+        },
+      },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("(from_text ILIKE $1 OR from_text ILIKE $2)");
+    expect(values).toEqual(["%alice%", "%bob%"]);
+  });
+
+  it("NOT FROM negates a text predicate and binds its param", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "NOT", value: { type: "FROM", value: "spam@x" } },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("NOT (from_text ILIKE $1)");
+    expect(values).toEqual(["%spam@x%"]);
+  });
+
+  it("continues param numbering from an already-populated values array", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = ["user-1", false]; // e.g. base user_id/sent params
+    const frag = buildCriterionClause(
+      {
+        type: "OR",
+        value: {
+          left: { type: "SUBJECT", value: "a" },
+          right: { type: "TO", value: "b" },
+        },
+      },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("(subject ILIKE $3 OR to_text ILIKE $4)");
+    expect(values).toEqual(["user-1", false, "%a%", "%b%"]);
+  });
+
+  it("drops an OR whose side imposes no constraint rather than over-narrowing", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      {
+        type: "OR",
+        value: {
+          left: { type: "FROM", value: "alice" },
+          right: { type: "ALL" }, // ALL → null fragment
+        },
+      },
+      "uid_account",
+      values as never
+    );
+    // FROM alice OR ALL = everything, so the whole disjunction is dropped.
+    expect(frag).toBeNull();
+  });
+
+  it("normalised NOT BEFORE flows a Date param through correctly", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const when = new Date("2026-01-01T00:00:00Z");
+    const frag = buildCriterionClause(
+      { type: "NOT", value: { type: "BEFORE", value: when } },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("NOT (date < $1)");
+    expect(values).toEqual([when]);
+  });
+
+  it("plain criteria are unaffected by the refactor", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    expect(buildCriterionClause({ type: "SEEN" }, "uid_account", values as never)).toBe(
+      "read = TRUE"
+    );
+    expect(buildCriterionClause({ type: "ALL" }, "uid_account", values as never)).toBeNull();
   });
 });

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -811,6 +811,166 @@ export const setMailFlags = async (
   }
 };
 
+/**
+ * Builds the SQL boolean fragment for a single IMAP SEARCH criterion, pushing any
+ * bound parameters onto `values` (1-indexed `$N` placeholders track `values.length`).
+ * Returns `null` for criteria that impose no constraint (ALL, unsupported keys), so
+ * the caller simply skips them. NOT/OR recurse so negation and disjunction compose
+ * instead of falling through and matching every message.
+ */
+export const buildCriterionClause = (
+  criterion: { type: string; value?: unknown },
+  uidField: string,
+  values: ParamValue[]
+): string | null => {
+  const type = criterion.type.toUpperCase();
+  switch (type) {
+    // Logical operators — recurse into operands carried on `value`.
+    case "NOT": {
+      const inner = buildCriterionClause(
+        criterion.value as { type: string; value?: unknown },
+        uidField,
+        values
+      );
+      return inner ? `NOT (${inner})` : null;
+    }
+    case "OR": {
+      const { left, right } = criterion.value as {
+        left: { type: string; value?: unknown };
+        right: { type: string; value?: unknown };
+      };
+      const l = buildCriterionClause(left, uidField, values);
+      const r = buildCriterionClause(right, uidField, values);
+      if (l && r) return `(${l} OR ${r})`;
+      // One side imposes no constraint: an OR with an unconstrained side matches
+      // everything, so drop the whole disjunction rather than over-narrow it.
+      return null;
+    }
+
+    // ALL: match everything — no additional condition needed
+    case "ALL":
+      return null;
+
+    // Flag / status criteria
+    case "UNSEEN":
+      return "read = FALSE";
+    case "SEEN":
+      return "read = TRUE";
+    case "FLAGGED":
+      return "saved = TRUE";
+    case "UNFLAGGED":
+      return "saved = FALSE";
+    // ANSWERED / DELETED / DRAFT are tracked as real boolean columns on the
+    // mails table (added upstream); map each to its schema column directly.
+    case "ANSWERED":
+      return "answered = TRUE";
+    case "UNANSWERED":
+      return "answered = FALSE";
+    case "DELETED":
+      return "deleted = TRUE";
+    case "UNDELETED":
+      return "deleted = FALSE";
+    case "DRAFT":
+      return "draft = TRUE";
+    case "UNDRAFT":
+      return "draft = FALSE";
+    // NEW = RECENT + UNSEEN; RECENT / OLD: not tracked, treat as ALL
+    case "NEW":
+      return "read = FALSE";
+    case "OLD":
+    case "RECENT":
+      return null; // no \Recent flag tracking; match all
+
+    // Text search criteria
+    case "SUBJECT":
+      values.push(`%${criterion.value}%`);
+      return `subject ILIKE $${values.length}`;
+    case "FROM":
+      values.push(`%${criterion.value}%`);
+      return `from_text ILIKE $${values.length}`;
+    case "TO":
+      values.push(`%${criterion.value}%`);
+      return `to_text ILIKE $${values.length}`;
+    case "CC":
+      values.push(`%${criterion.value}%`);
+      return `cc_text ILIKE $${values.length}`;
+    case "BCC":
+      values.push(`%${criterion.value}%`);
+      return `bcc_text ILIKE $${values.length}`;
+    case "BODY":
+    case "TEXT":
+    case "SUBJECT_TEXT": {
+      // Full-text search across subject (extend to body when indexed)
+      values.push(`%${criterion.value}%`);
+      const p = values.length;
+      return `(subject ILIKE $${p} OR from_text ILIKE $${p} OR to_text ILIKE $${p})`;
+    }
+
+    // Header search
+    case "HEADER": {
+      const { field, text } = criterion.value as { field: string; text: string };
+      const fieldLower = field.toLowerCase();
+      let column: string | null = null;
+      if (fieldLower === "subject") column = "subject";
+      else if (fieldLower === "from") column = "from_text";
+      else if (fieldLower === "to") column = "to_text";
+      else if (fieldLower === "message-id") column = "message_id";
+      // Unsupported header field — skip to avoid incorrect results
+      if (column === null) return null;
+      values.push(`%${text}%`);
+      return `${column} ILIKE $${values.length}`;
+    }
+
+    // Date criteria (using internal date — date column)
+    case "BEFORE":
+      values.push(criterion.value as Date);
+      return `date < $${values.length}`;
+    case "ON": {
+      const onDate = criterion.value as Date;
+      const nextDay = new Date(onDate);
+      nextDay.setDate(nextDay.getDate() + 1);
+      values.push(onDate, nextDay);
+      return `date >= $${values.length - 1} AND date < $${values.length}`;
+    }
+    case "SINCE":
+      values.push(criterion.value as Date);
+      return `date >= $${values.length}`;
+    // SENT* criteria use the same date column (we have only one date field)
+    case "SENTBEFORE":
+      values.push(criterion.value as Date);
+      return `date < $${values.length}`;
+    case "SENTON": {
+      const sentOnDate = criterion.value as Date;
+      const nextDay = new Date(sentOnDate);
+      nextDay.setDate(nextDay.getDate() + 1);
+      values.push(sentOnDate, nextDay);
+      return `date >= $${values.length - 1} AND date < $${values.length}`;
+    }
+    case "SENTSINCE":
+      values.push(criterion.value as Date);
+      return `date >= $${values.length}`;
+
+    // Size criteria: not tracked per-row; skip to avoid incorrect results
+    case "LARGER":
+    case "SMALLER":
+      return null;
+
+    // UID ranges (already split from UidCriterion in store.ts)
+    case "UID_EXACT":
+      values.push(criterion.value as number);
+      return `${uidField} = $${values.length}`;
+    case "UID_RANGE": {
+      const range = criterion.value as { start: number; end: number };
+      values.push(range.start, range.end);
+      return `${uidField} >= $${values.length - 1} AND ${uidField} <= $${values.length}`;
+    }
+
+    // Unsupported criterion — impose no constraint (caller skips it).
+    default:
+      return null;
+  }
+};
+
 export const searchMailsByUid = async (
   user_id: string,
   account: string | null,
@@ -836,167 +996,8 @@ export const searchMailsByUid = async (
     }
 
     for (const criterion of criteria) {
-      const type = criterion.type.toUpperCase();
-      switch (type) {
-        // ALL: match everything — no additional condition needed
-        case "ALL":
-          break;
-
-        // Flag / status criteria
-        case "UNSEEN":
-          conditions.push("read = FALSE");
-          break;
-        case "SEEN":
-          conditions.push("read = TRUE");
-          break;
-        case "FLAGGED":
-          conditions.push("saved = TRUE");
-          break;
-        case "UNFLAGGED":
-          conditions.push("saved = FALSE");
-          break;
-        case "ANSWERED":
-          conditions.push("answered = TRUE");
-          break;
-        case "UNANSWERED":
-          conditions.push("answered = FALSE");
-          break;
-        case "DELETED":
-          conditions.push("deleted = TRUE");
-          break;
-        case "UNDELETED":
-          conditions.push("deleted = FALSE");
-          break;
-        case "DRAFT":
-          conditions.push("draft = TRUE");
-          break;
-        case "UNDRAFT":
-          conditions.push("draft = FALSE");
-          break;
-        // NEW = RECENT + UNSEEN; RECENT / OLD: not tracked, treat as ALL
-        case "NEW":
-          conditions.push("read = FALSE");
-          break;
-        case "OLD":
-        case "RECENT":
-          break; // no \Recent flag tracking; match all
-
-        // Text search criteria
-        case "SUBJECT":
-          conditions.push(`subject ILIKE $${paramIdx}`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-        case "FROM":
-          conditions.push(`from_text ILIKE $${paramIdx}`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-        case "TO":
-          conditions.push(`to_text ILIKE $${paramIdx}`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-        case "CC":
-          conditions.push(`cc_text ILIKE $${paramIdx}`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-        case "BCC":
-          conditions.push(`bcc_text ILIKE $${paramIdx}`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-        case "BODY":
-        case "TEXT":
-        case "SUBJECT_TEXT":
-          // Full-text search across subject (extend to body when indexed)
-          conditions.push(`(subject ILIKE $${paramIdx} OR from_text ILIKE $${paramIdx} OR to_text ILIKE $${paramIdx})`);
-          values.push(`%${criterion.value}%`);
-          paramIdx++;
-          break;
-
-        // Header search
-        case "HEADER": {
-          const { field, text } = criterion.value as { field: string; text: string };
-          const fieldLower = field.toLowerCase();
-          if (fieldLower === "subject") {
-            conditions.push(`subject ILIKE $${paramIdx}`);
-          } else if (fieldLower === "from") {
-            conditions.push(`from_text ILIKE $${paramIdx}`);
-          } else if (fieldLower === "to") {
-            conditions.push(`to_text ILIKE $${paramIdx}`);
-          } else if (fieldLower === "message-id") {
-            conditions.push(`message_id ILIKE $${paramIdx}`);
-          } else {
-            // Unsupported header field — skip to avoid incorrect results
-            break;
-          }
-          values.push(`%${text}%`);
-          paramIdx++;
-          break;
-        }
-
-        // Date criteria (using internal date — date column)
-        case "BEFORE":
-          conditions.push(`date < $${paramIdx}`);
-          values.push(criterion.value as Date);
-          paramIdx++;
-          break;
-        case "ON": {
-          const onDate = criterion.value as Date;
-          const nextDay = new Date(onDate);
-          nextDay.setDate(nextDay.getDate() + 1);
-          conditions.push(`date >= $${paramIdx} AND date < $${paramIdx + 1}`);
-          values.push(onDate, nextDay);
-          paramIdx += 2;
-          break;
-        }
-        case "SINCE":
-          conditions.push(`date >= $${paramIdx}`);
-          values.push(criterion.value as Date);
-          paramIdx++;
-          break;
-        // SENT* criteria use the same date column (we have only one date field)
-        case "SENTBEFORE":
-          conditions.push(`date < $${paramIdx}`);
-          values.push(criterion.value as Date);
-          paramIdx++;
-          break;
-        case "SENTON": {
-          const sentOnDate = criterion.value as Date;
-          const nextDay = new Date(sentOnDate);
-          nextDay.setDate(nextDay.getDate() + 1);
-          conditions.push(`date >= $${paramIdx} AND date < $${paramIdx + 1}`);
-          values.push(sentOnDate, nextDay);
-          paramIdx += 2;
-          break;
-        }
-        case "SENTSINCE":
-          conditions.push(`date >= $${paramIdx}`);
-          values.push(criterion.value as Date);
-          paramIdx++;
-          break;
-
-        // Size criteria: not tracked per-row; skip to avoid incorrect results
-        case "LARGER":
-        case "SMALLER":
-          break;
-
-        // UID ranges (already split from UidCriterion in store.ts)
-        case "UID_EXACT":
-          conditions.push(`${uidField} = $${paramIdx}`);
-          values.push(criterion.value as number);
-          paramIdx++;
-          break;
-        case "UID_RANGE": {
-          const range = criterion.value as { start: number; end: number };
-          conditions.push(`${uidField} >= $${paramIdx} AND ${uidField} <= $${paramIdx + 1}`);
-          values.push(range.start, range.end);
-          paramIdx += 2;
-          break;
-        }
-      }
+      const frag = buildCriterionClause(criterion, uidField, values);
+      if (frag) conditions.push(frag);
     }
 
     const sql = `


### PR DESCRIPTION
Closes #551

## Problem

IMAP `SEARCH NOT <criterion>` and `SEARCH OR <c1> <c2>` silently ignored the logical operator and returned an **over-broad** (effectively match-all) result set. The parser and the `store.ts` dispatcher produced `NOT`/`OR` criteria correctly, but `searchMailsByUid` — which turns criteria into the SQL `WHERE` clause — had no `case "NOT"`, no `case "OR"`, and no `default`, so those criteria fell straight through the `switch` and contributed nothing to the query.

Danger is amplified when a client pipes a `SEARCH` result into a follow-up `STORE`/`COPY`/`MOVE`/`EXPUNGE`: e.g. `SEARCH NOT FLAGGED` then bulk-mark would touch **every** message instead of the intended subset.

## Root cause (two halves of the same path)

1. **Dispatcher** (`store.ts`) normalised top-level criteria into a flat `{ type, value }` shape but forwarded `NOT`/`OR` operands **raw** — the parser emits operands via `.criterion`/`.left`/`.right` with heterogeneous field names (`.date`, `.field`, `.value`). So even once the SQL layer handled `NOT`/`OR`, a nested `NOT BEFORE <date>` / `NOT HEADER ...` would have read the wrong field.
2. **SQL builder** (`mails.ts`) modelled criteria as a flat `conditions: string[]` joined with `AND`, structurally unable to express negation or disjunction.

## Fix

- **`store.ts`** — extract `simplifyCriterion(criterion)` and recurse into `NOT`/`OR` operands so their inner criteria are normalised to the same flat `{ type, value }` shape the SQL builder consumes. UID (which expands to multiple range entries) is still handled by the caller.
- **`mails.ts`** — extract `buildCriterionClause(criterion, uidField, values)`, a recursive helper returning one SQL boolean fragment per criterion (`NOT (...)`, `(a OR b)`) and pushing its bound params onto `values` (1-indexed `$N` tracks `values.length`). The top-level loop pushes each non-null fragment. An `OR`/`NOT` whose side imposes no constraint is dropped rather than over-narrowed (an `OR` with an unconstrained side matches everything).

No behaviour change for any existing single criterion — every prior `case` maps 1:1 to a returned fragment; the base `user_id`/`sent`/`expunged`/address conditions and `LIMIT 10000` / `ORDER BY` are untouched.

## Tests

- `mails.test.ts` — 7 new tests on `buildCriterionClause`: `NOT` wraps (`NOT (read = TRUE)`), `OR` joins with continuous param numbering, `NOT FROM` binds its param, numbering continues from a pre-populated `values` array, `OR` with an unconstrained side is dropped, a normalised `NOT BEFORE` flows a `Date` param through, and plain criteria are unchanged.
- `store.test.ts` — 6 new tests on `simplifyCriterion`: recursion normalises `NOT`/`OR` operands (flag, text→`.value`, date `.date`→`.value`, header `.field/.value`→`{field,text}`), and an `OR` operand that can't collapse to a single value (UID) drops the disjunction.
- Full server suite: **933 pass / 0 fail**. tsc clean. Verified green with `store.test.ts` loaded before `mails.test.ts` (the former mocks the mails repo process-globally) — no `mock.module` bleed.

## E2E — live IMAP server (port 10143, `EMAIL_DOMAIN=hoie.kim`)

Raw-socket session reproducing the issue (local dev DB: all mails `read = TRUE`, 0 unread):

| Query | Expected | Before fix | After fix |
|---|---|---|---|
| `SEARCH UNSEEN` | 0 | 0 | **0** ✅ |
| `SEARCH NOT SEEN` | 0 (= UNSEEN) | 10000 | **0** ✅ |
| `SEARCH SEEN` | all (capped 10000) | 10000 | **10000** ✅ |
| `SEARCH OR FROM <none> FROM <none>` | 0 | 10000 | **0** ✅ |
| `SEARCH NOT FROM <nonexistent>` | all | — | **10000** ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
