### PR TITLE
fix(imap): include UID item in untagged FETCH from a UID STORE (RFC 3501 §6.4.8)

### DIFF
--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -351,6 +351,63 @@ describe("storeFlagsTyped — UID item on UID-command FETCH (#589)", () => {
     const fetch = lines.find((l) => l.includes("FETCH"));
     expect(fetch).toBe("* 1 FETCH (FLAGS (\\Seen))\r\n");
   });
+
+  it("emits no untagged FETCH for a SILENT UID STORE", async () => {
+    const { store } = makeFlagStore([{ uid: 11395, read: true }]);
+    const { write, lines } = makeWriter();
+
+    await storeFlagsTyped(
+      "A3",
+      {
+        sequenceSet: { type: "uid", ranges: [{ start: 11395 }] },
+        operation: "+FLAGS.SILENT",
+        flags: ["\\Seen"],
+      },
+      true,
+      store,
+      "INBOX",
+      false,
+      seqState,
+      write
+    );
+
+    expect(lines.some((l) => l.startsWith("* "))).toBe(false);
+    expect(taggedResponses(lines, "A3")).toEqual([
+      "A3 OK STORE completed\r\n",
+    ]);
+  });
+
+  it("emits one FETCH per mail, each carrying its own UID, for a multi-message UID STORE", async () => {
+    const { store } = makeFlagStore([
+      { uid: 11395, read: true },
+      { uid: 11396, read: true },
+    ]);
+    const multiSeqState: SequenceState = {
+      seqToUid: [11395, 11396],
+      uidToSeq: new Map([
+        [11395, 1],
+        [11396, 2],
+      ]),
+    };
+    const { write, lines } = makeWriter();
+
+    await storeFlagsTyped(
+      "A4",
+      uidStoreRequest(11395, 11396),
+      true,
+      store,
+      "INBOX",
+      false,
+      multiSeqState,
+      write
+    );
+
+    const fetches = lines.filter((l) => l.includes("FETCH"));
+    expect(fetches).toEqual([
+      "* 1 FETCH (UID 11395 FLAGS (\\Seen))\r\n",
+      "* 2 FETCH (UID 11396 FLAGS (\\Seen))\r\n",
+    ]);
+  });
 });
 
 // ── Suite 2 helpers ──────────────────────────────────────────────────────────

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -269,7 +269,8 @@ describe("storeFlagsTyped — empty result (inbox #543)", () => {
       write
     );
 
-    expect(lines).toContain("* 1 FETCH (FLAGS (\\Seen))\r\n");
+    // UID STORE → the untagged FETCH must carry the UID item (#589).
+    expect(lines).toContain("* 1 FETCH (UID 5 FLAGS (\\Seen))\r\n");
     expect(taggedResponses(lines, "A003")).toEqual([
       "A003 OK STORE completed\r\n",
     ]);
@@ -294,6 +295,61 @@ describe("storeFlagsTyped — empty result (inbox #543)", () => {
     const tagged = taggedResponses(lines, "A004");
     expect(tagged.length).toBe(1);
     expect(tagged[0]).toContain("NO [READ-ONLY]");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// storeFlagsTyped — UID item on UID-command FETCH (#589, RFC 3501 §6.4.8)
+// ---------------------------------------------------------------------------
+
+const seqStoreRequest = (start: number, end?: number): StoreRequest => ({
+  sequenceSet: { type: "sequence", ranges: [{ start, end }] },
+  operation: "+FLAGS",
+  flags: ["\\Seen"],
+});
+
+describe("storeFlagsTyped — UID item on UID-command FETCH (#589)", () => {
+  const seqState: SequenceState = {
+    seqToUid: [11395],
+    uidToSeq: new Map([[11395, 1]]),
+  };
+
+  it("includes the UID item for a UID STORE", async () => {
+    const { store } = makeFlagStore([{ uid: 11395, read: true }]);
+    const { write, lines } = makeWriter();
+
+    await storeFlagsTyped(
+      "A1",
+      uidStoreRequest(11395),
+      true, // isUidCommand
+      store,
+      "INBOX",
+      false,
+      seqState,
+      write
+    );
+
+    const fetch = lines.find((l) => l.includes("FETCH"));
+    expect(fetch).toBe("* 1 FETCH (UID 11395 FLAGS (\\Seen))\r\n");
+  });
+
+  it("omits the UID item for a plain (sequence) STORE", async () => {
+    const { store } = makeFlagStore([{ uid: 11395, read: true }]);
+    const { write, lines } = makeWriter();
+
+    await storeFlagsTyped(
+      "A2",
+      seqStoreRequest(1),
+      false, // not a UID command
+      store,
+      "INBOX",
+      false,
+      seqState,
+      write
+    );
+
+    const fetch = lines.find((l) => l.includes("FETCH"));
+    expect(fetch).toBe("* 1 FETCH (FLAGS (\\Seen))\r\n");
   });
 });
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -322,7 +322,10 @@ export async function storeFlagsTyped(
             if (mail.draft) currentFlags.push("\\Draft");
             if (mail.answered) currentFlags.push("\\Answered");
 
-            write(`* ${seq} FETCH (FLAGS (${currentFlags.join(" ")}))\r\n`);
+            const uidItem = isUidStore ? `UID ${mail.uid} ` : "";
+            write(
+              `* ${seq} FETCH (${uidItem}FLAGS (${currentFlags.join(" ")}))\r\n`
+            );
           }
         }
       }


### PR DESCRIPTION
## Summary

The untagged `FETCH` that a `UID STORE` emits omitted the `UID` data item — it wrote `* <seq> FETCH (FLAGS (...))` with only a sequence number. RFC 3501 §6.4.8 requires the server to implicitly include the UID in **any** FETCH response caused by a UID command, so a client that issued `UID STORE` and tracks state by UID could not correlate the feedback.

## Root cause

`storeFlagsTyped` (`src/server/lib/imap/message-ops.ts`) computed `isUidStore` but only used it for endpoint resolution, never for the response shape. `mail.uid` was already in hand (used to resolve the sequence number two lines up), so the UID was available — just not emitted.

## Fix

When the command was a UID STORE, prepend the UID item to the untagged FETCH:

- UID STORE → `* <seq> FETCH (UID <n> FLAGS (...))`
- plain (sequence) STORE → `* <seq> FETCH (FLAGS (...))` (unchanged)

One-line shape change; a plain STORE response is byte-for-byte identical to before.

## Tests

Added two cases to `message-ops.test.ts` driving the real `storeFlagsTyped` with a fake store + captured writer, asserting the exact wire output:

- `includes the UID item for a UID STORE` → `* 1 FETCH (UID 11395 FLAGS (\Seen))`
- `omits the UID item for a plain (sequence) STORE` → `* 1 FETCH (FLAGS (\Seen))`

The pre-existing "still completes OK and emits FETCH when messages do match" case (a UID STORE) was updated to expect the now-required `UID` item.

## Verification

- `bun test src/server` → **1033 pass / 0 fail** (full suite, per the process-global `mock.module` isolation rule).
- `bun run typecheck` → clean.
- `bun run lint` → no new warnings in changed files.

E2E note: a live `UID STORE` against the running server is a flag *write* that would mutate this environment's prod-cloned dataset, so the verification drives the actual response-builder (`storeFlagsTyped`) end-to-end through a unit test with a captured socket writer and asserts the exact emitted bytes — stronger than inspecting a served source file.

Closes #589