### PR TITLE
fix(mails): reflow mail-body iframe when reply-thread blockquote unfolds

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -232,6 +232,14 @@ const MailBody = ({ mailId }: Props) => {
           }
         });
 
+      // Native `toggle` fires after the browser lays out the slotted
+      // content, so `scrollHeight` read in the handler reflects the new
+      // size — robust under keyboard activation and slow renders, where
+      // the body-level click listener's setTimeout(50) heuristic misses.
+      Array.from(content.querySelectorAll("details")).forEach((det) => {
+        det.addEventListener("toggle", () => adjustMailContentSize(iframeDom));
+      });
+
       adjustMailContentSize(iframeDom);
       const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);
       pendingTimers.current.push(id);


### PR DESCRIPTION
Closes the inbox UI bug Hoie flagged 2026-06-28: in a mail with a reply thread (where `MailBody.tsx` replaces the quoted blockquote with a native `<details>` for fold/unfold), clicking the summary to expand leaves the iframe stuck at the collapsed height — the body should stretch to match the unfolded content but doesn't.

## Root cause

`MailBody.tsx` attaches a single body-level click listener inside the iframe that re-runs `adjustMailContentSize` 50ms after every click:

```ts
content.addEventListener("click", () => {
  const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);
  pendingTimers.current.push(id);
});
```

Two failure modes:
1. **Keyboard activation of `<summary>` (Enter / Space) bypasses the click listener entirely** — the browser toggles `<details>.open` for both keyboard and mouse activation, but only the mouse fires the body click. Keyboard users see the details expand, then no reflow.
2. **The 50ms heuristic is fragile** — on slow renders, image loads inside the unfolded blockquote, or browsers that schedule the layout pass differently, the timer fires before the new `scrollHeight` is fully settled, so the recomputed iframe height is wrong.

## Fix

Attach a per-details `toggle` event listener after the blockquote→details replacement loop. The native `toggle` event fires after the browser applies the `open` attribute AND lays out the slotted content, so `scrollHeight` inside the handler is always correct — and it fires for ALL activation methods (mouse, Enter, Space, programmatic):

```ts
Array.from(content.querySelectorAll("details")).forEach((det) => {
  det.addEventListener("toggle", () => adjustMailContentSize(iframeDom));
});
```

The existing body-level click listener stays in place as a fallback for other dynamic content (image loads etc).

## Test plan

- [x] `bun run typecheck` → clean
- [x] **Synthetic Playwright repro on a controlled iframe with the exact processHtmlForViewer body styles** — confirmed: with the toggle listener, clicking `<summary>` (or activating via Enter/Space) correctly reflows the iframe from the collapsed height to the full unfolded height. The expanded content is fully visible; the iframe height matches `content.scrollHeight + 32`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
