### PR TITLE
fix(client): show starred sent mails in the Saved view (#568)

### DIFF
--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -31,6 +31,7 @@ import {
   onKeyboardActivate
 } from "client";
 import { MailsSynchronizer } from "client/Box";
+import { mergeSavedAccounts } from "./savedAccounts";
 
 import "./index.scss";
 
@@ -226,7 +227,7 @@ const Accounts = ({
     } else if (selectedCategory === Category.AllMails) {
       sortedAccountData = received;
     } else if (selectedCategory === Category.SavedMails) {
-      sortedAccountData = received.filter((e) => e.saved_doc_count);
+      sortedAccountData = mergeSavedAccounts(received, sent);
     } else if (selectedCategory === Category.SentMails) {
       sortedAccountData = sent;
     } else if (selectedCategory === Category.Search && searchHistory) {
@@ -274,7 +275,7 @@ const Accounts = ({
         let targetAccounts: Account[];
         if (e === Category.SentMails) targetAccounts = sent;
         else if (e === Category.NewMails) targetAccounts = received.filter((a) => a.unread_doc_count);
-        else if (e === Category.SavedMails) targetAccounts = received.filter((a) => a.saved_doc_count);
+        else if (e === Category.SavedMails) targetAccounts = mergeSavedAccounts(received, sent);
         else if (e === Category.Search) targetAccounts = searchHistory;
         else targetAccounts = received;
         if (

--- a/src/client/Box/components/Accounts/savedAccounts.test.ts
+++ b/src/client/Box/components/Accounts/savedAccounts.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import { Account } from "common";
+import { mergeSavedAccounts } from "./savedAccounts";
+
+const makeAccount = (
+  key: string,
+  saved_doc_count: number,
+  doc_count = saved_doc_count
+) =>
+  new Account({
+    key,
+    updated: new Date("2026-01-01"),
+    doc_count,
+    unread_doc_count: 0,
+    saved_doc_count
+  });
+
+describe("mergeSavedAccounts", () => {
+  it("includes received accounts that have starred mails", () => {
+    const received = [makeAccount("a@x.com", 2), makeAccount("b@x.com", 0)];
+    const result = mergeSavedAccounts(received, []);
+    expect(result.map((e) => e.key)).toEqual(["a@x.com"]);
+  });
+
+  it("includes sent accounts that have starred mails (regression for #568)", () => {
+    // A starred *sent* mail's account lives only in `sent`; before the fix
+    // the Saved view filtered `received` only, so it was unreachable.
+    const sent = [makeAccount("me@x.com", 1)];
+    const result = mergeSavedAccounts([], sent);
+    expect(result.map((e) => e.key)).toEqual(["me@x.com"]);
+    expect(result[0].saved_doc_count).toBe(1);
+  });
+
+  it("merges an account present in both folders into one entry with summed counts", () => {
+    const received = [makeAccount("me@x.com", 2, 5)];
+    const sent = [makeAccount("me@x.com", 3, 4)];
+    const result = mergeSavedAccounts(received, sent);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("me@x.com");
+    expect(result[0].saved_doc_count).toBe(5);
+    expect(result[0].doc_count).toBe(9);
+  });
+
+  it("excludes accounts with no starred mails from either folder", () => {
+    const received = [makeAccount("a@x.com", 0)];
+    const sent = [makeAccount("b@x.com", 0)];
+    expect(mergeSavedAccounts(received, sent)).toEqual([]);
+  });
+
+  it("does not mutate the source account objects", () => {
+    const shared = makeAccount("me@x.com", 2, 5);
+    const sent = [makeAccount("me@x.com", 3, 4)];
+    mergeSavedAccounts([shared], sent);
+    expect(shared.saved_doc_count).toBe(2);
+    expect(shared.doc_count).toBe(5);
+  });
+});

--- a/src/client/Box/components/Accounts/savedAccounts.ts
+++ b/src/client/Box/components/Accounts/savedAccounts.ts
@@ -1,0 +1,29 @@
+import { Account } from "common";
+
+/**
+ * Build the account list for the Saved Mails view. A starred mail can live
+ * in either the received or the sent folder, so the Saved view must union
+ * both — otherwise a starred *sent* mail's account never appears and the
+ * mail is unreachable from the collection it belongs to (#568).
+ *
+ * An address can be both a sent and a received account, so entries are
+ * merged by key (one tag per account) and their saved/doc counts summed,
+ * keeping the sort-by-size ordering correct.
+ */
+export const mergeSavedAccounts = (
+  received: Account[],
+  sent: Account[]
+): Account[] => {
+  const byKey = new Map<string, Account>();
+  for (const account of [...received, ...sent]) {
+    if (!account.saved_doc_count) continue;
+    const existing = byKey.get(account.key);
+    if (existing) {
+      existing.saved_doc_count += account.saved_doc_count;
+      existing.doc_count += account.doc_count;
+    } else {
+      byKey.set(account.key, new Account({ ...account }));
+    }
+  }
+  return [...byKey.values()];
+};

--- a/src/client/Box/components/index.ts
+++ b/src/client/Box/components/index.ts
@@ -33,7 +33,12 @@ export class MailsSynchronizer {
       if (category === Category.NewMails)
         countInAccounts = accountData?.unread_doc_count || 0;
       else if (category === Category.SavedMails)
-        countInAccounts = accountData?.saved_doc_count || 0;
+        // The Saved view spans both folders (#568), so a starred sent mail's
+        // account lives in `sent`, not `received`. Sum saved counts across both.
+        countInAccounts =
+          (accounts.received.find((e) => e.key === account)?.saved_doc_count ||
+            0) +
+          (accounts.sent.find((e) => e.key === account)?.saved_doc_count || 0);
       else countInAccounts = accountData?.doc_count || 0;
 
       const countInMails = mails.reduce((acc, e) => {

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -361,9 +361,9 @@ describe("getMailHeaders — envelope_to in received-branch address condition", 
     // expands to "to_address" at runtime; the static text contains the
     // token, so the test asserts on the template tokens directly.
     const exprMatch = fnSource.match(
-      /addressCondition\s*=\s*options\.sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+      /receivedCondition\s*=\s*`([^`]*)`/
     );
-    if (!exprMatch) throw new Error("addressCondition ternary not found");
+    if (!exprMatch) throw new Error("receivedCondition not found");
     const receivedSql = exprMatch[1];
     expect(receivedSql).toContain("${TO_ADDRESS}");
     expect(receivedSql).toContain("cc_address @>");
@@ -372,10 +372,8 @@ describe("getMailHeaders — envelope_to in received-branch address condition", 
   });
 
   it("sent branch's addressCondition remains from_address only", () => {
-    const exprMatch = fnSource.match(
-      /addressCondition\s*=\s*options\.sent\s*\?\s*`([^`]*)`/
-    );
-    if (!exprMatch) throw new Error("sent branch not found");
+    const exprMatch = fnSource.match(/sentCondition\s*=\s*`([^`]*)`/);
+    if (!exprMatch) throw new Error("sentCondition not found");
     const sentSql = exprMatch[1];
     expect(sentSql).toContain("${FROM_ADDRESS}");
     expect(sentSql).not.toContain("envelope_to");
@@ -556,5 +554,51 @@ describe("buildCriterionClause — BODY/TEXT search the message body (#552)", ()
     expect(frag).toContain("from_text ILIKE");
     expect(frag).toContain("to_text ILIKE");
     expect(frag).toContain("text ILIKE");
+  });
+});
+
+describe("getMailHeaders — saved query spans both folders (#568)", () => {
+  // A starred mail can be either sent or received. A saved query with no
+  // explicit folder must match an account address in EITHER from_address
+  // (sent) or the received to/cc/bcc/envelope_to branch — otherwise a
+  // starred sent mail is unreachable from the Saved view, the client-side
+  // complement of #384's server fix.
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(
+      /export const getMailHeaders[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeaders not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("uses the union (sent OR received) condition when saved && !sent", () => {
+    const exprMatch = fnSource.match(
+      /addressCondition\s*=\s*([\s\S]*?);/
+    );
+    if (!exprMatch) throw new Error("addressCondition assignment not found");
+    const expr = exprMatch[1];
+    // The saved-and-not-sent branch is the union of both folder conditions.
+    expect(expr).toContain("options.saved && !options.sent");
+    expect(expr).toContain("sentCondition} OR ${receivedCondition");
+  });
+
+  it("falls back to the sent-only or received-only condition otherwise", () => {
+    const exprMatch = fnSource.match(
+      /addressCondition\s*=\s*([\s\S]*?);/
+    );
+    if (!exprMatch) throw new Error("addressCondition assignment not found");
+    const expr = exprMatch[1];
+    expect(expr).toContain("options.sent");
+    // Non-union branches reuse the single-folder conditions verbatim.
+    expect(expr).toMatch(/\?\s*sentCondition/);
+    expect(expr).toContain(": receivedCondition");
   });
 });

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -270,9 +270,19 @@ export const getMailHeaders = async (
     // received-branch address expansion in `getAccountStats` (PR #525)
     // so that an account row surfaced by envelope_to still resolves to
     // its mails when the user clicks through.
-    const addressCondition = options.sent
-      ? `${FROM_ADDRESS} @> $2::jsonb`
-      : `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
+    const sentCondition = `${FROM_ADDRESS} @> $2::jsonb`;
+    const receivedCondition = `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
+    // The Saved view is a flat starred collection per account: a starred
+    // mail can be either sent or received, so a saved query with no explicit
+    // folder must span both branches. Without this, a starred *sent* mail is
+    // unreachable from the Saved view — the account address only matches
+    // from_address, never the received to/cc/bcc condition (#568).
+    const addressCondition =
+      options.saved && !options.sent
+        ? `(${sentCondition} OR ${receivedCondition})`
+        : options.sent
+        ? sentCondition
+        : receivedCondition;
     // Select only columns needed for mail headers — excludes html/text/attachments
     // to avoid loading full email bodies into memory for every concurrent request.
     const headerColumns = [


### PR DESCRIPTION
Closes #568

## Problem

The **Saved Mails** view could never display a starred **sent** mail. Its account list was built from `received` only, so a mail starred from the Sent view became unreachable from the Saved collection — even though the star was set and persisted. This is the client-side complement of #384, which fixed the *server* to forward `saved_doc_count` for sent accounts; the data flowed but the client never consumed it.

Two gaps had to close together:
1. **Account list** — the Saved category filtered `received` only, so a sent-saved account never appeared as a tag.
2. **Fetch semantics** — even if a sent account were listed, `GET /api/mails/headers/<account>?saved=1` used the *received* address branch (`to/cc/bcc/envelope_to`), so it returned nothing for an account that only matches on `from_address`.

## Fix

- **`mergeSavedAccounts` (new helper)** — the Saved account list is now the union of received-saved and sent-saved accounts, deduped by key (an address can be both a sent and a received account) with saved/doc counts summed so one tag per account and sort-by-size stays correct. Used by both the Saved account list and the category-switch default-account picker.
- **`MailsSynchronizer`** — the Saved staleness check now sums saved counts across both folders, so a selected sent-saved account isn't treated as count 0.
- **`getMailHeaders`** — a saved query with no explicit folder now spans both branches (`from_address` OR the received `to/cc/bcc/envelope_to` condition). The single-folder `sent`-only and received-only paths are unchanged, preserving #384's envelope_to expansion and the sent branch. This keeps the "Saved is a flat starred collection per account" model: all starred mails for an account, regardless of direction.

## Tests

- `savedAccounts.test.ts` (new) — sent-only account is included (the regression), both-folder account merges to one entry with summed counts, zero-saved accounts excluded, source objects not mutated.
- `mails.test.ts` — updated the existing `getMailHeaders` source-inspection tests to the refactored condition variables and added a block pinning the saved-and-not-sent union branch.
- Full suites green: server 922 pass / 0 fail, client 10 pass / 0 fail. `tsc` clean, eslint clean.

## E2E (live, real app, read-only)

Started the dev server on this branch and drove the UI with Playwright + authenticated API probes, against an account that already has both a starred **sent** mail and a starred **received** mail. Currency/PII redacted — addresses shown as placeholders.

- **API** `/api/mails/accounts` → the sent-saved account `<sent-acct>` carries `saved_doc_count` in the `sent` array (received-saved account `<recv-acct>` in `received`). ✅
- **Server fix** `GET /headers/<sent-acct>?saved=1` → returns the 1 starred sent mail. Read-only DB proof of before/after on the same account: received-only condition returned 0 rows, the union condition returns 1. ✅
- **UI** Saved Mails category → the `<sent-acct>` tag now appears alongside `<recv-acct>` (received-saved still present — no regression). ✅
- **UI** clicking the `<sent-acct>` tag → the starred sent mail renders in the list (reachable from Saved). ✅
- 0 console errors.

No-regression read-only check on the existing saved-**received** accounts: union vs received-only returned identical row counts (a pure recipient address never matches `from_address`).

> Note: the local dev DB's data domain differed from the configured `EMAIL_DOMAIN`, which left the account aggregation empty; ran the UI pass with the domain matched to the dataset (a test-env config detail, orthogonal to this change). The server-fix proof above does not depend on it.
