### PR TITLE
fix(test): handler-idle mock.module leak breaks idle-manager suite on CI

### DIFF
--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -10,29 +10,37 @@
  *      the pipelined command was silently dropped.
  */
 
-import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
+import { describe, it, expect, spyOn, beforeEach, afterAll } from "bun:test";
 import { EventEmitter } from "events";
+// idle-manager ↔ push ↔ server-barrel form a runtime import cycle: idle-manager
+// imports the `server` barrel (for `logger`), which re-exports push.ts, whose
+// top-level `createPush(realIdleManager)` needs the idleManager singleton.
+// Importing push first forces the graph to initialize in production order so the
+// singleton is constructed before we spy on it. (Same guard as idle-manager.test.ts.)
+import "../push";
+import { idleManager } from "./idle-manager";
 
-// Capture the real `./idle-manager` module BEFORE the `mock.module`
-// override below so `afterAll` can restore it. `mock.module` is
-// process-global; without the restore, a subsequent test file in the
-// same `bun test` process that imports `./idle-manager` (notably the
-// IDLE-heartbeat manager suite landing in this same directory) sees the
-// stubbed two-method `{ idleManager }` shape and loses the real
-// `idleManager` singleton (the module's only export).
-const realIdleManagerModule = await import("./idle-manager");
-
-const mockAddIdleSession = mock(() => {});
-const mockRemoveIdleSession = mock(() => {});
-mock.module("./idle-manager", () => ({
-  idleManager: {
-    addIdleSession: mockAddIdleSession,
-    removeIdleSession: mockRemoveIdleSession,
-  },
-}));
+// session.ts registers/unregisters IDLE sessions on the real `idleManager`
+// singleton. Spy on just those two methods (restored in afterAll) rather than
+// `mock.module`-ing the whole module: `mock.module` is process-global, and
+// replacing `./idle-manager` with a partial `{ idleManager }` stub drops the
+// singleton's other methods — notably `shutdown()` — which then breaks
+// idle-manager.test.ts when it runs later in the same `bun test` process
+// (TypeError: idleManager.shutdown is not a function). The previous
+// spread-restore in afterAll did not reliably reinstate the binding for that
+// sibling file. spyOn mutates the live singleton session.ts already holds and
+// reverts cleanly via mockRestore.
+const mockAddIdleSession = spyOn(idleManager, "addIdleSession").mockImplementation(
+  () => {}
+);
+const mockRemoveIdleSession = spyOn(
+  idleManager,
+  "removeIdleSession"
+).mockImplementation(() => {});
 
 afterAll(() => {
-  mock.module("./idle-manager", () => ({ ...realIdleManagerModule }));
+  mockAddIdleSession.mockRestore();
+  mockRemoveIdleSession.mockRestore();
 });
 
 import { ImapRequestHandler } from "./handler";


### PR DESCRIPTION
## Problem

`bun test src/server` is currently **red on `main`** (and therefore on every open PR rebased onto it): the 4 `IdleManager.notifyNewMail mailbox filtering` tests fail with

```
TypeError: idleManager.shutdown is not a function. (In 'idleManager.shutdown()', 'idleManager.shutdown' is undefined)
```

They pass in isolation but fail in the full suite — the signature of a cross-file `mock.module` leak.

## Root cause

`handler-idle.test.ts` replaced the entire `./idle-manager` module with a partial stub exposing only two methods:

```ts
mock.module("./idle-manager", () => ({
  idleManager: { addIdleSession, removeIdleSession },
}));
```

Bun's `mock.module` is **process-global**. When `idle-manager.test.ts` runs later in the same `bun test` process, its `idleManager` import resolves to that two-method stub, which has no `shutdown()` — so its `beforeEach`/`afterAll` blow up. The existing `afterAll` spread-restore (`mock.module(..., () => ({ ...realIdleManagerModule }))`) did not reliably reinstate the binding for the sibling file.

The collision only became active once both suites landed on `main` — `handler-idle.test.ts` (IDLE termination) and `idle-manager.test.ts` (the notifyNewMail mailbox filter) — turning CI red across the queue.

## Fix

Switch from whole-module `mock.module` to `spyOn` on the real singleton's two methods, restored via `mockRestore()` in `afterAll` — the same pattern that fixed the smtp / auth-rate-limit leak (merged PR #576). `spyOn` mutates the live `idleManager` binding that `session.ts` already holds and reverts cleanly, leaving `shutdown()` and the rest of the singleton intact for sibling files.

Also added the `import "../push"` cycle-busting guard that `idle-manager.test.ts` already uses: importing `./idle-manager` directly (now required for `spyOn`) otherwise triggers the idle-manager ↔ push ↔ server-barrel runtime import cycle (`createPush(realIdleManager)` before the singleton is constructed).

## Scope

One file: `src/server/lib/imap/handler-idle.test.ts`. Test-only; no production code touched. The two stubbed methods were never asserted (`toHaveBeenCalled`), only used as no-ops to keep handler tests off the real singleton, so behavior is unchanged.

## Verification

- `bunx tsc --noEmit`: clean
- `bun test handler-idle.test.ts idle-manager.test.ts` (the leak pair, together): 8 pass / 0 fail
- `bun test src/server` (full suite): **952 pass, 0 fail** (was 948 pass / 4 fail on `main`)

E2E: test-isolation fix on the IMAP IDLE path; no UI surface. Verified at the suite level as above.