### PR TITLE
fix(mails): atomic UID reservation to close the receive-path race (#617)

### DIFF
--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -553,21 +553,21 @@ export async function copyMessageTyped(
       newMail.sent = destIsSent;
 
       // Fresh UIDs in the destination's UID space. The `sent` arg
-      // matters: `getDomainUidNext`/`getAccountUidNext` query MAX(uid)
-      // WHERE sent=? so a copy to a Sent box without the arg would pick
-      // a UID from the received-side counter and collide with existing
-      // sent rows. (These are SELECT MAX(uid)+1 with no locking — see
-      // `repositories/mails.ts:388-427` — so concurrent COPYs against
-      // the same destination CAN race to the same UID. Pre-existing
-      // limitation across receive.ts/send.ts/append; not corrected here.)
+      // matters: the UID counter is keyed by `sent`, so a copy to a
+      // Sent box without the arg would draw from the received-side
+      // counter and collide with existing sent rows. Reservation is
+      // atomic (getDomainUidNext/getAccountUidNext upsert a per-(user,
+      // sent) counter), so concurrent COPYs to the same destination no
+      // longer race to the same UID. A reservation failure throws and
+      // is caught below as a tagged NO — never a fabricated UID.
       const newDomainUid = await getDomainUidNext(user.id, destIsSent);
       const newAccountUid = await getAccountUidNext(
         user.id,
         destAccount,
         destIsSent
       );
-      newMail.uid.domain = newDomainUid || 1;
-      newMail.uid.account = newAccountUid || 1;
+      newMail.uid.domain = newDomainUid;
+      newMail.uid.account = newAccountUid;
 
       const ok = await store.storeMail(newMail);
       if (!ok) {
@@ -804,8 +804,8 @@ export async function moveMessageTyped(
         destAccount,
         destIsSent
       );
-      newMail.uid.domain = newDomainUid || 1;
-      newMail.uid.account = newAccountUid || 1;
+      newMail.uid.domain = newDomainUid;
+      newMail.uid.account = newAccountUid;
 
       const ok = await store.storeMail(newMail);
       if (!ok) {
@@ -930,8 +930,8 @@ export async function appendMessage(
     const account = boxToAccount(user.username, targetMailbox);
     const domainUid = await getDomainUidNext(user.id);
     const accountUid = await getAccountUidNext(user.id, account);
-    mail.uid.domain = domainUid || 1;
-    mail.uid.account = accountUid || 1;
+    mail.uid.domain = domainUid;
+    mail.uid.account = accountUid;
 
     const result = await store.storeMail(mail);
 

--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -29,8 +29,6 @@ export {
   addressToUsername,
   saveBuffer,
   getAccounts,
-  getDomainUidNext,
-  getAccountUidNext,
   getText,
   ATTACHMENT_FOLDER,
   getAttachmentId,

--- a/src/server/lib/mails/receive.ts
+++ b/src/server/lib/mails/receive.ts
@@ -205,7 +205,7 @@ export const convertMail = async (
     pgGetAccountUidNext(user.id!, envelopeToAddress),
   ]);
 
-  const uid = new MailUid({ domain: domainUid || 0, account: accountUid || 0 });
+  const uid = new MailUid({ domain: domainUid, account: accountUid });
 
   return new Mail({
     messageId,

--- a/src/server/lib/mails/search.test.ts
+++ b/src/server/lib/mails/search.test.ts
@@ -2,26 +2,12 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 // Mock the postgres repository
 const mockSearchMails = mock(() => Promise.resolve([]));
-const mockGetDomainUidNext = mock(() => Promise.resolve(42));
-const mockGetAccountUidNext = mock(() => Promise.resolve(10));
 
 mock.module("../postgres/repositories/mails", () => ({
   searchMails: mockSearchMails,
-  getDomainUidNext: mockGetDomainUidNext,
-  getAccountUidNext: mockGetAccountUidNext,
 }));
 
-// Mock the logger
-mock.module("../logger", () => ({
-  logger: {
-    info: mock(() => {}),
-    error: mock(() => {}),
-    warn: mock(() => {}),
-    debug: mock(() => {}),
-  },
-}));
-
-import { searchMail, getDomainUidNext, getAccountUidNext } from "./search";
+import { searchMail } from "./search";
 import { SignedUser } from "common";
 
 const mockUser = new SignedUser({
@@ -174,55 +160,5 @@ describe("searchMail", () => {
     expect(results).toHaveLength(2);
     expect(results[0].id).toBe("m1");
     expect(results[1].id).toBe("m2");
-  });
-});
-
-describe("getDomainUidNext", () => {
-  beforeEach(() => {
-    mockGetDomainUidNext.mockClear();
-  });
-
-  it("should return the result from pgGetDomainUidNext", async () => {
-    mockGetDomainUidNext.mockResolvedValue(42);
-    const result = await getDomainUidNext("user-123");
-    expect(result).toBe(42);
-    expect(mockGetDomainUidNext).toHaveBeenCalledWith("user-123", false);
-  });
-
-  it("should pass sent=true when specified", async () => {
-    mockGetDomainUidNext.mockResolvedValue(5);
-    await getDomainUidNext("user-123", true);
-    expect(mockGetDomainUidNext).toHaveBeenCalledWith("user-123", true);
-  });
-
-  it("should return 1 on error", async () => {
-    mockGetDomainUidNext.mockRejectedValue(new Error("DB error"));
-    const result = await getDomainUidNext("user-123");
-    expect(result).toBe(1);
-  });
-});
-
-describe("getAccountUidNext", () => {
-  beforeEach(() => {
-    mockGetAccountUidNext.mockClear();
-  });
-
-  it("should return the result from pgGetAccountUidNext", async () => {
-    mockGetAccountUidNext.mockResolvedValue(10);
-    const result = await getAccountUidNext("user-123", "inbox");
-    expect(result).toBe(10);
-    expect(mockGetAccountUidNext).toHaveBeenCalledWith("user-123", "inbox", false);
-  });
-
-  it("should pass sent=true when specified", async () => {
-    mockGetAccountUidNext.mockResolvedValue(3);
-    await getAccountUidNext("user-123", "sent", true);
-    expect(mockGetAccountUidNext).toHaveBeenCalledWith("user-123", "sent", true);
-  });
-
-  it("should return 1 on error", async () => {
-    mockGetAccountUidNext.mockRejectedValue(new Error("DB error"));
-    const result = await getAccountUidNext("user-123", "inbox");
-    expect(result).toBe(1);
   });
 });

--- a/src/server/lib/mails/search.ts
+++ b/src/server/lib/mails/search.ts
@@ -1,11 +1,5 @@
 import { MailHeaderData, SignedUser, MailAddressValueType, Insight } from "common";
-import {
-  searchMails,
-  SearchMailModel,
-  getDomainUidNext as pgGetDomainUidNext,
-  getAccountUidNext as pgGetAccountUidNext,
-} from "../postgres/repositories/mails";
-import { logger } from "../logger";
+import { searchMails, SearchMailModel } from "../postgres/repositories/mails";
 
 export const searchMail = async (
   user: SignedUser,
@@ -44,29 +38,4 @@ export const searchMail = async (
       highlight: m.highlight,
     });
   });
-};
-
-export const getDomainUidNext = async (
-  userId: string,
-  sent: boolean = false
-): Promise<number | null> => {
-  try {
-    return await pgGetDomainUidNext(userId, sent);
-  } catch (error) {
-    logger.error("Error getting next UID", {}, error);
-    return 1;
-  }
-};
-
-export const getAccountUidNext = async (
-  userId: string,
-  account: string,
-  sent: boolean = false
-): Promise<number | null> => {
-  try {
-    return await pgGetAccountUidNext(userId, account, sent);
-  } catch (error) {
-    logger.error("Error getting next UID", {}, error);
-    return 1;
-  }
 };

--- a/src/server/lib/mails/send.ts
+++ b/src/server/lib/mails/send.ts
@@ -109,7 +109,7 @@ const getSentMail = async (
     getAccountUidNext(user.id, fromEmail, true)
   ]);
 
-  const uid = new MailUid({ domain: domainUid || 0, account: accountUid || 0 });
+  const uid = new MailUid({ domain: domainUid, account: accountUid });
 
   return new Mail({
     subject,

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -13,6 +13,7 @@ import {
   pushSubscriptionsTable,
   spamAllowlistTable,
   spamTrainingTable,
+  mailUidCountersTable,
 } from "./models";
 
 export const version = "1";
@@ -26,6 +27,7 @@ const tables: Table<unknown, Schema>[] = [
   pushSubscriptionsTable,
   spamAllowlistTable,
   spamTrainingTable,
+  mailUidCountersTable,
 ];
 
 export const postgresIsAvailable = async (): Promise<void> => {

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -5,6 +5,7 @@ export const SESSIONS = "sessions";
 export const PUSH_SUBSCRIPTIONS = "push_subscriptions";
 export const SPAM_ALLOWLIST = "spam_allowlist";
 export const SPAM_TRAINING = "spam_training";
+export const MAIL_UID_COUNTERS = "mail_uid_counters";
 
 // Common column names
 export const UPDATED = "updated";
@@ -49,6 +50,10 @@ export const EXPUNGED = "expunged";
 export const INSIGHT = "insight";
 export const UID_DOMAIN = "uid_domain";
 export const UID_ACCOUNT = "uid_account";
+// mail_uid_counters columns
+export const UID_KIND = "uid_kind";
+export const UID_SCOPE = "uid_scope";
+export const LAST_UID = "last_uid";
 export const SPAM_SCORE = "spam_score";
 export const SPAM_REASONS = "spam_reasons";
 export const IS_SPAM = "is_spam";

--- a/src/server/lib/postgres/models/index.ts
+++ b/src/server/lib/postgres/models/index.ts
@@ -7,3 +7,4 @@ export * from "./session";
 export * from "./push_subscription";
 export * from "./spam_allowlist";
 export * from "./spam_training";
+export * from "./mail_uid_counter";

--- a/src/server/lib/postgres/models/mail_uid_counter.ts
+++ b/src/server/lib/postgres/models/mail_uid_counter.ts
@@ -1,0 +1,88 @@
+import {
+  USER_ID,
+  UID_KIND,
+  UID_SCOPE,
+  SENT,
+  LAST_UID,
+  MAIL_UID_COUNTERS,
+} from "./common";
+import { Model, createTable } from "./base";
+
+// Type guards
+const isString = (v: unknown): v is string => typeof v === "string";
+const isNumber = (v: unknown): v is number => typeof v === "number";
+const isBoolean = (v: unknown): v is boolean => typeof v === "boolean";
+
+export interface MailUidCounterJSON {
+  user_id: string;
+  uid_kind: string;
+  uid_scope: string;
+  sent: boolean;
+  last_uid: number;
+}
+
+// Per-(user, kind, scope, sent) durable UID counter — the IMAP UIDNEXT model.
+// `uid_kind` discriminates the domain-wide sequence ("domain") from the
+// per-account sequence ("account") so an account whose address normalizes to ""
+// can never share a row with the domain counter. `last_uid` is the most recently
+// assigned UID; assignment is the atomic increment in getDomainUidNext /
+// getAccountUidNext, which is what makes concurrent mail receipt race-free
+// (a bare MAX(uid)+1 read could not).
+const mailUidCounterSchema = {
+  [USER_ID]: "UUID NOT NULL",
+  [UID_KIND]: "VARCHAR(16) NOT NULL",
+  [UID_SCOPE]: "TEXT NOT NULL",
+  [SENT]: "BOOLEAN NOT NULL",
+  [LAST_UID]: "BIGINT NOT NULL",
+};
+
+type MailUidCounterSchema = typeof mailUidCounterSchema;
+
+export class MailUidCounterModel extends Model<
+  MailUidCounterJSON,
+  MailUidCounterSchema
+> {
+  declare user_id: string;
+  declare uid_kind: string;
+  declare uid_scope: string;
+  declare sent: boolean;
+  declare last_uid: number;
+
+  static typeChecker = {
+    user_id: isString,
+    uid_kind: isString,
+    uid_scope: isString,
+    sent: isBoolean,
+    last_uid: isNumber,
+  };
+
+  constructor(data: unknown) {
+    super(data, MailUidCounterModel.typeChecker);
+  }
+
+  toJSON(): MailUidCounterJSON {
+    return {
+      user_id: this.user_id,
+      uid_kind: this.uid_kind,
+      uid_scope: this.uid_scope,
+      sent: this.sent,
+      last_uid: this.last_uid,
+    };
+  }
+}
+
+export const mailUidCountersTable = createTable({
+  name: MAIL_UID_COUNTERS,
+  // No surrogate id — the natural key is the composite below. primaryKey is
+  // required by the framework but only used by id-based helpers this table
+  // never calls; the real key is the PRIMARY KEY constraint.
+  primaryKey: USER_ID,
+  schema: mailUidCounterSchema,
+  constraints: [
+    `PRIMARY KEY (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT})`,
+  ],
+  ModelClass: MailUidCounterModel,
+  supportsSoftDelete: false,
+});
+
+export const mailUidCounterColumns = Object.keys(mailUidCountersTable.schema);

--- a/src/server/lib/postgres/repositories/mail-uid-reservation.test.ts
+++ b/src/server/lib/postgres/repositories/mail-uid-reservation.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression guard for the UID-assignment race (#617).
+ *
+ * `getDomainUidNext` / `getAccountUidNext` MUST assign UIDs through the atomic
+ * `mail_uid_counters` upsert (INSERT … ON CONFLICT … DO UPDATE last_uid + 1),
+ * NOT a bare `SELECT MAX(uid)+1` read. The bare read is a TOCTOU: two concurrent
+ * mail receipts read the same max and write the same UID, corrupting the mailbox
+ * (RFC 3501 §2.3.1.1 — UIDs must be unique and strictly ascending).
+ *
+ * The SQL is built by pure `build*UidQuery` helpers so this pins the shape with
+ * no pool interception (mock.module on the shared `../client` bleeds across the
+ * full suite). The actual concurrency proof — N parallel reservations yield
+ * strictly distinct UIDs — is the disposable-DB E2E in the PR body.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  buildDomainUidQuery,
+  buildAccountUidQuery,
+} from "./mails";
+import { mailUidCountersTable } from "../models";
+import { USER_ID, UID_KIND, UID_SCOPE, SENT, LAST_UID } from "../models";
+
+const userId = "11111111-1111-1111-1111-111111111111";
+
+describe("mail_uid_counters table", () => {
+  it("declares the composite PRIMARY KEY the reservation upsert conflicts on", () => {
+    expect(mailUidCountersTable.constraints).toContain(
+      `PRIMARY KEY (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT})`
+    );
+  });
+});
+
+describe("buildDomainUidQuery", () => {
+  it("reserves atomically via INSERT … ON CONFLICT DO UPDATE on mail_uid_counters", () => {
+    const { sql, values } = buildDomainUidQuery(userId, false);
+    expect(sql).toContain("INSERT INTO mail_uid_counters");
+    expect(sql).toContain(
+      `ON CONFLICT (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT})`
+    );
+    expect(sql).toContain(
+      `DO UPDATE SET ${LAST_UID} = mail_uid_counters.${LAST_UID} + 1`
+    );
+    expect(sql).toContain(`RETURNING ${LAST_UID} AS next_uid`);
+    // Seeds once from the live MAX so existing mailboxes stay continuous.
+    expect(sql).toContain("COALESCE(MAX(uid_domain), 0) + 1");
+    // kind = "domain", scope = "" — never collides with an account row.
+    expect(values).toEqual([userId, "domain", "", false]);
+  });
+
+  it("does NOT issue the racy bare MAX(uid)+1 read", () => {
+    const { sql } = buildDomainUidQuery(userId, false);
+    expect(sql).not.toContain("AS next_uid FROM mails");
+  });
+
+  it("passes sent=true through to the counter sequence", () => {
+    const { values } = buildDomainUidQuery(userId, true);
+    expect(values).toEqual([userId, "domain", "", true]);
+  });
+});
+
+describe("buildAccountUidQuery", () => {
+  it("reserves atomically, keyed by kind=account + the address scope", () => {
+    const { sql, values } = buildAccountUidQuery(userId, "user@hoie.kim", false);
+    expect(sql).toContain("INSERT INTO mail_uid_counters");
+    expect(sql).toContain(
+      `DO UPDATE SET ${LAST_UID} = mail_uid_counters.${LAST_UID} + 1`
+    );
+    expect(sql).toContain("COALESCE(MAX(uid_account), 0) + 1");
+    expect(values[1]).toBe("account");
+    expect(values[2]).toBe("user@hoie.kim");
+    expect(values[3]).toBe(false);
+    // jsonb match payload preserved for the seed's address-containment.
+    expect(values[4]).toBe(JSON.stringify([{ address: "user@hoie.kim" }]));
+  });
+
+  it("seeds the received sequence from to/cc/bcc/envelope containment", () => {
+    const { sql } = buildAccountUidQuery(userId, "user@hoie.kim", false);
+    expect(sql).toContain("to_address @> $5::jsonb");
+    expect(sql).toContain("cc_address @> $5::jsonb");
+    expect(sql).toContain("bcc_address @> $5::jsonb");
+    expect(sql).toContain("envelope_to @> $5::jsonb");
+  });
+
+  it("seeds the sent sequence from from_address containment", () => {
+    const { sql, values } = buildAccountUidQuery(userId, "user@hoie.kim", true);
+    expect(sql).toContain("from_address @> $5::jsonb");
+    expect(sql).not.toContain("to_address @> $5::jsonb");
+    expect(values[3]).toBe(true);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -27,6 +27,10 @@ import {
   ENVELOPE_TO,
   DELETED,
   EXPUNGED,
+  MAIL_UID_COUNTERS,
+  UID_KIND,
+  UID_SCOPE,
+  LAST_UID,
 } from "../models";
 
 /**
@@ -494,17 +498,90 @@ export const searchMails = async (
   }
 };
 
+/**
+ * Build the atomic UID-reservation upsert.
+ *
+ * The counter row in `mail_uid_counters` holds the most recently assigned UID.
+ * The INSERT seeds it once from the current `MAX(uid)` in `mails` (via `seedSql`,
+ * which reuses $1=user_id and $4=sent), so a deployment with existing mail keeps
+ * its sequence continuous — no UID renumbering, no UIDVALIDITY churn. Every call
+ * after the first conflicts on the composite key and takes the row lock through
+ * `DO UPDATE`, returning a strictly larger value.
+ *
+ * This is what closes the receive-path race (#617): a bare `MAX(uid)+1` read in
+ * `convertMail` followed by a later INSERT is a TOCTOU — two concurrent receipts
+ * read the same max and write the same UID. Funneling assignment through this
+ * single atomic statement removes the window for every write path (receive, send,
+ * IMAP APPEND), since they all assign through the two functions below.
+ *
+ * Pure (no DB) so the SQL shape is unit-testable without intercepting the pool.
+ * `seedParams` supply any extra placeholders `seedSql` references ($5…).
+ */
+const buildReserveUidQuery = (
+  user_id: string,
+  kind: string,
+  scope: string,
+  sent: boolean,
+  seedSql: string,
+  seedParams: ParamValue[]
+): { sql: string; values: ParamValue[] } => {
+  const sql = `
+    INSERT INTO ${MAIL_UID_COUNTERS} (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT}, ${LAST_UID})
+    VALUES ($1, $2, $3, $4, (${seedSql}))
+    ON CONFLICT (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT})
+    DO UPDATE SET ${LAST_UID} = ${MAIL_UID_COUNTERS}.${LAST_UID} + 1
+    RETURNING ${LAST_UID} AS next_uid
+  `;
+  return { sql, values: [user_id, kind, scope, sent, ...seedParams] };
+};
+
+/** Domain-wide UID-reservation query (kind="domain", no scope). */
+export const buildDomainUidQuery = (
+  user_id: string,
+  sent: boolean
+): { sql: string; values: ParamValue[] } => {
+  const seedSql = `
+      SELECT COALESCE(MAX(${UID_DOMAIN}), 0) + 1 FROM mails
+      WHERE user_id = $1 AND sent = $4
+    `;
+  return buildReserveUidQuery(user_id, "domain", "", sent, seedSql, []);
+};
+
+/** Per-account UID-reservation query (kind="account", scope=address). */
+export const buildAccountUidQuery = (
+  user_id: string,
+  account: string,
+  sent: boolean
+): { sql: string; values: ParamValue[] } => {
+  const addressJson = JSON.stringify([{ address: account }]);
+  const addressCondition = sent
+    ? `${FROM_ADDRESS} @> $5::jsonb`
+    : `(${TO_ADDRESS} @> $5::jsonb OR cc_address @> $5::jsonb OR bcc_address @> $5::jsonb OR envelope_to @> $5::jsonb)`;
+  const seedSql = `
+      SELECT COALESCE(MAX(${UID_ACCOUNT}), 0) + 1 FROM mails
+      WHERE user_id = $1
+        AND ${addressCondition}
+        AND sent = $4
+    `;
+  return buildReserveUidQuery(user_id, "account", account, sent, seedSql, [
+    addressJson,
+  ]);
+};
+
+const reserveNextUid = async (query: {
+  sql: string;
+  values: ParamValue[];
+}): Promise<number> => {
+  const result = await pool.query(query.sql, query.values);
+  return parseInt(result.rows[0]?.next_uid || "1", 10);
+};
+
 export const getDomainUidNext = async (
   user_id: string,
   sent: boolean = false
 ): Promise<number> => {
   try {
-    const sql = `
-      SELECT COALESCE(MAX(${UID_DOMAIN}), 0) + 1 AS next_uid FROM mails
-      WHERE user_id = $1 AND sent = $2
-    `;
-    const result = await pool.query(sql, [user_id, sent]);
-    return parseInt(result.rows[0]?.next_uid || "1", 10);
+    return await reserveNextUid(buildDomainUidQuery(user_id, sent));
   } catch (error) {
     logger.error("Error getting next UID", {}, error);
     return 1;
@@ -517,18 +594,7 @@ export const getAccountUidNext = async (
   sent: boolean = false
 ): Promise<number> => {
   try {
-    const addressJson = JSON.stringify([{ address: account }]);
-    const addressCondition = sent
-      ? `${FROM_ADDRESS} @> $2::jsonb`
-      : `(${TO_ADDRESS} @> $2::jsonb OR cc_address @> $2::jsonb OR bcc_address @> $2::jsonb OR envelope_to @> $2::jsonb)`;
-    const sql = `
-      SELECT COALESCE(MAX(${UID_ACCOUNT}), 0) + 1 AS next_uid FROM mails
-      WHERE user_id = $1
-        AND ${addressCondition}
-        AND sent = $3
-    `;
-    const result = await pool.query(sql, [user_id, addressJson, sent]);
-    return parseInt(result.rows[0]?.next_uid || "1", 10);
+    return await reserveNextUid(buildAccountUidQuery(user_id, account, sent));
   } catch (error) {
     logger.error("Error getting account UID next", {}, error);
     return 1;

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -576,6 +576,12 @@ const reserveNextUid = async (query: {
   return parseInt(result.rows[0]?.next_uid || "1", 10);
 };
 
+// The counter is now the authoritative UID source, so a reservation failure must
+// ABORT the save — never fall back to a fabricated UID. Returning 1 here (the old
+// behavior) would assign a value colliding with the mailbox's first message, the
+// exact duplicate-UID corruption this fix removes, now via the error path. Every
+// caller aborts cleanly on a throw: SMTP receive NACKs (sender retries), the send
+// route surfaces the error, and IMAP APPEND replies `NO` (client retries).
 export const getDomainUidNext = async (
   user_id: string,
   sent: boolean = false
@@ -584,7 +590,7 @@ export const getDomainUidNext = async (
     return await reserveNextUid(buildDomainUidQuery(user_id, sent));
   } catch (error) {
     logger.error("Error getting next UID", {}, error);
-    return 1;
+    throw error;
   }
 };
 
@@ -597,7 +603,7 @@ export const getAccountUidNext = async (
     return await reserveNextUid(buildAccountUidQuery(user_id, account, sent));
   } catch (error) {
     logger.error("Error getting account UID next", {}, error);
-    return 1;
+    throw error;
   }
 };
 

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -542,7 +542,7 @@ export const buildDomainUidQuery = (
 ): { sql: string; values: ParamValue[] } => {
   const seedSql = `
       SELECT COALESCE(MAX(${UID_DOMAIN}), 0) + 1 FROM mails
-      WHERE user_id = $1 AND sent = $4
+      WHERE ${USER_ID} = $1 AND ${SENT} = $4
     `;
   return buildReserveUidQuery(user_id, "domain", "", sent, seedSql, []);
 };
@@ -559,9 +559,9 @@ export const buildAccountUidQuery = (
     : `(${TO_ADDRESS} @> $5::jsonb OR cc_address @> $5::jsonb OR bcc_address @> $5::jsonb OR envelope_to @> $5::jsonb)`;
   const seedSql = `
       SELECT COALESCE(MAX(${UID_ACCOUNT}), 0) + 1 FROM mails
-      WHERE user_id = $1
+      WHERE ${USER_ID} = $1
         AND ${addressCondition}
-        AND sent = $4
+        AND ${SENT} = $4
     `;
   return buildReserveUidQuery(user_id, "account", account, sent, seedSql, [
     addressJson,


### PR DESCRIPTION
## What & why

Closes the IMAP UID-assignment race — the remaining, distinct root cause from #239 (PR #240 fixed only the count-reuse cause; the row-level reservation + DB guard it proposed were never implemented).

`uid_domain` / `uid_account` were assigned by a **read-then-insert TOCTOU**: `convertMail` read `COALESCE(MAX(uid),0)+1` and the row was INSERTed later in `saveMail`. The `await` between read and insert yields the event loop, so two concurrent receipts — the normal `saveMailHandler` per-recipient `Promise.all` fan-out, plus concurrent SMTP sessions — read the same max and write the **same UID**. Nothing at the DB layer stops it (the UID indexes are plain btree, not unique). Duplicate UIDs corrupt the seq↔uid maps `getAllUids` feeds, so `SEARCH`/`UID FETCH`/`UID STORE` misbehave (RFC 3501 §2.3.1.1: UIDs must be unique + strictly ascending).

## Fix

Funnel assignment through a durable per-`(user, kind, scope, sent)` counter table `mail_uid_counters` (the IMAP UIDNEXT model the issue proposed). `getDomainUidNext` / `getAccountUidNext` now issue a single atomic statement:

```
INSERT INTO mail_uid_counters (...) VALUES (..., (<seed: MAX(uid)+1>))
ON CONFLICT (user_id, uid_kind, uid_scope, sent)
DO UPDATE SET last_uid = mail_uid_counters.last_uid + 1
RETURNING last_uid
```

- **Seeded once** from the live `MAX(uid)` → existing mailboxes stay continuous; **no UID renumbering, no UIDVALIDITY churn**.
- After the first call, every reservation conflicts on the composite key and takes the row lock → strictly larger, distinct values even under full concurrency.
- A `uid_kind` discriminator (`"domain"` vs `"account"`) keeps an account whose address normalizes to `""` from sharing the domain counter row.
- Covers **all three write paths** (receive, send, IMAP APPEND) — they all assign through these two functions.
- SQL built by pure `build{Domain,Account}UidQuery` helpers so the shape is unit-testable without intercepting the shared `../client` pool (whose `mock.module` bleeds across the full suite).

## Out of scope — separate follow-up

The issue's fixes 2+3 (partial **unique** indexes + one-off renumber of the ~40 pre-#240 legacy duplicate rows). The renumber must **bump UIDVALIDITY** so clients resync, which makes it a distinct, riskier data migration from this race fix. The atomic counter already prevents *recurrence*; the unique index is belt-and-suspenders that can't be created until the legacy duplicates are cleared. Tracked in #620.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint` (changed files) — clean
- [x] `bun test src/server` — **1091 pass / 0 fail** (full suite; confirms no `mock.module` bleed)
- [x] reviewoie (inbox-reviewer): core fix confirmed race-free; 1 MED addressed (reservation failure now re-throws to abort the save instead of fabricating a colliding UID 1), 2 LOWs answered.
- [x] New `mail-uid-reservation.test.ts` — pins the atomic upsert shape (ON CONFLICT … DO UPDATE last_uid+1), the composite PK the conflict targets, the domain/account seed conditions, and asserts the racy `MAX(uid)+1 AS next_uid` read is gone.
- [x] **DB-level concurrency E2E** — disposable DB `inbox_e2e_617` (created+dropped by the harness; `POSTGRES_DATABASE` overridden, real `inbox` DB untouched). Browser can't reach this path — no UI consumes UID assignment — so the real `getDomainUidNext`/`getAccountUidNext` are driven directly. Seeded domain MAX=100, account MAX=50, then fired 20 concurrent reservations each:
  - **Baseline (old `MAX+1` read), 20 concurrent:** all returned `101` → **1/20 distinct = total collision** (the bug, reproduced).
  - **Fix `getDomainUidNext`, 20 concurrent:** `101..120` → **20/20 distinct, ascending, continuous** with the seeded MAX.
  - **Fix `getAccountUidNext`, 20 concurrent:** `51..70` → 20/20 distinct, ascending, continuous.
  - **kind isolation:** `getAccountUidNext("")` → `1` from its own empty-scope row, not the domain counter.
  - **sent-space independence:** `getDomainUidNext(sent=true)` → its own sequence from `1`, untouched by the received sequence (now at 120).
  - **reserve→insert lockstep:** 5 sequential reserve-then-insert → stored `121..125` contiguous, table `MAX(uid_domain)` tracks the counter (no counter↔table drift).

Server-side IMAP/receive change with no browser-rendered surface, so the disposable-DB E2E driving the real queries is the correct (and stronger) verification — same approach as the recent IMAP/receive PRs.
