### PR TITLE
fix(imap): FETCH ENVELOPE uses the RFC-correct formatEnvelope (#580)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1,12 +1,17 @@
 /**
- * Tests for fetch-helpers.ts — getRequestedFields column mapping.
- * Covers inbox #542: FETCH FLAGS must request the `answered` column so the
- * \Answered flag round-trips (STORE writes it, FETCH must read it back).
+ * Tests for fetch-helpers.ts.
+ *  - getRequestedFields column mapping. Covers inbox #542: FETCH FLAGS must
+ *    request the `answered` column so the \Answered flag round-trips (STORE
+ *    writes it, FETCH must read it back).
+ *  - buildFetchResponsePart FETCH response construction. Covers inbox #580:
+ *    the ENVELOPE case must emit the RFC 3501 §7.4.2 10-field envelope (From
+ *    in slot 3), not the dropped-From 11-field shape.
  */
 
 import { describe, it, expect, mock } from "bun:test";
 
-// fetch-helpers imports `logger` from "server"; stub it.
+// fetch-helpers only pulls `logger` from the server barrel; stub it so the
+// import does not drag in the full server (DB, etc.).
 mock.module("server", () => ({
   logger: {
     warn: mock(() => {}),
@@ -16,7 +21,9 @@ mock.module("server", () => ({
   }
 }));
 
-import { getRequestedFields } from "./fetch-helpers";
+import { getRequestedFields, buildFetchResponsePart } from "./fetch-helpers";
+import { formatEnvelope } from "./util";
+import type { MailType } from "common";
 
 describe("getRequestedFields", () => {
   describe("FLAGS", () => {
@@ -48,5 +55,54 @@ describe("getRequestedFields", () => {
     const fields = getRequestedFields([{ type: "FLAGS" }, { type: "INTERNALDATE" }]);
     expect(fields.has("answered")).toBe(true);
     expect(fields.has("date")).toBe(true);
+  });
+});
+
+describe("buildFetchResponsePart ENVELOPE", () => {
+  const mail: Partial<MailType> = {
+    date: "2024-01-15T10:30:00Z",
+    subject: "Hello",
+    from: {
+      text: "John Doe <john@example.com>",
+      value: [{ name: "John Doe", address: "john@example.com" }]
+    },
+    to: {
+      text: "Jane Roe <jane@example.com>",
+      value: [{ name: "Jane Roe", address: "jane@example.com" }]
+    },
+    messageId: "<test@example.com>"
+  };
+
+  it("delegates to the RFC-correct formatEnvelope", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "ENVELOPE" },
+      "doc-1",
+      "INBOX"
+    );
+    expect(part).toEqual({
+      type: "simple",
+      content: `ENVELOPE ${formatEnvelope(mail)}`
+    });
+  });
+
+  it("places From in slot 3, not slot 6, and keeps message-id in slot 10", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "ENVELOPE" },
+      "doc-1",
+      "INBOX"
+    );
+    if (part?.type !== "simple") throw new Error("expected simple part");
+
+    // ENVELOPE (date subject (from) (sender) (reply-to) (to) (cc) (bcc)
+    //           in-reply-to message-id) — RFC 3501 §7.4.2, exactly 10 fields.
+    const content = part.content;
+    // Slot 3 (From) sits immediately after the subject — the buggy shape put
+    // `NIL NIL NIL` there and pushed From into slot 6 (the To column).
+    expect(content).toContain('"Hello" (("John Doe"');
+    expect(content).not.toContain('"Hello" NIL NIL NIL');
+    // message-id sits in the envelope (slot 10), not dropped to NIL.
+    expect(content).toContain('"<test@example.com>"');
   });
 });

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -9,8 +9,8 @@ import { MailType } from "common";
 import { logger } from "server";
 import {
   encodeText,
-  formatAddressList,
   formatBodyStructure,
+  formatEnvelope,
   formatFlags,
   formatHeaders,
   formatInternalDate,
@@ -34,22 +34,6 @@ import {
 export type FetchResponsePart =
   | { type: "simple"; content: string }
   | { type: "literal"; content: string; header: string; length: number };
-
-// ---------------------------------------------------------------------------
-// Envelope
-// ---------------------------------------------------------------------------
-
-export function buildEnvelope(mail: Partial<MailType>): string {
-  const dateString = new Date(mail.date!).toUTCString();
-  const subject = (mail.subject || "").replace(/"/g, '\\"');
-  const from = formatAddressList(mail.from?.value);
-  const to = formatAddressList(mail.to?.value);
-  const cc = formatAddressList(mail.cc?.value);
-  const bcc = formatAddressList(mail.bcc?.value);
-  const messageId = mail.messageId || "<unknown@local>";
-
-  return `("${dateString}" "${subject}" NIL NIL NIL (${from}) (${to}) (${cc}) (${bcc}) NIL "${messageId}")`;
-}
 
 // ---------------------------------------------------------------------------
 // Body content extraction
@@ -330,7 +314,7 @@ export async function buildFetchResponsePart(
     }
 
     case "ENVELOPE": {
-      const envelope = buildEnvelope(mail);
+      const envelope = formatEnvelope(mail);
       return { type: "simple", content: `ENVELOPE ${envelope}` };
     }
 


### PR DESCRIPTION
## Problem

The IMAP `FETCH ... ENVELOPE` case called `buildEnvelope`, which emitted **11 fields** in the wrong order — RFC 3501 §7.4.2 defines ENVELOPE as exactly **10 fields**. Effect on every IMAP client (the standard message-list FETCH item): blank From column, the sender misplaced into the To column, NIL message-id, and a structurally malformed list that strict parsers reject.

A correct, unit-tested `formatEnvelope` already lived in `util.ts` but **nothing called it** — the live FETCH path was wired to the buggy `buildEnvelope`, which had zero coverage. Closes #580.

## Fix

- Point the `ENVELOPE` case at `formatEnvelope` (RFC-correct 10-field order, already tested).
- Delete the orphaned `buildEnvelope` (+ its now-unused `formatAddressList` import).
- Add a `buildFetchResponsePart` ENVELOPE-case test: asserts From sits in slot 3 (not slot 6), message-id in slot 10, and that the output equals `formatEnvelope` — the live path had no coverage before.

2 files, +2/−18 source + a new test file.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors
- [x] `bun test src/server` — **922 pass / 0 fail** (new test included; no `mock.module("server")` bleed into other suites)
- [x] New regression test **fails on `upstream/main`** (buggy 11-field shape), **passes on the fix** — verified by stash/pop.
- [x] **Live IMAP E2E** — booted Postgres + the real IMAP server on a high port against the local DB, `LOGIN admin`, `SELECT INBOX` (EXISTS = 11k+ messages), `UID FETCH 1:1 (ENVELOPE)`, read-only. Same message, fix vs `upstream/main` baseline. **Structure verbatim, identities redacted:**
  - **Baseline (buggy):** `("<date>" "<subject>" NIL NIL NIL (<from-group>) (<to-group>) (NIL) (NIL) NIL "<message-id>")` — **11 fields**; slots 3/4/5 = `NIL NIL NIL`, real From lands in slot 6 (the To column), message-id pushed to an illegal 11th field.
  - **Fix:** `("<date>" "<subject>" (<from-group>) (<sender-group>) (NIL) (<to-group>) (NIL) (NIL) NIL "<message-id>")` — **10 fields**; From populated in slot 3, the recipient in slot 6 (To), message-id back in slot 10.
  - The shift is exactly the issue’s symptom: From blank → populated, sender-in-To → real recipient in To, message-id slot-11 → slot-10.

Non-secret note: no UI/browser screen consumes this path (it is IMAP-protocol output), so verification is the raw IMAP wire, per the issue’s own reproduction method.