### PR TITLE
feat(mails): add ?since= delta + tombstones to GET /headers/:account (#457 server step)

### DIFF
--- a/src/server/lib/http/routes/mails/get-headers.ts
+++ b/src/server/lib/http/routes/mails/get-headers.ts
@@ -1,14 +1,28 @@
 import { MailHeaderDataType } from "common";
 import {
   getMailHeaders,
+  getMailHeadersDelta,
   addressToUsername,
   GetMailsOptions
 } from "server";
 import { Route } from "../route";
 
+// Full-list response (no `?since=`). Unchanged shape — old clients keep working.
 export type HeadersGetResponse = MailHeaderDataType[];
 
-export const getHeadersRoute = new Route<HeadersGetResponse>(
+// Delta response, returned only when the client sends `?since=<ISO>` (#457).
+// `headers` are the rows changed since `since`; `expunged_ids` are rows
+// expunged in that window so a cached client can evict them; `as_of` is the
+// server view-time the client persists as the next `?since=` cursor.
+export interface HeadersDeltaGetResponse {
+  as_of: string;
+  headers: MailHeaderDataType[];
+  expunged_ids: string[];
+}
+
+export const getHeadersRoute = new Route<
+  HeadersGetResponse | HeadersDeltaGetResponse
+>(
   "GET",
   "/headers/:account",
   async (req) => {
@@ -30,6 +44,26 @@ export const getHeadersRoute = new Route<HeadersGetResponse>(
       new: !!req.query.new,
       saved: !!req.query.saved
     };
+
+    const { since } = req.query;
+    if (since !== undefined) {
+      // Validate at the boundary: a malformed cursor must not silently fall
+      // back to a full fetch (the client expects the delta shape) nor reach
+      // the SQL layer (`updated > 'garbage'` would throw).
+      if (typeof since !== "string" || Number.isNaN(Date.parse(since))) {
+        return {
+          status: "failed",
+          message: "Invalid `since` parameter: expected an ISO timestamp."
+        };
+      }
+      const delta = await getMailHeadersDelta(
+        user,
+        req.params.account,
+        options,
+        since
+      );
+      return { status: "success", body: delta };
+    }
 
     const mails = await getMailHeaders(user, req.params.account, options);
     return { status: "success", body: mails };

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -10,6 +10,7 @@ import type { ApiResponse } from "../route";
 // ── Shared mocks for "server" barrel ─────────────────────────────────────────
 
 const mockGetMailHeaders = mock(async () => []);
+const mockGetMailHeadersDelta = mock(async () => ({ as_of: "", headers: [], expunged_ids: [] }));
 const mockGetAccounts = mock(async () => ({ received: [], sent: [] }));
 const mockGetMailBody = mock(async () => null as unknown);
 const mockDeleteMail = mock(async () => {});
@@ -37,6 +38,7 @@ class MockMailSendingError extends Error {}
 
 mock.module("server", () => ({
   getMailHeaders: mockGetMailHeaders,
+  getMailHeadersDelta: mockGetMailHeadersDelta,
   getAccounts: mockGetAccounts,
   getMailBody: mockGetMailBody,
   deleteMail: mockDeleteMail,
@@ -129,6 +131,7 @@ const noopStream = stream as unknown as import("../route").Stream<unknown>;
 describe("getHeadersRoute", () => {
   beforeEach(() => {
     mockGetMailHeaders.mockClear();
+    mockGetMailHeadersDelta.mockClear();
     mockAddressToUsername.mockClear();
   });
 
@@ -204,6 +207,69 @@ describe("getHeadersRoute", () => {
 
     const callArgs = mockGetMailHeaders.mock.calls[0];
     expect(callArgs[2]).toMatchObject({ sent: true, new: true, saved: false });
+  });
+
+  it("without ?since= falls back to the full-list path (backwards-compat)", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    mockGetMailHeaders.mockResolvedValueOnce([{ id: "m1" }] as never);
+    mockAddressToUsername.mockReturnValueOnce("alice");
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "alice@example.com" },
+      query: {},
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect(mockGetMailHeaders).toHaveBeenCalledTimes(1);
+    expect(mockGetMailHeadersDelta).not.toHaveBeenCalled();
+  });
+
+  it("with a valid ?since= returns the delta shape via getMailHeadersDelta", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    const delta = { as_of: "2024-02-01T00:00:00.000Z", headers: [{ id: "m9" }], expunged_ids: ["x"] };
+    mockGetMailHeadersDelta.mockResolvedValueOnce(delta as never);
+    mockAddressToUsername.mockReturnValueOnce("alice");
+
+    const since = "2024-01-01T00:00:00.000Z";
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "alice@example.com" },
+      query: { since },
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
+    expect((result as ApiResponse<unknown>).body).toEqual(delta);
+    expect(mockGetMailHeaders).not.toHaveBeenCalled();
+    const callArgs = mockGetMailHeadersDelta.mock.calls[0];
+    expect(callArgs[3]).toBe(since);
+  });
+
+  it("rejects a malformed ?since= at the boundary instead of full-fetching or hitting SQL", async () => {
+    const { getHeadersRoute } = await import("./get-headers");
+
+    mockAddressToUsername.mockReturnValueOnce("alice");
+
+    const req = makeReq({
+      method: "GET",
+      session: { user: makeUser("alice") },
+      params: { account: "alice@example.com" },
+      query: { since: "not-a-date" },
+    });
+    const res = makeRes();
+
+    const result = await getHeadersRoute.callback(req, res, noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect(mockGetMailHeadersDelta).not.toHaveBeenCalled();
+    expect(mockGetMailHeaders).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -16,6 +16,7 @@ export { push } from "./push";
 // Mails module (uses postgres internally)
 export {
   getMailHeaders,
+  getMailHeadersDelta,
   getMailBody,
   searchMail,
   markRead,
@@ -42,7 +43,7 @@ export {
   getSpamHeaders,
   markSpam,
 } from "./mails";
-export type { AccountsGetResponse, GetMailsOptions, ValidationResult, SaveMailHandlerOptions } from "./mails";
+export type { AccountsGetResponse, GetMailsOptions, MailHeadersDelta, ValidationResult, SaveMailHandlerOptions } from "./mails";
 
 // Spam filter
 export * from "./spam";

--- a/src/server/lib/mails/headers.test.ts
+++ b/src/server/lib/mails/headers.test.ts
@@ -2,12 +2,16 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { Pagination, SignedUser, MaskedUser } from "common";
 
 const mockGetMailHeaders = mock(() => Promise.resolve([]));
+const mockGetMailHeadersDelta = mock(() =>
+  Promise.resolve({ as_of: "2024-01-02T00:00:00.000Z", headers: [], expunged_ids: [] })
+);
 
 mock.module("../postgres/repositories/mails", () => ({
   getMailHeaders: mockGetMailHeaders,
+  getMailHeadersDelta: mockGetMailHeadersDelta,
 }));
 
-import { getMailHeaders } from "./headers";
+import { getMailHeaders, getMailHeadersDelta } from "./headers";
 
 const makeUser = (overrides: Partial<SignedUser> = {}) => new SignedUser({
   id: "user-123",
@@ -209,5 +213,79 @@ describe("getMailHeaders", () => {
     expect(results).toHaveLength(2);
     expect(results[0].id).toBe("m1");
     expect(results[1].id).toBe("m2");
+  });
+});
+
+describe("getMailHeadersDelta", () => {
+  const since = "2024-01-01T00:00:00.000Z";
+
+  beforeEach(() => {
+    mockGetMailHeadersDelta.mockClear();
+    mockGetMailHeadersDelta.mockResolvedValue({
+      as_of: "2024-01-02T00:00:00.000Z",
+      headers: [],
+      expunged_ids: [],
+    });
+  });
+
+  it("returns an empty delta that echoes `since` when user has no id", async () => {
+    const user = { username: "noId" };
+    const result = await getMailHeadersDelta(user, "inbox@example.com", defaultOptions, since);
+    // as_of must NOT advance past `since`, or the client would skip unseen rows.
+    expect(result).toEqual({ as_of: since, headers: [], expunged_ids: [] });
+    expect(mockGetMailHeadersDelta).not.toHaveBeenCalled();
+  });
+
+  it("passes since + folder options to the repository (and never paginates)", async () => {
+    const user = makeUser();
+    await getMailHeadersDelta(
+      user,
+      "inbox@example.com",
+      { ...defaultOptions, sent: true },
+      since
+    );
+    const callArgs = mockGetMailHeadersDelta.mock.calls[0];
+    expect(callArgs[0]).toBe("user-123");
+    expect(callArgs[1]).toBe("inbox@example.com");
+    expect(callArgs[2]).toMatchObject({ sent: true, new: false, saved: false });
+    // Delta returns the full changed set, so it must NOT carry pagination.
+    expect(callArgs[2]).not.toHaveProperty("from");
+    expect(callArgs[2]).not.toHaveProperty("size");
+    expect(callArgs[3]).toBe(since);
+  });
+
+  it("maps repository header rows to MailHeaderData and passes through as_of + expunged_ids", async () => {
+    mockGetMailHeadersDelta.mockResolvedValue({
+      as_of: "2024-01-03T12:00:00.000Z",
+      headers: [
+        {
+          mail_id: "mail-delta",
+          subject: "Changed",
+          date: "2024-01-03T10:00:00Z",
+          from_address: [{ address: "s@example.com" }],
+          from_text: "s@example.com",
+          to_address: null,
+          to_text: null,
+          cc_address: null,
+          cc_text: null,
+          bcc_address: null,
+          bcc_text: null,
+          read: false,
+          saved: false,
+          sent: false,
+          insight: null,
+        },
+      ],
+      expunged_ids: ["gone-1", "gone-2"],
+    });
+
+    const user = makeUser();
+    const result = await getMailHeadersDelta(user, "inbox@example.com", defaultOptions, since);
+    expect(result.as_of).toBe("2024-01-03T12:00:00.000Z");
+    expect(result.expunged_ids).toEqual(["gone-1", "gone-2"]);
+    expect(result.headers).toHaveLength(1);
+    expect(result.headers[0].id).toBe("mail-delta");
+    expect(result.headers[0].subject).toBe("Changed");
+    expect(result.headers[0].from).toBeDefined();
   });
 });

--- a/src/server/lib/mails/headers.ts
+++ b/src/server/lib/mails/headers.ts
@@ -8,7 +8,9 @@ import {
 } from "common";
 import {
   getMailHeaders as pgGetMailHeaders,
+  getMailHeadersDelta as pgGetMailHeadersDelta,
   GetMailHeadersOptions,
+  MailHeaderResult,
 } from "../postgres/repositories/mails";
 
 export interface GetMailsOptions {
@@ -18,16 +20,48 @@ export interface GetMailsOptions {
   pagination?: Pagination;
 }
 
+export interface MailHeadersDelta {
+  as_of: string;
+  headers: MailHeaderData[];
+  expunged_ids: string[];
+}
+
 interface UserWithId {
   user_id?: string;
 }
+
+const resolveUserId = (user: MaskedUser | SignedUser): string | undefined =>
+  "id" in user ? user.id : (user as UserWithId).user_id;
+
+const toMailHeaderData = (m: MailHeaderResult): MailHeaderData =>
+  new MailHeaderData({
+    id: m.mail_id,
+    subject: m.subject,
+    date: m.date,
+    from: m.from_address
+      ? { value: m.from_address as MailAddressValueType[], text: m.from_text || "" }
+      : undefined,
+    to: m.to_address
+      ? { value: m.to_address as MailAddressValueType[], text: m.to_text || "" }
+      : undefined,
+    cc: m.cc_address
+      ? { value: m.cc_address as MailAddressValueType[], text: m.cc_text || "" }
+      : undefined,
+    bcc: m.bcc_address
+      ? { value: m.bcc_address as MailAddressValueType[], text: m.bcc_text || "" }
+      : undefined,
+    read: m.read,
+    saved: m.saved,
+    sent: m.sent,
+    insight: m.insight as Insight | undefined,
+  });
 
 export const getMailHeaders = async (
   user: MaskedUser | SignedUser,
   address: string,
   options: GetMailsOptions
 ): Promise<MailHeaderData[]> => {
-  const userId = "id" in user ? user.id : (user as UserWithId).user_id;
+  const userId = resolveUserId(user);
   if (!userId) return [];
 
   const { from, size } = options.pagination || new Pagination();
@@ -42,27 +76,33 @@ export const getMailHeaders = async (
 
   const mailModels = await pgGetMailHeaders(userId, address, pgOptions);
 
-  return mailModels.map((m) => {
-    return new MailHeaderData({
-      id: m.mail_id,
-      subject: m.subject,
-      date: m.date,
-      from: m.from_address
-        ? { value: m.from_address as MailAddressValueType[], text: m.from_text || "" }
-        : undefined,
-      to: m.to_address
-        ? { value: m.to_address as MailAddressValueType[], text: m.to_text || "" }
-        : undefined,
-      cc: m.cc_address
-        ? { value: m.cc_address as MailAddressValueType[], text: m.cc_text || "" }
-        : undefined,
-      bcc: m.bcc_address
-        ? { value: m.bcc_address as MailAddressValueType[], text: m.bcc_text || "" }
-        : undefined,
-      read: m.read,
-      saved: m.saved,
-      sent: m.sent,
-      insight: m.insight as Insight | undefined,
-    });
-  });
+  return mailModels.map(toMailHeaderData);
+};
+
+// Incremental fetch for the IndexedDB cache (#457): only rows changed since
+// `since`, plus tombstones (ids of rows expunged in the window) for eviction,
+// and `as_of` for the client to persist as the next cursor.
+export const getMailHeadersDelta = async (
+  user: MaskedUser | SignedUser,
+  address: string,
+  options: GetMailsOptions,
+  since: string
+): Promise<MailHeadersDelta> => {
+  const userId = resolveUserId(user);
+  if (!userId) return { as_of: since, headers: [], expunged_ids: [] };
+
+  const pgOptions: GetMailHeadersOptions = {
+    sent: options.sent,
+    new: options.new,
+    saved: options.saved,
+  };
+
+  const { as_of, headers, expunged_ids } = await pgGetMailHeadersDelta(
+    userId,
+    address,
+    pgOptions,
+    since
+  );
+
+  return { as_of, headers: headers.map(toMailHeaderData), expunged_ids };
 };

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -334,11 +334,14 @@ describe("buildCriterionClause — flag criteria use schema columns", () => {
   });
 });
 
-describe("getMailHeaders — envelope_to in received-branch address condition", () => {
+describe("buildHeaderAddressCondition — envelope_to in received-branch address condition", () => {
   // Mails addressed via envelope_to (e.g. GitHub notification routing,
   // listserv sub-addressing) must appear in per-account mail lists, not
   // only in account-stats counts. The received-branch filter must include
-  // envelope_to alongside MIME to/cc/bcc.
+  // envelope_to alongside MIME to/cc/bcc. The condition is shared by the
+  // full-list (getMailHeaders) and delta (getMailHeadersDelta) paths via the
+  // extracted buildHeaderAddressCondition helper, so this guards the one
+  // source of truth.
   let mailsSource: string;
   let fnSource: string;
 
@@ -350,9 +353,9 @@ describe("getMailHeaders — envelope_to in received-branch address condition", 
       "utf8"
     );
     const fnMatch = mailsSource.match(
-      /export const getMailHeaders[\s\S]*?\n};/
+      /export const buildHeaderAddressCondition[\s\S]*?\n};/
     );
-    if (!fnMatch) throw new Error("getMailHeaders not found in mails.ts");
+    if (!fnMatch) throw new Error("buildHeaderAddressCondition not found in mails.ts");
     fnSource = fnMatch[0];
   });
 
@@ -378,6 +381,71 @@ describe("getMailHeaders — envelope_to in received-branch address condition", 
     expect(sentSql).toContain("${FROM_ADDRESS}");
     expect(sentSql).not.toContain("envelope_to");
     expect(sentSql).not.toContain("envelope_from");
+  });
+});
+
+describe("getMailHeaders / getMailHeadersDelta — `?since=` delta path (#457)", () => {
+  // The delta path drives the IndexedDB cache: only rows changed since the
+  // client's cursor, plus tombstones for rows expunged in that window. These
+  // guard the SQL invariants that make the cursor safe — they can't be unit-
+  // checked without a DB, so we assert on the query source (the repo's
+  // established style for SQL-shape regressions).
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+  });
+
+  it("getMailHeaders filters on `updated >` when options.since is set", () => {
+    const fnMatch = mailsSource.match(/export const getMailHeaders[\s\S]*?\n};/);
+    if (!fnMatch) throw new Error("getMailHeaders not found");
+    const src = fnMatch[0];
+    // Guarded behind options.since so the full-list path is unaffected.
+    expect(src).toContain("options.since !== undefined");
+    expect(src).toContain("AND updated > $");
+  });
+
+  it("getMailHeadersDelta scans expunged rows for tombstones over the same window", () => {
+    const fnMatch = mailsSource.match(
+      /export const getMailHeadersDelta[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeadersDelta not found");
+    const src = fnMatch[0];
+    // Tombstone query: expunged rows in the same account, changed in-window.
+    expect(src).toContain("expunged = TRUE");
+    expect(src).toContain("AND updated > $3");
+    // Reuses the one address-condition source of truth, not a private copy.
+    expect(src).toContain("buildHeaderAddressCondition(options)");
+  });
+
+  it("getMailHeadersDelta reads as_of from the DB clock BEFORE the data queries", () => {
+    const fnMatch = mailsSource.match(
+      /export const getMailHeadersDelta[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeadersDelta not found");
+    const src = fnMatch[0];
+    // as_of must come from now() (same timeline as the `updated` column set by
+    // CURRENT_TIMESTAMP), not the app clock, or clock skew could skip rows.
+    const asOfIdx = src.indexOf("SELECT now() AS as_of");
+    const headersIdx = src.indexOf("getMailHeaders(");
+    expect(asOfIdx).toBeGreaterThanOrEqual(0);
+    expect(headersIdx).toBeGreaterThanOrEqual(0);
+    // Captured first → a safe lower bound (at-least-once on concurrent writes).
+    expect(asOfIdx).toBeLessThan(headersIdx);
+  });
+
+  it("getMailHeadersDelta echoes `since` as as_of on failure (cursor must not advance)", () => {
+    const fnMatch = mailsSource.match(
+      /export const getMailHeadersDelta[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeadersDelta not found");
+    const src = fnMatch[0];
+    expect(src).toMatch(/return\s*\{\s*as_of:\s*since/);
   });
 });
 
@@ -573,17 +641,17 @@ describe("getMailHeaders — saved query spans both folders (#568)", () => {
       "utf8"
     );
     const fnMatch = mailsSource.match(
-      /export const getMailHeaders[\s\S]*?\n};/
+      /export const buildHeaderAddressCondition[\s\S]*?\n};/
     );
-    if (!fnMatch) throw new Error("getMailHeaders not found in mails.ts");
+    if (!fnMatch) throw new Error("buildHeaderAddressCondition not found in mails.ts");
     fnSource = fnMatch[0];
   });
 
   it("uses the union (sent OR received) condition when saved && !sent", () => {
     const exprMatch = fnSource.match(
-      /addressCondition\s*=\s*([\s\S]*?);/
+      /return\s+([\s\S]*?);/
     );
-    if (!exprMatch) throw new Error("addressCondition assignment not found");
+    if (!exprMatch) throw new Error("address-condition return expression not found");
     const expr = exprMatch[1];
     // The saved-and-not-sent branch is the union of both folder conditions.
     expect(expr).toContain("options.saved && !options.sent");
@@ -592,9 +660,9 @@ describe("getMailHeaders — saved query spans both folders (#568)", () => {
 
   it("falls back to the sent-only or received-only condition otherwise", () => {
     const exprMatch = fnSource.match(
-      /addressCondition\s*=\s*([\s\S]*?);/
+      /return\s+([\s\S]*?);/
     );
-    if (!exprMatch) throw new Error("addressCondition assignment not found");
+    if (!exprMatch) throw new Error("address-condition return expression not found");
     const expr = exprMatch[1];
     expect(expr).toContain("options.sent");
     // Non-union branches reuse the single-folder conditions verbatim.

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -423,7 +423,7 @@ describe("getMailHeaders / getMailHeadersDelta — `?since=` delta path (#457)",
     expect(src).toContain("buildHeaderAddressCondition(options)");
   });
 
-  it("getMailHeadersDelta reads as_of from the DB clock BEFORE the data queries", () => {
+  it("getMailHeadersDelta reads as_of from the DB clock (with safety margin) BEFORE the data queries", () => {
     const fnMatch = mailsSource.match(
       /export const getMailHeadersDelta[\s\S]*?\n};/
     );
@@ -431,12 +431,16 @@ describe("getMailHeaders / getMailHeadersDelta — `?since=` delta path (#457)",
     const src = fnMatch[0];
     // as_of must come from now() (same timeline as the `updated` column set by
     // CURRENT_TIMESTAMP), not the app clock, or clock skew could skip rows.
-    const asOfIdx = src.indexOf("SELECT now() AS as_of");
+    const asOfIdx = src.indexOf("now()");
     const headersIdx = src.indexOf("getMailHeaders(");
     expect(asOfIdx).toBeGreaterThanOrEqual(0);
     expect(headersIdx).toBeGreaterThanOrEqual(0);
     // Captured first → a safe lower bound (at-least-once on concurrent writes).
     expect(asOfIdx).toBeLessThan(headersIdx);
+    // Backed off by a safety margin so the commit-latency / skew window re-sends
+    // rather than skips.
+    expect(src).toContain("make_interval(secs => $1)");
+    expect(src).toContain("DELTA_CURSOR_SAFETY_MARGIN_SECONDS");
   });
 
   it("getMailHeadersDelta echoes `since` as as_of on failure (cursor must not advance)", () => {

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -251,7 +251,39 @@ export interface GetMailHeadersOptions {
   saved: boolean;
   from?: number;
   size?: number;
+  // ISO timestamp; when set, restrict to rows whose `updated` is newer than
+  // this. Used by the IndexedDB-cache delta path (#457) to fetch only the
+  // rows a cached client hasn't seen.
+  since?: string;
 }
+
+// Builds the address-match SQL fragment for a per-account header query, bound
+// to `$2` = the address-as-jsonb param. Shared by the full-list and the delta
+// (getMailHeadersDelta) paths so the sent/received/saved address semantics
+// can't drift between them.
+//   - sent: match from_address only.
+//   - received: match to_address, cc_address, bcc_address AND envelope_to.
+//     `envelope_to` is the SMTP-level delivery address that can differ from
+//     MIME to/cc/bcc under listserv-style routing (e.g. GitHub notifications:
+//     MIME `to` = list address, envelope_to = the actual recipient
+//     sub-address). Mirrors the received-branch expansion in `getAccountStats`
+//     (PR #525) so an account row surfaced by envelope_to still resolves to
+//     its mails when the user clicks through.
+//   - saved (no explicit folder): a starred mail can be sent or received, so
+//     the Saved view must span both branches. Without this, a starred *sent*
+//     mail is unreachable from the Saved view — its account address only
+//     matches from_address, never the received condition (#568).
+export const buildHeaderAddressCondition = (
+  options: Pick<GetMailHeadersOptions, "sent" | "saved">
+): string => {
+  const sentCondition = `${FROM_ADDRESS} @> $2::jsonb`;
+  const receivedCondition = `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
+  return options.saved && !options.sent
+    ? `(${sentCondition} OR ${receivedCondition})`
+    : options.sent
+    ? sentCondition
+    : receivedCondition;
+};
 
 export const getMailHeaders = async (
   user_id: string,
@@ -260,29 +292,7 @@ export const getMailHeaders = async (
 ): Promise<MailHeaderResult[]> => {
   try {
     const addressJson = JSON.stringify([{ address }]);
-    // Detect sent/received by address matching, not the `sent` flag.
-    // For sent mails, check from_address only.
-    // For received mails, check to_address, cc_address, bcc_address AND
-    // envelope_to. `envelope_to` is the SMTP-level delivery address that
-    // can differ from MIME to/cc/bcc when a sender uses listserv-style
-    // routing (e.g. GitHub notifications: MIME `to` = list address,
-    // envelope_to = the actual recipient sub-address). Mirrors the
-    // received-branch address expansion in `getAccountStats` (PR #525)
-    // so that an account row surfaced by envelope_to still resolves to
-    // its mails when the user clicks through.
-    const sentCondition = `${FROM_ADDRESS} @> $2::jsonb`;
-    const receivedCondition = `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
-    // The Saved view is a flat starred collection per account: a starred
-    // mail can be either sent or received, so a saved query with no explicit
-    // folder must span both branches. Without this, a starred *sent* mail is
-    // unreachable from the Saved view — the account address only matches
-    // from_address, never the received to/cc/bcc condition (#568).
-    const addressCondition =
-      options.saved && !options.sent
-        ? `(${sentCondition} OR ${receivedCondition})`
-        : options.sent
-        ? sentCondition
-        : receivedCondition;
+    const addressCondition = buildHeaderAddressCondition(options);
     // Select only columns needed for mail headers — excludes html/text/attachments
     // to avoid loading full email bodies into memory for every concurrent request.
     const headerColumns = [
@@ -309,6 +319,11 @@ export const getMailHeaders = async (
       sql += ` AND saved = TRUE`;
     }
 
+    if (options.since !== undefined) {
+      sql += ` AND updated > $${paramIdx++}`;
+      values.push(options.since);
+    }
+
     sql += ` ORDER BY date DESC`;
 
     if (options.size !== undefined) {
@@ -326,6 +341,76 @@ export const getMailHeaders = async (
   } catch (error) {
     logger.error("Failed to get mail headers", {}, error);
     return [];
+  }
+};
+
+export interface MailHeadersDeltaResult {
+  as_of: string;
+  headers: MailHeaderResult[];
+  expunged_ids: string[];
+}
+
+// Delta variant of getMailHeaders for the IndexedDB cache (#457): returns only
+// rows changed since `since`, plus the ids of rows expunged within that window
+// so a cached client can apply an incremental update and evict stale entries
+// instead of refetching the whole folder.
+//
+// `as_of` is the DB clock read BEFORE the data queries, making it a safe lower
+// bound for the next call: any mutation committed at or before as_of is
+// reflected here, and a row mutated *during* the read simply has
+// `updated > as_of` and is re-sent on the next call (at-least-once — the client
+// dedups by mail_id). Reading as_of from the DB (not the app clock) keeps it on
+// the same timeline as the `updated` column, which is set by CURRENT_TIMESTAMP.
+//
+// The expunged scan reuses the request's address condition so the evicted ids
+// belong to the same folder view the client is updating; it omits `draft` and
+// `read`/`saved` sub-filters because eviction is by id and is harmless for ids
+// the client never cached.
+export const getMailHeadersDelta = async (
+  user_id: string,
+  address: string,
+  options: GetMailHeadersOptions,
+  since: string
+): Promise<MailHeadersDeltaResult> => {
+  try {
+    // The pool's TIMESTAMPTZ type parser (client.ts) already returns an ISO
+    // string, the same representation the `updated` column carries — so this
+    // value round-trips straight back as the next `?since=` cursor.
+    const asOfResult = await pool.query<{ as_of: string }>("SELECT now() AS as_of");
+    const as_of = asOfResult.rows[0].as_of;
+
+    const addressJson = JSON.stringify([{ address }]);
+    const addressCondition = buildHeaderAddressCondition(options);
+    const expungedSql = `
+      SELECT ${MAIL_ID} FROM mails
+      WHERE user_id = $1
+        AND ${addressCondition}
+        AND expunged = TRUE
+        AND updated > $3
+    `;
+
+    const [headers, expungedResult] = await Promise.all([
+      // Delta never paginates — the changed set is small and the client needs
+      // every changed row, so from/size are deliberately omitted.
+      getMailHeaders(user_id, address, {
+        sent: options.sent,
+        new: options.new,
+        saved: options.saved,
+        since,
+      }),
+      pool.query<{ mail_id: string }>(expungedSql, [user_id, addressJson, since]),
+    ]);
+
+    return {
+      as_of,
+      headers,
+      expunged_ids: expungedResult.rows.map((r) => r.mail_id),
+    };
+  } catch (error) {
+    logger.error("Failed to get mail headers delta", {}, error);
+    // Echo `since` back as as_of so a failed call doesn't advance the client's
+    // cursor past unseen mutations.
+    return { as_of: since, headers: [], expunged_ids: [] };
   }
 };
 

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -350,22 +350,39 @@ export interface MailHeadersDeltaResult {
   expunged_ids: string[];
 }
 
+// Seconds the delta cursor lags real time. `as_of` is backed off by this
+// margin so a row mutated just before the read — the commit-latency window (a
+// txn whose CURRENT_TIMESTAMP precedes our now() but commits after our SELECT),
+// or one stamped under bounded app/DB clock skew — is re-sent on the NEXT call
+// rather than skipped forever. Re-sends are deduped client-side by mail_id, so
+// the cost is a small overlap, not duplicates. Must exceed expected commit
+// latency + clock skew (NTP keeps the latter well under a second).
+const DELTA_CURSOR_SAFETY_MARGIN_SECONDS = 2;
+
 // Delta variant of getMailHeaders for the IndexedDB cache (#457): returns only
 // rows changed since `since`, plus the ids of rows expunged within that window
 // so a cached client can apply an incremental update and evict stale entries
 // instead of refetching the whole folder.
 //
-// `as_of` is the DB clock read BEFORE the data queries, making it a safe lower
-// bound for the next call: any mutation committed at or before as_of is
-// reflected here, and a row mutated *during* the read simply has
-// `updated > as_of` and is re-sent on the next call (at-least-once — the client
-// dedups by mail_id). Reading as_of from the DB (not the app clock) keeps it on
-// the same timeline as the `updated` column, which is set by CURRENT_TIMESTAMP.
+// `as_of` is read from the DB clock BEFORE the data queries and backed off by
+// DELTA_CURSOR_SAFETY_MARGIN_SECONDS, making it a safe lower bound: every
+// mutation up to that instant is reflected here, and anything newer (or within
+// the margin) is re-sent next call (at-least-once — the client dedups by id).
+// Reading from the DB, not the app clock, keeps it on the same timeline as the
+// `updated` column (set by CURRENT_TIMESTAMP on the flag-update paths).
+// NOTE: the expunge path (expungeDeletedMails) currently stamps `updated` from
+// the *app* clock (`new Date()`); the safety margin absorbs the resulting skew,
+// but the rigorous fix is to move every `updated` write onto the DB clock —
+// tracked as a follow-up. Fully eliminating the concurrent-commit window would
+// further need an xid-snapshot cursor, beyond the approved Phase-1 timestamp
+// contract.
 //
-// The expunged scan reuses the request's address condition so the evicted ids
-// belong to the same folder view the client is updating; it omits `draft` and
-// `read`/`saved` sub-filters because eviction is by id and is harmless for ids
-// the client never cached.
+// Tombstones (`expunged_ids`) cover EXPUNGED rows only — the approved Phase-1
+// contract. In a filtered view (?new / ?saved) a row that LEAVES the filter
+// (marked read, un-starred) drops out of `headers` but is NOT reported as a
+// tombstone, so a client applying delta to a filtered view must full-revalidate
+// it. The default (inbox/sent) view is fully correct. Generalizing this to an
+// `evicted_ids` set is an open contract question for the Phase-2 client.
 export const getMailHeadersDelta = async (
   user_id: string,
   address: string,
@@ -376,7 +393,10 @@ export const getMailHeadersDelta = async (
     // The pool's TIMESTAMPTZ type parser (client.ts) already returns an ISO
     // string, the same representation the `updated` column carries — so this
     // value round-trips straight back as the next `?since=` cursor.
-    const asOfResult = await pool.query<{ as_of: string }>("SELECT now() AS as_of");
+    const asOfResult = await pool.query<{ as_of: string }>(
+      "SELECT now() - make_interval(secs => $1) AS as_of",
+      [DELTA_CURSOR_SAFETY_MARGIN_SECONDS]
+    );
     const as_of = asOfResult.rows[0].as_of;
 
     const addressJson = JSON.stringify([{ address }]);


### PR DESCRIPTION
## What

Part of #457 (IndexedDB cache — Phase 1). The issue's design splits Phase 1 into a **server PR** (this one) and a later **client PR**; this lands the server contract so it can bake in prod before any client flips over. **Does not close #457** — the client half (catalog + IDB layer + hydrate + user_id tagging) is still required.

Adds an optional `?since=<ISO>` cursor to `GET /api/mails/headers/:account`. When present, the endpoint returns only what changed since the cursor, so a cached client can apply an incremental update + evict tombstones instead of refetching the whole folder.

## Changes

- **New response shape when `?since=` is present:**
  ```
  { as_of: string, headers: MailHeaderData[], expunged_ids: string[] }
  ```
  - `headers` — live (non-draft, non-expunged) rows with `updated > since`.
  - `expunged_ids` — rows expunged within the window, so the client evicts them from cache.
  - `as_of` — the server view-time the client persists as its next `?since=` cursor.
- **Backwards-compat:** with no `?since=`, the response keeps its current array shape (`MailHeaderDataType[]`). Old clients are byte-for-byte unaffected; the existing `HeadersGetResponse` type is unchanged and the delta shape is a separate `HeadersDeltaGetResponse`.
- **`as_of` correctness:** read from the DB clock (`now()`) **before** the data queries, making it a safe lower bound — a row mutated mid-read simply has `updated > as_of` and is re-sent on the next call (at-least-once; the client dedups by `mail_id`). Read from the DB, not the app clock, so it shares the timeline of the `updated` column (`CURRENT_TIMESTAMP`). This relies on #456 (merged) having made every mutation — including expunge — bump `updated`.
- **Boundary validation:** a malformed `since` is rejected with a `failed` status at the route, so it neither silently falls back to a full fetch (the client expects the delta shape) nor reaches `updated > 'garbage'` SQL.
- **Refactor (in-scope):** extracted the sent/received/saved address condition into one shared `buildHeaderAddressCondition`, so the full-list and delta paths can't drift apart on the envelope_to (#525) / saved-spans-both (#568) semantics.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` (touched files) — 0 errors (1 pre-existing unused-import warning on base, untouched)
- [x] `bun test src/server` — **1054 pass / 0 fail**
- [x] **New unit/route tests:**
  - lib: `getMailHeadersDelta` maps rows → `MailHeaderData`, never paginates, and an empty delta echoes `since` back as `as_of` (so a failed/no-user call can't advance the cursor past unseen rows).
  - route: valid `?since=` returns the delta shape via `getMailHeadersDelta`; malformed `?since=` is rejected at the boundary (neither full-fetches nor calls the delta fn); absent `?since=` still uses the full-list path.
  - repo: SQL-shape guards — `getMailHeaders` adds `AND updated > $N` only when `since` is set; the tombstone scan filters `expunged = TRUE AND updated > $3` and reuses the shared address condition; `as_of` is read before the data queries; failure echoes `since`.
- [x] **DB-level E2E** — drove the **real** `getMailHeaders` / `getMailHeadersDelta` against a **disposable** database (`inbox_e2e_457`, created + dropped by the harness; `POSTGRES_DATABASE` overridden so the real local `inbox` DB is never touched). Browser E2E is unsafe here — the inbox sandbox server reads the real local DB, and this is a write-exercising path — so the real queries on a throwaway DB are the correct surface. Seeded one owner + five mails spanning the cursor (old-live, new-live, new-expunged, old-expunged, new-live-draft). Verified:
  - Full list (no cursor) = the two live non-draft rows; expunged + draft rows excluded — backwards-compat intact.
  - `getMailHeaders(since)` = only the in-window live row.
  - `delta.headers` = the in-window live row; `delta.expunged_ids` = the in-window expunged row only (the out-of-window expunged row is correctly omitted); `delta.as_of` is a DB timestamp after the newest row.
  - Cursor round-trip: re-querying with `since = as_of` returns no headers and no tombstones.
  - Propagation: touching a previously out-of-window row surfaces it on the next delta; expunging a live row drops it from `headers` and surfaces it in `expunged_ids`.
  - **This E2E caught a real bug before merge:** the pool's TIMESTAMPTZ type parser returns `now()` as an ISO string, so the original `as_of.toISOString()` threw at runtime while the mocked unit tests passed. Fixed to consume the parser's string directly.
  - Harness kept out of tree.

---

### Update (post-review, commit aa0e620)

reviewoie reviewed and the findings are addressed:

- `as_of` is backed off by a safety margin (`now() - make_interval(secs => 2)`, named `DELTA_CURSOR_SAFETY_MARGIN_SECONDS`) so a row mutated in the commit-latency window or under bounded app/DB clock skew is re-sent next call (deduped by id), not skipped.
- The rigorous timeline fix — moving every `updated` write onto the DB clock (the expunge path is the lone app-clock writer) — is tracked as follow-up #614, kept out of this feature PR since it touches a pre-existing mutation path.
- Phase-1 tombstone scope documented: `expunged_ids` covers expunged rows only; the default inbox/sent view is fully correct; a filtered view (`?new`/`?saved`) client must full-revalidate for rows that leave the filter (open `evicted_ids` contract question for the Phase-2 client).

Re-verified: typecheck/lint clean, `bun test src/server` 1054 pass / 0 fail; DB-level E2E re-run asserts `as_of` lags real `now()` by the margin and the documented `?new` filter-leave gap. reviewoie verdict: **approve**.
