### PR TITLE
fix(imap): SEARCH accepts quoted-string arguments (#586)

### DIFF
--- a/src/server/lib/imap/parsers/search-parsers.test.ts
+++ b/src/server/lib/imap/parsers/search-parsers.test.ts
@@ -214,6 +214,60 @@ describe("parseSearchCriteria", () => {
     });
   });
 
+  // RFC 3501 §6.4.4 / §9: search-key arguments are astring, which may be a
+  // quoted string. Every MUA (Thunderbird, Apple Mail, …) quotes its argument,
+  // so a quoted-string value must parse, not return BAD.
+  describe("quoted-string criteria", () => {
+    it("parses SUBJECT with a quoted single-word value", () => {
+      const c = ctx('SUBJECT "order"');
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({ type: "SUBJECT", value: "order" });
+    });
+
+    it("parses SUBJECT with a quoted multi-word phrase", () => {
+      const c = ctx('SUBJECT "order confirmation"');
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({
+        type: "SUBJECT",
+        value: "order confirmation",
+      });
+    });
+
+    it("parses FROM with a quoted value", () => {
+      const c = ctx('FROM "alice@example.com"');
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({
+        type: "FROM",
+        value: "alice@example.com",
+      });
+    });
+
+    it("parses BODY/TEXT with quoted phrases", () => {
+      expect(parseSearchCriteria(ctx('BODY "two words"')).value?.[0]).toEqual({
+        type: "BODY",
+        value: "two words",
+      });
+      expect(parseSearchCriteria(ctx('TEXT "two words"')).value?.[0]).toEqual({
+        type: "TEXT",
+        value: "two words",
+      });
+    });
+
+    it("parses HEADER with quoted field and quoted value", () => {
+      const c = ctx('HEADER "Message-Id" "<abc@host>"');
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({
+        type: "HEADER",
+        field: "Message-Id",
+        value: "<abc@host>",
+      });
+    });
+  });
+
   describe("size criteria", () => {
     it("parses LARGER with size", () => {
       const c = ctx("LARGER 1000");

--- a/src/server/lib/imap/parsers/search-parsers.ts
+++ b/src/server/lib/imap/parsers/search-parsers.ts
@@ -10,6 +10,7 @@ import {
   parseDate,
   parseNumber,
   parseSequenceSet,
+  parseString,
   skipWhitespace
 } from "./primitive-parsers";
 
@@ -231,7 +232,7 @@ export const parseSearchCriteria = (
           break;
         case "FROM":
           skipWhitespace(context);
-          const fromValue = parseAtom(context);
+          const fromValue = parseString(context);
           if (fromValue.success) {
             criteria.push({
               type: "FROM",
@@ -247,7 +248,7 @@ export const parseSearchCriteria = (
           break;
         case "TO":
           skipWhitespace(context);
-          const toValue = parseAtom(context);
+          const toValue = parseString(context);
           if (toValue.success) {
             criteria.push({
               type: "TO",
@@ -263,7 +264,7 @@ export const parseSearchCriteria = (
           break;
         case "CC":
           skipWhitespace(context);
-          const ccValue = parseAtom(context);
+          const ccValue = parseString(context);
           if (ccValue.success) {
             criteria.push({
               type: "CC",
@@ -279,7 +280,7 @@ export const parseSearchCriteria = (
           break;
         case "BCC":
           skipWhitespace(context);
-          const bccValue = parseAtom(context);
+          const bccValue = parseString(context);
           if (bccValue.success) {
             criteria.push({
               type: "BCC",
@@ -295,7 +296,7 @@ export const parseSearchCriteria = (
           break;
         case "SUBJECT":
           skipWhitespace(context);
-          const subjectValue = parseAtom(context);
+          const subjectValue = parseString(context);
           if (subjectValue.success) {
             criteria.push({
               type: "SUBJECT",
@@ -311,7 +312,7 @@ export const parseSearchCriteria = (
           break;
         case "BODY":
           skipWhitespace(context);
-          const bodyValue = parseAtom(context);
+          const bodyValue = parseString(context);
           if (bodyValue.success) {
             criteria.push({
               type: "BODY",
@@ -327,7 +328,7 @@ export const parseSearchCriteria = (
           break;
         case "TEXT":
           skipWhitespace(context);
-          const textValue = parseAtom(context);
+          const textValue = parseString(context);
           if (textValue.success) {
             criteria.push({
               type: "TEXT",
@@ -343,9 +344,9 @@ export const parseSearchCriteria = (
           break;
         case "HEADER":
           skipWhitespace(context);
-          const headerField = parseAtom(context);
+          const headerField = parseString(context);
           skipWhitespace(context);
-          const headerValue = parseAtom(context);
+          const headerValue = parseString(context);
           if (headerField.success && headerValue.success) {
             criteria.push({
               type: "HEADER",


### PR DESCRIPTION
## Problem

`SEARCH` / `UID SEARCH` rejected any search key whose argument was a **quoted string** with `BAD Invalid search criteria`. Since RFC 3501 requires quoting for any value containing a space, **every multi-word search failed**, and clients that quote even single-word arguments (Thunderbird, Apple Mail, and most MUAs) got a hard `BAD` instead of results.

Closes #586.

## Root cause

The value reads for `FROM`/`TO`/`CC`/`BCC`/`SUBJECT`/`BODY`/`TEXT` and both the field and value of `HEADER` in `parsers/search-parsers.ts` called `parseAtom`, which by definition breaks on `"` (`primitive-parsers.ts:28`). When the argument starts with `"`, `position === start` → the value parse fails → the whole criteria parse fails → the handler emits `BAD`.

## Fix

Swap `parseAtom` → `parseString` for those **value** reads only. `parseString` (`primitive-parsers.ts:118`) dispatches to `parseQuotedString` when the next char is `"` and otherwise falls back to `parseAtom`, so unquoted single-token searches keep working unchanged while quoted arguments start parsing. The criteria **keyword** itself still uses `parseAtom`. Multi-word values flow into the existing `ILIKE` substring match downstream, giving the RFC-correct phrase search — no downstream change needed.

Net: 1 source file (+9 `parseString` value reads, +1 import) + 5 regression tests.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` (changed files) — clean
- [x] `bun test src/server/lib/imap/parsers/search-parsers.test.ts` — 50 pass / 0 fail. New `quoted-string criteria` block (5 tests: SUBJECT quoted single/phrase, FROM quoted, BODY/TEXT quoted, HEADER quoted field+value) **fails 5/5 on `upstream/main`, passes on this branch** (stash-verified).
- [x] `bun test src/server` — 954 pass / 4 fail. The 4 fails are the pre-existing `IdleManager.notifyNewMail` cross-test `mock.module` leak (fails identically on clean `upstream/main`; passes in isolation) being fixed by the open PR #585 — **not introduced here** (this branch is 949→954 pass, zero new failures).
- [x] **Live-IMAP E2E** — booted the real IMAP server on a high port against the local DB, `LOGIN admin`, `SELECT INBOX` (`* 11322 EXISTS`), read-only `UID SEARCH` (SEARCH does not mutate). Fix vs `upstream/main` baseline, same server/data:
  - `UID SEARCH SUBJECT order` (unquoted control): baseline **OK 813 hits**, fix **OK 813 hits** — unchanged.
  - `UID SEARCH SUBJECT "order"` (quoted single word): baseline **BAD Invalid search criteria**, fix **OK 813 hits** (identical set to the unquoted control).
  - `UID SEARCH SUBJECT "order confirmation"` (quoted phrase): baseline **BAD**, fix **OK 13 hits** (correct narrower phrase subset of the 813).
  - `UID SEARCH HEADER "Subject" "order"` (quoted field + value): baseline **BAD**, fix **OK 813 hits**.
  - Exactly the issue's reproduction resolved: every quoted form went BAD→OK while the unquoted control is byte-for-byte unchanged.

No browser UI consumes the raw IMAP SEARCH path, so the live IMAP wire is the correct verification surface (per CLAUDE.md's "drive the real path when E2E can't reach via browser").