### PR TITLE
fix(imap): SELECT [UNSEEN n] reports first-unseen seq, not the unread count

### DIFF
--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -378,14 +378,23 @@ export async function selectMailbox(
       return;
     }
 
-    const { total, unread } = countResult;
+    const { total } = countResult;
     setSelected(cleanName, total);
 
     const uidValidity = await getImapUidValidity(store.getUser().id);
 
+    // [UNSEEN <n>] is the sequence number of the first unseen message, not the
+    // unread count (RFC 3501 §7.1). Map the lowest-UID unread message to its
+    // 1-based sequence position; omit the response code entirely when all read.
+    const firstUnseenUid = await store.getFirstUnseenUid(cleanName);
+    const firstUnseenSeq =
+      firstUnseenUid !== null ? seqState.uidToSeq.get(firstUnseenUid) : undefined;
+
     write(`* ${total} EXISTS\r\n`);
     write(`* 0 RECENT\r\n`);
-    write(`* OK [UNSEEN ${unread}] Message ${unread} is first unseen\r\n`);
+    if (firstUnseenSeq) {
+      write(`* OK [UNSEEN ${firstUnseenSeq}] Message ${firstUnseenSeq} is first unseen\r\n`);
+    }
     const uidNext =
       seqState.seqToUid.length > 0
         ? seqState.seqToUid[seqState.seqToUid.length - 1] + 1

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -18,6 +18,9 @@ const mockSearchMailsByUid = mock(() => Promise.resolve([]));
 const mockSaveMail = mock(() => Promise.resolve({ _id: "x" }));
 const mockExpunge = mock(() => Promise.resolve(0));
 const mockGetAllUids = mock(() => Promise.resolve([]));
