### PR TITLE
fix(imap): align COPYUID source/dest sets positionally for out-of-order sets (#624)

### DIFF
--- a/src/server/lib/imap/copy.test.ts
+++ b/src/server/lib/imap/copy.test.ts
@@ -24,14 +24,89 @@
  * documented Bun hazard, full server-suite runs verify there's no bleed).
  */
 
-import { describe, it, expect } from "bun:test";
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "bun:test";
+import { restoreLeaves } from "test-helpers";
 import type { MailType, SignedUser } from "common";
-import { copyMessageTyped } from "./message-ops";
 import { Store } from "./store";
 import type { CopyRequest } from "./types";
 import type { SequenceState } from "./sequence-resolver";
 
 const VALID_USER: SignedUser = { id: "u1", username: "admin" } as SignedUser;
+
+const STORED_UIDVALIDITY = 1716512400;
+
+// A schema-valid users row so usersTable.queryOne's `new UserModel(row)`
+// validates inside getImapUidValidity (imap_uid_validity pre-set → returned
+// directly). Mirrors the move.test.ts / message-ops.test.ts FakePool fixture.
+const USER_ROW = {
+  user_id: "u1",
+  username: "admin",
+  password: null,
+  email: null,
+  expiry: null,
+  token: null,
+  updated: null,
+  is_deleted: null,
+  imap_uid_validity: STORED_UIDVALIDITY,
+};
+
+// getDomainUidNext / getAccountUidNext both SELECT ... AS next_uid. Hand back a
+// monotonically-increasing value per call so each cloned mail gets a distinct
+// dest UID in the copy loop's call order (domain then account).
+let uidCounter = 100;
+const mockQuery = mock(async (sql: string) => {
+  if (typeof sql === "string" && sql.includes("next_uid")) {
+    return { rows: [{ next_uid: String(uidCounter++) }], rowCount: 1 };
+  }
+  return { rows: [USER_ROW], rowCount: 1 };
+});
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+  on() {}
+}
+
+const pgMock = () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+});
+
+// Mock `pg` (NOT the `server` barrel) so the real getDomainUidNext /
+// getAccountUidNext / getImapUidValidity run against the FakePool and keep
+// their real identities — stubbing the barrel would bleed across files via
+// Bun's process-global mock.module. The control-flow tests below never reach
+// the per-mail loop, so the mocked pool is harmless to them; the happy-path
+// tests exercise it. `afterAll(restoreLeaves)` + resetPool re-mocks pg to real.
+mock.module("pg", pgMock);
+
+const { copyMessageTyped } = await import("./message-ops");
+const { resetPool } = await import("../postgres/client");
+
+beforeAll(() => {
+  mock.module("pg", pgMock);
+  resetPool();
+});
+
+afterAll(() => {
+  restoreLeaves();
+  resetPool();
+});
+
+beforeEach(() => {
+  mockQuery.mockClear();
+  uidCounter = 100;
+});
 
 const emptySeqState = (): SequenceState => ({
   seqToUid: [],
@@ -167,15 +242,114 @@ describe("COPY with empty source range (#520)", () => {
   });
 });
 
