### PR TITLE
fix(imap): partial BODY[...] fetch literal must equal emitted octets

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -21,8 +21,9 @@ mock.module("server", () => ({
   }
 }));
 
-import { getRequestedFields, buildFetchResponsePart } from "./fetch-helpers";
+import { getRequestedFields, buildFetchResponsePart, buildBodyResponsePart } from "./fetch-helpers";
 import { formatEnvelope } from "./util";
+import { BodyFetch } from "./types";
 import type { MailType } from "common";
 
 describe("getRequestedFields", () => {
@@ -104,5 +105,53 @@ describe("buildFetchResponsePart ENVELOPE", () => {
     expect(content).not.toContain('"Hello" NIL NIL NIL');
     // message-id sits in the envelope (slot 10), not dropped to NIL.
     expect(content).toContain('"<test@example.com>"');
+  });
+});
+
+describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", () => {
+  // A long text body so a <0.10> partial is a genuine sub-range slice.
+  const mail = {
+    messageId: "msg-partial-test",
+    text: "The quick brown fox jumps over the lazy dog, then does it all again.",
+  };
+
+  it("announces a literal length equal to the octets actually emitted", async () => {
+    const fetch: BodyFetch = {
+      type: "BODY",
+      peek: false,
+      section: { type: "TEXT" },
+      partial: { start: 0, length: 10 },
+    };
+
+    const part = await buildBodyResponsePart(mail, fetch, "doc-1", "INBOX");
+
+    expect(part).not.toBeNull();
+    expect(part!.type).toBe("literal");
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    // The {N} literal header must match the bytes that follow it on the wire;
+    // before the fix the partial branch appended an uncounted CRLF, advertising
+    // {10} while emitting 12 octets and desyncing the client's parse.
+    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    // A <0.10> partial returns exactly 10 octets — no trailing CRLF.
+    expect(part!.length).toBe(10);
+    expect(part!.header).toContain("<0.10>");
+    expect(part!.content.endsWith("\r\n")).toBe(false);
+  });
+
+  it("matches literal length to emitted octets at a non-zero offset too", async () => {
+    const fetch: BodyFetch = {
+      type: "BODY",
+      peek: false,
+      section: { type: "TEXT" },
+      partial: { start: 5, length: 8 },
+    };
+
+    const part = await buildBodyResponsePart(mail, fetch, "doc-1", "INBOX");
+
+    expect(part).not.toBeNull();
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    expect(part!.length).toBe(8);
+    expect(part!.header).toContain("<5.8>");
   });
 });

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -267,7 +267,11 @@ export async function buildBodyResponsePart(
       length = Buffer.byteLength(finalContent, "utf8");
     }
     header += `<${start}.${Math.min(partialLength, length)}>`;
-    finalContent += "\r\n";
+    // A partial fetch returns exactly the requested substring — no trailing
+    // CRLF. (The non-partial branch below appends one and recounts `length`;
+    // doing that here would emit 2 octets more than the `{length}` literal
+    // and the `<start.length>` annotation both advertise, desyncing clients
+    // that read exactly `length` octets.)
   } else if (section.type !== "HEADER") {
     finalContent += "\r\n";
     length = Buffer.byteLength(finalContent, "utf8");


### PR DESCRIPTION
Closes #581

## Problem

A partial body fetch (`FETCH ... BODY[section]<start.length>`) announced a `{N}` literal byte count that was **2 bytes short of the octets actually written**. `buildBodyResponsePart` (`src/server/lib/imap/fetch-helpers.ts`) appended a trailing `
` to the partial slice **without recomputing `length`**:

```ts
header += `<${start}.${Math.min(partialLength, length)}>`;
finalContent += "
";   // length NOT updated → literal undercounts by 2
```

`writeFetchResponse` then emits `{length}
${content}` — so for `BODY[TEXT]<0.10>` it advertised `{10}` but wrote 12 octets. A conforming client reads exactly 10 literal octets, then finds a stray `
` where it expects the next token, desyncing the parse of that response and every later response on the connection.

The non-partial branch already recomputes `length` after its CRLF append; the partial branch was the outlier.

## Fix

Don't append a CRLF to partial slices at all. A `<start.length>` partial returns exactly the requested substring, so the `<0.10>` annotation, the `{10}` literal, and the emitted octets now all agree (10/10/10) — the RFC 3501 behavior. The non-partial branch is untouched and stays self-consistent.

(Chose this over "recompute `length` to 12": that would still leave the `<0.10>` partial-length annotation contradicting a 12-byte literal. Returning exactly the requested octets is both internally consistent and RFC-correct.)

## Test plan

- Added `buildBodyResponsePart — partial fetch literal length (#581)` with two cases (offset 0 and a non-zero offset) asserting `Buffer.byteLength(content) === length` and exact octet counts. **Both fail on the pre-fix code** (byteLength 12 vs advertised 10) and pass after.
- `bun test src/server/lib/imap/fetch-helpers.test.ts` → 6 pass. `session-utils` + `fetch-parsers` + `fetch-helpers` together → 78 pass.
- `bun run typecheck` clean; `eslint` clean on the changed code (one pre-existing unused-`logger` warning on `main`, untouched here).
- Full `src/server/lib/imap/` run shows 4 pre-existing `idle-manager.test.ts` failures (a known `mock.module` process-global isolation artifact on `main`, reproduced on a clean checkout — unrelated to this change); my files add 2 passing tests.