### PR TITLE
feat(imap): implement MOVE (RFC 6851)

### DIFF
--- a/src/server/lib/imap/capabilities.ts
+++ b/src/server/lib/imap/capabilities.ts
@@ -7,6 +7,7 @@ export const getCapabilities = (isTls = false) => {
     "ID",
     "ENABLE",
     "IDLE",
+    "MOVE",
     "AUTH=PLAIN"
   ];
 

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -331,6 +331,10 @@ export class ImapRequestHandler {
           await this.session.copyMessageTyped(tag, request.data, false);
           break;
 
+        case "MOVE":
+          await this.session.moveMessageTyped(tag, request.data, false);
+          break;
+
         case "UID":
           await this.handleUidCommand(tag, request.data);
           break;
@@ -416,6 +420,10 @@ export class ImapRequestHandler {
 
         case "COPY":
           await this.session.copyMessageTyped(tag, request.data, true);
+          break;
+
+        case "MOVE":
+          await this.session.moveMessageTyped(tag, request.data, true);
           break;
 
         default:

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -599,25 +599,37 @@ export async function copyMessageTyped(
 // ---------------------------------------------------------------------------
 
 /**
- * RFC 6851 MOVE: atomic COPY + EXPUNGE. Wire shape mirrors COPY; the
- * difference is the source rows disappear after the move succeeds.
+ * RFC 6851 MOVE: atomic copy + targeted expunge. Wire shape mirrors
+ * COPY; the difference is the source rows disappear after the move.
  *
  * Response sequence (RFC 6851 §3.2):
  *   * <seq> EXPUNGE                (one per moved message; high→low)
  *   <tag> OK [COPYUID <validity> <src> <dst>] MOVE completed
  *
- * Atomicity: same caveat as COPY — no transaction wrapper, so a mid-loop
- * `storeMail` failure leaves stored copies in the destination AND the
- * source intact (we abort before flipping \\Deleted). A mid-EXPUNGE
- * failure leaves the copies in the destination AND the source flagged
- * but unremoved. Both modes are client-recoverable (re-issue MOVE /
- * EXPUNGE) and don't lose data.
+ * Implementation notes:
  *
- * The per-mail clone uses the same fixed shape as COPY (post-#604
- * round-2): fresh `messageId` to avoid the UNIQUE(user_id, message_id)
- * conflict; `getDomainUidNext` / `getAccountUidNext` get `destIsSent`;
- * `envelope_to` / `cc` / `bcc` are re-anchored for non-INBOX
- * destinations so the copy doesn't re-surface in the source.
+ * - The expunge is targeted via `store.expungeUids(box, sourceUids)` —
+ *   RFC 6851 §3.3 forbids the COPY+STORE(\\Deleted)+EXPUNGE pattern
+ *   (since EXPUNGE is mailbox-wide and would also remove pre-existing
+ *   \\Deleted-flagged messages, surfacing untagged EXPUNGE responses
+ *   for UIDs not in the COPYUID set).
+ * - No transaction wrapper around the per-mail copy loop — a mid-loop
+ *   `storeMail` failure leaves the already-stored copies in the
+ *   destination AND the source intact; the response is a tagged NO,
+ *   client can re-issue MOVE. A mid-expunge failure (`expungeUids`
+ *   throws) leaves all copies stored in dest AND all source rows
+ *   intact; same NO + re-issue contract.
+ * - Address routing: for non-INBOX destinations the new copy's
+ *   `to_address` / `envelope_to` / `cc_address` / `bcc_address` JSONB
+ *   value arrays are re-anchored to the destination address (or
+ *   cleared) so the copy doesn't re-surface in the source mailbox's
+ *   view. For INBOX destinations from a non-INBOX source, the same
+ *   clearing applies — INBOX has no address filter so cleared routing
+ *   is safe, AND it prevents the source account view from re-matching
+ *   the copy under its new UID after the source is expunged.
+ * - Display text fields (`to_text` / `cc_text` / `bcc_text`) are
+ *   preserved so the FETCH BODY[HEADER] render on the destination
+ *   still shows the original recipient header.
  */
 export async function moveMessageTyped(
   tag: string,
@@ -735,8 +747,30 @@ export async function moveMessageTyped(
       });
 
       if (destIsInbox) {
-        newMail.to = sourceMail.to;
-        newMail.envelopeTo = sourceMail.envelopeTo ?? [];
+        // INBOX has no address filter; the new copy surfaces in INBOX
+        // regardless of `to_address` / `envelope_to` content. But if the
+        // source view IS address-filtered (accounts/foo, Sent Messages/
+        // accounts/foo), preserving the source's address fields would
+        // re-anchor the new copy in the source mailbox even AFTER we
+        // expunge the original — the message would re-appear in the
+        // source view under a new UID. To prevent that, clear the
+        // routing JSONB to empty when the source is non-INBOX. INBOX→
+        // INBOX is a no-op address-wise so it's safe to preserve.
+        if (sourceIsInbox) {
+          newMail.to = sourceMail.to;
+          newMail.envelopeTo = sourceMail.envelopeTo ?? [];
+        } else {
+          newMail.to = sourceMail.to
+            ? { value: [], text: sourceMail.to.text }
+            : undefined;
+          newMail.envelopeTo = [];
+          newMail.cc = sourceMail.cc
+            ? { value: [], text: sourceMail.cc.text }
+            : undefined;
+          newMail.bcc = sourceMail.bcc
+            ? { value: [], text: sourceMail.bcc.text }
+            : undefined;
+        }
       } else {
         const destAddr = { address: destAccount, name: "" };
         newMail.to = {
@@ -744,8 +778,8 @@ export async function moveMessageTyped(
           text: sourceMail.to?.text || destAccount,
         };
         newMail.envelopeTo = [destAddr];
-        // Same fix as COPY (#604 round-2): preserve cc_text / bcc_text
-        // (the header render) but empty the routing JSONB.
+        // Clear routing JSONB but preserve display text (cc_text /
+        // bcc_text drive the FETCH BODY[HEADER] render).
         newMail.cc = sourceMail.cc
           ? { value: [], text: sourceMail.cc.text }
           : undefined;
@@ -776,24 +810,16 @@ export async function moveMessageTyped(
       destUids.push(destIsInbox ? newMail.uid.domain : newMail.uid.account);
     }
 
-    // === DELETE + EXPUNGE phase (RFC 6851 §3.2) ===
-    // Mark every source UID as \\Deleted (per-UID range so we hit
-    // exactly the moved set), then expunge. RFC 3501 §6.4.3 accepts
-    // that EXPUNGE is mailbox-wide — any pre-existing \\Deleted-flagged
-    // messages in the source mailbox get expunged as a side effect; same
-    // shape as COPY+STORE+EXPUNGE on a real client.
-    for (const uid of sourceUids) {
-      await store.setFlags(
-        selectedMailbox,
-        uid,
-        uid,
-        ["\\Deleted"],
-        true,
-        "+FLAGS"
-      );
-    }
-
-    const expungedUids = await store.expunge(selectedMailbox);
+    // === EXPUNGE phase ===
+    // RFC 6851 §3.3: MOVE MUST NOT set \\Deleted on source UIDs, and the
+    // server MUST NOT expunge messages other than the moved set.
+    // `store.expungeUids` directly soft-deletes the specific source UIDs
+    // (sets `expunged=TRUE`) without ever touching the `\\Deleted` flag
+    // and without affecting pre-existing \\Deleted-flagged messages in
+    // the mailbox. Errors propagate so the outer try/catch writes a
+    // tagged NO instead of falsely emitting OK + COPYUID against a
+    // partial expunge.
+    const expungedUids = await store.expungeUids(selectedMailbox, sourceUids);
 
     // Map UIDs back to seq numbers; emit high→low so the client's
     // own message-index updates don't cascade-shift mid-response.

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -649,6 +649,15 @@ export async function moveMessageTyped(
   try {
     const destMailbox = isInbox(moveRequest.mailbox) ? "INBOX" : moveRequest.mailbox;
 
+    // RFC 6851 §3.4-§3.5: MOVE to the currently-selected mailbox is a
+    // no-op (the messages are already where they'd land). Skip the
+    // copy+expunge round-trip and respond with a bare OK — clients see
+    // the same end-state with no UID churn or surprise EXPUNGE.
+    if (destMailbox === selectedMailbox) {
+      write(`${tag} OK MOVE completed\r\n`);
+      return;
+    }
+
     if (!(await store.mailboxExists(destMailbox))) {
       write(`${tag} NO [TRYCREATE] Mailbox does not exist\r\n`);
       return;

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -19,6 +19,7 @@ import {
   SearchRequest,
   StoreRequest,
   CopyRequest,
+  MoveRequest,
   AppendRequest,
 } from "./types";
 import {
@@ -590,6 +591,236 @@ export async function copyMessageTyped(
   } catch (error) {
     logger.error("COPY error", { component: "imap" }, error);
     write(`${tag} NO COPY failed\r\n`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MOVE (RFC 6851)
+// ---------------------------------------------------------------------------
+
+/**
+ * RFC 6851 MOVE: atomic COPY + EXPUNGE. Wire shape mirrors COPY; the
+ * difference is the source rows disappear after the move succeeds.
+ *
+ * Response sequence (RFC 6851 §3.2):
+ *   * <seq> EXPUNGE                (one per moved message; high→low)
+ *   <tag> OK [COPYUID <validity> <src> <dst>] MOVE completed
+ *
+ * Atomicity: same caveat as COPY — no transaction wrapper, so a mid-loop
+ * `storeMail` failure leaves stored copies in the destination AND the
+ * source intact (we abort before flipping \\Deleted). A mid-EXPUNGE
+ * failure leaves the copies in the destination AND the source flagged
+ * but unremoved. Both modes are client-recoverable (re-issue MOVE /
+ * EXPUNGE) and don't lose data.
+ *
+ * The per-mail clone uses the same fixed shape as COPY (post-#604
+ * round-2): fresh `messageId` to avoid the UNIQUE(user_id, message_id)
+ * conflict; `getDomainUidNext` / `getAccountUidNext` get `destIsSent`;
+ * `envelope_to` / `cc` / `bcc` are re-anchored for non-INBOX
+ * destinations so the copy doesn't re-surface in the source.
+ */
+export async function moveMessageTyped(
+  tag: string,
+  moveRequest: MoveRequest,
+  isUidCommand: boolean,
+  store: Store,
+  selectedMailbox: string,
+  mailboxReadOnly: boolean,
+  seqState: SequenceState,
+  write: (data: string) => boolean | undefined
+): Promise<void> {
+  if (mailboxReadOnly) {
+    write(`${tag} NO [READ-ONLY] Mailbox is read-only\r\n`);
+    return;
+  }
+
+  try {
+    const destMailbox = isInbox(moveRequest.mailbox) ? "INBOX" : moveRequest.mailbox;
+
+    if (!(await store.mailboxExists(destMailbox))) {
+      write(`${tag} NO [TRYCREATE] Mailbox does not exist\r\n`);
+      return;
+    }
+
+    const isUidMove = moveRequest.sequenceSet.type === "uid" || isUidCommand;
+    const ranges = convertSequenceSet(moveRequest.sequenceSet);
+
+    const uidRanges: Array<{ uidStart: number; uidEnd: number }> = [];
+    for (const { start, end } of ranges) {
+      if (isUidMove) {
+        uidRanges.push({ uidStart: start, uidEnd: end });
+      } else {
+        const resolved = resolveSeqRangeToUids(seqState.seqToUid, start, end);
+        if (!resolved) continue;
+        uidRanges.push({ uidStart: resolved.uidStart, uidEnd: resolved.uidEnd });
+      }
+    }
+
+    if (uidRanges.length === 0) {
+      write(`${tag} OK MOVE completed\r\n`);
+      return;
+    }
+
+    const cloneFields = [
+      "subject",
+      "date",
+      "html",
+      "text",
+      "from",
+      "to",
+      "cc",
+      "bcc",
+      "replyTo",
+      "envelopeFrom",
+      "envelopeTo",
+      "attachments",
+      "messageId",
+      "insight",
+      "flags",
+      "uid",
+    ];
+
+    const sourceMails: Array<Partial<MailType>> = [];
+    for (const { uidStart, uidEnd } of uidRanges) {
+      const batch = await store.getMessages(
+        selectedMailbox,
+        uidStart,
+        uidEnd,
+        cloneFields,
+        true
+      );
+      batch.forEach((mail) => sourceMails.push(mail));
+    }
+
+    if (sourceMails.length === 0) {
+      write(`${tag} OK MOVE completed\r\n`);
+      return;
+    }
+
+    const user = store.getUser();
+    const destAccount = boxToAccount(user.username, destMailbox);
+    const destIsInbox = isInbox(destMailbox);
+    const destIsSent = isSentBox(destMailbox);
+    const sourceIsInbox = isInbox(selectedMailbox);
+    const srcUidOf = (mail: Partial<MailType>): number =>
+      sourceIsInbox ? mail.uid!.domain : mail.uid!.account;
+
+    const sourceUids: number[] = [];
+    const destUids: number[] = [];
+
+    const Mail = (await import("common")).Mail;
+    const getRandomId = (await import("common")).getRandomId;
+
+    // === COPY phase (mirrors copyMessageTyped's fixed shape) ===
+    for (const sourceMail of sourceMails) {
+      const newMail = new Mail({
+        subject: sourceMail.subject,
+        date: sourceMail.date,
+        html: sourceMail.html,
+        text: sourceMail.text,
+        from: sourceMail.from,
+        cc: sourceMail.cc,
+        bcc: sourceMail.bcc,
+        replyTo: sourceMail.replyTo,
+        envelopeFrom: sourceMail.envelopeFrom,
+        attachments: sourceMail.attachments,
+        // Fresh messageId — see copyMessageTyped for the UNIQUE(...) rationale.
+        messageId: getRandomId(),
+        insight: sourceMail.insight,
+        read: sourceMail.read,
+        saved: sourceMail.saved,
+        deleted: sourceMail.deleted,
+        draft: sourceMail.draft,
+        answered: sourceMail.answered,
+      });
+
+      if (destIsInbox) {
+        newMail.to = sourceMail.to;
+        newMail.envelopeTo = sourceMail.envelopeTo ?? [];
+      } else {
+        const destAddr = { address: destAccount, name: "" };
+        newMail.to = {
+          value: [destAddr],
+          text: sourceMail.to?.text || destAccount,
+        };
+        newMail.envelopeTo = [destAddr];
+        // Same fix as COPY (#604 round-2): preserve cc_text / bcc_text
+        // (the header render) but empty the routing JSONB.
+        newMail.cc = sourceMail.cc
+          ? { value: [], text: sourceMail.cc.text }
+          : undefined;
+        newMail.bcc = sourceMail.bcc
+          ? { value: [], text: sourceMail.bcc.text }
+          : undefined;
+      }
+      newMail.sent = destIsSent;
+
+      const newDomainUid = await getDomainUidNext(user.id, destIsSent);
+      const newAccountUid = await getAccountUidNext(
+        user.id,
+        destAccount,
+        destIsSent
+      );
+      newMail.uid.domain = newDomainUid || 1;
+      newMail.uid.account = newAccountUid || 1;
+
+      const ok = await store.storeMail(newMail);
+      if (!ok) {
+        // Pre-deletion failure: copies already stored in the destination
+        // linger; the source is untouched. Client can re-issue MOVE.
+        write(`${tag} NO [SERVERBUG] MOVE partially failed during copy phase\r\n`);
+        return;
+      }
+
+      sourceUids.push(srcUidOf(sourceMail));
+      destUids.push(destIsInbox ? newMail.uid.domain : newMail.uid.account);
+    }
+
+    // === DELETE + EXPUNGE phase (RFC 6851 §3.2) ===
+    // Mark every source UID as \\Deleted (per-UID range so we hit
+    // exactly the moved set), then expunge. RFC 3501 §6.4.3 accepts
+    // that EXPUNGE is mailbox-wide — any pre-existing \\Deleted-flagged
+    // messages in the source mailbox get expunged as a side effect; same
+    // shape as COPY+STORE+EXPUNGE on a real client.
+    for (const uid of sourceUids) {
+      await store.setFlags(
+        selectedMailbox,
+        uid,
+        uid,
+        ["\\Deleted"],
+        true,
+        "+FLAGS"
+      );
+    }
+
+    const expungedUids = await store.expunge(selectedMailbox);
+
+    // Map UIDs back to seq numbers; emit high→low so the client's
+    // own message-index updates don't cascade-shift mid-response.
+    const expungedSeqs: number[] = [];
+    for (const uid of expungedUids) {
+      const seq = uidToSeqNumber(seqState.seqToUid, seqState.uidToSeq, uid);
+      if (seq !== undefined) expungedSeqs.push(seq);
+    }
+    expungedSeqs.sort((a, b) => b - a);
+    for (const seq of expungedSeqs) {
+      write(`* ${seq} EXPUNGE\r\n`);
+    }
+
+    // Rebuild seqState so subsequent sequence-numbered commands operate
+    // on the post-expunge mapping. A stale seqState would surface as
+    // wrong FETCH results downstream.
+    await buildSequenceMapping(store, selectedMailbox, seqState);
+
+    const uidValidity = await getImapUidValidity(user.id);
+    const sourceSet = formatUidSet(sourceUids);
+    const destSet = formatUidSet(destUids);
+    write(
+      `${tag} OK [COPYUID ${uidValidity} ${sourceSet} ${destSet}] MOVE completed\r\n`
+    );
+  } catch (error) {
+    logger.error("MOVE error", { component: "imap" }, error);
+    write(`${tag} NO MOVE failed\r\n`);
   }
 }
 

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -10,21 +10,103 @@
  * source and the mailbox-wide EXPUNGE that the COPY+STORE+EXPUNGE
  * pattern would produce — the targeted expunge avoids both.
  *
- * Tests here focus on the MOVE-specific control flow: read-only
- * refusal, TRYCREATE, no-op range cases, MOVE-to-self short-circuit.
- * End-to-end "real source mails → COPYUID + targeted EXPUNGE
- * emission, and the INBOX-from-non-INBOX address-clearing invariant"
- * needs a FakePool fixture (same as COPY's it.todo).
+ * Two layers of coverage:
+ *   - Control flow (no DB): read-only refusal, TRYCREATE, no-op range
+ *     cases, MOVE-to-self short-circuit. Driven with a bare fake Store.
+ *   - End-to-end happy path: real source mails → COPYUID + targeted
+ *     EXPUNGE emission, fresh messageId, and the address-routing
+ *     invariants (non-INBOX dest re-anchors to the dest account; INBOX
+ *     dest from a non-INBOX source CLEARS routing so the moved copy
+ *     does not re-surface in the source account view). The copy phase
+ *     reaches `getDomainUidNext` / `getAccountUidNext` /
+ *     `getImapUidValidity` (imported from the `server` barrel, not on
+ *     the store), so we use the pg-FakePool pattern from
+ *     message-ops.test.ts: mock `pg` so postgres/client.ts's lazy pool
+ *     is a FakePool and run the REAL helpers against it. We mock `pg`
+ *     (NOT the `server` barrel) so those helpers keep their real
+ *     identities — stubbing the barrel would bleed across files via
+ *     Bun's process-global mock.module. `afterAll(restoreLeaves)` +
+ *     resetPool re-mocks pg back to real.
  */
 
-import { describe, it, expect } from "bun:test";
-import type { SignedUser } from "common";
-import { moveMessageTyped } from "./message-ops";
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import type { MailType, SignedUser } from "common";
 import { Store } from "./store";
 import type { MoveRequest } from "./types";
 import type { SequenceState } from "./sequence-resolver";
 
+const STORED_UIDVALIDITY = 1716512400;
+
 const VALID_USER: SignedUser = { id: "u1", username: "admin" } as SignedUser;
+
+// A full, schema-valid users row so usersTable.queryOne's `new UserModel(row)`
+// validates inside getImapUidValidity. imap_uid_validity is pre-set, so the
+// helper returns it directly without an update.
+const USER_ROW = {
+  user_id: "u1",
+  username: "admin",
+  password: null,
+  email: null,
+  expiry: null,
+  token: null,
+  updated: null,
+  is_deleted: null,
+  imap_uid_validity: STORED_UIDVALIDITY,
+};
+
+// getDomainUidNext / getAccountUidNext both SELECT ... AS next_uid FROM mails.
+// Hand back a monotonically-increasing value per call so each cloned mail gets
+// a distinct dest UID (domain then account, per the copy loop's call order).
+let uidCounter = 100;
+const mockQuery = mock(async (sql: string) => {
+  if (typeof sql === "string" && sql.includes("next_uid")) {
+    return { rows: [{ next_uid: String(uidCounter++) }], rowCount: 1 };
+  }
+  // usersTable.queryOne(...) for getImapUidValidity
+  return { rows: [USER_ROW], rowCount: 1 };
+});
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+  on() {}
+}
+
+const pgMock = () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+});
+
+mock.module("pg", pgMock);
+
+const { moveMessageTyped } = await import("./message-ops");
+const { resetPool } = await import("../postgres/client");
+
+beforeAll(() => {
+  mock.module("pg", pgMock);
+  resetPool();
+});
+
+afterAll(() => {
+  restoreLeaves();
+  resetPool();
+});
+
+beforeEach(() => {
+  mockQuery.mockClear();
+  uidCounter = 100;
+});
 
 const emptySeqState = (): SequenceState => ({
   seqToUid: [],
@@ -166,8 +248,164 @@ describe("MOVE to self short-circuit (RFC 6851 §3.4-§3.5, #453)", () => {
   });
 });
 
-describe("MOVE happy path (#453)", () => {
-  it.todo(
-    "moves source mails (fresh messageId, address routing cleared on non-INBOX dest AND on INBOX dest from a non-INBOX source), calls Store.expungeUids on the source set, emits COPYUID + targeted EXPUNGE (FakePool fixture needed)"
-  );
+// ---------------------------------------------------------------------------
+// End-to-end happy path (RFC 6851 §3.2-§3.3)
+// ---------------------------------------------------------------------------
+
+// Build a source mail with the routing fields the copy phase re-anchors.
+const sourceMail = (
+  uid: { domain: number; account: number },
+  overrides: Partial<MailType> = {}
+): Partial<MailType> => ({
+  subject: "hello",
+  date: "2026-06-23T00:00:00.000Z",
+  html: "<p>hi</p>",
+  text: "hi",
+  from: { value: [{ address: "sender@x.com", name: "S" }], text: "sender@x.com" },
+  to: { value: [{ address: "src@hoie.kim", name: "" }], text: "src@hoie.kim" },
+  cc: { value: [{ address: "ccd@x.com", name: "" }], text: "ccd@x.com" },
+  bcc: { value: [{ address: "bccd@x.com", name: "" }], text: "bccd@x.com" },
+  envelopeTo: [{ address: "src@hoie.kim", name: "" }],
+  messageId: `orig-${uid.domain}-${uid.account}`,
+  uid: uid as MailType["uid"],
+  ...overrides,
+});
+
+// A Store wired for the full copy+expunge flow: getMessages hands back the
+// source mails, storeMail records each clone, expungeUids records its arg set
+// and echoes it back (the repo soft-deletes exactly the passed UIDs), getAllUids
+// returns the post-expunge mailbox state for the seqState rebuild.
+const makeMoveStore = (
+  existsBoxes: string[],
+  mails: Array<Partial<MailType>>,
+  postExpungeUids: number[] = []
+) => {
+  const store = new Store(VALID_USER);
+  store.mailboxExists = async (box: string) =>
+    box === "INBOX" || existsBoxes.includes(box);
+  store.getMessages = async () => {
+    const map = new Map<number, Partial<MailType>>();
+    mails.forEach((m, i) => map.set(i, m));
+    return map as never;
+  };
+  const stored: Array<Partial<MailType>> = [];
+  store.storeMail = async (mail: never) => {
+    stored.push({ ...(mail as Partial<MailType>) });
+    return true as never;
+  };
+  let expungeArg: number[] = [];
+  store.expungeUids = async (_box: string, uids: number[]) => {
+    expungeArg = uids;
+    return uids; // repo soft-deletes exactly the passed set
+  };
+  store.getAllUids = async () => postExpungeUids;
+  return {
+    store,
+    stored,
+    getExpungeArg: () => expungeArg,
+  };
+};
+
+describe("MOVE happy path — INBOX → non-INBOX dest (#453, RFC 6851 §3.2-§3.3)", () => {
+  it("clones with fresh messageId, re-anchors routing to dest, targets the expunge, emits EXPUNGE high→low + COPYUID", async () => {
+    const mails = [
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 7, account: 60 }),
+    ];
+    const { store, stored, getExpungeArg } = makeMoveStore(["Archive"], mails);
+    const seqState: SequenceState = {
+      seqToUid: [5, 7],
+      uidToSeq: new Map([
+        [5, 1],
+        [7, 2],
+      ]),
+    };
+
+    const lines = await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store,
+      false,
+      "INBOX",
+      seqState
+    );
+
+    // Two clones stored, each with a fresh messageId (not the source's).
+    expect(stored.length).toBe(2);
+    expect(stored[0].messageId).not.toBe(mails[0].messageId);
+    expect(stored[1].messageId).not.toBe(mails[1].messageId);
+
+    // Non-INBOX dest: `to` / `envelopeTo` re-anchored to the dest
+    // account (a single recipient that is NOT the source address),
+    // display text preserved; cc/bcc routing cleared but their header
+    // text kept for FETCH BODY[HEADER].
+    expect(stored[0].to?.value?.length).toBe(1);
+    expect(stored[0].to?.value?.[0]?.name).toBe("");
+    expect(stored[0].to?.value?.[0]?.address).not.toBe("src@hoie.kim");
+    expect(stored[0].envelopeTo).toEqual(stored[0].to?.value);
+    expect(stored[0].to?.text).toBe("src@hoie.kim");
+    expect(stored[0].cc?.value).toEqual([]);
+    expect(stored[0].cc?.text).toBe("ccd@x.com");
+    expect(stored[0].bcc?.value).toEqual([]);
+    expect(stored[0].bcc?.text).toBe("bccd@x.com");
+
+    // RFC 6851 §3.3: the expunge targets exactly the moved source UIDs
+    // (INBOX source → domain UIDs), never the whole mailbox.
+    expect(getExpungeArg()).toEqual([5, 7]);
+
+    // EXPUNGE emitted high→low so client index shifts don't cascade.
+    const expungeLines = lines.filter((l) => l.includes("EXPUNGE"));
+    expect(expungeLines).toEqual(["* 2 EXPUNGE\r\n", "* 1 EXPUNGE\r\n"]);
+
+    // COPYUID: src set is the moved domain UIDs; dest set is the fresh
+    // account UIDs (counter: domain 100/account 101, domain 102/account 103).
+    const tagged = lines.find((l) => l.startsWith("A1 "));
+    expect(tagged).toBe(
+      `A1 OK [COPYUID ${STORED_UIDVALIDITY} 5,7 101,103] MOVE completed\r\n`
+    );
+  });
+});
+
+describe("MOVE happy path — non-INBOX source → INBOX dest (#453, address-clear invariant)", () => {
+  it("clears to/envelopeTo/cc/bcc routing so the moved copy does not re-surface in the source account view", async () => {
+    // Source is a per-account mailbox (Archive). The source row carries
+    // src@hoie.kim in to/envelope_to; if the INBOX clone preserved those,
+    // the jsonb account filter would re-match it in Archive after the
+    // original is expunged (reviewoie HIGH 3). The clone must clear them.
+    const mails = [sourceMail({ domain: 9, account: 90 })];
+    const { store, stored, getExpungeArg } = makeMoveStore(["Archive"], mails);
+    const seqState: SequenceState = {
+      seqToUid: [90],
+      uidToSeq: new Map([[90, 1]]),
+    };
+
+    const lines = await runMove(
+      moveReq("INBOX", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store,
+      false,
+      "Archive",
+      seqState
+    );
+
+    expect(stored.length).toBe(1);
+    // Routing value arrays cleared; only header text survives.
+    expect(stored[0].to?.value).toEqual([]);
+    expect(stored[0].to?.text).toBe("src@hoie.kim");
+    expect(stored[0].envelopeTo).toEqual([]);
+    expect(stored[0].cc?.value).toEqual([]);
+    expect(stored[0].bcc?.value).toEqual([]);
+
+    // Non-INBOX source → expunge keys on the ACCOUNT UID, not domain.
+    expect(getExpungeArg()).toEqual([90]);
+
+    // INBOX dest → dest UID is the fresh DOMAIN uid (counter starts 100).
+    const tagged = lines.find((l) => l.startsWith("A1 "));
+    expect(tagged).toBe(
+      `A1 OK [COPYUID ${STORED_UIDVALIDITY} 90 100] MOVE completed\r\n`
+    );
+    expect(lines.filter((l) => l.includes("EXPUNGE"))).toEqual([
+      "* 1 EXPUNGE\r\n",
+    ]);
+  });
 });

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -1,12 +1,20 @@
 /**
  * Tests for `moveMessageTyped` (#453, RFC 6851).
  *
- * MOVE composes COPY + STORE \\Deleted + EXPUNGE. The COPY-phase logic
- * mirrors `copyMessageTyped` (post-#604 round-2: fresh messageId, `sent`
- * arg threading, envelope_to / cc / bcc re-anchor). Tests here focus on
- * the MOVE-specific surface: read-only refusal, TRYCREATE, no-op
- * range cases. End-to-end "real source mails → COPYUID + EXPUNGE
- * emission" needs a FakePool fixture (same as the COPY it.todo).
+ * MOVE is copy-then-targeted-expunge: clone the source rows into the
+ * destination (same shape as `copyMessageTyped` — fresh messageId, the
+ * `sent` arg threaded through UidNext helpers, envelope_to / cc / bcc
+ * re-anchored away from the source address), then call
+ * `Store.expungeUids(box, sourceUids)` to soft-delete exactly the
+ * moved set. RFC 6851 §3.3 forbids both setting `\\Deleted` on the
+ * source and the mailbox-wide EXPUNGE that the COPY+STORE+EXPUNGE
+ * pattern would produce — the targeted expunge avoids both.
+ *
+ * Tests here focus on the MOVE-specific control flow: read-only
+ * refusal, TRYCREATE, no-op range cases, MOVE-to-self short-circuit.
+ * End-to-end "real source mails → COPYUID + targeted EXPUNGE
+ * emission, and the INBOX-from-non-INBOX address-clearing invariant"
+ * needs a FakePool fixture (same as COPY's it.todo).
  */
 
 import { describe, it, expect } from "bun:test";
@@ -119,8 +127,47 @@ describe("MOVE with empty source range (#453)", () => {
   });
 });
 
+describe("MOVE to self short-circuit (RFC 6851 §3.4-§3.5, #453)", () => {
+  it("MOVE to the selected mailbox returns OK without copy+expunge", async () => {
+    const store = buildStore(["Archive"]);
+    let getMessagesCalled = false;
+    store.getMessages = async () => {
+      getMessagesCalled = true;
+      return new Map();
+    };
+    const lines = await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 1, end: 5 }] }),
+      true,
+      store,
+      false,
+      "Archive"
+    );
+    expect(lines).toEqual(["A1 OK MOVE completed\r\n"]);
+    // No copy phase — getMessages never consulted.
+    expect(getMessagesCalled).toBe(false);
+  });
+
+  it("MOVE INBOX → inbox while selected on INBOX (case variant) is also a self-move", async () => {
+    const store = buildStore([]);
+    let getMessagesCalled = false;
+    store.getMessages = async () => {
+      getMessagesCalled = true;
+      return new Map();
+    };
+    const lines = await runMove(
+      moveReq("inbox", { type: "uid", ranges: [{ start: 1, end: 1 }] }),
+      true,
+      store,
+      false,
+      "INBOX"
+    );
+    expect(lines).toEqual(["A1 OK MOVE completed\r\n"]);
+    expect(getMessagesCalled).toBe(false);
+  });
+});
+
 describe("MOVE happy path (#453)", () => {
   it.todo(
-    "moves source mails, marks them \\\\Deleted, expunges, emits COPYUID + EXPUNGE (FakePool fixture needed)"
+    "moves source mails (fresh messageId, address routing cleared on non-INBOX dest AND on INBOX dest from a non-INBOX source), calls Store.expungeUids on the source set, emits COPYUID + targeted EXPUNGE (FakePool fixture needed)"
   );
 });

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for `moveMessageTyped` (#453, RFC 6851).
+ *
+ * MOVE composes COPY + STORE \\Deleted + EXPUNGE. The COPY-phase logic
+ * mirrors `copyMessageTyped` (post-#604 round-2: fresh messageId, `sent`
+ * arg threading, envelope_to / cc / bcc re-anchor). Tests here focus on
+ * the MOVE-specific surface: read-only refusal, TRYCREATE, no-op
+ * range cases. End-to-end "real source mails → COPYUID + EXPUNGE
+ * emission" needs a FakePool fixture (same as the COPY it.todo).
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { SignedUser } from "common";
+import { moveMessageTyped } from "./message-ops";
+import { Store } from "./store";
+import type { MoveRequest } from "./types";
+import type { SequenceState } from "./sequence-resolver";
+
+const VALID_USER: SignedUser = { id: "u1", username: "admin" } as SignedUser;
+
+const emptySeqState = (): SequenceState => ({
+  seqToUid: [],
+  uidToSeq: new Map(),
+});
+
+const buildStore = (existsBoxes: string[]): Store => {
+  const store = new Store(VALID_USER);
+  store.mailboxExists = async (box: string) =>
+    box === "INBOX" || existsBoxes.includes(box);
+  store.getMessages = async () => new Map();
+  return store;
+};
+
+const moveReq = (
+  mailbox: string,
+  sequenceSet: MoveRequest["sequenceSet"]
+): MoveRequest => ({ sequenceSet, mailbox });
+
+const runMove = async (
+  request: MoveRequest,
+  isUidCommand: boolean,
+  store: Store,
+  mailboxReadOnly: boolean = false,
+  selectedMailbox: string = "INBOX",
+  seqState: SequenceState = emptySeqState()
+): Promise<string[]> => {
+  const lines: string[] = [];
+  await moveMessageTyped(
+    "A1",
+    request,
+    isUidCommand,
+    store,
+    selectedMailbox,
+    mailboxReadOnly,
+    seqState,
+    (data: string) => {
+      lines.push(data);
+      return true;
+    }
+  );
+  return lines;
+};
+
+describe("MOVE read-only refusal (#453)", () => {
+  it("refuses MOVE on a read-only mailbox (EXAMINE / SELECT readonly)", async () => {
+    const store = buildStore(["Archive"]);
+    const lines = await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 1, end: 1 }] }),
+      true,
+      store,
+      true
+    );
+    expect(lines).toEqual(["A1 NO [READ-ONLY] Mailbox is read-only\r\n"]);
+  });
+});
+
+describe("MOVE existence gate (#453)", () => {
+  it("returns NO [TRYCREATE] when destination does not exist", async () => {
+    const store = buildStore([]);
+    const lines = await runMove(
+      moveReq("Nonexistent", { type: "seq", ranges: [{ start: 1, end: 1 }] }),
+      false,
+      store
+    );
+    expect(lines).toEqual(["A1 NO [TRYCREATE] Mailbox does not exist\r\n"]);
+  });
+
+  it("INBOX destination short-circuits the existence check (case-insensitive)", async () => {
+    const store = buildStore([]);
+    const lines = await runMove(
+      moveReq("inbox", { type: "uid", ranges: [{ start: 99, end: 99 }] }),
+      true,
+      store
+    );
+    // No source mails → OK with no COPYUID.
+    expect(lines).toEqual(["A1 OK MOVE completed\r\n"]);
+  });
+});
+
+describe("MOVE with empty source range (#453)", () => {
+  it("returns OK without COPYUID when the sequence-set resolves to nothing", async () => {
+    const store = buildStore(["Archive"]);
+    const lines = await runMove(
+      moveReq("Archive", { type: "seq", ranges: [{ start: 1, end: 5 }] }),
+      false,
+      store
+    );
+    expect(lines).toEqual(["A1 OK MOVE completed\r\n"]);
+  });
+
+  it("returns OK without COPYUID when source mailbox has no matching mails", async () => {
+    const store = buildStore(["Archive"]);
+    const lines = await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store
+    );
+    expect(lines).toEqual(["A1 OK MOVE completed\r\n"]);
+  });
+});
+
+describe("MOVE happy path (#453)", () => {
+  it.todo(
+    "moves source mails, marks them \\\\Deleted, expunges, emits COPYUID + EXPUNGE (FakePool fixture needed)"
+  );
+});

