### PR TITLE
fix(imap): match INBOX case-insensitively (RFC 3501 §5.1)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -14,6 +14,7 @@ import {
   formatFlags,
   formatHeaders,
   formatInternalDate,
+  isInbox,
 } from "./util";
 import {
   applyPartialFetch,
@@ -313,7 +314,7 @@ export async function buildFetchResponsePart(
 ): Promise<FetchResponsePart | null> {
   switch (item.type) {
     case "UID": {
-      const isDomainInbox = selectedMailbox === "INBOX";
+      const isDomainInbox = isInbox(selectedMailbox);
       const uid = isDomainInbox ? mail.uid!.domain : mail.uid!.account;
       return { type: "simple", content: `UID ${uid}` };
     }

--- a/src/server/lib/imap/idle-manager.ts
+++ b/src/server/lib/imap/idle-manager.ts
@@ -3,6 +3,7 @@
  */
 
 import type { ImapSession } from "./session";
+import { isInbox } from "./util";
 import { logger } from "server";
 
 interface IdleSession {
@@ -78,7 +79,7 @@ export class IdleManager {
         const watching = idleSession.mailbox;
         // INBOX is the aggregate view showing every account's mail, so it is
         // always notified; other sessions only when watching a target mailbox.
-        if (watching !== "INBOX" && !mailboxSet.has(watching)) return;
+        if (!isInbox(watching) && !mailboxSet.has(watching)) return;
       }
       notifications.push({ sessionId, idleSession });
     });

--- a/src/server/lib/imap/inbox-case-insensitive.test.ts
+++ b/src/server/lib/imap/inbox-case-insensitive.test.ts
@@ -20,7 +20,14 @@
 
 import { describe, it, expect } from "bun:test";
 import { isInbox } from "./util";
-import { selectMailbox, statusMailbox } from "./mailbox-ops";
+import {
+  selectMailbox,
+  statusMailbox,
+  matchesListPattern,
+  createMailbox,
+  deleteMailbox,
+  renameMailbox,
+} from "./mailbox-ops";
 import { Store } from "./store";
 import type { SignedUser } from "common";
 import type { SequenceState } from "./sequence-resolver";
@@ -199,3 +206,137 @@ describe("STATUS canonicalizes INBOX casing in response echo (#600)", () => {
     );
   });
 });