+// Build a source mail carrying a distinguishing subject + UID so the COPYUID
+// pairing can be cross-checked against the stored clone.
+const sourceMail = (
+  uid: { domain: number; account: number },
+  overrides: Partial<MailType> = {}
+): Partial<MailType> => ({
+  subject: `src-${uid.domain}`,
+  date: "2026-06-27T00:00:00.000Z",
+  html: "<p>hi</p>",
+  text: "hi",
+  from: { value: [{ address: "sender@x.com", name: "S" }], text: "sender@x.com" },
+  to: { value: [{ address: "src@hoie.kim", name: "" }], text: "src@hoie.kim" },
+  envelopeTo: [{ address: "src@hoie.kim", name: "" }],
+  messageId: `orig-${uid.domain}-${uid.account}`,
+  uid: uid as MailType["uid"],
+  ...overrides,
+});
+
+// A Store wired for the full copy flow: getMessages hands back the source
+// mails in the supplied (copy) order; storeMail records each clone (so the
+// test can read the dest UID actually assigned to each source).
+const makeCopyStore = (
+  existsBoxes: string[],
+  mails: Array<Partial<MailType>>
+) => {
+  const store = new Store(VALID_USER);
+  store.mailboxExists = async (box: string) =>
+    box === "INBOX" || existsBoxes.includes(box);
+  store.getMessages = async () => {
+    const map = new Map<number, Partial<MailType>>();
+    mails.forEach((m, i) => map.set(i, m));
+    return map as never;
+  };
+  const stored: Array<Partial<MailType>> = [];
+  store.storeMail = async (mail: never) => {
+    stored.push({ ...(mail as Partial<MailType>) });
+    return true as never;
+  };
+  return { store, stored };
+};
+
 describe("COPY happy path (#520)", () => {
-  // End-to-end "real source mails → COPYUID emission" needs a FakePool
-  // fixture (per the users.test.ts pattern) so the module-imported
-  // postgres helpers `getDomainUidNext` / `getAccountUidNext` /
-  // `getImapUidValidity` can be intercepted without mock.module's
-  // process-global hoist. TODO follow-up.
-  it.todo(
-    "copies source mails to destination with fresh UIDs and emits COPYUID (FakePool fixture needed)"
-  );
+  it("copies source mails to a non-INBOX dest with fresh UIDs and emits COPYUID", async () => {
+    const mails = [
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 7, account: 70 }),
+    ];
+    const { store, stored } = makeCopyStore(["Archive"], mails);
+    const lines = await runCopy(
+      copyReq("Archive", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+    expect(stored.length).toBe(2);
+    // Fresh messageId on each clone.
+    expect(stored[0].messageId).not.toBe(mails[0].messageId);
+    // Non-INBOX dest → dest UID is the fresh account UID (counter: domain
+    // 100/account 101, domain 102/account 103).
+    expect(lines).toEqual([
+      `A1 OK [COPYUID ${STORED_UIDVALIDITY} 5,7 101,103] COPY completed\r\n`,
+    ]);
+  });
+});
+
+describe("COPY COPYUID positional pairing — out-of-order set (#624, RFC 4315 §3)", () => {
+  it("pairs the n-th source UID with the n-th dest UID for a non-ascending sequence-set", async () => {
+    // `UID COPY 5,3` — client lists the higher UID first. getMessages
+    // returns the mails in that copy order (uid 5 then uid 3). The fix
+    // sorts the source mails ascending before assigning dest UIDs so the
+    // COPYUID source-set and dest-set (each independently sorted by
+    // `formatUidSet`) report the REAL mapping, not an inverted one.
+    const mails = [
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 3, account: 30 }),
+    ];
+    const { store, stored } = makeCopyStore(["Archive"], mails);
+    const lines = await runCopy(
+      copyReq("Archive", { type: "uid", ranges: [{ start: 3, end: 5 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+
+    const tagged = lines.find((l) => l.startsWith("A1 OK [COPYUID"))!;
+    const m = tagged.match(/\[COPYUID \d+ ([\d,:]+) ([\d,:]+)\]/)!;
+    const expand = (set: string): number[] =>
+      set.split(",").flatMap((part) => {
+        if (!part.includes(":")) return [Number(part)];
+        const [a, b] = part.split(":").map(Number);
+        const out: number[] = [];
+        for (let i = a; i <= b; i++) out.push(i);
+        return out;
+      });
+    const srcSet = expand(m[1]);
+    const destSet = expand(m[2]);
+    expect(srcSet.length).toBe(destSet.length);
+    const claimedPairing = new Map<number, number>();
+    srcSet.forEach((s, i) => claimedPairing.set(s, destSet[i]));
+
+    expect(stored.length).toBe(2);
+    const actualDestOf = (srcUid: number): number =>
+      stored.find((c) => c.subject === `src-${srcUid}`)!.uid!.account;
+
+    // COPYUID must report the real source→dest mapping.
+    expect(claimedPairing.get(3)).toBe(actualDestOf(3));
+    expect(claimedPairing.get(5)).toBe(actualDestOf(5));
+    // Smaller source UID owns the smaller dest UID — fails on pre-#624 code.
+    expect(actualDestOf(3)).toBeLessThan(actualDestOf(5));
+  });
 });
 
 describe("COPY dispatch — sequence vs UID semantics (#520)", () => {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -739,7 +739,8 @@ export async function moveMessageTyped(
     // RFC 4315 §3 (via RFC 6851 §4.3): keep the COPYUID source/dest sets
     // positionally aligned for out-of-order sequence-sets — assign dest
     // UIDs in ascending source-UID order. See copyMessageTyped for the
-    // full rationale. Sorting also tidies the targeted EXPUNGE emission.
+    // full rationale. (The EXPUNGE emission order is set separately by the
+    // explicit high→low sort below, so it is unaffected by this.)
     sourceMails.sort((a, b) => srcUidOf(a) - srcUidOf(b));
 
     const sourceUids: number[] = [];

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -472,6 +472,16 @@ export async function copyMessageTyped(
     const srcUidOf = (mail: Partial<MailType>): number =>
       sourceIsInbox ? mail.uid!.domain : mail.uid!.account;
 
+    // RFC 4315 §3: the COPYUID source-set and dest-set must correspond
+    // positionally (n-th source UID ↔ n-th dest UID). The two sets are
+    // built by `formatUidSet`, which sorts each independently. To keep
+    // that sort from desynchronizing the pairing for an out-of-order
+    // sequence-set (e.g. `UID COPY 5,3`), assign dest UIDs in ascending
+    // source-UID order: sort the materialized source mails ascending here
+    // so the copy loop pushes both `sourceUids` and `destUids` already
+    // ascending, and `formatUidSet`'s independent sorts stay aligned.
+    sourceMails.sort((a, b) => srcUidOf(a) - srcUidOf(b));
+
     const sourceUids: number[] = [];
     const destUids: number[] = [];
 
@@ -725,6 +735,12 @@ export async function moveMessageTyped(
     const sourceIsInbox = isInbox(selectedMailbox);
     const srcUidOf = (mail: Partial<MailType>): number =>
       sourceIsInbox ? mail.uid!.domain : mail.uid!.account;
+
+    // RFC 4315 §3 (via RFC 6851 §4.3): keep the COPYUID source/dest sets
+    // positionally aligned for out-of-order sequence-sets — assign dest
+    // UIDs in ascending source-UID order. See copyMessageTyped for the
+    // full rationale. Sorting also tidies the targeted EXPUNGE emission.
+    sourceMails.sort((a, b) => srcUidOf(a) - srcUidOf(b));
 
     const sourceUids: number[] = [];
     const destUids: number[] = [];

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -409,3 +409,67 @@ describe("MOVE happy path — non-INBOX source → INBOX dest (#453, address-cle
     ]);
   });
 });
+
+describe("MOVE COPYUID positional pairing — out-of-order set (#624, RFC 4315 §3)", () => {
+  it("pairs the n-th source UID with the n-th dest UID for a non-ascending sequence-set", async () => {
+    // `UID MOVE 5,3` — the client lists the higher UID first. The copy
+    // loop must assign dest UIDs in ascending source-UID order so the
+    // COPYUID source-set and dest-set (each independently sorted by
+    // `formatUidSet`) stay positionally aligned. getMessages hands the
+    // mails back in the request's copy order (uid 5 then uid 3); the fix
+    // sorts them ascending before assigning dest UIDs.
+    const mails = [
+      sourceMail({ domain: 5, account: 50 }, { subject: "src-5" }),
+      sourceMail({ domain: 3, account: 30 }, { subject: "src-3" }),
+    ];
+    const { store, stored } = makeMoveStore(["Archive"], mails);
+    const seqState: SequenceState = {
+      seqToUid: [3, 5],
+      uidToSeq: new Map([
+        [3, 1],
+        [5, 2],
+      ]),
+    };
+
+    const lines = await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 3, end: 3 }] }),
+      true,
+      store,
+      false,
+      "INBOX",
+      seqState
+    );
+
+    // Parse the emitted COPYUID source-set ↔ dest-set into a positional map.
+    const tagged = lines.find((l) => l.startsWith("A1 OK [COPYUID"))!;
+    const m = tagged.match(/\[COPYUID \d+ ([\d,:]+) ([\d,:]+)\]/)!;
+    const expand = (set: string): number[] =>
+      set.split(",").flatMap((part) => {
+        if (!part.includes(":")) return [Number(part)];
+        const [a, b] = part.split(":").map(Number);
+        const out: number[] = [];
+        for (let i = a; i <= b; i++) out.push(i);
+        return out;
+      });
+    const srcSet = expand(m[1]);
+    const destSet = expand(m[2]);
+    expect(srcSet.length).toBe(destSet.length);
+    const claimedPairing = new Map<number, number>();
+    srcSet.forEach((s, i) => claimedPairing.set(s, destSet[i]));
+
+    // Ground truth: each stored clone keeps its source's subject and carries
+    // the dest account UID it was actually assigned (non-INBOX dest).
+    expect(stored.length).toBe(2);
+    const actualDestOf = (srcUid: number): number => {
+      const clone = stored.find((c) => c.subject === `src-${srcUid}`)!;
+      return clone.uid!.account;
+    };
+
+    // The COPYUID response must report the REAL mapping, not an inverted one.
+    expect(claimedPairing.get(3)).toBe(actualDestOf(3));
+    expect(claimedPairing.get(5)).toBe(actualDestOf(5));
+    // And the smaller source UID must own the smaller dest UID (ascending
+    // assignment) — the assertion that fails on the pre-#624 code.
+    expect(actualDestOf(3)).toBeLessThan(actualDestOf(5));
+  });
+});


