### PR TITLE
fix(search): exclude drafts from search, push badge, and spam list (#611)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -285,6 +285,58 @@ describe("getAccountStats — envelope_to inclusion in received address expansio
   });
 });
 
+describe("draft-exclusion invariant — user-facing read paths hide drafts (#611)", () => {
+  // A draft lives in the IMAP Drafts folder; the web client presents no Drafts
+  // view, so a draft must not surface in ANY user-facing read surface (folder
+  // lists, per-account counts, search results, push badge, spam list). The
+  // invariant is enforced query-side with `AND draft = FALSE`. getMailHeaders
+  // and getAccountStats already carried it; searchMails / getUnreadNotifications
+  // / getSpamMails dropped it (#611) so a draft showed in search but in no
+  // folder/count. These source-scan guards pin the filter on every path so they
+  // cannot re-drift independently. Source-text scanning (not a live query) is
+  // used here because module-mock interactions make pool.query mocking fragile
+  // in the full suite — same rationale as the getAccountStats guard above.
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+  });
+
+  const bodyOf = (name: string): string => {
+    const re = new RegExp(`export const ${name}[\\s\\S]*?\\n};`);
+    const m = mailsSource.match(re);
+    if (!m) throw new Error(`${name} not found in mails.ts`);
+    return m[0];
+  };
+
+  // Every user-facing read path that must hide drafts.
+  const draftHidingPaths = [
+    "getMailHeaders",
+    "getAccountStats",
+    "searchMails",
+    "getUnreadNotifications",
+    "getSpamMails",
+  ];
+
+  for (const name of draftHidingPaths) {
+    it(`${name} filters draft = FALSE`, () => {
+      expect(bodyOf(name)).toMatch(/draft = FALSE/);
+    });
+  }
+
+  it("searchMails keeps the draft filter alongside its existing expunged filter", () => {
+    // Guard against a regression that removes one filter while editing the other.
+    const body = bodyOf("searchMails");
+    expect(body).toMatch(/expunged = FALSE/);
+    expect(body).toMatch(/draft = FALSE/);
+  });
+});
+
 describe("buildCriterionClause — flag criteria use schema columns", () => {
   // Regression guard (originally on searchMailsByUid's inline switch, retargeted
   // here when #551 extracted the per-criterion logic into buildCriterionClause):

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -352,10 +352,14 @@ export const searchMails = async (
           'StartSel=<em>, StopSel=</em>, MaxWords=50, MinWords=10') as subject_highlight,
         ts_headline('english', text, plainto_tsquery('english', $2), 
           'StartSel=<em>, StopSel=</em>, MaxWords=50, MinWords=10') as text_highlight
-      FROM mails 
-      WHERE user_id = $1 
+      FROM mails
+      WHERE user_id = $1
         AND search_vector @@ plainto_tsquery('english', $2)
         AND expunged = FALSE
+        -- Drafts belong to the IMAP Drafts folder, not the search results;
+        -- mirrors the draft filter on getMailHeaders / getAccountStats so a
+        -- draft never surfaces in a view (search) that no folder/count shows.
+        AND draft = FALSE
       ORDER BY rank DESC, date DESC
       LIMIT 1000
     `;
@@ -1045,8 +1049,11 @@ export const getUnreadNotifications = async (
         user_id,
         COUNT(*) FILTER (WHERE read = FALSE) as unread_count,
         MAX(date) as latest
-      FROM mails 
-      WHERE user_id IN (${placeholders}) AND sent = FALSE AND expunged = FALSE
+      FROM mails
+      -- draft = FALSE: a user's own unsent draft must not ring the new-mail
+      -- push badge. Mirrors getMailHeaders / getAccountStats so the badge count
+      -- matches the headers list view (drafts live in the Drafts folder).
+      WHERE user_id IN (${placeholders}) AND sent = FALSE AND expunged = FALSE AND draft = FALSE
       GROUP BY user_id
     `;
 
@@ -1223,8 +1230,10 @@ export const expungeDeletedMails = async (
 export const getSpamMails = async (user_id: string): Promise<MailModel[]> => {
   try {
     const sql = `
-      SELECT * FROM mails 
-      WHERE user_id = $1 AND is_spam = TRUE AND sent = FALSE AND expunged = FALSE
+      SELECT * FROM mails
+      -- draft = FALSE mirrors the other user-facing read paths: a draft belongs
+      -- to the Drafts folder, never to the spam list, even if flagged is_spam.
+      WHERE user_id = $1 AND is_spam = TRUE AND sent = FALSE AND expunged = FALSE AND draft = FALSE
       ORDER BY date DESC
     `;
     const result = await pool.query(sql, [user_id]);


### PR DESCRIPTION
## Summary

Three user-facing read paths dropped the `AND draft = FALSE` filter that `getMailHeaders` and `getAccountStats` enforce by design. A draft therefore surfaced in places that present **no Drafts view**, while showing in no folder list and counting in no per-account stat:

| Read path | Surface | Before | After |
|---|---|---|---|
| `searchMails` (`mails.ts`) | web search box (`GET /api/mails/search/:value`) | draft appears in results | excluded |
| `getUnreadNotifications` (`mails.ts`) | push badge `count` | draft inflates the badge | excluded |
| `getSpamMails` (`mails.ts`) | spam list | draft appears (if flagged spam) | excluded |

The invariant is documented in-code at `getAccountStats`: *"drafts belong to the IMAP Drafts folder, not to the per-account inbox view."* It was enforced on the folder-list and count paths but silently dropped on the three above, so a draft that matched a search term opened a mail the user could not reach through any folder.

This is the same one-line omission in all three queries, so it is fixed as one pass (per the issue's "fix the whole invariant in one pass" question — yes). A source-scan regression guard now asserts **every** user-facing read path carries the filter, so they cannot re-drift independently.

## Scope notes

- The unused `_field` arg the issue mentions as a separate cleanup is **left out** — it is a distinct concern (search field filtering), not the draft invariant.
- `getUnreadNotifications` was the second instance flagged in closed #507 / abandoned PR #508; #507 was correctly closed because *that* May incident's cause was `envelope_to` (fixed in #525/#526), not drafts. The draft filter the PR-508 change would have added never landed — this PR lands it on the merits, it does not reopen the #507 incident.

## Root cause

Each query built its `WHERE` with `expunged = FALSE` (and `sent`/`is_spam` as applicable) but never added `AND draft = FALSE`. The sibling read paths that feed the visible folder/count views do.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/server` — 1037 pass / 0 fail
- [x] **Regression guard** (`mails.test.ts`, source-scan — the established pattern in this file, robust against the full-suite `mock.module` interactions): asserts `getMailHeaders`, `getAccountStats`, `searchMails`, `getUnreadNotifications`, `getSpamMails` all carry `draft = FALSE`. The 4 new assertions **fail on `upstream/main`** (searchMails / getUnreadNotifications / getSpamMails / searchMails-keeps-both) and **pass on this branch**; the 2 already-correct paths pass on both.
- [x] **DB-level E2E** driving the real `searchMails` / `getUnreadNotifications` / `getSpamMails` against a **disposable** database (`inbox_e2e_611`, created + dropped by the harness; the real local `inbox` DB was never touched — `POSTGRES_DATABASE` overridden). The symptom is latent in prod today (0 draft rows), so the browser cannot reach it without a draft; this drives the actual queries instead. Seeded one normal unread mail (`a`) and one **draft** (`b`) sharing a search term, with `b` also unread + flagged spam:
  - **Baseline (`upstream/main` source):** search → `[a, b]` (draft leaks, count 2); unread badge → 2 (draft inflates); spam → `[b]` (draft leaks). All three surfaces show the draft — the bug.
  - **This branch:** search → `[a]` (count 1); unread badge → 1; spam → `[]`. Draft excluded from every surface.

Harness kept in `/tmp/e2e-611.ts` (out of tree).

Closes #611