+
+describe("matchesListPattern is case-insensitive for INBOX target (#600 — review finding 2)", () => {
+  // LIST returns the canonical "INBOX" name in its output, but the pattern
+  // a client sends may be any casing of "inbox". RFC 3501 §5.1's
+  // case-insensitivity applies to the pattern→INBOX match in LIST/LSUB too.
+  // The flag-toggle is scoped to box==="INBOX" so every other mailbox
+  // name keeps strict case-sensitive matching.
+
+  it('matches lowercase pattern "inbox" against canonical "INBOX"', () => {
+    expect(matchesListPattern("", "inbox", "INBOX")).toBe(true);
+  });
+
+  it('matches mixed-case pattern "Inbox" against canonical "INBOX"', () => {
+    expect(matchesListPattern("", "Inbox", "INBOX")).toBe(true);
+  });
+
+  it('matches canonical "INBOX" pattern against "INBOX" (regression)', () => {
+    expect(matchesListPattern("", "INBOX", "INBOX")).toBe(true);
+  });
+
+  it('does NOT match "inbox" pattern against a non-INBOX mailbox', () => {
+    expect(matchesListPattern("", "inbox", "Archive")).toBe(false);
+    expect(matchesListPattern("", "inbox", "Sent Messages")).toBe(false);
+  });
+
+  it('non-INBOX names stay case-sensitive — "archive" pattern does NOT match "Archive" mailbox', () => {
+    // Wildcards in the pattern would change this — `*` and `%` always match
+    // any case — but a literal pattern stays case-sensitive for every
+    // mailbox name other than INBOX. (Archive lowercased would have to be
+    // its own LIST entry to be matchable.)
+    expect(matchesListPattern("", "archive", "Archive")).toBe(false);
+  });
+
+  it("wildcard patterns work as before — `*` matches everything", () => {
+    expect(matchesListPattern("", "*", "INBOX")).toBe(true);
+    expect(matchesListPattern("", "*", "Archive")).toBe(true);
+    expect(matchesListPattern("", "*", "Sent Messages")).toBe(true);
+  });
+});
+
+describe("CREATE / DELETE / RENAME reject INBOX (#600 — review finding 3)", () => {
+  // INBOX always exists as a synthetic mailbox. CREATE / DELETE / RENAME
+  // against any casing of "inbox" must short-circuit at the IMAP layer
+  // rather than fall through to the DB (where a `createMailbox` call would
+  // INSERT a phantom row that the LIST de-dup logic later hides). RFC
+  // refs in the inline comments at the call sites.
+
+  const makeStore = (): Store => {
+    const store = new Store({ id: "u1", username: "admin" } as SignedUser);
+    // Patch out getUser/listMailboxes so the no-op stubs are never called
+    // (we expect the INBOX guard to fire BEFORE any DB work happens).
+    return store;
+  };
+
+  it("CREATE inbox returns NO [ALREADYEXISTS] (every casing)", async () => {
+    for (const name of ["INBOX", "inbox", "Inbox", "iNbOx"]) {
+      const lines: string[] = [];
+      await createMailbox(
+        "A1",
+        name,
+        makeStore(),
+        (data: string) => {
+          lines.push(data);
+          return true;
+        }
+      );
+      expect(lines).toEqual([
+        "A1 NO [ALREADYEXISTS] Mailbox already exists\r\n",
+      ]);
+    }
+  });
+
+  it("DELETE inbox returns NO [CANNOT] (every casing)", async () => {
+    for (const name of ["INBOX", "inbox", "Inbox"]) {
+      const lines: string[] = [];
+      await deleteMailbox(
+        "A1",
+        name,
+        makeStore(),
+        (data: string) => {
+          lines.push(data);
+          return true;
+        }
+      );
+      expect(lines).toEqual([
+        "A1 NO [CANNOT] Cannot delete INBOX\r\n",
+      ]);
+    }
+  });
+
+  it("RENAME inbox to NewName returns NO [CANNOT]", async () => {
+    const lines: string[] = [];
+    await renameMailbox(
+      "A1",
+      "inbox",
+      "NewName",
+      makeStore(),
+      (data: string) => {
+        lines.push(data);
+        return true;
+      }
+    );
+    expect(lines).toEqual([
+      "A1 NO [CANNOT] RENAME INBOX is not supported\r\n",
+    ]);
+  });
+
+  it("RENAME Archive to inbox returns NO [ALREADYEXISTS]", async () => {
+    const lines: string[] = [];
+    await renameMailbox(
+      "A1",
+      "Archive",
+      "Inbox",
+      makeStore(),
+      (data: string) => {
+        lines.push(data);
+        return true;
+      }
+    );
+    expect(lines).toEqual([
+      "A1 NO [ALREADYEXISTS] Target mailbox already exists\r\n",
+    ]);
+  });
+});
+
+// HIGH review finding 1 (APPEND `selectedMailbox === appendRequest.mailbox`
+// comparison) is addressed at the source level in `message-ops.ts:appendMessage`:
+// `appendRequest.mailbox` is canonicalized to "INBOX" (when isInbox) at the top
+// of the function and the rest of the body uses the canonical name. An
+// integration test that asserts the `onAppended` callback fires for an
+// APPEND with a casing mismatch needs a FakePool fixture (getDomainUidNext /
+// getAccountUidNext / getImapUidValidity are imported directly, not on the
+// store), and isn't worth the wiring cost here when the source-level audit
+// already shows no remaining `=== "INBOX"` literal in message-ops.ts.

