### PR TITLE
fix(send): normalize sent-mail addresses to lowercase (#573)

### DIFF
--- a/src/server/lib/mails/send.test.ts
+++ b/src/server/lib/mails/send.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+import { parseAddressList } from "./send";
+
+describe("parseAddressList — case normalization (#573)", () => {
+  it("lowercases a single address", () => {
+    expect(parseAddressList("Hoie@Hoie.Kim")).toEqual([
+      { address: "hoie@hoie.kim" }
+    ]);
+  });
+
+  it("splits, trims, and lowercases a comma-separated list", () => {
+    expect(parseAddressList("Alice@X.com,  Bob@Y.COM ")).toEqual([
+      { address: "alice@x.com" },
+      { address: "bob@y.com" }
+    ]);
+  });
+
+  it("drops empty entries", () => {
+    expect(parseAddressList("a@x.com,, , b@x.com")).toEqual([
+      { address: "a@x.com" },
+      { address: "b@x.com" }
+    ]);
+  });
+
+  it("returns an empty list for an empty string", () => {
+    expect(parseAddressList("")).toEqual([]);
+  });
+});
+
+describe("getSentMail — sender address normalization (#573)", () => {
+  // getSentMail builds the *stored* Mail (delivery uses the raw mailToSend via
+  // sendMailgunMail). It hits the DB for UID allocation, so the from-address
+  // lowercasing is pinned by source inspection rather than a live call. A
+  // mixed-case sender must not fragment the Sent account list.
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const source = await fs.readFile(
+      path.join(import.meta.dir, "send.ts"),
+      "utf8"
+    );
+    const match = source.match(/const getSentMail[\s\S]*?\n};/);
+    if (!match) throw new Error("getSentMail not found in send.ts");
+    fnSource = match[0];
+  });
+
+  it("lowercases the constructed from email", () => {
+    expect(fnSource).toMatch(
+      /fromEmail\s*=\s*`\$\{sender\}@\$\{userDomain\}`\.toLowerCase\(\)/
+    );
+  });
+
+  it("builds recipient lists through the lowercasing parseAddressList", () => {
+    expect(fnSource).toContain("parseAddressList(to)");
+    expect(fnSource).not.toMatch(/const parseAddresses\s*=/);
+  });
+});

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -76,6 +76,20 @@ export const sendMail = async (
   }
 };
 
+/**
+ * Split a comma-separated address string into address objects, lowercasing
+ * each address. Mirrors the receive-path normalization in `convertAddressValue`
+ * (receive.ts) so stored addresses group case-insensitively — without this the
+ * send path stored addresses verbatim, fragmenting the per-account list when a
+ * sender/recipient was typed with any uppercase letter.
+ */
+export const parseAddressList = (str: string) =>
+  str
+    .split(",")
+    .map((addr) => addr.trim())
+    .filter(Boolean)
+    .map((address) => ({ address: address.toLowerCase() }));
+
 const getSentMail = async (
   user: SignedUser,
   mailToSend: MailDataToSend,
@@ -87,7 +101,7 @@ const getSentMail = async (
 
   const text = getText(html);
   const userDomain = getUserDomain(username);
-  const fromEmail = `${sender}@${userDomain}`;
+  const fromEmail = `${sender}@${userDomain}`.toLowerCase();
   const attachments = (await getAttachmentsToSave(files)) || [];
 
   const [domainUid, accountUid] = await Promise.all([
@@ -96,13 +110,6 @@ const getSentMail = async (
   ]);
 
   const uid = new MailUid({ domain: domainUid || 0, account: accountUid || 0 });
-
-  const parseAddresses = (str: string) =>
-    str
-      .split(",")
-      .map((addr) => addr.trim())
-      .filter(Boolean)
-      .map((address) => ({ address }));
 
   return new Mail({
     subject,
@@ -115,11 +122,11 @@ const getSentMail = async (
       value: [{ name: senderFullName || undefined, address: fromEmail }],
       text: senderFullName ? `${senderFullName} <${fromEmail}>` : fromEmail
     },
-    to: { value: parseAddresses(to), text: to },
-    cc: !cc ? undefined : { value: parseAddresses(cc), text: cc },
-    bcc: !bcc ? undefined : { value: parseAddresses(bcc), text: bcc },
+    to: { value: parseAddressList(to), text: to },
+    cc: !cc ? undefined : { value: parseAddressList(cc), text: cc },
+    bcc: !bcc ? undefined : { value: parseAddressList(bcc), text: bcc },
     envelopeFrom: [{ name: senderFullName || undefined, address: fromEmail }],
-    envelopeTo: parseAddresses(to),
+    envelopeTo: parseAddressList(to),
     replyTo: {
       value: [{ name: senderFullName || undefined, address: fromEmail }],
       text: fromEmail


### PR DESCRIPTION
Closes #573

## Problem

The **outbound-send path stored email addresses verbatim** (no case-normalization), while the receive path lowercases every address via `convertAddressValue`. Because the Sent account list groups by the **exact** address string (`getAccountStats` does `GROUP BY address`), a mail composed with a non-lowercase sender produced a **duplicate account row** — the same logical address split into two entries (`Hoie` vs `hoie`) with counts that never reconcile. Sender validation permits uppercase, so this is reachable for any new send, not just legacy data.

## Fix (normalize on write — mirrors the receive path)

- `getSentMail`: lowercase the constructed from-email (`` `${sender}@${userDomain}`.toLowerCase() ``).
- Extracted the inline recipient parser into an exported **`parseAddressList`** that lowercases each address (matching `convertAddressValue` in `receive.ts`), used for `to`/`cc`/`bcc`/`envelopeTo`.

Scope is deliberately the **write path only**. The optional "case-insensitive `GROUP BY` + containment" defense-in-depth from the issue is left out — it would have to change grouping and `@>` matching together to avoid orphaning the two legacy rows, which is a larger, separate change. This PR stops new fragmentation at the source; the two pre-existing legacy rows are untouched (no destructive backfill).

**Delivery is unaffected** — `sendMail` dispatches via `sendMailgunMail(username, mailToSend, …)` using the raw user input *before* `getSentMail` runs; the lowercasing only touches the **stored** Mail record that feeds the account list.

## Tests

`send.test.ts` (new):
- `parseAddressList` — lowercases a single address, splits/trims/lowercases a comma list, drops empty entries, handles the empty string.
- `getSentMail` — source check pinning the from-email lowercasing and that recipients route through `parseAddressList` (the function allocates UIDs via the DB, so the from path is pinned by source inspection — consistent with the existing `getMailHeaders` tests in `mails.test.ts`).

Full server suite green: **928 pass / 0 fail**. `tsc` clean, eslint clean.

## E2E note

This path **cannot be safely driven end-to-end**: exercising it means actually sending mail through Mailgun and writing a record. Per the repo's E2E guidance I ran the assertions I can — the `parseAddressList` unit tests prove the normalization behaviorally, and the source check pins the from-email path. The fragmentation symptom and root cause were verified live in the issue (#573) against a prod snapshot.
