### PR TITLE
fix(imap): partial BODY[...] literal length must match emitted octets

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -16,7 +16,8 @@ mock.module("server", () => ({
   }
 }));
 
-import { getRequestedFields } from "./fetch-helpers";
+import { getRequestedFields, buildBodyResponsePart } from "./fetch-helpers";
+import { BodyFetch } from "./types";
 
 describe("getRequestedFields", () => {
   describe("FLAGS", () => {
@@ -48,5 +49,53 @@ describe("getRequestedFields", () => {
     const fields = getRequestedFields([{ type: "FLAGS" }, { type: "INTERNALDATE" }]);
     expect(fields.has("answered")).toBe(true);
     expect(fields.has("date")).toBe(true);
+  });
+});
+
+// inbox #581: a partial BODY[...]<start.length> fetch must announce a literal
+// `{N}` equal to the octets actually emitted. The bug appended a trailing CRLF
+// to the partial slice without recomputing `length`, so `{N}` was 2 bytes short
+// of the content — desyncing any client that reads exactly N literal octets.
+describe("buildBodyResponsePart partial literal length (#581)", () => {
+  // Text-only mail → BODY[TEXT] is base64(text)+CRLF, long enough to slice.
+  const mail = {
+    text: "The quick brown fox jumps over the lazy dog, twice over."
+  };
+  const textFetch = (partial?: { start: number; length: number }): BodyFetch => ({
+    type: "BODY",
+    peek: false,
+    section: { type: "TEXT" },
+    partial
+  });
+
+  it("literal length equals emitted octets for a mid-body partial slice", async () => {
+    const part = await buildBodyResponsePart(mail, textFetch({ start: 0, length: 10 }), "doc1", "INBOX");
+    expect(part?.type).toBe("literal");
+    if (part?.type !== "literal") throw new Error("expected literal");
+    // The core invariant the bug violated: {N} === actual octet count.
+    expect(Buffer.byteLength(part.content, "utf8")).toBe(part.length);
+    // A <0.10> partial returns exactly 10 octets — no stray trailing CRLF.
+    expect(part.length).toBe(10);
+    expect(part.content.endsWith("\r\n")).toBe(false);
+  });
+
+  it("literal length equals emitted octets for a non-zero start slice", async () => {
+    const part = await buildBodyResponsePart(mail, textFetch({ start: 4, length: 6 }), "doc1", "INBOX");
+    if (part?.type !== "literal") throw new Error("expected literal");
+    expect(Buffer.byteLength(part.content, "utf8")).toBe(part.length);
+    expect(part.length).toBe(6);
+  });
+
+  it("literal length equals emitted octets when the partial covers the whole body", async () => {
+    const part = await buildBodyResponsePart(mail, textFetch({ start: 0, length: 100000 }), "doc1", "INBOX");
+    if (part?.type !== "literal") throw new Error("expected literal");
+    expect(Buffer.byteLength(part.content, "utf8")).toBe(part.length);
+  });
+
+  it("non-partial TEXT fetch still appends and counts the trailing CRLF (regression)", async () => {
+    const part = await buildBodyResponsePart(mail, textFetch(), "doc1", "INBOX");
+    if (part?.type !== "literal") throw new Error("expected literal");
+    expect(Buffer.byteLength(part.content, "utf8")).toBe(part.length);
+    expect(part.content.endsWith("\r\n")).toBe(true);
   });
 });

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -283,7 +283,10 @@ export async function buildBodyResponsePart(
       length = Buffer.byteLength(finalContent, "utf8");
     }
     header += `<${start}.${Math.min(partialLength, length)}>`;
-    finalContent += "\r\n";
+    // A `<start.length>` partial returns exactly the requested octets — no
+    // trailing CRLF. (The non-partial branch appends one and recounts `length`;
+    // appending here without recounting would make the announced literal `{N}`
+    // two bytes short of the octets emitted, desyncing the client parse.)
   } else if (section.type !== "HEADER") {
     finalContent += "\r\n";
     length = Buffer.byteLength(finalContent, "utf8");


### PR DESCRIPTION
## Problem

A partial body fetch (`FETCH ... BODY[...]<start.length>`) announced a literal byte count 2 bytes short of the octets actually sent. `buildBodyResponsePart` (`src/server/lib/imap/fetch-helpers.ts`) appended a trailing `\r\n` to the partial slice **without recomputing the literal `length`**, so the `{N}` header undercounted by the CRLF. A client that reads exactly `N` literal octets (as the protocol requires) was then left with a stray `\r\n` in the stream, desyncing the parse of that response and every later response on the connection.

The non-partial branch already recomputes `length` after its CRLF append — the partial branch was the outlier that forgot to.

Closes #581

## Fix

A `<start.length>` partial returns exactly the requested octets, so the partial branch no longer appends a CRLF at all (rather than appending-and-recounting). The non-partial branch is unchanged. One-line removal + clarifying comment.

## Tests

Added `buildBodyResponsePart` unit coverage (there was none) pinning the core invariant the bug violated — `{N} == Buffer.byteLength(content)` — across four cases:
- mid-body partial slice (`<0.10>`): returns exactly 10 octets, no trailing CRLF
- non-zero start slice (`<4.6>`): exactly 6 octets
- partial that covers the whole body (`<0.100000>`)
- non-partial `BODY[TEXT]` (regression): still appends and counts the trailing CRLF

`bun test src/server/lib/imap/fetch-helpers.test.ts` → 8 pass. Typecheck clean.

## E2E (live IMAP server)

Started the IMAP server (`IMAP_PORT=21433`), logged in as admin, `SELECT INBOX` (11322 messages), and issued a partial fetch over a raw IMAP socket:

```
C: a3 FETCH 1 (BODY[TEXT]<0.10>)
S: * 1 FETCH (BODY[TEXT]<0.10> {10}\r\n--boundary)\r\n
S: a3 OK FETCH completed
```

The announced literal is `{10}` and exactly **10** octets (`--boundary`, a structural MIME token) follow before the closing `)` — no stray CRLF. Before the fix this same fetch emitted 12 octets (`--boundary\r\n`) after a `{10}` header, which is the desync the issue reported. Verified programmatically: the two characters immediately after the N announced octets are `)\r` (response close), not body bytes.