### PR TITLE
fix(imap): SEARCH/UID SEARCH returns all matches, not the oldest 10000 (#553)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -491,3 +491,34 @@ describe("buildCriterionClause — NOT/OR SQL generation (regression for #551)",
     expect(buildCriterionClause({ type: "ALL" }, "uid_account", values as never)).toBeNull();
   });
 });
+
+describe("searchMailsByUid — no result cap (#553)", () => {
+  // A `LIMIT 10000` with `ORDER BY uid ASC` made SEARCH/UID SEARCH drop
+  // the NEWEST messages once a mailbox exceeded 10000 — the worst-possible
+  // truncation for an email client and an RFC 3501 §6.4.4 violation (SEARCH
+  // must return all matching messages). The enumeration siblings getAllUids
+  // and getMailsByRange are unbounded; the search path must match.
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(
+      /export const searchMailsByUid[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("searchMailsByUid not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("the search SQL has no LIMIT clause", () => {
+    const sqlMatch = fnSource.match(
+      /const sql = `([\s\S]*?SELECT[\s\S]*?)`/
+    );
+    if (!sqlMatch) throw new Error("search SQL not found");
+    expect(sqlMatch[1]).not.toMatch(/\bLIMIT\b/i);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1000,11 +1000,14 @@ export const searchMailsByUid = async (
       if (frag) conditions.push(frag);
     }
 
+    // No LIMIT: per RFC 3501 §6.4.4 SEARCH must return every matching
+    // message. A cap with ORDER BY uid ASC would silently drop the
+    // newest messages on mailboxes larger than the cap. Consistent with
+    // the unbounded getAllUids / getMailsByRange enumeration paths.
     const sql = `
-      SELECT ${uidField} as uid FROM mails 
+      SELECT ${uidField} as uid FROM mails
       WHERE ${conditions.join(" AND ")}
       ORDER BY ${uidField} ASC
-      LIMIT 10000
     `;
 
     const result = await pool.query(sql, values);


### PR DESCRIPTION
## Summary

`searchMailsByUid` capped every IMAP `SEARCH` / `UID SEARCH` at a hardcoded `LIMIT 10000` with `ORDER BY uid ASC`. Once a mailbox exceeds 10000 messages, SEARCH silently returned only the **oldest** 10000 and dropped the **newest** — the worst-possible truncation for a mail client, and an RFC 3501 §6.4.4 violation (SEARCH must return *all* matching messages). Clients that enumerate via `SEARCH ALL` / `UID SEARCH ALL` / `SEARCH UNSEEN` / `SEARCH SINCE` never saw recent mail.

FETCH/STORE/EXPUNGE were unaffected — `getAllUids` and `getMailsByRange` have no cap — so the search path was also internally inconsistent with the rest of the repository.

Closes #553.

## Change

`src/server/lib/postgres/repositories/mails.ts` — remove the `LIMIT 10000` from the SEARCH query, matching the unbounded enumeration siblings.

## Verification

**Against the real local DB** — the largest received mailbox (11322 messages, true max uid 11395):

| | rows returned | max uid returned |
|---|---|---|
| before (`LIMIT 10000`) | 10000 | 10049 |
| after (no cap) | **11322** | **11395** |

The old cap hid the 1322 highest-UID (most recently delivered) messages. After the change, all 11322 are returned.

**Unit test** (`mails.test.ts`, source-inspection pattern consistent with the existing tests in this file): asserts the search SQL builder contains no `LIMIT` clause.

`bun test src/server/lib/postgres/repositories/mails.test.ts` → 20 pass / 0 fail. `tsc --noEmit` clean.

Server-side IMAP change — no UI surface.
