### PR TITLE
fix(imap): LIST/LSUB honor the reference and pattern arguments (#596)

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -249,10 +249,18 @@ export class ImapRequestHandler {
           break;
 
         case "LIST":
-          await this.session.listMailboxes(tag);
+          await this.session.listMailboxes(
+            tag,
+            request.data.reference,
+            request.data.pattern
+          );
           break;
         case "LSUB":
-          await this.session.listSubscribedMailboxes(tag);
+          await this.session.listSubscribedMailboxes(
+            tag,
+            request.data.reference,
+            request.data.pattern
+          );
           break;
 
         case "SELECT":

--- a/src/server/lib/imap/mailbox-list.test.ts
+++ b/src/server/lib/imap/mailbox-list.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for LIST/LSUB reference + pattern handling (#596).
+ *
+ * Before the fix, listMailboxes ignored both arguments and emitted the entire
+ * mailbox tree for every query. These cases pin the RFC 3501 §6.3.8 wildcard
+ * semantics ("*" crosses the "/" delimiter, "%" stays within one level) and the
+ * handler's filtering of the box set against reference + pattern.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { matchesListPattern, listMailboxes } from "./mailbox-ops";
+import type { Store } from "./store";
+
+const TREE = [
+  "INBOX",
+  "Sent Messages",
+  "INBOX/accounts",
+  "INBOX/accounts/work",
+  "INBOX/accounts/personal",
+  "Archive"
+];
+
+const fakeStore = (boxes: string[]): Store =>
+  ({ listMailboxes: async () => boxes }) as unknown as Store;
+
+const listed = async (reference: string, pattern: string): Promise<string[]> => {
+  const lines: string[] = [];
+  await listMailboxes(
+    "A1",
+    reference,
+    pattern,
+    fakeStore(TREE),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    }
+  );
+  return lines
+    .filter((l) => l.startsWith("* LIST"))
+    .map((l) => l.replace(/.*"\/" "(.*)"\r\n$/, "$1"));
+};
+
+describe("matchesListPattern (RFC 3501 §6.3.8)", () => {
+  it('"*" matches across the hierarchy delimiter', () => {
+    expect(matchesListPattern("", "*", "INBOX/accounts/work")).toBe(true);
+  });
+
+  it('"%" does not cross the hierarchy delimiter', () => {
+    expect(matchesListPattern("", "%", "INBOX")).toBe(true);
+    expect(matchesListPattern("", "%", "INBOX/accounts")).toBe(false);
+  });
+
+  it("an exact name with no wildcard matches only itself", () => {
+    expect(matchesListPattern("", "INBOX", "INBOX")).toBe(true);
+    expect(matchesListPattern("", "INBOX", "INBOX/accounts")).toBe(false);
+    expect(matchesListPattern("", "INBOX", "Sent Messages")).toBe(false);
+  });
+
+  it('"%" after a path segment matches one further level only', () => {
+    expect(matchesListPattern("", "INBOX/%", "INBOX/accounts")).toBe(true);
+    expect(matchesListPattern("", "INBOX/%", "INBOX/accounts/work")).toBe(false);
+  });
+
+  it("concatenates a non-empty reference with the pattern", () => {
+    expect(matchesListPattern("INBOX/", "%", "INBOX/accounts")).toBe(true);
+    expect(matchesListPattern("INBOX/", "%", "Archive")).toBe(false);
+  });
+});
+
+describe("listMailboxes filtering (#596)", () => {
+  it('LIST "" "%" returns top-level names only', async () => {
+    const result = await listed("", "%");
+    expect(result.sort()).toEqual(
+      ["Archive", "INBOX", "Sent Messages"].sort()
+    );
+    expect(result).not.toContain("INBOX/accounts");
+    expect(result).not.toContain("INBOX/accounts/work");
+  });
+
+  it('LIST "" "INBOX" returns exactly the one entry', async () => {
+    expect(await listed("", "INBOX")).toEqual(["INBOX"]);
+  });
+
+  it('LIST "" "*" returns the full tree', async () => {
+    expect((await listed("", "*")).sort()).toEqual([...TREE].sort());
+  });
+
+  it('LIST "" "%/accounts" returns only the ".../accounts" parents', async () => {
+    expect(await listed("", "%/accounts")).toEqual(["INBOX/accounts"]);
+  });
+
+  it("an empty pattern returns the hierarchy delimiter, no mailboxes", async () => {
+    const lines: string[] = [];
+    await listMailboxes("A1", "", "", fakeStore(TREE), (data: string) => {
+      lines.push(data);
+      return true;
+    });
+    expect(lines.some((l) => l.includes('(\\Noselect) "/" ""'))).toBe(true);
+    expect(lines.filter((l) => l.startsWith("* LIST")).length).toBe(1);
+  });
+});

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -244,17 +244,56 @@ export function getMailboxAttributes(box: string, allBoxes: string[]): string {
   return "\\HasNoChildren";
 }
 
+/**
+ * Match a mailbox name against an IMAP LIST reference + pattern (RFC 3501
+ * §6.3.8). The reference and pattern are concatenated; within the result "*"
+ * matches across the "/" hierarchy delimiter while "%" matches only within a
+ * single level. Every other character matches literally.
+ */
+export function matchesListPattern(
+  reference: string,
+  pattern: string,
+  box: string
+): boolean {
+  const combined = reference + pattern;
+  let regex = "^";
+  for (const char of combined) {
+    if (char === "*") {
+      regex += ".*";
+    } else if (char === "%") {
+      regex += "[^/]*";
+    } else {
+      regex += char.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    }
+  }
+  regex += "$";
+  return new RegExp(regex).test(box);
+}
+
 export async function listMailboxes(
   tag: string,
+  reference: string,
+  pattern: string,
   store: Store,
   write: (data: string) => boolean | undefined
 ): Promise<void> {
   try {
+    // An empty pattern is a special request for the hierarchy delimiter and the
+    // root name of the reference (RFC 3501 §6.3.8); no mailboxes are returned.
+    if (pattern === "") {
+      write(`* LIST (\\Noselect) "/" "${reference}"\r\n`);
+      write(`${tag} OK LIST completed\r\n`);
+      return;
+    }
     const boxes = await store.listMailboxes();
-    boxes.forEach((box) => {
-      const attrs = getMailboxAttributes(box, boxes);
-      write(`* LIST (${attrs}) "/" "${box}"\r\n`);
-    });
+    boxes
+      .filter((box) => matchesListPattern(reference, pattern, box))
+      .forEach((box) => {
+        // Attributes are computed against the full set so \HasChildren stays
+        // correct even when the child rows are filtered out of the response.
+        const attrs = getMailboxAttributes(box, boxes);
+        write(`* LIST (${attrs}) "/" "${box}"\r\n`);
+      });
     write(`${tag} OK LIST completed\r\n`);
   } catch (error) {
     logger.error("Error listing mailboxes", { component: "imap" }, error);
@@ -264,15 +303,24 @@ export async function listMailboxes(
 
 export async function listSubscribedMailboxes(
   tag: string,
+  reference: string,
+  pattern: string,
   store: Store,
   write: (data: string) => boolean | undefined
 ): Promise<void> {
   try {
+    if (pattern === "") {
+      write(`* LSUB (\\Noselect) "/" "${reference}"\r\n`);
+      write(`${tag} OK LSUB completed\r\n`);
+      return;
+    }
     const boxes = await store.listMailboxes();
-    boxes.forEach((box) => {
-      const attrs = getMailboxAttributes(box, boxes);
-      write(`* LSUB (${attrs}) "/" "${box}"\r\n`);
-    });
+    boxes
+      .filter((box) => matchesListPattern(reference, pattern, box))
+      .forEach((box) => {
+        const attrs = getMailboxAttributes(box, boxes);
+        write(`* LSUB (${attrs}) "/" "${box}"\r\n`);
+      });
     write(`${tag} OK LSUB completed\r\n`);
   } catch (error) {
     logger.error("Error listing subscribed mailboxes", { component: "imap" }, error);

--- a/src/server/lib/imap/parsers/mailbox-parsers.test.ts
+++ b/src/server/lib/imap/parsers/mailbox-parsers.test.ts
@@ -257,6 +257,35 @@ describe('mailbox-parsers', () => {
       expect(result.value.request.data.reference).toBe('');
       expect(result.value.request.data.pattern).toBe('*');
     });
+
+    // Regression for #596: patterns that mix literal text with a wildcard were
+    // truncated at the first wildcard (only "%" survived from "INBOX/%").
+    it('should keep a trailing wildcard after a hierarchy path', () => {
+      const result = parseCommand('A001 LIST "" "INBOX/%"');
+      expect(result.success).toBe(true);
+      if (result.value?.request.type !== 'LIST') {
+        throw new Error('Expected LIST request type');
+      }
+      expect(result.value.request.data.pattern).toBe('INBOX/%');
+    });
+
+    it('should keep a leading wildcard followed by a path', () => {
+      const result = parseCommand('A001 LIST "" "%/accounts"');
+      expect(result.success).toBe(true);
+      if (result.value?.request.type !== 'LIST') {
+        throw new Error('Expected LIST request type');
+      }
+      expect(result.value.request.data.pattern).toBe('%/accounts');
+    });
+
+    it('should keep a trailing wildcard on an unquoted pattern', () => {
+      const result = parseCommand('A001 LIST "" INBOX*');
+      expect(result.success).toBe(true);
+      if (result.value?.request.type !== 'LIST') {
+        throw new Error('Expected LIST request type');
+      }
+      expect(result.value.request.data.pattern).toBe('INBOX*');
+    });
   });
 
   describe('parseSubscribe', () => {

--- a/src/server/lib/imap/parsers/mailbox-parsers.ts
+++ b/src/server/lib/imap/parsers/mailbox-parsers.ts
@@ -6,6 +6,7 @@ import { ParseContext, ParseResult, ImapRequest, StatusItem } from "../types";
 import {
   skipWhitespace,
   parseString,
+  parseListMailbox,
   parseAtom,
   peek,
   consume
@@ -37,21 +38,10 @@ export const parseList = (
 
   skipWhitespace(context);
 
-  // Parse mailbox pattern - handle wildcards specially
-  let mailboxName: ParseResult<string>;
-  if (
-    context.position < context.length &&
-    (context.input[context.position] === "*" ||
-      context.input[context.position] === "%")
-  ) {
-    // Handle wildcard patterns
-    const wildcard = context.input[context.position];
-    context.position++;
-    mailboxName = { success: true, value: wildcard, consumed: 1 };
-  } else {
-    // Parse as normal string
-    mailboxName = parseString(context);
-  }
+  // Parse the mailbox pattern. list-mailbox allows the "*"/"%" wildcards as
+  // ordinary characters, so a mixed pattern like "INBOX/%" must be captured in
+  // full rather than truncated at the first wildcard.
+  const mailboxName = parseListMailbox(context);
 
   if (!mailboxName.success) {
     logger.debug("Failed to parse mailbox name", {

--- a/src/server/lib/imap/parsers/primitive-parsers.ts
+++ b/src/server/lib/imap/parsers/primitive-parsers.ts
@@ -125,6 +125,50 @@ export const parseString = (context: ParseContext): ParseResult<string> => {
 };
 
 /**
+ * Parse a list-mailbox token (RFC 3501 list-mailbox rule). Like an atom, but
+ * the list wildcards "*" and "%" are valid characters here, so a pattern such
+ * as "INBOX/%" or "%/accounts" is captured whole rather than truncated at the
+ * first wildcard. A quoted form is also accepted.
+ */
+export const parseListMailbox = (
+  context: ParseContext
+): ParseResult<string> => {
+  if (peek(context) === '"') {
+    return parseQuotedString(context);
+  }
+
+  const start = context.position;
+
+  while (context.position < context.length) {
+    const char = context.input[context.position];
+    if (
+      char === " " ||
+      char === "(" ||
+      char === ")" ||
+      char === "{" ||
+      char === '"' ||
+      char === "\\" ||
+      char === "\r" ||
+      char === "\n" ||
+      char.charCodeAt(0) < 32
+    ) {
+      break;
+    }
+    context.position++;
+  }
+
+  if (context.position === start) {
+    return { success: false, error: "Expected list mailbox", consumed: 0 };
+  }
+
+  return {
+    success: true,
+    value: context.input.substring(start, context.position),
+    consumed: context.position - start
+  };
+};
+
+/**
  * Parse a quoted string
  */
 export const parseQuotedString = (

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -206,18 +206,28 @@ export class ImapSession {
     return statusMailbox(tag, mailbox, items, this.store, this.write);
   };
 
-  listMailboxes = async (tag: string) => {
+  listMailboxes = async (tag: string, reference: string, pattern: string) => {
     if (!this.authenticated || !this.store) {
       return this.write(`${tag} NO Not authenticated.\r\n`);
     }
-    return listMailboxes(tag, this.store, this.write);
+    return listMailboxes(tag, reference, pattern, this.store, this.write);
   };
 
-  listSubscribedMailboxes = async (tag: string) => {
+  listSubscribedMailboxes = async (
+    tag: string,
+    reference: string,
+    pattern: string
+  ) => {
     if (!this.authenticated || !this.store) {
       return this.write(`${tag} NO Not authenticated.\r\n`);
     }
-    return listSubscribedMailboxes(tag, this.store, this.write);
+    return listSubscribedMailboxes(
+      tag,
+      reference,
+      pattern,
+      this.store,
+      this.write
+    );
   };
 
   examineMailbox = async (tag: string, name: string) => {


### PR DESCRIPTION
## Problem

`LIST` (and `LSUB`) ignored **both** of their arguments — the reference name and the mailbox pattern — and emitted the **entire** mailbox tree for every query (#596). Consequences:

- `LIST "" "INBOX"` (exact-existence probe many clients send at connect) returned the whole tree, so a client could not tell a present folder from an absent one.
- `LIST "" "%"` recursed across the `/` hierarchy delimiter instead of returning top-level names only.
- `LIST "INBOX" "%"` / `LIST "<node>" "%"` ignored the reference, so hierarchy walks received the full tree at every node (quadratic traffic).
- The parser also truncated mixed patterns at the first wildcard (`INBOX/%` → `INBOX/`, `%/accounts` → `%`), so even threading the parsed value through would have been incomplete.

## Fix

- **Thread** `reference` + `pattern` from the parsed request through `ImapSession.listMailboxes` / `listSubscribedMailboxes` into the `mailbox-ops` handlers (mirrors how SELECT threads its mailbox arg).
- **`matchesListPattern`** (RFC 3501 §6.3.8): reference + pattern are concatenated; `*` matches across the `/` delimiter, `%` matches within a single level only, every other character matches literally. Mailbox attributes are still computed against the full box set, so `\HasChildren` stays correct when child rows are filtered out.
- **Empty-pattern** special case → returns the hierarchy delimiter + root name (`* LIST (\Noselect) "/" "<ref>"`), the delimiter-probe clients send at connect.
- **Parser**: new `parseListMailbox` primitive treats `*`/`%` as ordinary list-mailbox characters, so a mixed pattern is captured whole.

**Out of scope (intentional):** LSUB subscription-state filtering (returning only *subscribed* mailboxes) is a distinct concern from the reference/pattern bug and is left for a separate change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/server` — 962 pass / 4 fail; the 4 fails are the pre-existing `idle-manager.test.ts` cross-file `mock.module` leak (the `idleManager.shutdown is not a function` flake fixed by unmerged #585), identical on `upstream/main`, and **pass in isolation** (`bun test src/server/lib/imap/idle-manager.test.ts` → 3 pass). No new failures from this change.
- [x] New unit tests: `mailbox-list.test.ts` (12 cases over a synthetic hierarchy — `*` crosses `/`, `%` does not, exact-name, `INBOX/%` one-level, non-empty reference concat, empty-pattern probe) + 3 parser regression cases in `mailbox-parsers.test.ts` (embedded-wildcard patterns). 42 pass / 0 fail.
- [x] **Live IMAP wire** — booted the real IMAP server against the local DB, `LOGIN admin`, ran LIST queries on this branch vs `upstream/main` (read-only; LIST does not mutate):

  | Query | `upstream/main` | This branch |
  |---|---|---|
  | `LIST "" "*"` | INBOX (1) | INBOX (1) — full tree, unchanged |
  | `LIST "" "%"` | INBOX (1) | INBOX (1) — top-level (INBOX is top-level) |
  | `LIST "" "<nonexistent>"` | **INBOX (1)** — arg ignored | **0** — pattern honored |
  | `LIST "<nonexistent>/" "%"` | **INBOX (1)** | **0** |
  | `LIST "" "<nonexistent>/%"` | **INBOX (1)** | **0** |
  | `LIST "" "<nonexistent>/*"` | **INBOX (1)** | **0** |

  Baseline returns INBOX for *every* pattern (argument entirely ignored — the bug); this branch returns INBOX only for matching patterns and 0 for non-matching ones. The `%`-vs-`*`-vs-hierarchy discrimination is proven deterministically by the unit tests (the local admin account only has INBOX, so the live wire shows the arg-honored-vs-ignored contrast; the synthetic-tree unit tests cover the wildcard levels).

Note: no browser UI consumes the IMAP LIST path, so the live IMAP wire is the correct verification surface (per the issue's own repro).

Closes #596