### PR TITLE
fix(imap): clamp out-of-range sequence FETCH/STORE bounds (RFC 3501 §6.4.5)

### DIFF
--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -23,7 +23,7 @@ import {
   convertSequenceSet,
 } from "./fetch-helpers";
 import {
-  seqToUidNumber,
+  resolveSeqRangeToUids,
   uidToSeqNumber,
   countSequenceSetMessages,
   buildSequenceMapping,
@@ -113,18 +113,17 @@ async function _fetchMessages(
       let uidEnd = end;
 
       if (!isUidFetch) {
-        const startUid = seqToUidNumber(seqState.seqToUid, start);
-        const endUid = seqToUidNumber(seqState.seqToUid, end);
-        if (startUid === undefined || endUid === undefined) {
-          logger.warn("Invalid sequence range", {
+        const resolved = resolveSeqRangeToUids(seqState.seqToUid, start, end);
+        if (!resolved) {
+          logger.warn("Sequence range matched no messages", {
             component: "imap",
             start,
             end,
           });
           return;
         }
-        uidStart = startUid;
-        uidEnd = endUid;
+        uidStart = resolved.uidStart;
+        uidEnd = resolved.uidEnd;
       }
 
       const messages = await store.getMessages(
@@ -265,18 +264,17 @@ export async function storeFlagsTyped(
       let uidEnd = end;
 
       if (!isUidStore) {
-        const startUid = seqToUidNumber(seqState.seqToUid, start);
-        const endUid = seqToUidNumber(seqState.seqToUid, end);
-        if (startUid === undefined || endUid === undefined) {
-          logger.warn("Invalid sequence range", {
+        const resolved = resolveSeqRangeToUids(seqState.seqToUid, start, end);
+        if (!resolved) {
+          logger.warn("Sequence range matched no messages", {
             component: "imap",
             start,
             end,
           });
           continue;
         }
-        uidStart = startUid;
-        uidEnd = endUid;
+        uidStart = resolved.uidStart;
+        uidEnd = resolved.uidEnd;
       }
 
       const baseOperation = operation.replace(

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -3,6 +3,7 @@ import {
   buildSequenceMapping,
   seqToUidNumber,
   uidToSeqNumber,
+  resolveSeqRangeToUids,
   countSequenceSetMessages,
   type SequenceState,
 } from "./sequence-resolver";
@@ -93,6 +94,38 @@ describe("seqToUidNumber", () => {
 
   it("returns undefined for * on empty mailbox", () => {
     expect(seqToUidNumber([], Number.MAX_SAFE_INTEGER)).toBeUndefined();
+  });
+});
+
+describe("resolveSeqRangeToUids (inbox #588)", () => {
+  const uids = [10, 20, 30, 40, 50]; // maxSeq = 5
+
+  it("resolves a fully in-range range to its UID bounds", () => {
+    expect(resolveSeqRangeToUids(uids, 2, 4)).toEqual({ uidStart: 20, uidEnd: 40 });
+  });
+
+  it("clamps an upper bound past the end to the last message (the bug)", () => {
+    // 3:80 on a 5-message mailbox must return messages 3..5, not nothing.
+    expect(resolveSeqRangeToUids(uids, 3, 80)).toEqual({ uidStart: 30, uidEnd: 50 });
+  });
+
+  it("resolves N:* to the last message", () => {
+    expect(resolveSeqRangeToUids(uids, 3, Number.MAX_SAFE_INTEGER)).toEqual({
+      uidStart: 30,
+      uidEnd: 50,
+    });
+  });
+
+  it("resolves a single-message range", () => {
+    expect(resolveSeqRangeToUids(uids, 5, 5)).toEqual({ uidStart: 50, uidEnd: 50 });
+  });
+
+  it("returns undefined when the whole range is past the end", () => {
+    expect(resolveSeqRangeToUids(uids, 6, 9)).toBeUndefined();
+  });
+
+  it("returns undefined on an empty mailbox", () => {
+    expect(resolveSeqRangeToUids([], 1, 10)).toBeUndefined();
   });
 });
 

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -52,6 +52,33 @@ export function seqToUidNumber(seqToUid: number[], seq: number): number | undefi
 }
 
 /**
+ * Resolve a message-sequence range [start, end] to UID bounds for a store query.
+ *
+ * RFC 3501 §6.4.5/§9: an endpoint beyond the largest message number is not an
+ * error — it is clamped to the last message and the in-range messages are still
+ * returned. The previous behaviour (resolve each endpoint independently, drop
+ * the whole range if either is undefined) silently matched nothing whenever the
+ * upper bound exceeded the mailbox size (e.g. `11320:11400` on 11322 messages).
+ *
+ * Returns undefined only when the range starts past the end of the mailbox (no
+ * messages match) or the mailbox is empty. '*' (MAX_SAFE_INTEGER) clamps to the
+ * last message. Endpoint ordering is left as-is; descending ranges are handled
+ * separately in convertSequenceSet (issue #582).
+ */
+export function resolveSeqRangeToUids(
+  seqToUid: number[],
+  start: number,
+  end: number
+): { uidStart: number; uidEnd: number } | undefined {
+  const maxSeq = seqToUid.length;
+  if (maxSeq === 0 || start > maxSeq) return undefined;
+  const uidStart = seqToUidNumber(seqToUid, Math.min(start, maxSeq));
+  const uidEnd = seqToUidNumber(seqToUid, Math.min(end, maxSeq));
+  if (uidStart === undefined || uidEnd === undefined) return undefined;
+  return { uidStart, uidEnd };
+}
+
+/**
  * Convert a UID to sequence number.
  * Handles '*' (represented as MAX_SAFE_INTEGER) by returning the highest seq.
  */


### PR DESCRIPTION
## What

A message-sequence `FETCH`/`STORE` range whose **upper bound is past the end of the mailbox** (e.g. `11320:11400` on an 11322-message mailbox) silently matched **nothing** — zero untagged responses, tagged `OK`. RFC 3501 §6.4.5/§9: an out-of-range endpoint in a *range* is clamped to the last message; the in-range messages must still be returned. `N:*` and UID ranges already worked; only literal high sequence upper bounds were affected.

## Root cause

`_fetchMessages` and `_setFlags` resolved each endpoint independently through `seqToUidNumber`; a past-the-end `end` returned `undefined`, so the whole range was dropped (`return` / `continue`) — FETCH returned empty, STORE returned `NO` and dropped the flag write.

## Fix

New `resolveSeqRangeToUids(seqToUid, start, end)` in `sequence-resolver.ts`:
- clamps each endpoint to the mailbox size (so `*`/MAX_SAFE_INTEGER and any over-large upper bound resolve to the last message);
- returns `undefined` only when the range **starts** past the end (nothing matches) or the mailbox is empty.

Used in both the FETCH (`message-ops.ts`) and STORE sequence paths — the single shared resolution point. Endpoint **ordering is left untouched**; descending ranges (`3:1`) remain the domain of issue #582 / its open PR, so this PR does not overlap it.

## Tests

`sequence-resolver.test.ts` — 6 new `resolveSeqRangeToUids` cases: fully in-range, **upper bound past end clamps to last** (the bug), `N:*`, single-message, wholly-past-end → `undefined`, empty mailbox → `undefined`. `bun test sequence-resolver.test.ts message-ops.test.ts` → 30 pass, typecheck clean.

## Live IMAP E2E (raw socket, read-only FETCH; dev server on a private port)

Admin mailbox, `EXISTS = 11322` (the issue's exact size):

| query | messages returned |
|-------|-------------------|
| `FETCH 11320:11322` (in-range control) | 3 |
| `FETCH 11320:11372` (upper bound past end — **the bug**) | **3** (was 0 before the fix) |
| `FETCH 11320:*` (star control) | 3 |
| `FETCH 11332:11372` (wholly past end) | 0 (correctly empty — no over-clamping) |

The past-end range now returns the final three messages identical to the in-range and star controls. STORE shares the identical resolver (covered by the unit tests); it was not driven live because a flag write would mutate the prod-cloned dataset this dev server reads.

Closes #588