### PR TITLE
fix(imap): SEARCH BODY/TEXT now consult the message body (#552)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -522,3 +522,39 @@ describe("searchMailsByUid — no result cap (#553)", () => {
     expect(sqlMatch[1]).not.toMatch(/\bLIMIT\b/i);
   });
 });
+
+describe("buildCriterionClause — BODY/TEXT search the message body (#552)", () => {
+  // RFC 3501 §6.4.4: BODY matches the message body; TEXT matches header +
+  // body. The prior impl ORed only subject/from_text/to_text, so IMAP
+  // `SEARCH BODY <s>` / `SEARCH TEXT <s>` never consulted the `text`
+  // (plain-text body) column and missed virtually every body-content match.
+
+  it("BODY matches the body column only", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "BODY", value: "needle" },
+      "uid_account",
+      values as never,
+    );
+    expect(frag).toBe("text ILIKE $1");
+    // Body-only per RFC: must not fold in the header columns.
+    expect(frag).not.toContain("subject ILIKE");
+    expect(frag).not.toContain("from_text ILIKE");
+    expect(values).toEqual(["%needle%"]);
+  });
+
+  it("TEXT matches header columns plus the body column", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "TEXT", value: "needle" },
+      "uid_account",
+      values as never,
+    );
+    expect(frag).toContain("subject ILIKE");
+    expect(frag).toContain("from_text ILIKE");
+    expect(frag).toContain("to_text ILIKE");
+    expect(frag).toContain("text ILIKE");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -897,13 +897,16 @@ export const buildCriterionClause = (
     case "BCC":
       values.push(`%${criterion.value}%`);
       return `bcc_text ILIKE $${values.length}`;
-    case "BODY":
+    // RFC 3501 §6.4.4: BODY matches the message body; TEXT matches header + body.
+    case "BODY": {
+      values.push(`%${criterion.value}%`);
+      return `text ILIKE $${values.length}`;
+    }
     case "TEXT":
     case "SUBJECT_TEXT": {
-      // Full-text search across subject (extend to body when indexed)
       values.push(`%${criterion.value}%`);
       const p = values.length;
-      return `(subject ILIKE $${p} OR from_text ILIKE $${p} OR to_text ILIKE $${p})`;
+      return `(subject ILIKE $${p} OR from_text ILIKE $${p} OR to_text ILIKE $${p} OR text ILIKE $${p})`;
     }
 
     // Header search


### PR DESCRIPTION
## Summary

IMAP `SEARCH BODY <string>` and `SEARCH TEXT <string>` never searched the message body. `searchMailsByUid` handled `BODY`/`TEXT`/`SUBJECT_TEXT` with a single header-only condition (`subject ILIKE … OR from_text ILIKE … OR to_text ILIKE …`), so the populated `text` (plain-text body) column was never consulted — a false-negative correctness bug and an RFC 3501 §6.4.4 violation.

Closes #552.

## Change

`src/server/lib/postgres/repositories/mails.ts` — split the shared case per RFC 3501 §6.4.4:
- **`BODY`** → matches the body column only (`text ILIKE`).
- **`TEXT`** (and the legacy, parser-unused `SUBJECT_TEXT`) → matches header columns **plus** body (`subject/from_text/to_text/text ILIKE`).

The `text` column already exists, is populated, and is searched by the web full-text path (`search_vector`); it was simply absent from the IMAP SEARCH condition.

## Verification

**Against the real local DB** (term `unsubscribe`):

| Query | Before | After |
|---|---|---|
| `SEARCH BODY "unsubscribe"` | 4 (header-only) | **3751** (body) |
| body-only matches dropped by old impl | 3747 missed | 0 missed |

The old condition returned 4 when ~3751 messages contain the term in their body — it missed 3747 matches that have the term only in the body, not the subject/from/to.

**Unit tests** (`mails.test.ts`, source-inspection pattern consistent with the existing `getAccountStats`/`getMailHeaders` tests in this file):
- BODY case matches the body column and does not fold in header columns.
- TEXT/SUBJECT_TEXT case matches header columns plus the body column.

`bun test src/server/lib/postgres/repositories/mails.test.ts` → 21 pass / 0 fail. `tsc --noEmit` clean.

Server-side IMAP change — no UI surface.
