### PR TITLE
fix(test): stop smtp.test global mock leaking into auth-rate-limit suite

### DIFF
--- a/src/server/lib/smtp.test.ts
+++ b/src/server/lib/smtp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, beforeEach, afterEach } from "bun:test";
+import { describe, expect, it, mock, spyOn, beforeEach, afterEach, afterAll } from "bun:test";
 import bcrypt from "bcryptjs";
 import type {
   SMTPServer,
@@ -6,6 +6,7 @@ import type {
   SMTPServerDataStream,
   SMTPServerAuthentication
 } from "smtp-server";
+import * as authRateLimit from "./auth-rate-limit";
 
 // Mock dependencies before importing project code (Bun requirement)
 const mockGetUser = mock(() => Promise.resolve(null));
@@ -47,18 +48,15 @@ mock.module("mailparser", () => ({
   simpleParser: mockSimpleParser
 }));
 
-// Mock auth-rate-limit so we can drive the rate-limit branch in onAuth without
-// needing 10 real failed attempts (each takes 500ms in production code).
-// Safe to mock globally here — no other test file currently exercises imap/auth.ts.
-const mockIsAuthRateLimited = mock((_ip: string) => false);
-const mockRecordAuthFailure = mock((_ip: string) => Promise.resolve(false));
-const mockResetAuthFailures = mock((_ip: string) => undefined);
-
-mock.module("./auth-rate-limit", () => ({
-  isAuthRateLimited: mockIsAuthRateLimited,
-  recordAuthFailure: mockRecordAuthFailure,
-  resetAuthFailures: mockResetAuthFailures,
-}));
+// Stub auth-rate-limit so we can drive the rate-limit branch in onAuth without
+// needing 10 real failed attempts (each takes 500ms in production code). We use
+// spyOn (restored in afterAll) rather than mock.module: mock.module is process-
+// global in Bun and would replace the real implementation in auth-rate-limit.test.ts
+// when that file runs after this one, making its threshold assertions see the
+// always-false stub. spyOn mutates the live module binding and is reverted cleanly.
+const mockIsAuthRateLimited = spyOn(authRateLimit, "isAuthRateLimited").mockReturnValue(false);
+const mockRecordAuthFailure = spyOn(authRateLimit, "recordAuthFailure").mockResolvedValue(false);
+const mockResetAuthFailures = spyOn(authRateLimit, "resetAuthFailures").mockReturnValue(undefined);
 
 // Note: we deliberately do NOT mock "./alarm" globally — `mock.module` is
 // process-wide in Bun, and a global mock leaks into alarm.test.ts. Instead
@@ -67,6 +65,14 @@ mock.module("./auth-rate-limit", () => ({
 
 // Import the actual SMTP handlers after mocks are set up
 import { onAuth, onData } from "./smtp";
+
+// Revert the auth-rate-limit spies after this file so the real implementation is
+// restored for any test file that runs later (e.g. auth-rate-limit.test.ts).
+afterAll(() => {
+  mockIsAuthRateLimited.mockRestore();
+  mockRecordAuthFailure.mockRestore();
+  mockResetAuthFailures.mockRestore();
+});
 
 describe("onAuth handler", () => {
   const originalEnv = process.env;
@@ -78,6 +84,7 @@ describe("onAuth handler", () => {
     mockRecordAuthFailure.mockReset();
     mockRecordAuthFailure.mockImplementation(() => Promise.resolve(false));
     mockResetAuthFailures.mockReset();
+    mockResetAuthFailures.mockImplementation(() => undefined);
     process.env = { ...originalEnv, EMAIL_DOMAIN: "test.com" };
   });
 


### PR DESCRIPTION
## Problem

CI has been intermittently red on recent inbox PRs (#572, #574, #575) with the **same** two failures, both in `auth-rate-limit.test.ts`:

- `isAuthRateLimited > returns true after MAX_FAILURES (10) failures` — `Expected: true, Received: false`
- `recordAuthFailure > returns true on the 10th failure (threshold hit)` — `Expected: true, Received: false`

Note the fingerprint: **only the assertions that expect `true` fail; every assertion that expects `false` passes.** That is exactly what happens when the real rate-limiter is replaced by an always-false stub — `recordAuthFailure` increments nothing and `isAuthRateLimited` returns `false`.

## Root cause

`smtp.test.ts` stubs the limiter with `mock.module("./auth-rate-limit", …)`. In Bun `mock.module` is **process-global** and persists across files in the same `bun test` run. Its own comment said it was *"Safe to mock globally here — no other test file currently exercises imap/auth.ts"* — but `auth-rate-limit.test.ts` (added later, in #533) directly tests the real module.

When `smtp.test.ts` runs **before** `auth-rate-limit.test.ts` in the same run, the global stub bleeds into the real module's own suite. File execution order is filesystem-dependent, so this reproduces on the Linux CI runner but not on local macOS (where `auth-rate-limit` sorts before `smtp`, so the stub is never installed when the real suite runs). Rerunning CI did not clear it — it is order/environment-deterministic, not a transient flake.

Minimal Bun repro (two files, polluter sorts first): the second file sees the stub. `mock.restore()` does **not** undo `mock.module`; only switching off `mock.module` fixes it.

## Fix

Replace the global `mock.module("./auth-rate-limit")` with `spyOn(authRateLimit, …)` on the live module binding, reverted in `afterAll`. spyOn reaches `smtp.ts`'s named imports via ESM live bindings (verified), keeps the same always-false stub behaviour during smtp's own tests, and — because the spies are restored — leaves the real implementation in place for any file that runs afterward. With no global `mock.module` of this module anywhere, the bleed cannot occur regardless of file order or platform.

**Test-file only — no production code changes.**

## Verification (local, macOS, bun 1.3.14)

- `bun test src/server/lib/smtp.test.ts` → 27 pass / 0 fail
- `bun test src/server/lib/auth-rate-limit.test.ts src/server/lib/smtp.test.ts` (both orders) → 37 pass / 0 fail
- `bun test` (full repo) → 930 pass / 0 fail
- `bun run typecheck` → clean
- `bun run lint` → 0 errors

The Linux-only ordering that triggers the original failure can't be forced on macOS, so the live red→green confirmation is this PR's own CI run. The fix is correct by construction: removing the only global mock of `auth-rate-limit` removes the only mechanism that can replace it.

Once this merges, #572 / #574 / #575 should go green on their next CI run with no code change of their own.
