### PR TITLE
fix(imap): return NO for SELECT/EXAMINE/STATUS on a non-existent mailbox (RFC 3501 §6.3.1/2/10)

### DIFF
--- a/src/server/lib/imap/mailbox-existence.test.ts
+++ b/src/server/lib/imap/mailbox-existence.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for mailbox-existence validation on SELECT / EXAMINE / STATUS (#595).
+ *
+ * Before the fix, all three commands detected non-existence solely via
+ * `countMessages(...) === null`, but countMessages returns a zero-count
+ * aggregate (never null) for an unknown name — so every invented mailbox
+ * "succeeded" as a valid-but-empty mailbox. RFC 3501 §6.3.1/2/10 require a
+ * tagged NO for a non-existent mailbox. These cases pin: NO for an unknown
+ * name across SELECT/EXAMINE/STATUS, and OK for a real (existing-but-empty)
+ * mailbox.
+ *
+ * Uses a fake Store (the mailbox-list.test.ts pattern) so no DB is touched.
+ * The STATUS OK case requests no UIDVALIDITY item, so statusMailbox never
+ * reaches getImapUidValidity.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { selectMailbox, statusMailbox } from "./mailbox-ops";
+import { Store } from "./store";
+import type { SignedUser } from "common";
+import type { SequenceState } from "./sequence-resolver";
+
+const REAL_MAILBOXES = ["INBOX", "Sent Messages", "Archive"];
+
+// mailboxExists consults listMailboxes(); countMessages backs the STATUS OK
+// path (an existing-but-empty mailbox aggregates to total 0). mailboxExists
+// mirrors the Store contract so the handler gate is exercised end-to-end; the
+// real Store.mailboxExists is unit-tested separately below.
+const fakeStore = (boxes: string[]): Store =>
+  ({
+    listMailboxes: async () => boxes,
+    mailboxExists: async (box: string) => box === "INBOX" || boxes.includes(box),
+    countMessages: async () => ({ total: 0, unread: 0, maxUid: 0 }),
+  }) as unknown as Store;
+
+const emptySeqState = (): SequenceState => ({
+  seqToUid: [],
+  uidToSeq: new Map(),
+});
+
+const runSelect = async (name: string, readOnly: boolean) => {
+  const lines: string[] = [];
+  await selectMailbox(
+    "A1",
+    name,
+    readOnly,
+    fakeStore(REAL_MAILBOXES),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    },
+    emptySeqState(),
+    () => {},
+    () => {}
+  );
+  return lines;
+};
+
+const runStatus = async (mailbox: string) => {
+  const lines: string[] = [];
+  await statusMailbox(
+    "A1",
+    mailbox,
+    ["MESSAGES", "UIDNEXT", "UNSEEN"],
+    fakeStore(REAL_MAILBOXES),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    }
+  );
+  return lines;
+};
+
+describe("mailbox-existence validation (#595)", () => {
+  it("SELECT on an unknown mailbox returns NO and no EXISTS", async () => {
+    const lines = await runSelect("ThisMailboxDoesNotExist", false);
+    expect(lines).toEqual(["A1 NO Mailbox does not exist\r\n"]);
+    expect(lines.some((l) => l.includes("EXISTS"))).toBe(false);
+  });
+
+  it("EXAMINE on an unknown mailbox returns NO and no EXISTS", async () => {
+    const lines = await runSelect("NopeNotHere", true);
+    expect(lines).toEqual(["A1 NO Mailbox does not exist\r\n"]);
+    expect(lines.some((l) => l.includes("EXISTS"))).toBe(false);
+  });
+
+  it("SELECT on a per-account box for a non-existent account returns NO", async () => {
+    const lines = await runSelect(
+      "INBOX/accounts/zzz-no-such-account",
+      false
+    );
+    expect(lines).toEqual(["A1 NO Mailbox does not exist\r\n"]);
+  });
+
+  it("STATUS on an unknown mailbox returns NO and no untagged STATUS", async () => {
+    const lines = await runStatus("GarbageBox");
+    expect(lines).toEqual(["A1 NO Mailbox does not exist\r\n"]);
+    expect(lines.some((l) => l.startsWith("* STATUS"))).toBe(false);
+  });
+
+  it("STATUS on a real (empty) mailbox still returns OK with a STATUS line", async () => {
+    const lines = await runStatus("Archive");
+    expect(lines).toContain(
+      '* STATUS "Archive" (MESSAGES 0 UIDNEXT 1 UNSEEN 0)\r\n'
+    );
+    expect(lines).toContain("A1 OK STATUS completed\r\n");
+    expect(lines.some((l) => l.includes("NO Mailbox does not exist"))).toBe(
+      false
+    );
+  });
+
+  it("INBOX always validates as existing", async () => {
+    // Even with an empty list (e.g. a brand-new account), INBOX must exist.
+    const lines: string[] = [];
+    await statusMailbox(
+      "A1",
+      "INBOX",
+      ["MESSAGES"],
+      fakeStore([]),
+      (data: string) => {
+        lines.push(data);
+        return true;
+      }
+    );
+    expect(lines).toContain("A1 OK STATUS completed\r\n");
+    expect(lines.some((l) => l.includes("NO Mailbox does not exist"))).toBe(
+      false
+    );
+  });
+});
+
+describe("Store.mailboxExists (#595)", () => {
+  // The constructor only stashes the user (no DB), so we can build a real
+  // Store and override its listMailboxes to exercise the real mailboxExists.
+  const makeStore = (boxes: string[]): Store => {
+    const store = new Store({ id: "u1", username: "admin" } as SignedUser);
+    store.listMailboxes = async () => boxes;
+    return store;
+  };
+
+  it("returns true for INBOX without consulting the list", async () => {
+    const store = new Store({ id: "u1", username: "admin" } as SignedUser);
+    store.listMailboxes = async () => {
+      throw new Error("listMailboxes should not be called for INBOX");
+    };
+    expect(await store.mailboxExists("INBOX")).toBe(true);
+  });
+
+  it("returns true for a listed mailbox", async () => {
+    const store = makeStore(REAL_MAILBOXES);
+    expect(await store.mailboxExists("Sent Messages")).toBe(true);
+    expect(await store.mailboxExists("Archive")).toBe(true);
+  });
+
+  it("returns false for an unlisted name", async () => {
+    const store = makeStore(REAL_MAILBOXES);
+    expect(await store.mailboxExists("GarbageBox")).toBe(false);
+  });
+});

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -181,6 +181,11 @@ export async function statusMailbox(
   write: (data: string) => boolean | undefined
 ): Promise<void> {
   try {
+    if (!(await store.mailboxExists(mailbox))) {
+      write(`${tag} NO Mailbox does not exist\r\n`);
+      return;
+    }
+
     const countResult = await store.countMessages(mailbox);
 
     if (countResult === null) {
@@ -365,6 +370,11 @@ export async function selectMailbox(
   }
 
   try {
+    if (!(await store.mailboxExists(cleanName))) {
+      write(`${tag} NO Mailbox does not exist\r\n`);
+      return;
+    }
+
     setSelected(cleanName, 0);
 
     await buildSequenceMapping(store, cleanName, seqState);

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -235,6 +235,21 @@ export class Store {
     }
   };
 
+  /**
+   * Whether `box` names a mailbox that actually exists for this user. INBOX
+   * always exists; every other name must be a member of the listable set
+   * (the unified Sent folder, the accounts/ parents, per-account boxes, and
+   * user-created mailboxes). countMessages can't answer this — it returns a
+   * zero-count aggregate for any unknown name — so SELECT/EXAMINE/STATUS must
+   * gate on this to return a tagged NO for phantom mailboxes rather than
+   * reporting them as valid-but-empty (RFC 3501 §6.3.1/2/10). See #595.
+   */
+  mailboxExists = async (box: string): Promise<boolean> => {
+    if (box === "INBOX") return true;
+    const mailboxes = await this.listMailboxes();
+    return mailboxes.includes(box);
+  };
+
   countMessages = async (
     box: string
   ): Promise<{ total: number; unread: number; maxUid: number } | null> => {


### PR DESCRIPTION
## Summary

`SELECT`, `EXAMINE`, and `STATUS` returned a tagged `OK` for mailbox names that **do not exist**, reporting the phantom mailbox as a valid, empty mailbox (`* 0 EXISTS` / `MESSAGES 0`). RFC 3501 §6.3.1 (SELECT), §6.3.2 (EXAMINE), and §6.3.10 (STATUS) require a tagged `NO` for a non-existent mailbox.

## Root cause

All three handlers detected non-existence solely via `countMessages(...) === null` (`mailbox-ops.ts`), but `countMessages` is a pure `COUNT(*)` aggregate that returns a zero-count for any unknown name — it only returns `null` on a DB exception. So the `=== null` guard fired only on DB errors, never on "mailbox doesn't exist." There was no positive existence check anywhere on the read path; `resolveBox` maps any string to an account address that simply matches zero rows.

## Fix

- **`Store.mailboxExists(box)`** (`store.ts`): `INBOX` always exists; every other name must be a member of the listable set (`listMailboxes()` — unified Sent, the `accounts/` parents, per-account boxes, and user-created mailboxes).
- Gate `selectMailbox` and `statusMailbox` on it **before** the count; emit `<tag> NO Mailbox does not exist` when false. An existing-but-empty mailbox still SELECTs/STATUSes `OK` (it's in `listMailboxes()` regardless of message count).

## Tests

New `mailbox-existence.test.ts` (fake-Store pattern, no DB):
- `NO` across SELECT / EXAMINE / STATUS for invented names + a per-account box for a non-existent account, asserting no phantom `* EXISTS` / `* STATUS`.
- `OK` for a real (empty) mailbox; INBOX always validates.
- `Store.mailboxExists` contract: INBOX fast-path (without consulting the list), listed → true, unlisted → false.

## Verification

- `bun test src/server` → **1040 pass / 0 fail**.
- `bun run typecheck` → clean. `bun run lint` → no new warnings in changed files.
- **Live IMAP E2E** against a locally-started server (fix applied), authenticated as `admin`, raw protocol session:

| Command | Result |
|---|---|
| `SELECT ThisMailboxDoesNotExist` | `NO Mailbox does not exist` (no `* EXISTS`) |
| `EXAMINE NopeNotHere` | `NO Mailbox does not exist` (no `* EXISTS`) |
| `STATUS GarbageBox (MESSAGES UIDNEXT UNSEEN)` | `NO Mailbox does not exist` (no `* STATUS`) |
| `SELECT "INBOX/accounts/zzz-no-such-account"` | `NO Mailbox does not exist` |
| `SELECT INBOX` | `OK [READ-WRITE]` with `* EXISTS` |
| `STATUS INBOX (MESSAGES)` | `OK STATUS completed` |

All 11 live assertions passed.

Closes #595