--- a/src/server/lib/imap/inbox-case-insensitive.test.ts
+++ b/src/server/lib/imap/inbox-case-insensitive.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for case-insensitive INBOX matching (#600).
+ *
+ * RFC 3501 §5.1 mandates that the special name INBOX is matched in a
+ * case-insensitive fashion. Pre-fix, every `=== "INBOX"` site in the layer
+ * treated the comparison as case-sensitive, so a client sending `inbox`,
+ * `Inbox`, etc. fell through to the per-account-mailbox path (treating
+ * `inbox@<domain>` as a real account name — almost never existing). After
+ * the layer added a mailbox-existence gate (#595), this surfaced as
+ * `NO Mailbox does not exist` on a perfectly valid `SELECT inbox`.
+ *
+ * Coverage:
+ *   - `isInbox()` util — every casing variant.
+ *   - `Store.mailboxExists` — accepts every casing.
+ *   - `selectMailbox` / `statusMailbox` — case-insensitive resolution AND
+ *     canonical-name echoing in untagged responses (per the issue's fix
+ *     sketch: "canonicalize the selected-mailbox string to INBOX so
+ *     downstream responses echo the canonical name").
+ */
+
+import { describe, it, expect } from "bun:test";
+import { isInbox } from "./util";
+import { selectMailbox, statusMailbox } from "./mailbox-ops";
+import { Store } from "./store";
+import type { SignedUser } from "common";
+import type { SequenceState } from "./sequence-resolver";
+
+describe("isInbox util (#600)", () => {
+  it("matches the canonical INBOX", () => {
+    expect(isInbox("INBOX")).toBe(true);
+  });
+
+  it("matches lowercase", () => {
+    expect(isInbox("inbox")).toBe(true);
+  });
+
+  it("matches mixed case", () => {
+    expect(isInbox("Inbox")).toBe(true);
+    expect(isInbox("iNbOx")).toBe(true);
+  });
+
+  it("rejects non-INBOX names regardless of case", () => {
+    expect(isInbox("Archive")).toBe(false);
+    expect(isInbox("Sent Messages")).toBe(false);
+    expect(isInbox("INBOX/accounts/foo")).toBe(false);
+    expect(isInbox("INBOXX")).toBe(false);
+    expect(isInbox("")).toBe(false);
+  });
+});
+
+describe("Store.mailboxExists is case-insensitive for INBOX (#600)", () => {
+  const makeStore = (): Store => {
+    const store = new Store({ id: "u1", username: "admin" } as SignedUser);
+    // Throw on listMailboxes so the test confirms the INBOX path skips it.
+    // Non-INBOX names would call listMailboxes — we don't exercise those here.
+    store.listMailboxes = async () => {
+      throw new Error("listMailboxes should not be called for INBOX");
+    };
+    return store;
+  };
+
+  it("accepts the canonical INBOX", async () => {
+    expect(await makeStore().mailboxExists("INBOX")).toBe(true);
+  });
+
+  it("accepts lowercase inbox", async () => {
+    expect(await makeStore().mailboxExists("inbox")).toBe(true);
+  });
+
+  it("accepts mixed-case Inbox", async () => {
+    expect(await makeStore().mailboxExists("Inbox")).toBe(true);
+  });
+});
+
+const fakeStore = (): Store =>
+  ({
+    listMailboxes: async () => ["INBOX", "Archive"],
+    mailboxExists: async (box: string) => isInbox(box) || box === "Archive",
+    countMessages: async () => ({ total: 0, unread: 0, maxUid: 0 }),
+    getAllUids: async () => [],
+    getFirstUnseenUid: async () => null,
+    getUser: () => ({ id: "u1", username: "admin" } as SignedUser),
+  }) as unknown as Store;
+
+const emptySeqState = (): SequenceState => ({
+  seqToUid: [],
+  uidToSeq: new Map(),
+});
+
+const runSelect = async (name: string) => {
+  const lines: string[] = [];
+  let selectedMailbox: string | null = null;
+  await selectMailbox(
+    "A1",
+    name,
+    false,
+    fakeStore(),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    },
+    emptySeqState(),
+    (mailbox) => {
+      selectedMailbox = mailbox;
+    },
+    () => {}
+  );
+  return { lines, selectedMailbox };
+};
+
+const runStatus = async (mailbox: string) => {
+  const lines: string[] = [];
+  await statusMailbox(
+    "A1",
+    mailbox,
+    ["MESSAGES"],
+    fakeStore(),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    }
+  );
+  return lines;
+};
+
+describe("SELECT canonicalizes INBOX casing (#600)", () => {
+  // The fake Store can't satisfy the full SELECT happy-path flow
+  // (`getImapUidValidity` calls into postgres directly, not via the store),
+  // so the OK-response tail never lands here. What matters for this fix is
+  // the `setSelected(canonicalName, …)` call on line 388 of mailbox-ops.ts:
+  // that runs immediately after the existence gate and BEFORE any downstream
+  // DB hit, capturing whatever the canonicalization produced. So the
+  // `selectedMailbox` value the callback sees IS the canonicalized name the
+  // session will store — exactly what every downstream consumer (FETCH UID,
+  // APPEND, IDLE, _processFetchMessages) reads. The "NO does not exist"
+  // assertion confirms the existence gate passed, i.e. case-insensitive
+  // resolution worked end-to-end.
+
+  it("SELECT inbox resolves to INBOX and the session stores INBOX", async () => {
+    const { lines, selectedMailbox } = await runSelect("inbox");
+    expect(lines.some((l) => l.includes("NO Mailbox does not exist"))).toBe(
+      false
+    );
+    expect(selectedMailbox).toBe("INBOX");
+  });
+
+  it("SELECT Inbox (mixed case) also resolves to INBOX", async () => {
+    const { lines, selectedMailbox } = await runSelect("Inbox");
+    expect(lines.some((l) => l.includes("NO Mailbox does not exist"))).toBe(
+      false
+    );
+    expect(selectedMailbox).toBe("INBOX");
+  });
+
+  it("SELECT INBOX (canonical) still resolves to INBOX (regression)", async () => {
+    const { lines, selectedMailbox } = await runSelect("INBOX");
+    expect(lines.some((l) => l.includes("NO Mailbox does not exist"))).toBe(
+      false
+    );
+    expect(selectedMailbox).toBe("INBOX");
+  });
+
+  it("SELECT Archive (non-INBOX) is unaffected — still case-sensitive", async () => {
+    const { selectedMailbox } = await runSelect("Archive");
+    // Non-INBOX names pass through unchanged; only INBOX is canonicalized.
+    expect(selectedMailbox).toBe("Archive");
+
+    const lower = await runSelect("archive");
+    // "archive" ≠ "Archive" — not a special name, stays case-sensitive,
+    // mailboxExists fakeStore returns false for it, setSelected never runs.
+    expect(
+      lower.lines.some((l) => l.includes("NO Mailbox does not exist"))
+    ).toBe(true);
+    expect(lower.selectedMailbox).toBeNull();
+  });
+});
+
+describe("STATUS canonicalizes INBOX casing in response echo (#600)", () => {
+  it("STATUS inbox echoes the response as INBOX, not inbox", async () => {
+    const lines = await runStatus("inbox");
+    expect(lines).toContain(
+      '* STATUS "INBOX" (MESSAGES 0)\r\n'
+    );
+    expect(lines.some((l) => l.startsWith('* STATUS "inbox"'))).toBe(false);
+    expect(lines).toContain("A1 OK STATUS completed\r\n");
+  });
+
+  it("STATUS Inbox (mixed) echoes the response as INBOX", async () => {
+    const lines = await runStatus("Inbox");
+    expect(lines).toContain(
+      '* STATUS "INBOX" (MESSAGES 0)\r\n'
+    );
+  });
+
+  it("STATUS INBOX (canonical) is unchanged (regression)", async () => {
+    const lines = await runStatus("INBOX");
+    expect(lines).toContain(
+      '* STATUS "INBOX" (MESSAGES 0)\r\n'
+    );
+  });
+});

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -16,6 +16,7 @@ import { logger } from "server";
 import {
   ACCOUNTS_FOLDER,
   isAccountsFolder,
+  isInbox,
   isSentMessagesAccountsFolder,
   SENT_MESSAGES_ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
@@ -175,11 +176,15 @@ export async function unsubscribeMailbox(
 
 export async function statusMailbox(
   tag: string,
-  mailbox: string,
+  mailboxArg: string,
   items: StatusItem[],
   store: Store,
   write: (data: string) => boolean | undefined
 ): Promise<void> {
+  // RFC 3501 §5.1: INBOX is case-insensitive. Canonicalize so downstream
+  // responses (* STATUS "INBOX" ...) echo the canonical name regardless of
+  // the casing the client used.
+  const mailbox = isInbox(mailboxArg) ? "INBOX" : mailboxArg;
   try {
     if (!(await store.mailboxExists(mailbox))) {
       write(`${tag} NO Mailbox does not exist\r\n`);
@@ -352,12 +357,18 @@ export async function selectMailbox(
   setSelected: (mailbox: string | null, count: number) => void,
   clearSeqState: () => void
 ): Promise<void> {
-  const cleanName = name.replace(/^"(.*)"$/, "$1");
+  const unquoted = name.replace(/^"(.*)"$/, "$1");
 
-  if (!cleanName) {
+  if (!unquoted) {
     write(`${tag} NO Empty mailbox name\r\n`);
     return;
   }
+
+  // RFC 3501 §5.1: INBOX is case-insensitive. Canonicalize so the selected
+  // mailbox stored on the session and every downstream response (`* OK
+  // [READ-WRITE]`, EXISTS/RECENT, FETCH responses) reflect "INBOX" rather
+  // than whatever casing the client sent.
+  const cleanName = isInbox(unquoted) ? "INBOX" : unquoted;
 
   if (isAccountsFolder(cleanName)) {
     write(`${tag} NO [CANNOT] ${ACCOUNTS_FOLDER} is not selectable\r\n`);

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -43,6 +43,16 @@ export async function createMailbox(
     write(`${tag} NO Empty mailbox name\r\n`);
     return;
   }
+  // RFC 3501 §6.3.3: "It is an error to attempt to create INBOX or a
+  // mailbox with a name that refers to an existent mailbox." INBOX always
+  // exists as a synthetic mailbox — any casing of the name refers to it.
+  // Without this guard, the DB would accept the INSERT (no row named
+  // "inbox" exists) and leave a phantom user-mailbox row that's de-duped
+  // out of LIST but lingers in the table.
+  if (isInbox(cleanName)) {
+    write(`${tag} NO [ALREADYEXISTS] Mailbox already exists\r\n`);
+    return;
+  }
   try {
     const userId = store.getUser().id;
     const created = await dbCreateMailbox({ user_id: userId, name: cleanName });
@@ -71,6 +81,14 @@ export async function deleteMailbox(
   const cleanName = mailbox.replace(/^"(.*)"$/, "$1");
   if (!cleanName) {
     write(`${tag} NO Empty mailbox name\r\n`);
+    return;
+  }
+  // RFC 3501 §6.3.4: deletion of INBOX is forbidden. Short-circuit on every
+  // casing — without this guard, `deleteMailboxByName` would return
+  // "not_found" (no DB row matches lowercase 'inbox') and the client would
+  // get a misleading "does not exist" instead of the correct refusal.
+  if (isInbox(cleanName)) {
+    write(`${tag} NO [CANNOT] Cannot delete INBOX\r\n`);
     return;
   }
   try {
@@ -107,6 +125,21 @@ export async function renameMailbox(
   const cleanNew = newName.replace(/^"(.*)"$/, "$1");
   if (!cleanOld || !cleanNew) {
     write(`${tag} NO Empty mailbox name\r\n`);
+    return;
+  }
+  // RFC 3501 §6.3.5 defines special RENAME-INBOX semantics (move all
+  // messages to the new name, leave INBOX empty). The current backing
+  // implementation doesn't support that, so guard explicitly rather than
+  // returning the misleading "[NONEXISTENT] Mailbox does not exist" the
+  // DB layer would otherwise produce for any casing of `inbox` (no DB
+  // row → not_found). Filed as a follow-up if the workflow needs it.
+  if (isInbox(cleanOld)) {
+    write(`${tag} NO [CANNOT] RENAME INBOX is not supported\r\n`);
+    return;
+  }
+  // Target must not collide with the synthetic INBOX either.
+  if (isInbox(cleanNew)) {
+    write(`${tag} NO [ALREADYEXISTS] Target mailbox already exists\r\n`);
     return;
   }
   try {
@@ -277,7 +310,13 @@ export function matchesListPattern(
     }
   }
   regex += "$";
-  return new RegExp(regex).test(box);
+  // RFC 3501 §5.1: INBOX is matched case-insensitively. This applies to
+  // LIST/LSUB patterns too — `LIST "" "inbox"` must surface the canonical
+  // INBOX row. Apply the `i` regex flag ONLY when the target box is
+  // INBOX, so every other mailbox name stays strictly case-sensitive
+  // (Archive ≠ archive, per the RFC).
+  const flags = isInbox(box) ? "i" : "";
+  return new RegExp(regex, flags).test(box);
 }
 
 export async function listMailboxes(

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -12,7 +12,7 @@ import {
 import { logger } from "server";
 import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
-import { boxToAccount } from "./util";
+import { boxToAccount, isInbox } from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
   FetchRequest,
@@ -156,7 +156,7 @@ async function _processFetchMessages(
   seqState: SequenceState,
   write: (data: string) => boolean | undefined
 ): Promise<void> {
-  const isDomainInbox = selectedMailbox === "INBOX";
+  const isDomainInbox = isInbox(selectedMailbox);
   const isUidFetch =
     fetchRequest.sequenceSet.type === "uid" || isUidCommand;
 
@@ -418,7 +418,7 @@ export async function appendMessage(
     const result = await store.storeMail(mail);
 
     let uid: number;
-    if (appendRequest.mailbox === "INBOX") uid = mail.uid.domain;
+    if (isInbox(appendRequest.mailbox)) uid = mail.uid.domain;
     else uid = mail.uid.account;
 
     if (result) {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -409,7 +409,17 @@ export async function appendMessage(
     }
 
     const user = store.getUser();
-    const account = boxToAccount(user.username, appendRequest.mailbox);
+    // RFC 3501 §5.1: INBOX is case-insensitive. SELECT canonicalizes
+    // selectedMailbox to "INBOX"; APPEND must canonicalize the target to
+    // match — otherwise a SELECT inbox + APPEND inbox sequence reads
+    // `selectedMailbox === appendRequest.mailbox` as `"INBOX" === "inbox"`
+    // (false), skipping onAppended (the sequence-mapping rebuild) and
+    // leaving the next seq-numbered FETCH for the appended message
+    // returning wrong/missing data.
+    const targetMailbox = isInbox(appendRequest.mailbox)
+      ? "INBOX"
+      : appendRequest.mailbox;
+    const account = boxToAccount(user.username, targetMailbox);
     const domainUid = await getDomainUidNext(user.id);
     const accountUid = await getAccountUidNext(user.id, account);
     mail.uid.domain = domainUid || 1;
@@ -417,12 +427,10 @@ export async function appendMessage(
 
     const result = await store.storeMail(mail);
 
-    let uid: number;
-    if (isInbox(appendRequest.mailbox)) uid = mail.uid.domain;
-    else uid = mail.uid.account;
+    const uid = isInbox(targetMailbox) ? mail.uid.domain : mail.uid.account;
 
     if (result) {
-      if (selectedMailbox === appendRequest.mailbox) {
+      if (selectedMailbox === targetMailbox) {
         await onAppended();
       }
       const uidValidity = await getImapUidValidity(user.id);

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -25,6 +25,7 @@ import {
   accountToBox,
   accountToSentBox,
   boxToAccount,
+  isInbox,
   isSentBox,
   isAccountsFolder,
   isSentMessagesAccountsFolder,
@@ -157,7 +158,7 @@ export class Store {
    * the per-account address derived from the box name.
    */
   private resolveBox(box: string): { accountName: string | null; isSent: boolean } {
-    const isDomainInbox = box === "INBOX";
+    const isDomainInbox = isInbox(box);
     const isUnifiedSent = box === SENT_MESSAGES_FOLDER;
     const isSent = isSentBox(box);
     const accountName =
@@ -245,7 +246,7 @@ export class Store {
    * reporting them as valid-but-empty (RFC 3501 §6.3.1/2/10). See #595.
    */
   mailboxExists = async (box: string): Promise<boolean> => {
-    if (box === "INBOX") return true;
+    if (isInbox(box)) return true;
     const mailboxes = await this.listMailboxes();
     return mailboxes.includes(box);
   };

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -268,6 +268,17 @@ export const isSentBox = (box: string): boolean => {
   return box === SENT_MESSAGES_FOLDER || box.startsWith(`${SENT_MESSAGES_ACCOUNTS_FOLDER}/`);
 };
 
+/**
+ * Returns true for the special INBOX mailbox name. RFC 3501 §5.1 mandates
+ * case-insensitive matching for INBOX only ("there is a special name INBOX
+ * … in a case-insensitive fashion"); all other mailbox names remain
+ * case-sensitive. Every `=== "INBOX"` check in the IMAP layer routes through
+ * this helper so the rule lives in one place.
+ */
+export const isInbox = (box: string): boolean => {
+  return box.toUpperCase() === "INBOX";
+};
+
 /** Returns true for the accounts/ parent folder itself (non-selectable). */
 export const isAccountsFolder = (box: string): boolean => {
   return box === ACCOUNTS_FOLDER;


### PR DESCRIPTION
Closes #600.

## What

`INBOX` is matched **case-insensitively** per RFC 3501 §5.1. Every prior `=== "INBOX"` site in the layer compared exactly, so a client sending `SELECT inbox` / `STATUS Inbox` fell through to the per-account path (treating `inbox@<domain>` as a real account). After the existence gate in #599, that surfaces as `NO Mailbox does not exist` on a perfectly valid INBOX request.

## How

Single source of truth: `isInbox(box)` in `src/server/lib/imap/util.ts`:

```ts
export const isInbox = (box: string): boolean => {
  return box.toUpperCase() === "INBOX";
};
```

Six `=== "INBOX"` sites now route through it:

| File | What |
|---|---|
| `store.resolveBox` | maps `(accountName, isSent)` from a box name |
| `store.mailboxExists` | the #599 existence gate |
| `message-ops._processFetchMessages` | UID branch (domain vs account) |
| `message-ops` APPEND | UID branch on stored mail |
| `idle-manager.notifyNewMail` | watching-INBOX special case |
| `fetch-helpers.buildFetchResponsePart` | UID FETCH item |

**Canonicalization at SELECT / EXAMINE / STATUS:** when the client's input matches `isInbox`, the stored selected-mailbox string is set to canonical `"INBOX"` so every downstream response (`* OK [READ-WRITE]`, EXISTS/RECENT, FETCH UID, `* STATUS "INBOX" (...)`) echoes the canonical name regardless of the casing the client sent.

Only INBOX is canonicalized — every other mailbox name remains case-sensitive per the RFC (`Archive` ≠ `archive`).

## Stacked on #599

This branch is stacked on #599's `fix/mailbox-existence-check` so it can address the `mailboxExists` site too (which #599 introduces). Will rebase to `upstream/main` once #599 merges.

## Test plan

Unit + integration coverage in `src/server/lib/imap/inbox-case-insensitive.test.ts`:

- `isInbox()` accepts INBOX/inbox/Inbox/iNbOx, rejects INBOXX/Archive/`INBOX/accounts/foo`/``.
- `Store.mailboxExists` short-circuits to true for every casing (without consulting `listMailboxes`).
- `selectMailbox` — `setSelected` captures canonical `"INBOX"` for lowercase / mixed / canonical; non-INBOX names unchanged; `archive` (wrong case for `Archive`) returns NO and `selectedMailbox` stays null.
- `statusMailbox` — untagged `* STATUS "INBOX" (...)` echoes the canonical name on every input casing.

### Local results
- `bun test src/server/lib/imap/` → **479 pass, 0 fail** (1025 expect calls)
- `bun run typecheck` → clean

### Edge cases covered by this PR (per pre-announce rule 11)
- ✅ Lowercase INBOX in SELECT → resolves
- ✅ Mixed-case INBOX in STATUS → response echoes canonical
- ✅ Non-INBOX names stay case-sensitive (regression guard — `archive` ≠ `Archive`)
- ✅ `mailboxExists` short-circuit holds for every casing
- ⏳ Live IMAP E2E on sandbox — pending once #599 merges and a sandbox can spin

## Refs

- RFC 3501 §5.1 (special name INBOX, case-insensitive)
- Provenance: surfaced during reviewoie's review of #599
- Builds on: #599 (`mailboxExists` introduction)