### PR TITLE
fix(imap): normalize descending FETCH/STORE sequence ranges (RFC 3501 §9)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1,13 +1,12 @@
 /**
  * Tests for fetch-helpers.ts.
  *  - getRequestedFields column mapping. Covers inbox #542 (FETCH FLAGS must
- *    request the `answered` column so the \Answered flag round-trips) and
- *    inbox #587 (RFC822 / RFC822.HEADER / RFC822.TEXT alias BODY[] /
- *    BODY[HEADER] / BODY[TEXT] per RFC 3501 §6.4.5 — must request the same
- *    columns and emit the same bytes as their BODY[...] equivalents).
+ *    request the `answered` column so the \Answered flag round-trips).
  *  - buildFetchResponsePart FETCH response construction. Covers inbox #580:
  *    the ENVELOPE case must emit the RFC 3501 §7.4.2 10-field envelope (From
  *    in slot 3), not the dropped-From 11-field shape.
+ *  - convertSequenceSet normalization. Covers inbox #582: a descending
+ *    seq/UID range like `3:1` must resolve the same as `1:3` (RFC 3501 §9).
  */
 
 import { describe, it, expect, mock } from "bun:test";
@@ -23,9 +22,14 @@ mock.module("server", () => ({
   }
 }));
 
-import { getRequestedFields, buildFetchResponsePart, buildBodyResponsePart } from "./fetch-helpers";
+import {
+  getRequestedFields,
+  buildFetchResponsePart,
+  buildBodyResponsePart,
+  convertSequenceSet,
+} from "./fetch-helpers";
 import { formatEnvelope } from "./util";
-import { BodyFetch } from "./types";
+import { BodyFetch, SequenceSet } from "./types";
 import type { MailType } from "common";
 
 describe("getRequestedFields", () => {
@@ -252,5 +256,50 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
     expect(part!.length).toBe(8);
     expect(part!.header).toContain("<5.8>");
+  });
+});
+
+// inbox #582: RFC 3501 §9 — a seq/UID range is order-independent, so `3:1` must
+// resolve to the same set as `1:3`. The unnormalized version passed the raw
+// endpoints into a `uid >= start AND uid <= end` predicate, so a descending
+// range produced `>= 3 AND <= 1` → matched nothing (FETCH empty / STORE NO).
+const MAX = Number.MAX_SAFE_INTEGER; // the parser's expansion of `*`
+const seqSet = (ranges: { start: number; end?: number }[]): SequenceSet => ({
+  type: "sequence",
+  ranges
+});
+
+describe("convertSequenceSet normalizes descending ranges (#582)", () => {
+  it("flips a descending range to ascending (3:1 ≡ 1:3)", () => {
+    expect(convertSequenceSet(seqSet([{ start: 3, end: 1 }]))).toEqual([
+      { start: 1, end: 3 }
+    ]);
+  });
+
+  it("leaves an ascending range unchanged (1:3)", () => {
+    expect(convertSequenceSet(seqSet([{ start: 1, end: 3 }]))).toEqual([
+      { start: 1, end: 3 }
+    ]);
+  });
+
+  it("normalizes *:1 (MAX:1) to 1:MAX so it covers the whole mailbox", () => {
+    expect(convertSequenceSet(seqSet([{ start: MAX, end: 1 }]))).toEqual([
+      { start: 1, end: MAX }
+    ]);
+  });
+
+  it("keeps a single number as a unit range (end defaults to start)", () => {
+    expect(convertSequenceSet(seqSet([{ start: 5 }]))).toEqual([
+      { start: 5, end: 5 }
+    ]);
+  });
+
+  it("normalizes each range independently in a multi-range set", () => {
+    expect(
+      convertSequenceSet(seqSet([{ start: 5, end: 2 }, { start: 7, end: 9 }]))
+    ).toEqual([
+      { start: 2, end: 5 },
+      { start: 7, end: 9 }
+    ]);
   });
 });

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -243,7 +243,15 @@ export function addBodyFields(
 export function convertSequenceSet(
   sequenceSet: import("./types").SequenceSet
 ): { start: number; end: number }[] {
-  return sequenceSet.ranges.map(({ start, end = start }) => ({ start, end }));
+  // RFC 3501 §9: a seq/UID range is order-independent — `3:1` ≡ `1:3`. The
+  // wildcard `*` is already expanded to MAX_SAFE_INTEGER by the parser, so
+  // normalizing min/max here (the single resolution point shared by FETCH and
+  // STORE) covers descending ranges like `3:1`, `5:1`, and `*:1` without the
+  // empty `uid >= 3 AND uid <= 1` predicate they would otherwise produce.
+  return sequenceSet.ranges.map(({ start, end = start }) => ({
+    start: Math.min(start, end),
+    end: Math.max(start, end),
+  }));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A descending sequence/UID range in `FETCH` and `STORE` (e.g. `3:1`, `5:1`, `*:1`) silently matched **nothing**. RFC 3501 §9 states a seq/UID range is order-independent — `3:1` is exactly equivalent to `1:3`. inbox passed the range endpoints straight into a `uid >= start AND uid <= end` SQL predicate, so a descending range produced `uid >= 3 AND uid <= 1` → empty result: FETCH returned no data, STORE returned `NO` and dropped the flag update.

Closes #582

## Fix

Normalize each range to `{ start: min, end: max }` in `convertSequenceSet` — the single range-resolution point shared by both the FETCH path (`message-ops.ts` `_collectMessages`) and the STORE path (`message-ops.ts` STORE handler). The wildcard `*` is already expanded to `MAX_SAFE_INTEGER` by the parser before this point, so `*:1` correctly normalizes to `1:*` and covers the whole mailbox. A single normalization point keeps FETCH and STORE consistent.

## Tests

Added `convertSequenceSet` unit coverage (there was none) pinning:
- descending `3:1` flips to `1:3`
- ascending `1:3` unchanged
- `*:1` (MAX:1) → `1:MAX`
- single number stays a unit range
- each range in a multi-range set normalized independently

`bun test src/server/lib/imap/fetch-helpers.test.ts` → 9 pass. Typecheck clean.

## E2E (live IMAP server)

Started the IMAP server (`IMAP_PORT=21434`), logged in as admin, `SELECT INBOX`, and compared descending vs ascending **read-only** FETCH over a raw IMAP socket (no STORE — the dev server reads the real local DB, so writes were deliberately avoided; the STORE path shares the identical resolver):

```
C: FETCH 1:3 (UID FLAGS)   -> 3 messages, UIDs [1,2,3]
C: FETCH 3:1 (UID FLAGS)   -> 3 messages, UIDs [1,2,3]   (was: 0 before the fix)
C: FETCH 5:2 (UID)         -> UIDs [2,3,4,5]
C: FETCH 2:5 (UID)         -> UIDs [2,3,4,5]
```

Descending `3:1` now returns the same set as `1:3`, and `5:2` matches `2:5` — the empty-result desync the issue reported is gone.