### PR TITLE
revert(mails): ResizeObserver fallback (#628) — fires "loop completed with undelivered notifications" on every open

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -47,15 +47,12 @@ const MailBody = ({ mailId }: Props) => {
 
   const iframeElement = useRef<HTMLIFrameElement>(null);
   const pendingTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
   // Cancel all pending timers when the component unmounts
   useEffect(() => {
     return () => {
       pendingTimers.current.forEach(clearTimeout);
       pendingTimers.current = [];
-      resizeObserverRef.current?.disconnect();
-      resizeObserverRef.current = null;
     };
   }, []);
 
@@ -242,33 +239,6 @@ const MailBody = ({ mailId }: Props) => {
       Array.from(content.querySelectorAll("details")).forEach((det) => {
         det.addEventListener("toggle", () => adjustMailContentSize(iframeDom));
       });
-
-      // Defense-in-depth fallback for browsers/contexts where the `toggle`
-      // event on `<details>` doesn't reliably reach our listener — iOS
-      // Safari has been the recurring case (#627 fix worked in macOS
-      // Chrome but not Safari mobile). ResizeObserver fires whenever the
-      // body's content rect changes height, so any unfolding (details
-      // toggle, image load, font swap, web-font fallback) reflows the
-      // iframe. Guarded with `suppressResize` so the body height change
-      // adjustMailContentSize itself causes (iframe height "auto" →
-      // body's `height: 100%` follows) doesn't recurse.
-      resizeObserverRef.current?.disconnect();
-      let suppressResize = false;
-      const resizeObserver = new ResizeObserver(() => {
-        if (suppressResize) return;
-        suppressResize = true;
-        try {
-          adjustMailContentSize(iframeDom);
-        } finally {
-          requestAnimationFrame(() =>
-            requestAnimationFrame(() => {
-              suppressResize = false;
-            }),
-          );
-        }
-      });
-      resizeObserver.observe(content);
-      resizeObserverRef.current = resizeObserver;
 
       adjustMailContentSize(iframeDom);
       const id = setTimeout(() => adjustMailContentSize(iframeDom), 50);


### PR DESCRIPTION
**Revert #628.** Reproduced locally — the ResizeObserver setup throws a `ResizeObserver loop completed with undelivered notifications` window error on every mail-body open. In macOS Chrome it surfaces as a non-fatal console error; in Safari mobile (per Hoie 2026-06-28) it manifests as a visible client error.

## Why it loops despite `suppressResize`

`adjustMailContentSize` mutates `iframeDom.style.height` between `"auto"` and a px value during measurement. The iframe body has `height: 100%` from `processHtmlForViewer`'s injected CSS, so its content rect tracks the iframe — both mutations queue ResizeObserver notifications. The `suppressResize` flag drops the queued notifications when they fire, but the browser still flags the drop as "undelivered" and emits the window error.

Reproduced in a controlled synthetic harness: 2 observer firings, 1 suppressed, 1 window error per mail open.

## Plan after revert

A non-ResizeObserver path for Safari mobile: bump the body-level click listener's `setTimeout(50)` to a longer delay (250–500ms) so iOS Safari's slower layout settle can be measured, and combine with the existing #627 `<details>.toggle` listener (which handles Chrome cleanly). The two together cover Chrome's keyboard activation case + Safari's tap timing without the loop risk. Follow-up PR.

## Test plan

- [x] `bun run typecheck` → clean
- [x] **Synthetic repro of the loop confirmed pre-revert** — same harness with the revert applied shows 0 window errors, 0 ResizeObserver firings.
- [ ] macOS Chrome smoke after merge — reply-thread `<details>` toggle still reflows via the #627 path.
- [ ] iOS Safari smoke — back to the original "doesn't reflow" state (the fix this revert removes wasn't working on Safari anyway; we just stop the loop error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