### PR DESCRIPTION
## What

`COPY` and `MOVE` built their RFC 4315 `[COPYUID <validity> <src-set> <dst-set>]` response by passing the source-UID set and the dest-UID set to `formatUidSet` **independently** — and `formatUidSet` sorts each set. The two arrays (`sourceUids` / `destUids`) are populated **positionally paired** in copy order, so for a non-ascending sequence-set (e.g. `UID COPY 5,3 Archive`) the two independent sorts desynchronize and the server reports an **inverted** source→dest UID mapping while still returning a tagged `OK`. A client that trusts COPYUID to track its messages across the copy (offline/sync caches, account-migration tools, IMAP proxies) then corrupts its local UID state silently. Single ascending ranges — the common case — are unaffected because copy order already equals ascending source order.

## Root cause

`message-ops.ts` assigns dest UIDs monotonically in **copy order**, which follows the parser's as-written range order (`UID COPY 5,3` → copy order `[5, 3]`). `sourceUids`/`destUids` are pushed in that order (positionally paired), then `formatUidSet` sorts each independently:
- source `[5,3]` → `"3,5"`, dest `[destA, destB]` → `"destA:destB"`.
- Read positionally the response claims `3↔destA`, `5↔destB`, but the real copies are `5↔destA`, `3↔destB`. **Inverted.**