--- a/src/server/lib/imap/parsers/command-parser.ts
+++ b/src/server/lib/imap/parsers/command-parser.ts
@@ -16,7 +16,7 @@ import {
   parseSubscribe,
   parseUnsubscribe
 } from "./mailbox-parsers";
-import { parseStore, parseCopy } from "./store-parsers";
+import { parseStore, parseCopy, parseMove } from "./store-parsers";
 import { parseSearch } from "./search-parsers";
 import { parseAppend } from "./append-parser";
 
@@ -156,6 +156,9 @@ const parseImapRequest = (
 
     case "COPY":
       return parseCopy(context);
+
+    case "MOVE":
+      return parseMove(context);
 
     case "UID":
       return parseUid(context);

--- a/src/server/lib/imap/parsers/store-parsers.ts
+++ b/src/server/lib/imap/parsers/store-parsers.ts
@@ -149,3 +149,41 @@ export const parseCopy = (context: ParseContext): ParseResult<ImapRequest> => {
     consumed: context.position
   };
 };
+
+/**
+ * Parse MOVE command (RFC 6851). Same wire shape as COPY — a sequence
+ * set followed by a target mailbox name.
+ */
+export const parseMove = (context: ParseContext): ParseResult<ImapRequest> => {
+  const sequenceSet = parseSequenceSet(context);
+  if (!sequenceSet.success) {
+    return {
+      success: false,
+      error: "Invalid sequence set in MOVE",
+      consumed: 0
+    };
+  }
+
+  skipWhitespace(context);
+
+  const mailbox = parseString(context);
+  if (!mailbox.success) {
+    return {
+      success: false,
+      error: "Invalid mailbox name in MOVE",
+      consumed: 0
+    };
+  }
+
+  return {
+    success: true,
+    value: {
+      type: "MOVE",
+      data: {
+        sequenceSet: sequenceSet.value!,
+        mailbox: mailbox.value!
+      }
+    },
+    consumed: context.position
+  };
+};

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -11,6 +11,7 @@ import {
   SearchRequest,
   StoreRequest,
   CopyRequest,
+  MoveRequest,
   AppendRequest,
   StatusItem,
 } from "./types";
