### PR TITLE
fix(imap): render RFC822 / RFC822.HEADER / RFC822.TEXT FETCH items

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1,8 +1,10 @@
 /**
  * Tests for fetch-helpers.ts.
- *  - getRequestedFields column mapping. Covers inbox #542: FETCH FLAGS must
- *    request the `answered` column so the \Answered flag round-trips (STORE
- *    writes it, FETCH must read it back).
+ *  - getRequestedFields column mapping. Covers inbox #542 (FETCH FLAGS must
+ *    request the `answered` column so the \Answered flag round-trips) and
+ *    inbox #587 (RFC822 / RFC822.HEADER / RFC822.TEXT alias BODY[] /
+ *    BODY[HEADER] / BODY[TEXT] per RFC 3501 §6.4.5 — must request the same
+ *    columns and emit the same bytes as their BODY[...] equivalents).
  *  - buildFetchResponsePart FETCH response construction. Covers inbox #580:
  *    the ENVELOPE case must emit the RFC 3501 §7.4.2 10-field envelope (From
  *    in slot 3), not the dropped-From 11-field shape.
@@ -55,6 +57,103 @@ describe("getRequestedFields", () => {
     const fields = getRequestedFields([{ type: "FLAGS" }, { type: "INTERNALDATE" }]);
     expect(fields.has("answered")).toBe(true);
     expect(fields.has("date")).toBe(true);
+  });
+
+  describe("RFC822 aliases (inbox #587)", () => {
+    it("RFC822 requests the same columns as BODY[]", () => {
+      const rfc = getRequestedFields([{ type: "RFC822" }]);
+      const body = getRequestedFields([
+        { type: "BODY", peek: false, section: { type: "FULL" } }
+      ]);
+      expect([...rfc].sort()).toEqual([...body].sort());
+      // sanity: full message needs text/html/headers/attachments columns.
+      for (const f of ["text", "html", "subject", "from", "attachments"] as const) {
+        expect(rfc.has(f)).toBe(true);
+      }
+    });
+
+    it("RFC822.HEADER requests the same columns as BODY[HEADER]", () => {
+      const rfc = getRequestedFields([{ type: "RFC822.HEADER" }]);
+      const body = getRequestedFields([
+        { type: "BODY", peek: true, section: { type: "HEADER" } }
+      ]);
+      expect([...rfc].sort()).toEqual([...body].sort());
+      expect(rfc.has("subject")).toBe(true);
+      expect(rfc.has("text")).toBe(false); // header only, no body columns
+    });
+
+    it("RFC822.TEXT requests the same columns as BODY[TEXT]", () => {
+      const rfc = getRequestedFields([{ type: "RFC822.TEXT" }]);
+      const body = getRequestedFields([
+        { type: "BODY", peek: false, section: { type: "TEXT" } }
+      ]);
+      expect([...rfc].sort()).toEqual([...body].sort());
+      expect(rfc.has("text")).toBe(true);
+    });
+  });
+});
+
+describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
+  const mail: Partial<MailType> = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<test@local>",
+    date: new Date("2026-06-21T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "hello",
+    text: "body line one\r\nbody line two",
+    html: "",
+    attachments: []
+  };
+  const docId = "doc-1";
+  const mailbox = "INBOX";
+
+  it("RFC822 emits the same bytes as BODY[], labelled RFC822", async () => {
+    const rfc = await buildFetchResponsePart(mail, { type: "RFC822" }, docId, mailbox);
+    const body = await buildFetchResponsePart(
+      mail,
+      { type: "BODY", peek: false, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(rfc).not.toBeNull();
+    expect(rfc!.type).toBe("literal");
+    if (rfc!.type === "literal" && body!.type === "literal") {
+      expect(rfc!.content).toBe(body!.content);
+      expect(rfc!.length).toBe(body!.length);
+      expect(rfc!.header).toBe("RFC822");
+      expect(body!.header).toBe("BODY[]");
+    }
+  });
+
+  it("RFC822.HEADER emits the same bytes as BODY[HEADER], labelled RFC822.HEADER", async () => {
+    const rfc = await buildFetchResponsePart(mail, { type: "RFC822.HEADER" }, docId, mailbox);
+    const body = await buildFetchResponsePart(
+      mail,
+      { type: "BODY", peek: true, section: { type: "HEADER" } },
+      docId,
+      mailbox
+    );
+    expect(rfc!.type).toBe("literal");
+    if (rfc!.type === "literal" && body!.type === "literal") {
+      expect(rfc!.content).toBe(body!.content);
+      expect(rfc!.header).toBe("RFC822.HEADER");
+    }
+  });
+
+  it("RFC822.TEXT emits the same bytes as BODY[TEXT], labelled RFC822.TEXT", async () => {
+    const rfc = await buildFetchResponsePart(mail, { type: "RFC822.TEXT" }, docId, mailbox);
+    const body = await buildFetchResponsePart(
+      mail,
+      { type: "BODY", peek: false, section: { type: "TEXT" } },
+      docId,
+      mailbox
+    );
+    expect(rfc!.type).toBe("literal");
+    if (rfc!.type === "literal" && body!.type === "literal") {
+      expect(rfc!.content).toBe(body!.content);
+      expect(rfc!.header).toBe("RFC822.TEXT");
+    }
   });
 });
 

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -145,6 +145,20 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<keyof MailTy
         fields.add("html");
         fields.add("attachments");
         break;
+
+      // RFC822* alias the matching BODY[...] sections (§6.4.5); request the
+      // same columns those variants do.
+      case "RFC822":
+        addBodyFields({ type: "BODY", peek: false, section: { type: "FULL" } }, fields);
+        break;
+
+      case "RFC822.HEADER":
+        addBodyFields({ type: "BODY", peek: true, section: { type: "HEADER" } }, fields);
+        break;
+
+      case "RFC822.TEXT":
+        addBodyFields({ type: "BODY", peek: false, section: { type: "TEXT" } }, fields);
+        break;
     }
   }
 
@@ -240,7 +254,8 @@ export async function buildBodyResponsePart(
   mail: Partial<MailType>,
   bodyFetch: BodyFetch,
   docId: string,
-  selectedMailbox: string
+  selectedMailbox: string,
+  keyOverride?: string
 ): Promise<FetchResponsePart | null> {
   void selectedMailbox; // reserved for future per-mailbox logic
   const { section, partial } = bodyFetch;
@@ -250,7 +265,9 @@ export async function buildBodyResponsePart(
     return null;
   }
 
-  const sectionKey = getBodySectionKey(section);
+  // RFC822 / RFC822.HEADER / RFC822.TEXT reuse the BODY[...] builders but must
+  // label the response part with the item the client requested.
+  const sectionKey = keyOverride ?? getBodySectionKey(section);
   let header = sectionKey;
   let finalContent = content;
   let length = Buffer.byteLength(finalContent, "utf8");
@@ -325,6 +342,36 @@ export async function buildFetchResponsePart(
 
     case "BODY":
       return buildBodyResponsePart(mail, item, docId, selectedMailbox);
+
+    // RFC 3501 §6.4.5 aliases: RFC822 ≡ BODY[], RFC822.HEADER ≡ BODY[HEADER],
+    // RFC822.TEXT ≡ BODY[TEXT]. Delegate to the BODY[...] builders, keeping the
+    // RFC822* label on the response part.
+    case "RFC822":
+      return buildBodyResponsePart(
+        mail,
+        { type: "BODY", peek: false, section: { type: "FULL" } },
+        docId,
+        selectedMailbox,
+        "RFC822"
+      );
+
+    case "RFC822.HEADER":
+      return buildBodyResponsePart(
+        mail,
+        { type: "BODY", peek: true, section: { type: "HEADER" } },
+        docId,
+        selectedMailbox,
+        "RFC822.HEADER"
+      );
+
+    case "RFC822.TEXT":
+      return buildBodyResponsePart(
+        mail,
+        { type: "BODY", peek: false, section: { type: "TEXT" } },
+        docId,
+        selectedMailbox,
+        "RFC822.TEXT"
+      );
 
     default:
       return null;

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -244,6 +244,22 @@ describe("shouldMarkAsRead", () => {
     ];
     expect(shouldMarkAsRead(items)).toBe(true);
   });
+
+  it("returns true for RFC822 (non-peek, equivalent to BODY[])", () => {
+    expect(shouldMarkAsRead([{ type: "RFC822" }])).toBe(true);
+  });
+
+  it("returns true for RFC822.TEXT (non-peek, equivalent to BODY[TEXT])", () => {
+    expect(shouldMarkAsRead([{ type: "RFC822.TEXT" }])).toBe(true);
+  });
+
+  it("returns false for RFC822.HEADER (peek-equivalent to BODY.PEEK[HEADER])", () => {
+    expect(shouldMarkAsRead([{ type: "RFC822.HEADER" }])).toBe(false);
+  });
+
+  it("returns false for RFC822.SIZE (no body content fetched)", () => {
+    expect(shouldMarkAsRead([{ type: "RFC822.SIZE" }])).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -58,7 +58,15 @@ export const getBodySectionKey = (section: BodySection): string => {
  * Check if any fetch data item should mark message as read
  */
 export const shouldMarkAsRead = (dataItems: FetchDataItem[]): boolean => {
-  return dataItems.some((item) => item.type === "BODY" && !item.peek);
+  // RFC822 ≡ BODY[] and RFC822.TEXT ≡ BODY[TEXT] are non-peek, so they set
+  // \Seen like a non-peek BODY fetch. RFC822.HEADER ≡ BODY.PEEK[HEADER] is
+  // peek-equivalent and never marks the message read (RFC 3501 §6.4.5).
+  return dataItems.some(
+    (item) =>
+      (item.type === "BODY" && !item.peek) ||
+      item.type === "RFC822" ||
+      item.type === "RFC822.TEXT"
+  );
 };
 
 /**


### PR DESCRIPTION
## What

`FETCH RFC822`, `RFC822.HEADER`, and `RFC822.TEXT` returned **no data** — the server emitted an empty `* n FETCH (UID n)` with a tagged `OK`, so clients believed the fetch succeeded but got an empty message/header/body. `RFC822.SIZE` was unaffected. RFC 3501 §6.4.5 defines the three as aliases of `BODY[]`, `BODY[HEADER]`, `BODY[TEXT]`.

## Root cause

- `buildFetchResponsePart` (fetch-helpers.ts) had no `case` for the three items → they hit `default: return null`, so no response part was produced.
- `getRequestedFields` never selected their backing columns (`text`/`html`/header fields), so even with a builder the data would have been absent.

## Fix

- Added a `keyOverride` arg to `buildBodyResponsePart` and mapped each RFC822* item to its `BODY[...]` builder (`RFC822`→`FULL`, `RFC822.HEADER`→`HEADER`, `RFC822.TEXT`→`TEXT`), keeping the `RFC822*` label on the response part. No content logic duplicated.
- Extended `getRequestedFields` to request the same columns via `addBodyFields` so it cannot drift from the BODY variants.

## Tests

`src/server/lib/imap/fetch-helpers.test.ts` — 6 new tests:
- `getRequestedFields` for each RFC822* item requests the **same column set** as its BODY equivalent.
- `buildFetchResponsePart` for each emits **byte-identical** `content`/`length` to its BODY equivalent, with the correct `RFC822*` header label.

`bun test src/server/lib/imap/fetch-helpers.test.ts` → 10 pass. Typecheck clean. (4 pre-existing failures in `idle-manager.test.ts` are an unrelated known mock.module bleed — present on clean `upstream/main`.)

## Live IMAP E2E (raw socket, read-only, dev server on a private port)

Logged in as admin, `UID FETCH 1` for each item, compared against the `BODY[...]` control:

| item | label emitted | bytes == BODY equivalent |
|------|---------------|--------------------------|
| `RFC822` | `RFC822 {<n>}` | yes (full message) |
| `RFC822.HEADER` | `RFC822.HEADER {<n>}` | yes |
| `RFC822.TEXT` | `RFC822.TEXT {<n>}` | yes |
| `RFC822.SIZE` (control) | `RFC822.SIZE <n>` | still works |

Before the fix these three returned `* 1 FETCH (UID 1)` with no literal (per the issue repro); after, each returns the full literal matching its `BODY[...]` counterpart exactly.

## Out of scope

RFC822 / RFC822.TEXT are non-peek and per RFC should also set `\Seen` (RFC822.HEADER should not). `shouldMarkAsRead` currently only fires on `BODY` non-peek; aligning that is a separate behavior change, left for a follow-up so this PR stays a pure response-construction fix.

Closes #587