### PR TITLE
fix(mails): ResizeObserver fallback for mail-body iframe reflow on Safari mobile

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -47,12 +47,15 @@ const MailBody = ({ mailId }: Props) => {
 
   const iframeElement = useRef<HTMLIFrameElement>(null);
   const pendingTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
   // Cancel all pending timers when the component unmounts
   useEffect(() => {
     return () => {
       pendingTimers.current.forEach(clearTimeout);
       pendingTimers.current = [];
+      resizeObserverRef.current?.disconnect();
+      resizeObserverRef.current = null;
     };
   }, []);
 
@@ -239,6 +242,33 @@ const MailBody = ({ mailId }: Props) => {
       Array.from(content.querySelectorAll("details")).forEach((det) => {
         det.addEventListener("toggle", () => adjustMailContentSize(iframeDom));
       });
+
+      // Defense-in-depth fallback for browsers/contexts where the `toggle`
+      // event on `<details>` doesn't reliably reach our listener — iOS
+      // Safari has been the recurring case (#627 fix worked in macOS
+      // Chrome but not Safari mobile). ResizeObserver fires whenever the
+      // body's content rect changes height, so any unfolding (details
+      // toggle, image load, font swap, web-font fallback) reflows the
+      // iframe. Guarded with `suppressResize` so the body height change
+      // adjustMailContentSize itself causes (iframe height "auto" →
+      // body's `height: 100%` follows) doesn't recurse.
+      resizeObserverRef.current?.disconnect();
+      let suppressResize = false;
+      const resizeObserver = new ResizeObserver(() => {
+        if (suppressResize) return;
+        suppressResize = true;
+        try {
+          adjustMailContentSize(iframeDom);
+        } finally {
+          requestAnimationFrame(() =>
+            requestAnimationFrame(() => {
+              suppressResize = false;
+            }),
+          );
+        }
+      });
+      resizeObserver.observe(content);
+      resizeObserverRef.current = resizeObserver;
 
       adjustMailContentSize(iframeDom);
       const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);


### PR DESCRIPTION
Follow-up to #627: Hoie 2026-06-28 reported the reply-thread fold/unfold reflow works in macOS Chrome (where the native `toggle` event reliably reaches our handler) but **not in iOS Safari mobile** — the iframe stays at the collapsed height when the user taps `<summary>`.

## Root cause hypothesis

The `toggle` event on `<details>` is spec-supported in iOS Safari since iOS 6, but a few quirks recur in practice:
- Touch-vs-click dispatch order on iOS can desync the toggle event for cross-document listeners (outer document observing iframe element).
- Even when the event fires, layout settles asynchronously across the iframe boundary and a one-shot listener can read stale measurements.

I can't pin the exact iOS quirk from the report alone, but the cure is the same regardless: stop relying on a single-event hook for "the iframe content changed size" and observe the size directly.

## Fix

Add a `ResizeObserver` on the iframe body, alongside the existing `toggle` listener and body-click `setTimeout(50)`. ResizeObserver fires whenever the body's content rect changes height — `<details>` toggle, image load, web-font swap, fallback font, anything. Catches the iOS case without needing to diagnose which exact quirk is suppressing `toggle`.

```ts
resizeObserverRef.current?.disconnect();
let suppressResize = false;
const resizeObserver = new ResizeObserver(() => {
  if (suppressResize) return;
  suppressResize = true;
  try {
    adjustMailContentSize(iframeDom);
  } finally {
    requestAnimationFrame(() =>
      requestAnimationFrame(() => {
        suppressResize = false;
      }),
    );
  }
});
resizeObserver.observe(content);
resizeObserverRef.current = resizeObserver;
```

### Why the `suppressResize` guard

`adjustMailContentSize` sets `iframeDom.style.height = "auto"` momentarily to re-measure. Because the iframe body has `height: 100%` (from `processHtmlForViewer`'s injected CSS), the body's content rect height follows the iframe height down — which would re-fire ResizeObserver mid-measurement and recurse. The two-rAF wait gives the layout pass time to settle before we resume listening.

### Why the observer is tracked in a ref

`onLoadIframe` re-runs every time the iframe `srcDoc` reloads (user navigates to a different mail). The previous observer is explicitly disconnected at the top of the new run, and the unmount cleanup disconnects the active one. Without this, observers would leak as the user clicks through mails.

## Test plan

- [x] `bun run typecheck` → clean
- [x] **macOS Chrome regression check** — `<details>` toggle still reflows the iframe (the `toggle` listener path is unchanged; the ResizeObserver is additive and works in Chrome too as belt-and-suspenders).
- [ ] **iOS Safari mobile** — the case this PR exists to fix. Hoie to verify on the sandbox after merge: open a mail with a reply thread, tap `<summary>`, confirm the iframe stretches to fit the unfolded content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