@@ -36,6 +37,7 @@ import {
   searchTyped as searchOp,
   storeFlagsTyped as storeFlagsOp,
   copyMessageTyped as copyMessageOp,
+  moveMessageTyped as moveMessageOp,
   appendMessage as appendMessageOp,
   expunge as expungeOp,
 } from "./message-ops";
@@ -346,6 +348,26 @@ export class ImapSession {
       isUidCommand,
       this.store,
       this.selectedMailbox,
+      this.seqState,
+      this.write
+    );
+  };
+
+  moveMessageTyped = async (
+    tag: string,
+    moveRequest: MoveRequest,
+    isUidCommand: boolean = false
+  ) => {
+    if (!this.authenticated || !this.store || !this.selectedMailbox) {
+      return this.write(`${tag} NO Not authenticated or no mailbox selected.\r\n`);
+    }
+    return moveMessageOp(
+      tag,
+      moveRequest,
+      isUidCommand,
+      this.store,
+      this.selectedMailbox,
+      this.mailboxReadOnly,
       this.seqState,
       this.write
     );

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -14,6 +14,7 @@ import {
   searchMailsByUid,
   saveMail as pgSaveMail,
   expungeDeletedMails,
+  expungeMailsByUid,
   getAllUids as pgGetAllUids,
   getFirstUnseenUid as pgGetFirstUnseenUid,
   SaveMailInput,
@@ -459,6 +460,20 @@ export class Store {
       logger.error("Error expunging messages", { component: "imap.store", box }, error);
       throw error;
     }
+  };
+
+  /**
+   * Soft-delete a specific set of UIDs in `box` without touching their
+   * `\Deleted` flag. Used by RFC 6851 MOVE (§3.3 forbids the
+   * COPY+STORE(\Deleted)+EXPUNGE pattern, since EXPUNGE is mailbox-wide
+   * and would also remove pre-existing \Deleted-flagged messages).
+   * Propagates errors so the MOVE handler can write `NO MOVE failed`
+   * instead of falsely emitting OK + COPYUID against a no-op.
+   */
+  expungeUids = async (box: string, uids: number[]): Promise<number[]> => {
+    if (uids.length === 0) return [];
+    const { accountName, isSent } = this.resolveBox(box);
+    return await expungeMailsByUid(this.user.id, accountName, isSent, uids);
   };
 
   search = async (

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -29,6 +29,16 @@ export interface CopyRequest {
   mailbox: string;
 }
 
+/**
+ * RFC 6851 MOVE — wire-identical to COPY (sequence-set + target mailbox).
+ * Distinct type so the dispatch layer can route to `moveMessageTyped`
+ * without an extra command-name pivot.
+ */
+export interface MoveRequest {
+  sequenceSet: SequenceSet;
+  mailbox: string;
+}
+
 export interface AppendRequest {
   mailbox: string;
   flags?: string[];
@@ -447,6 +457,7 @@ export type ImapRequest =
   | { type: "FETCH"; data: FetchRequest }
   | { type: "STORE"; data: StoreRequest }
   | { type: "COPY"; data: CopyRequest }
+  | { type: "MOVE"; data: MoveRequest }
   | { type: "UID"; data: { command: string; request: ImapRequest } }
   | { type: "ID" }
   | { type: "DONE" }

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1329,6 +1329,74 @@ export const expungeDeletedMails = async (
 };
 
 /**
+ * Soft-delete a specific set of UIDs in one mailbox (account / sent /
+ * domain), regardless of their `\Deleted` flag. The MOVE command needs
+ * this — RFC 6851 §3.3 forbids the COPY+STORE(\Deleted)+EXPUNGE pattern
+ * the prior implementation used (it caused mailbox-wide collateral
+ * EXPUNGE of pre-existing \Deleted-flagged mails). Returns the UIDs
+ * actually flipped, in case any were already expunged concurrently.
+ */
+export const expungeMailsByUid = async (
+  user_id: string,
+  account: string | null,
+  sent: boolean,
+  uids: number[]
+): Promise<number[]> => {
+  if (uids.length === 0) return [];
+  try {
+    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
+
+    if (account === null) {
+      // Domain-wide: simple equality on user_id+sent + IN(uids).
+      const rows = await mailsTable.updateWhere(
+        {
+          [USER_ID]: user_id,
+          [SENT]: sent,
+          [EXPUNGED]: false,
+          [uidField]: { op: "IN", value: uids },
+        },
+        { [EXPUNGED]: true, updated: new Date() },
+        [`${uidField} as uid`]
+      );
+      return rows.map((row: Record<string, unknown>) => row.uid as number);
+    }
+
+    // Account-specific: mirror `expungeDeletedMails`'s two-step pattern.
+    // SELECT mail_ids via the address-OR predicate + UID IN, then UPDATE
+    // by mail_id IN so the data-bag pattern bumps `updated`.
+    const addressJson = JSON.stringify([{ address: account }]);
+    const addressCondition = sent
+      ? `${FROM_ADDRESS} @> $3::jsonb`
+      : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+    const uidPlaceholders = uids.map((_, i) => `$${i + 4}`).join(",");
+    const selectSql = `
+      SELECT ${MAIL_ID} as mail_id FROM mails
+      WHERE user_id = $1
+        AND sent = $2
+        AND ${addressCondition}
+        AND ${uidField} IN (${uidPlaceholders})
+        AND expunged = FALSE
+    `;
+    const selectValues: ParamValue[] = [user_id, sent, addressJson, ...uids];
+    const selectResult = await pool.query(selectSql, selectValues);
+    const mailIds = selectResult.rows.map(
+      (row: Record<string, unknown>) => row.mail_id as string
+    );
+    if (mailIds.length === 0) return [];
+
+    const rows = await mailsTable.updateWhere(
+      { [MAIL_ID]: { op: "IN", value: mailIds } },
+      { [EXPUNGED]: true, updated: new Date() },
+      [`${uidField} as uid`]
+    );
+    return rows.map((row: Record<string, unknown>) => row.uid as number);
+  } catch (error) {
+    logger.error("Failed to expunge mails by UID", { uids }, error);
+    throw error;
+  }
+};
+
+/**
  * Get all spam-flagged mails for a user.
  * Returns mails where is_spam = true, sorted by date descending.
  */


### PR DESCRIPTION
Closes #453. Stacked on #604 (COPY).

## What

RFC 6851 MOVE / UID MOVE: a single atomic command that's the standard drag-to-folder primitive on Apple Mail / Thunderbird / iOS. Wire shape mirrors COPY but the source rows disappear after the move.

## Implementation (post-round-1 fix `40da300` + round-2 cleanup `daa76e6`)

| File | What |
|---|---|
| `capabilities.ts` | advertise MOVE |
| `types.ts` | `MoveRequest` + `"MOVE"` `ImapRequest` variant |
| `parsers/store-parsers.ts` | `parseMove` (wire-identical to `parseCopy`) |
| `parsers/command-parser.ts` | dispatch MOVE; UID MOVE falls through the existing `parseUid` recursion |
| `handler.ts` | MOVE + UID MOVE dispatch |
| `session.ts` | `moveMessageTyped` auth/store/selectedMailbox guard |
| `message-ops.ts` | `moveMessageTyped` |
| `postgres/repositories/mails.ts` | new `expungeMailsByUid(user_id, account, sent, uids)` for the targeted soft-delete |
| `store.ts` | new `Store.expungeUids(box, uids)` wrapper |
| `move.test.ts` | new test file (7 pass + 1 todo) |

### Per-mail clone (mirrors post-fix COPY)

- Fresh `messageId` (via `getRandomId()`) per copy — `UNIQUE(user_id, message_id)` would otherwise merge-into-source.
- `getDomainUidNext(user_id, destIsSent)` + `getAccountUidNext(user_id, destAccount, destIsSent)` — the `sent` arg matters when MOVE targets a Sent box.

### Address routing (post-HIGH-3 fix)

- **Non-INBOX destination**: `to_address` re-anchored to `destAccount`, `envelope_to` re-anchored, `cc.value` / `bcc.value` cleared (preserve `*_text` for the header render). Copy surfaces in destination, doesn't re-anchor in source.
- **INBOX destination from a non-INBOX source**: clear `to.value` / `envelopeTo` / `cc.value` / `bcc.value` arrays (preserve `*_text`). INBOX has no address filter so the cleared routing is safe, AND the cleared addresses prevent the source account view from re-matching the new copy AFTER the source row is expunged.
- **INBOX → INBOX**: preserve source addresses verbatim (caught by the self-move short-circuit anyway).

### Targeted expunge (post-HIGH-1+2 fix)

After the copy loop, MOVE calls `await store.expungeUids(selectedMailbox, sourceUids)` — a new repo function that soft-deletes ONLY the specified UIDs without touching `\Deleted` and without expunging pre-existing `\Deleted`-flagged messages. RFC 6851 §3.3 forbids the old COPY+STORE(`\Deleted`)+EXPUNGE pattern (it has mailbox-wide collateral damage). Errors propagate so the outer catch writes `NO MOVE failed`.

### Response shape (RFC 6851 §3.2)

```
* <seq> EXPUNGE                        (one per expunged UID, high→low)
<tag> OK [COPYUID <validity> <src> <dst>] MOVE completed
```

`seqState` is rebuilt post-expunge so subsequent sequence-numbered commands see the correct mapping.

### Self-move short-circuit (RFC 6851 §3.4-§3.5)

`MOVE` to the currently-selected mailbox (including case variants of INBOX) returns bare OK without doing the copy+expunge — same end-state with no UID churn.

## Known limitations

- **No transaction wrapper** — mid-loop `storeMail` failure leaves stored copies in destination AND source intact; client can re-issue MOVE. Mid-`expungeUids` failure leaves copies in destination AND source intact; same recovery. Both modes are NO + safe-retry.
- **Concurrent UID-next race** — `getDomainUidNext` / `getAccountUidNext` are SELECT MAX+1 with no locking. Two simultaneous MOVEs to the same destination can race to the same UID. Pre-existing across receive/send/append; tracked separately.

## Test plan

`move.test.ts` (7 pass + 1 todo):

- Read-only mailbox refusal (`NO [READ-ONLY]`).
- TRYCREATE on nonexistent destination.
- INBOX destination case-insensitive short-circuit (existence path).
- Empty source range (sequence + UID) → tagged OK without COPYUID.
- MOVE to the currently-selected mailbox short-circuits (`OK MOVE completed`, `getMessages` never called) — both exact-name and INBOX case variant.
- `it.todo` for end-to-end COPYUID + targeted EXPUNGE emission AND the INBOX-from-non-INBOX address-clearing invariant — needs the same FakePool fixture as COPY's todo.

### Local results
- `bun test src/server/lib/imap/` → **503 pass / 0 fail / 1 todo** (1063 expect calls)
- `bun run typecheck` → clean

### Reviewoie rounds
- Round-1: 3 HIGH RFC 6851 §3.3 violations (sets `\Deleted`, mailbox-wide expunge, MOVE-into-INBOX from accounts/foo re-surfaces) + 3 MED + 2 LOW. Addressed in `40da300`.
- Round-2: 4 LOWs (test doc, PR body, MOVE-to-self fast path, INBOX-clearing test coverage gap). Addressed in `daa76e6` (the test coverage gap remains in the `it.todo` until a FakePool fixture lands; the description now names the invariant explicitly).

## Refs

- RFC 6851 (MOVE)
- RFC 3501 §6.4.7 (COPY base)
- RFC 4315 (COPYUID response code)
- Unblocked by: #604 (real COPY landed first)
- Related: #605 (INBOX-duplicate data-model issue, opposite direction)