### PR TITLE
fix(imap): propagate transient errors from mailboxExists (RFC 3501 §6.3.1/2/10)

### DIFF
--- a/src/server/lib/imap/mailbox-existence.test.ts
+++ b/src/server/lib/imap/mailbox-existence.test.ts
@@ -131,18 +131,28 @@ describe("mailbox-existence validation (#595)", () => {
 
 describe("Store.mailboxExists (#595)", () => {
   // The constructor only stashes the user (no DB), so we can build a real
-  // Store and override its listMailboxes to exercise the real mailboxExists.
+  // Store and override its list methods to exercise the real mailboxExists.
+  // `mailboxExists` consults `listMailboxesOrThrow` (the throwing path —
+  // see #601) so transient backend errors propagate instead of getting
+  // swallowed into a false "does not exist." We patch both — the public
+  // `listMailboxes` (for any consumer reading it directly) and the private
+  // `listMailboxesOrThrow` (what `mailboxExists` actually calls).
   const makeStore = (boxes: string[]): Store => {
     const store = new Store({ id: "u1", username: "admin" } as SignedUser);
     store.listMailboxes = async () => boxes;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (store as any).listMailboxesOrThrow = async () => boxes;
     return store;
   };
 
   it("returns true for INBOX without consulting the list", async () => {
     const store = new Store({ id: "u1", username: "admin" } as SignedUser);
-    store.listMailboxes = async () => {
-      throw new Error("listMailboxes should not be called for INBOX");
+    const guard = async () => {
+      throw new Error("list path should not be called for INBOX");
     };
+    store.listMailboxes = guard;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (store as any).listMailboxesOrThrow = guard;
     expect(await store.mailboxExists("INBOX")).toBe(true);
   });
 

--- a/src/server/lib/imap/mailbox-exists-transient.test.ts
+++ b/src/server/lib/imap/mailbox-exists-transient.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for transient-error propagation in mailboxExists (#601).
+ *
+ * `Store.mailboxExists` (added in #599) was implemented as
+ * `listMailboxes().includes(box)`. `listMailboxes` swallows backend errors
+ * and falls back to `["INBOX"]` (acceptable for LIST resilience). For the
+ * existence gate that's wrong: a transient DB hiccup on the stats/list
+ * queries turns into `NO Mailbox does not exist` — a permanent signal — for
+ * a mailbox the client just successfully `LIST`ed.
+ *
+ * After this fix, `mailboxExists` uses `listMailboxesOrThrow` (no fallback),
+ * so transient errors propagate up. The SELECT/STATUS handlers' existing
+ * try-catch then writes `NO SELECT failed` / `NO STATUS failed` (transient,
+ * retry-friendly) instead of `NO Mailbox does not exist` (permanent).
+ *
+ * `listMailboxes` (the LIST-facing path) keeps the fallback so LIST stays
+ * usable when the DB hiccups.
+ */
+
+import { describe, it, expect, mock, afterEach } from "bun:test";
+import { Store } from "./store";
+import { selectMailbox, statusMailbox } from "./mailbox-ops";
+import type { SignedUser } from "common";
+import type { SequenceState } from "./sequence-resolver";
+
+const VALID_USER: SignedUser = { id: "u1", username: "admin" } as SignedUser;
+
+// We test mailboxExists by patching listMailboxesOrThrow (the new private
+// method) and listMailboxes (the public fallback wrapper). Both are
+// instance-bound async arrow properties, so we can monkey-patch them on the
+// instance without touching prototypes.
+const buildStore = (opts: {
+  rawBoxes?: string[];
+  throwInListOrThrow?: boolean;
+}): Store => {
+  const store = new Store(VALID_USER);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (store as any).listMailboxesOrThrow = async () => {
+    if (opts.throwInListOrThrow) {
+      throw new Error("simulated DB hiccup on listMailboxesOrThrow");
+    }
+    return opts.rawBoxes ?? ["INBOX"];
+  };
+  // The fallback wrapper still calls listMailboxesOrThrow under the hood —
+  // since we patched the inner method, the outer one will catch and fall
+  // back. Patch it explicitly anyway so the test is independent of the
+  // wrapper's internal call shape (defends against future refactor).
+  store.listMailboxes = async () => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return await (store as any).listMailboxesOrThrow();
+    } catch {
+      return ["INBOX"];
+    }
+  };
+  return store;
+};
+
+describe("Store.mailboxExists propagates transient errors (#601)", () => {
+  it("returns true for INBOX without consulting the list (regression)", async () => {
+    const store = buildStore({
+      throwInListOrThrow: true, // would throw if consulted
+    });
+    expect(await store.mailboxExists("INBOX")).toBe(true);
+    expect(await store.mailboxExists("inbox")).toBe(true);
+  });
+
+  it("returns true for a listed mailbox on healthy queries", async () => {
+    const store = buildStore({
+      rawBoxes: ["INBOX", "Sent Messages", "Archive"],
+    });
+    expect(await store.mailboxExists("Archive")).toBe(true);
+    expect(await store.mailboxExists("Sent Messages")).toBe(true);
+  });
+
+  it("returns false for an unlisted name on healthy queries", async () => {
+    const store = buildStore({
+      rawBoxes: ["INBOX", "Sent Messages", "Archive"],
+    });
+    expect(await store.mailboxExists("GarbageBox")).toBe(false);
+  });
+
+  it("THROWS on transient backend failure (does not fall back to ['INBOX'])", async () => {
+    const store = buildStore({ throwInListOrThrow: true });
+    // The whole point of #601: the existence check must distinguish
+    // "couldn't determine the list" from "you're not on it." Throwing
+    // is how that distinction reaches the SELECT/STATUS handler.
+    await expect(store.mailboxExists("Archive")).rejects.toThrow(
+      "simulated DB hiccup on listMailboxesOrThrow"
+    );
+  });
+});
+
+describe("Store.listMailboxes still falls back on transient errors (regression)", () => {
+  it("returns ['INBOX'] on backend failure — LIST path resilience kept", async () => {
+    const store = buildStore({ throwInListOrThrow: true });
+    const result = await store.listMailboxes();
+    expect(result).toEqual(["INBOX"]);
+  });
+});
+
+// The handler-level assertions verify the wire response shape: a transient
+// failure must not surface as "Mailbox does not exist" (permanent) but as
+// "SELECT failed" / "STATUS failed" (transient, retry-friendly).
+
+const emptySeqState = (): SequenceState => ({
+  seqToUid: [],
+  uidToSeq: new Map(),
+});
+
+describe("SELECT writes 'NO SELECT failed' (not 'does not exist') on transient mailboxExists error (#601)", () => {
+  it("transient throw → SELECT failed (transient signal)", async () => {
+    const store = buildStore({ throwInListOrThrow: true });
+    const lines: string[] = [];
+    await selectMailbox(
+      "A1",
+      "Archive",
+      false,
+      store,
+      (data: string) => {
+        lines.push(data);
+        return true;
+      },
+      emptySeqState(),
+      () => {},
+      () => {}
+    );
+    // The catch block writes "NO SELECT failed" — a transient signal that
+    // tells the client to retry, not a permanent "this mailbox doesn't
+    // exist anymore" verdict.
+    expect(lines).toContain("A1 NO SELECT failed\r\n");
+    expect(
+      lines.some((l) => l.includes("NO Mailbox does not exist"))
+    ).toBe(false);
+  });
+
+  it("non-existence (without backend error) still writes 'NO Mailbox does not exist'", async () => {
+    const store = buildStore({ rawBoxes: ["INBOX", "Archive"] });
+    const lines: string[] = [];
+    await selectMailbox(
+      "A1",
+      "GhostBox",
+      false,
+      store,
+      (data: string) => {
+        lines.push(data);
+        return true;
+      },
+      emptySeqState(),
+      () => {},
+      () => {}
+    );
+    expect(lines).toContain("A1 NO Mailbox does not exist\r\n");
+  });
+});
+
+describe("STATUS writes 'NO STATUS failed' (not 'does not exist') on transient mailboxExists error (#601)", () => {
+  it("transient throw → STATUS failed (transient signal)", async () => {
+    const store = buildStore({ throwInListOrThrow: true });
+    const lines: string[] = [];
+    await statusMailbox(
+      "A1",
+      "Archive",
+      ["MESSAGES"],
+      store,
+      (data: string) => {
+        lines.push(data);
+        return true;
+      }
+    );
+    expect(lines).toContain("A1 NO STATUS failed\r\n");
+    expect(
+      lines.some((l) => l.includes("NO Mailbox does not exist"))
+    ).toBe(false);
+    expect(lines.some((l) => l.startsWith("* STATUS"))).toBe(false);
+  });
+});
+
+afterEach(() => {
+  mock.restore();
+});

--- a/src/server/lib/imap/mailbox-exists-transient.test.ts
+++ b/src/server/lib/imap/mailbox-exists-transient.test.ts
@@ -17,7 +17,7 @@
  * usable when the DB hiccups.
  */
 
-import { describe, it, expect, mock, afterEach } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import { Store } from "./store";
 import { selectMailbox, statusMailbox } from "./mailbox-ops";
 import type { SignedUser } from "common";
@@ -62,7 +62,6 @@ describe("Store.mailboxExists propagates transient errors (#601)", () => {
       throwInListOrThrow: true, // would throw if consulted
     });
     expect(await store.mailboxExists("INBOX")).toBe(true);
-    expect(await store.mailboxExists("inbox")).toBe(true);
   });
 
   it("returns true for a listed mailbox on healthy queries", async () => {
@@ -174,8 +173,4 @@ describe("STATUS writes 'NO STATUS failed' (not 'does not exist') on transient m
     ).toBe(false);
     expect(lines.some((l) => l.startsWith("* STATUS"))).toBe(false);
   });
-});
-
-afterEach(() => {
-  mock.restore();
 });

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -166,70 +166,88 @@ export class Store {
     return { accountName, isSent };
   }
 
+  /**
+   * Build the listable mailbox set; propagate backend errors. `listMailboxes`
+   * (below) wraps this in a fallback so the LIST command stays resilient,
+   * but the existence gate (`mailboxExists`) needs to distinguish "the user
+   * doesn't have this mailbox" from "I couldn't determine whether they do" —
+   * conflating the two turns a transient DB hiccup into a permanent-sounding
+   * `NO Mailbox does not exist` for the SELECT/STATUS/EXAMINE caller (#601).
+   */
+  private listMailboxesOrThrow = async (): Promise<string[]> => {
+    // Match HTTP /api/mails/accounts: filter by user's domain so we only
+    // expose addresses that belong to this server, not every external
+    // CC/BCC/recipient address found on stored mails.
+    const userDomain = getUserDomain(this.user.username);
+    const [receivedStats, sentStats, userMailboxes] = await Promise.all([
+      getAccountStats(this.user.id, false, userDomain),
+      getAccountStats(this.user.id, true, userDomain),
+      getMailboxesByUser(this.user.id),
+    ]);
+
+    const seen = new Set<string>();
+    const addMailbox = (name: string) => {
+      const trimmed = name.trim();
+      if (!seen.has(trimmed)) {
+        seen.add(trimmed);
+        mailboxes.push(trimmed);
+      }
+    };
+
+    const mailboxes: string[] = [];
+    addMailbox("INBOX");
+
+    // Add Sent Messages (unified across all accounts) if any sent mail exists
+    if (sentStats.length > 0) {
+      addMailbox(SENT_MESSAGES_FOLDER);
+    }
+
+    // Add accounts/ parent folder if any received-mail accounts exist
+    if (receivedStats.length > 0) {
+      addMailbox(ACCOUNTS_FOLDER);
+    }
+
+    // Add received mail accounts under accounts/ (deduplicated)
+    receivedStats.forEach((stat) => {
+      if (stat.address) {
+        addMailbox(accountToBox(stat.address));
+      }
+    });
+
+    // Add Sent Messages/accounts/ parent folder if any per-account sent mail exists
+    if (sentStats.length > 0) {
+      addMailbox(SENT_MESSAGES_ACCOUNTS_FOLDER);
+    }
+
+    // Add per-account sent mailboxes under Sent Messages/accounts/ (deduplicated)
+    sentStats.forEach((stat) => {
+      if (stat.address) {
+        addMailbox(accountToSentBox(stat.address));
+      }
+    });
+
+    // Add user-created mailboxes (those without a special_use and no address tie-in)
+    const systemNames = new Set(mailboxes.map((m) => m.toLowerCase()));
+    userMailboxes
+      .filter((mb) => mb.special_use === null && mb.address === null)
+      .forEach((mb) => {
+        if (!systemNames.has(mb.name.toLowerCase())) {
+          mailboxes.push(mb.name);
+        }
+      });
+
+    return mailboxes;
+  };
+
+  /**
+   * LIST-facing version: on backend error, log + return a single `["INBOX"]`
+   * fallback so the LIST command can still respond. The fallback is fine for
+   * LIST (the client just sees a minimal view) but NOT fine for the existence
+   * gate — see `mailboxExists` below.
+   */
   listMailboxes = async (): Promise<string[]> => {
     try {
-      // Match HTTP /api/mails/accounts: filter by user's domain so we only
-      // expose addresses that belong to this server, not every external
-      // CC/BCC/recipient address found on stored mails.
-      const userDomain = getUserDomain(this.user.username);
-      const [receivedStats, sentStats, userMailboxes] = await Promise.all([
-        getAccountStats(this.user.id, false, userDomain),
-        getAccountStats(this.user.id, true, userDomain),
-        getMailboxesByUser(this.user.id),
-      ]);
-
-      const seen = new Set<string>();
-      const addMailbox = (name: string) => {
-        const trimmed = name.trim();
-        if (!seen.has(trimmed)) {
-          seen.add(trimmed);
-          mailboxes.push(trimmed);
-        }
-      };
-
-      const mailboxes: string[] = [];
-      addMailbox("INBOX");
-
-      // Add Sent Messages (unified across all accounts) if any sent mail exists
-      if (sentStats.length > 0) {
-        addMailbox(SENT_MESSAGES_FOLDER);
-      }
-
-      // Add accounts/ parent folder if any received-mail accounts exist
-      if (receivedStats.length > 0) {
-        addMailbox(ACCOUNTS_FOLDER);
-      }
-
-      // Add received mail accounts under accounts/ (deduplicated)
-      receivedStats.forEach((stat) => {
-        if (stat.address) {
-          addMailbox(accountToBox(stat.address));
-        }
-      });
-
-      // Add Sent Messages/accounts/ parent folder if any per-account sent mail exists
-      if (sentStats.length > 0) {
-        addMailbox(SENT_MESSAGES_ACCOUNTS_FOLDER);
-      }
-
-      // Add per-account sent mailboxes under Sent Messages/accounts/ (deduplicated)
-      sentStats.forEach((stat) => {
-        if (stat.address) {
-          addMailbox(accountToSentBox(stat.address));
-        }
-      });
-
-      // Add user-created mailboxes (those without a special_use and no address tie-in)
-      const systemNames = new Set(mailboxes.map((m) => m.toLowerCase()));
-      userMailboxes
-        .filter((mb) => mb.special_use === null && mb.address === null)
-        .forEach((mb) => {
-          if (!systemNames.has(mb.name.toLowerCase())) {
-            mailboxes.push(mb.name);
-          }
-        });
-
-      return mailboxes;
+      return await this.listMailboxesOrThrow();
     } catch (error) {
       logger.error("Error listing mailboxes", { component: "imap.store" }, error);
       return ["INBOX"];
@@ -244,10 +262,17 @@ export class Store {
    * zero-count aggregate for any unknown name — so SELECT/EXAMINE/STATUS must
    * gate on this to return a tagged NO for phantom mailboxes rather than
    * reporting them as valid-but-empty (RFC 3501 §6.3.1/2/10). See #595.
+   *
+   * Uses `listMailboxesOrThrow` (not the fallback `listMailboxes`) so a
+   * transient DB error propagates: the SELECT/STATUS handler's existing
+   * try-catch then writes `NO SELECT failed` / `NO STATUS failed` (a
+   * retry-friendly transient signal) instead of `NO Mailbox does not exist`
+   * (a permanent signal that makes the client treat the mailbox as deleted).
+   * See #601.
    */
   mailboxExists = async (box: string): Promise<boolean> => {
     if (isInbox(box)) return true;
-    const mailboxes = await this.listMailboxes();
+    const mailboxes = await this.listMailboxesOrThrow();
     return mailboxes.includes(box);
   };
 


### PR DESCRIPTION
Closes #601. Rebased directly onto `main` — this PR now stands alone (the INBOX case-insensitive work it was previously branched over lives in PR #602, which is independent).

## Problem

`Store.mailboxExists` (added in #599) was implemented as
`listMailboxes().includes(box)`. `listMailboxes` swallows backend errors and
falls back to `["INBOX"]` — fine for LIST resilience but **wrong for an
existence gate**.

On a transient DB hiccup hitting the stats / mailboxes-by-user queries:

1. `listMailboxes()` throws internally → catch returns `["INBOX"]`
2. `mailboxExists("Archive")` returns `false` (Archive ∉ `["INBOX"]`)
3. SELECT/STATUS handler writes `<tag> NO Mailbox does not exist`
4. **Client receives a permanent signal — may stop retrying, treat as deleted.**

`countMessages` (used elsewhere in the same handler) uses a separate query
path and returns `null` on the same kind of error. The two existence signals
disagreed: `countMessages` said "exists, empty"; `mailboxExists` said "does
not exist." Whichever the handler consulted first dictated the response.

## Fix

Split the list builder:

- **`listMailboxesOrThrow`** (private) — does the queries, propagates any
  error. Used only by `mailboxExists`.
- **`listMailboxes`** (public, unchanged contract) — wraps `listMailboxesOrThrow`
  in the existing `["INBOX"]` fallback so the LIST command stays resilient.

`mailboxExists` now uses `listMailboxesOrThrow`. Transient errors propagate
up. The SELECT/STATUS handlers' existing try-catch then writes:

- `<tag> NO SELECT failed` (transient, retry-friendly) on SELECT/EXAMINE
- `<tag> NO STATUS failed` (transient, retry-friendly) on STATUS

…instead of `NO Mailbox does not exist` (permanent).

**No client-facing API change for the healthy path.** Only the failure mode
is corrected. `mailboxExists("INBOX")` still short-circuits to `true` without
consulting the list.

## Scope

3 files: `store.ts` (the `listMailboxes` / `listMailboxesOrThrow` split) plus
two test files.