Note the emitted COPYUID *string* is byte-identical with or without the fix (both sets get sorted) — the defect is that the string's positional claim contradicts the actual stored clone's assigned UID.

## Fix

Sort the materialized `sourceMails` by source UID **ascending before the copy loop**, so dest UIDs are assigned in ascending-source order and both `formatUidSet` calls stay positionally aligned. Applied to both `copyMessageTyped` and `moveMessageTyped` (the latter's copy phase mirrors COPY; sorting also tidies its targeted-EXPUNGE emission). The existing comment at the `getMessages` loop already anticipated this sort ("downstream we sort by source UID for the COPYUID response") — the code never actually did it; this completes the intended design.

3 files: `message-ops.ts` (+2 sorts), `copy.test.ts` (+harness/+2 tests), `move.test.ts` (+1 test).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (16 pre-existing warnings, none in touched files)
- [x] `bun test src/server` — **1110 pass / 0 fail** (verifies no `mock.module("pg")` bleed from adding the FakePool fixture to `copy.test.ts`)
- [x] **Regression tests drive the REAL `copyMessageTyped` / `moveMessageTyped`** (only the `pg` Pool is faked, so dest-UID assignment is deterministic; the real ordering + COPYUID-build code runs). For an out-of-order `UID COPY 5,3` / `UID MOVE 5,3`:
  - Parse the emitted COPYUID `src-set ↔ dst-set` into a positional map, then cross-check each pair against which **stored clone** (identified by subject) actually received which dest UID.
  - **Baseline (fix reverted, test kept):** COPYUID claims `3→101` while the clone of source-UID 3 was actually assigned account UID 103 → assertion fails (proves the inversion). Verified by stashing only `message-ops.ts`.
  - **Fix:** the smaller source UID owns the smaller dest UID; COPYUID reports the real mapping → passes. For COPY and for MOVE.
  - Ascending control (`UID COPY 5,7` → `5,7 101,103`) passes on both baseline and fix (unaffected, as expected).
  - Retired the COPY happy-path `.todo` (ported the `move.test.ts` pg-FakePool fixture) — COPY now has real end-to-end COPYUID-emission coverage.

### Why this verification surface

No browser UI consumes the IMAP COPYUID wire response, so the real path is the IMAP command handler — driven directly here. A live-IMAP run against the local dev/sandbox is write-unsafe for this command (COPY/MOVE insert + expunge rows, and the local sandbox reads the real local `inbox` DB), and the inversion is invisible in the COPYUID *string* alone (both sets are sorted) — it only surfaces by correlating each copied message to its assigned dest UID, which is exactly what the FakePool regression tests do deterministically against the production functions.

Closes #624
