### PR TITLE
feat(client): register service worker for every authenticated session + tear down on logout

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -13,7 +13,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Account, SignedUser, ReplyData } from "common";
 import { DomainGetResponse } from "server";
 
-import { Header, SignIn, Box, SignUp, ErrorBoundary, useLocalStorage, Notifier, call, callUser, queryClient } from "client";
+import { Header, SignIn, Box, SignUp, ErrorBoundary, useLocalStorage, Notifier, call, callUser, queryClient, registerServiceWorker } from "client";
 
 export enum Category {
   NewMails = "New Mails",
@@ -168,6 +168,9 @@ const App = ({ user: session }: Props) => {
       setSearchHistory([]);
       setNewMailsTotal(0);
     } else {
+      // Register the SW for every authenticated session, not just push opt-ins,
+      // so the asset cache + offline-navigation fallback reach all users (#458).
+      registerServiceWorker();
       new Notifier().subscribe();
     }
   }, [

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -29,7 +29,8 @@ import {
   QueryCache,
   call,
   onKeyboardActivate,
-  clearCachedQueries
+  clearCachedQueries,
+  unregisterServiceWorker
 } from "client";
 import { MailsSynchronizer } from "client/Box";
 import { mergeSavedAccounts } from "./savedAccounts";
@@ -380,6 +381,9 @@ const Accounts = ({
       // Drop the IndexedDB query cache so the next user on this browser can't be
       // seeded with this user's cached mail headers (#457).
       await clearCachedQueries();
+      // Tear down the SW + Cache Storage so the logged-out browser holds no
+      // cached app shell / assets from this session (#458).
+      await unregisterServiceWorker();
       // Clear compose draft data so it doesn't leak to the next user on this browser
       [
         "name",

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -10,3 +10,4 @@ export * from "./a11y";
 export * from "./mails";
 export * from "./cacheCatalog";
 export * from "./cachePersist";
+export * from "./serviceWorker";

--- a/src/client/lib/serviceWorker.test.ts
+++ b/src/client/lib/serviceWorker.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, afterEach, mock } from "bun:test";
+import { registerServiceWorker, unregisterServiceWorker } from "./serviceWorker";
+
+// Minimal mutable view of the browser globals the module touches, so the tests
+// can stub them without `any` (eslint forbids it) and restore afterwards.
+type MutableGlobals = {
+  navigator: { serviceWorker?: unknown };
+  caches?: { keys(): Promise<string[]>; delete(key: string): Promise<boolean> };
+};
+const g = globalThis as unknown as MutableGlobals;
+
+const realNavigator = g.navigator;
+const realCaches = g.caches;
+
+afterEach(() => {
+  g.navigator = realNavigator;
+  if (realCaches === undefined) delete g.caches;
+  else g.caches = realCaches;
+});
+
+describe("registerServiceWorker", () => {
+  it("registers the SW script when the API is available", async () => {
+    const register = mock(async () => ({}));
+    g.navigator = { serviceWorker: { register } };
+    await registerServiceWorker();
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register.mock.calls[0][0]).toBe("/service-worker.js");
+  });
+
+  it("no-ops when serviceWorker is unavailable", async () => {
+    g.navigator = {};
+    // Must not throw.
+    await registerServiceWorker();
+  });
+
+  it("swallows a registration rejection", async () => {
+    const register = mock(async () => {
+      throw new Error("nope");
+    });
+    g.navigator = { serviceWorker: { register } };
+    await registerServiceWorker();
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unregisterServiceWorker", () => {
+  it("unregisters every registration and deletes every cache", async () => {
+    const unregisterA = mock(async () => true);
+    const unregisterB = mock(async () => true);
+    const getRegistrations = mock(async () => [
+      { unregister: unregisterA },
+      { unregister: unregisterB },
+    ]);
+    g.navigator = { serviceWorker: { getRegistrations } };
+
+    const del = mock(async () => true);
+    g.caches = { keys: mock(async () => ["inbox-v1", "old"]), delete: del };
+
+    await unregisterServiceWorker();
+
+    expect(unregisterA).toHaveBeenCalledTimes(1);
+    expect(unregisterB).toHaveBeenCalledTimes(1);
+    expect(del).toHaveBeenCalledTimes(2);
+    expect(del.mock.calls.map((c) => c[0]).sort()).toEqual(["inbox-v1", "old"]);
+  });
+
+  it("clears caches even when serviceWorker is unavailable", async () => {
+    g.navigator = {};
+    const del = mock(async () => true);
+    g.caches = { keys: mock(async () => ["inbox-v1"]), delete: del };
+    await unregisterServiceWorker();
+    expect(del).toHaveBeenCalledTimes(1);
+  });
+
+  it("no-ops when neither serviceWorker nor caches exist", async () => {
+    g.navigator = {};
+    delete g.caches;
+    // Must not throw.
+    await unregisterServiceWorker();
+  });
+});

--- a/src/client/lib/serviceWorker.ts
+++ b/src/client/lib/serviceWorker.ts
@@ -1,0 +1,53 @@
+/**
+ * Service-worker lifecycle for the IndexedDB-cache rollout (Phase 2, #458).
+ *
+ * `public/service-worker.js` precaches the SPA shell, serves hashed `/assets/*`
+ * cache-first, and falls back to the cached shell for offline navigations.
+ * Until now it was registered only as a side effect of opting in to push
+ * (`Notifier.subscribe`, which bails unless notification permission is granted),
+ * so users who never enabled notifications got none of the offline/asset-cache
+ * benefit. Register it for every authenticated session instead, and tear it
+ * down on logout so a shared browser never serves the previous user's cached
+ * shell.
+ */
+
+const SW_URL = "/service-worker.js";
+
+/**
+ * Register the SW for an authenticated session. Idempotent and safe to call on
+ * every auth resolve — the browser dedups registration by script URL. No-ops
+ * where the API is unavailable (older browsers, insecure origins).
+ */
+export const registerServiceWorker = async (): Promise<void> => {
+  if (!("serviceWorker" in navigator)) return;
+  try {
+    await navigator.serviceWorker.register(SW_URL);
+  } catch (error) {
+    console.error("Service worker registration failed:", error);
+  }
+};
+
+/**
+ * Tear down the SW and every Cache Storage entry on logout so the next user on
+ * this browser can't be served the previous user's cached shell or asset set.
+ * Pairs with `clearCachedQueries()` (the IndexedDB query-cache clear) at the
+ * logout site.
+ */
+export const unregisterServiceWorker = async (): Promise<void> => {
+  if ("serviceWorker" in navigator) {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((r) => r.unregister()));
+    } catch (error) {
+      console.error("Service worker unregister failed:", error);
+    }
+  }
+  if (typeof caches !== "undefined") {
+    try {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((key) => caches.delete(key)));
+    } catch (error) {
+      console.error("Cache storage clear failed:", error);
+    }
+  }
+};


### PR DESCRIPTION
## What

Phase 2 step of the IndexedDB-cache rollout (**part of #458**): register the service worker for **every authenticated session**, not just push opt-ins, and tear it down on logout.

`public/service-worker.js` already precaches the SPA shell, serves hashed `/assets/*` cache-first, and falls back to the cached shell for offline navigations. But the only registration site is `Notifier.subscribe()`, which returns early unless `Notification.permission === "granted"`. So today only users who granted notification permission ever get a registered SW — everyone else gets none of the asset-cache / offline-navigation benefit the SW was built to provide.

## Changes

- **New `src/client/lib/serviceWorker.ts`**
  - `registerServiceWorker()` — registers `/service-worker.js`; idempotent (browser dedups by script URL) and feature-guarded (no-ops where `serviceWorker` is unavailable).
  - `unregisterServiceWorker()` — unregisters every registration **and** deletes every Cache Storage entry.
- **`App.tsx`** — calls `registerServiceWorker()` on every authenticated session (the `userInfo`-set branch), independent of push permission. The existing `Notifier().subscribe()` call stays (its own idempotent register is unaffected).
- **`Accounts` logout** — calls `unregisterServiceWorker()` alongside the existing `clearCachedQueries()` IndexedDB clear, so a shared browser never serves the previous user's cached shell/assets.
- **Unit tests** (`serviceWorker.test.ts`) — register happy-path + URL, no-op when unavailable, swallowed rejection; unregister clears all registrations + all caches, caches-cleared-without-SW, and the all-absent no-op.

## Out of scope (follow-ups tracked on #458)

- The SW `/api/*` offline-proxy — pending Hoie's design call. The current SW deliberately skips `/api`, and Phase 1's hydrate-before-render already covers cold-load offline reads, so the proxy is only load-bearing for mid-session offline fetches. Re-surfaced on the issue.
- The offline UX layer (`IsOnlineContext`, offline banner, disabled-when-offline mutators).

## Testing

- `bun run typecheck` — clean.
- `eslint` on all touched files — clean.
- `bun test src/client` — 34 pass, 0 fail (6 new).
- **E2E (Playwright, real UI on a dev server I started this session):**
  - At page load, `Notification.permission` was **`denied`** (headless chromium) and VAPID push keys are unset on the server — i.e. the *old* push-gated path could never register a SW here.
  - After logging in (`admin`), a SW for `/service-worker.js` was registered and the `inbox-v1` asset cache appeared — proving registration is now **decoupled from push permission**.
  - After logout, **zero** SW registrations remained and **zero** Cache Storage entries remained — teardown confirmed.
  - All four assertions PASS.