+const mockGetFirstUnseenUid = mock<(...args: unknown[]) => Promise<number | null>>(() =>
+  Promise.resolve(null)
+);
 
 mock.module("../postgres/repositories/mails", () => ({
   getAccountStats: mockGetAccountStats,
@@ -28,6 +31,7 @@ mock.module("../postgres/repositories/mails", () => ({
   saveMail: mockSaveMail,
   expungeDeletedMails: mockExpunge,
   getAllUids: mockGetAllUids,
+  getFirstUnseenUid: mockGetFirstUnseenUid,
 }));
 
 const mockGetMailboxesByUser = mock(() => Promise.resolve([]));
@@ -146,5 +150,33 @@ describe("simplifyCriterion — NOT/OR operand normalisation (regression for #55
     expect(
       simplifyCriterion({ type: "HEADER", field: "Subject", value: "hi" } as never)
     ).toEqual({ type: "HEADER", value: { field: "Subject", text: "hi" } });
+  });
+});
+
+describe("Store.getFirstUnseenUid", () => {
+  beforeEach(() => {
+    mockGetFirstUnseenUid.mockClear();
+    mockGetFirstUnseenUid.mockResolvedValue(null);
+  });
+
+  it("forwards the resolved account/sent for INBOX and returns the unseen UID", async () => {
+    mockGetFirstUnseenUid.mockResolvedValue(42);
+    const store = new Store(makeUser());
+    const result = await store.getFirstUnseenUid("INBOX");
+
+    expect(result).toBe(42);
+    expect(mockGetFirstUnseenUid).toHaveBeenCalledWith("user-123", null, false);
+  });
+
+  it("returns null when every message is read", async () => {
+    mockGetFirstUnseenUid.mockResolvedValue(null);
+    const store = new Store(makeUser());
+    expect(await store.getFirstUnseenUid("INBOX")).toBeNull();
+  });
+
+  it("returns null instead of throwing when the repository query fails", async () => {
+    mockGetFirstUnseenUid.mockRejectedValue(new Error("db down"));
+    const store = new Store(makeUser());
+    expect(await store.getFirstUnseenUid("INBOX")).toBeNull();
   });
 });

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -15,6 +15,7 @@ import {
   saveMail as pgSaveMail,
   expungeDeletedMails,
   getAllUids as pgGetAllUids,
+  getFirstUnseenUid as pgGetFirstUnseenUid,
   SaveMailInput,
   UpdatedMailFlags,
   StoreOperationType,
@@ -257,6 +258,20 @@ export class Store {
     } catch (error) {
       logger.error("Error getting all UIDs", { component: "imap.store", box }, error);
       return [];
+    }
+  };
+
+  /**
+   * UID of the first (lowest-UID) unseen message in a mailbox, or null when
+   * everything is read. Used to derive the `[UNSEEN <seq>]` SELECT response.
+   */
+  getFirstUnseenUid = async (box: string): Promise<number | null> => {
+    try {
+      const { accountName, isSent } = this.resolveBox(box);
+      return await pgGetFirstUnseenUid(this.user.id, accountName, isSent);
+    } catch (error) {
+      logger.error("Error getting first unseen UID", { component: "imap.store", box }, error);
+      return null;
     }
   };
 

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1098,6 +1098,56 @@ export const getAllUids = async (
 };
 
 /**
+ * UID of the lowest-UID unread (unseen) message in a mailbox, or null when
+ * every message is read. Used to emit the RFC 3501 `[UNSEEN <seq>]` SELECT
+ * response code, where the value is the sequence number of the first unseen
+ * message — never the unread count.
+ */
+export const getFirstUnseenUid = async (
+  user_id: string,
+  account: string | null,
+  sent: boolean
+): Promise<number | null> => {
+  try {
+    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
+
+    let sql: string;
+    let values: ParamValue[];
+
+    if (account === null) {
+      // Domain-wide query (exclude expunged messages)
+      sql = `
+        SELECT ${uidField} as uid FROM mails
+        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE
+        ORDER BY ${uidField} ASC
+        LIMIT 1
+      `;
+      values = [user_id, sent];
+    } else {
+      // Account-specific query (exclude expunged messages)
+      const addressJson = JSON.stringify([{ address: account }]);
+      const addressCondition = sent
+        ? `${FROM_ADDRESS} @> $3::jsonb`
+        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      sql = `
+        SELECT ${uidField} as uid FROM mails
+        WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND expunged = FALSE AND read = FALSE
+        ORDER BY ${uidField} ASC
+        LIMIT 1
+      `;
+      values = [user_id, sent, addressJson];
+    }
+
+    const result = await pool.query(sql, values);
+    const uid = result.rows[0]?.uid;
+    return uid === undefined ? null : (uid as number);
+  } catch (error) {
+    logger.error("Failed to get first unseen UID", {}, error);
+    return null;
+  }
+};
+
+/**
  * Soft-delete messages marked with \Deleted flag (EXPUNGE operation)
  * Sets expunged = TRUE instead of hard deleting.
  * Returns the UIDs of expunged messages for EXPUNGE responses.


### PR DESCRIPTION
## Summary
`SELECT`/`EXAMINE` reported the `[UNSEEN n]` response code using the **count of unread messages** as if it were the **sequence number of the first unseen message** (RFC 3501 §7.1 — "n is the message sequence number of the first unseen message"). Two defects:

1. **Wrong value when unread > 0** — `[UNSEEN 5]` with 5 unread pointed at sequence position 5 (the 5th message by UID, very likely already read), not the first unseen one.
2. **Invalid value when unread = 0** — emitted `[UNSEEN 0]`; sequence numbers are 1-based, so `0` is a protocol violation. RFC says omit the code entirely when nothing is unseen.

## Fix
- New `getFirstUnseenUid(user, account, sent)` in the mails repository — `SELECT <uidField> … WHERE read = FALSE ORDER BY <uidField> ASC LIMIT 1`, returning the lowest-UID unread message's UID or `null`. Mirrors the existing `getAllUids` query (same expunge/account/sent filters) so the UID maps cleanly onto the sequence mapping.
- `Store.getFirstUnseenUid` thin wrapper.
- `selectMailbox` maps that UID to its 1-based sequence number via `seqState.uidToSeq` (already built for SELECT) and only writes the `[UNSEEN …]` line when a first-unseen message exists. Dropped the now-unused `unread` destructure.

## E2E testing
Booted Postgres + the IMAP listener (port 1143) against the local dataset on this branch and drove a raw IMAP session.

**All-read mailbox (admin INBOX, 0 unread) — defect 2, the exact issue reproduction:**
```
a2 SELECT INBOX
* 11322 EXISTS
* 0 RECENT
* OK [UIDVALIDITY 1773693320] UIDs valid
* OK [UIDNEXT 11396] Predicted next UID
* FLAGS (\Seen \Flagged \Deleted \Draft \Answered)
* OK [PERMANENTFLAGS (…)] Flags permitted
a2 OK [READ-WRITE] SELECT completed
```
The invalid `* OK [UNSEEN 0] Message 0 is first unseen` line is now **gone**.

**Unread message present — defect 1:** marked the 5th-by-UID message unread inside a transaction we ROLLED BACK (nothing persisted — confirmed the row's `read` flag returned to `true` afterward). The first-unseen query returned that message's UID and the computed sequence number was **5** (the real position), not the unread count of **1**:
```
getFirstUnseenUid result = 5  (expect 5)
computed sequence number = 5  (expect 5)
PASS: emits [UNSEEN 5] — the real seq, not the unread count (which would be 1)
post-rollback read flag  = true
```

## Tests
- Added `Store.getFirstUnseenUid` unit tests (forwards resolved account/sent, returns the UID, returns null on all-read, returns null instead of throwing on query failure).
- Full server suite green: `bun test src/server` → **923 pass, 0 fail**. Typecheck clean, lint 0 errors.

Closes #554
