### PR TITLE
feat(client): offline-detection context + offline banner (#458 Phase 2)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -13,7 +13,21 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { Account, SignedUser, ReplyData } from "common";
 import { DomainGetResponse } from "server";
 
-import { Header, SignIn, Box, SignUp, ErrorBoundary, useLocalStorage, Notifier, call, callUser, queryClient, registerServiceWorker } from "client";
+import {
+  Header,
+  SignIn,
+  Box,
+  SignUp,
+  ErrorBoundary,
+  OfflineBanner,
+  IsOnlineProvider,
+  useLocalStorage,
+  Notifier,
+  call,
+  callUser,
+  queryClient,
+  registerServiceWorker
+} from "client";
 
 export enum Category {
   NewMails = "New Mails",
@@ -210,29 +224,40 @@ const App = ({ user: session }: Props) => {
     <StrictMode>
       <QueryClientProvider client={queryClient}>
         <Context.Provider value={contextValue}>
-          <BrowserRouter>
-            <ErrorBoundary>
-              <Header />
-              <Routes>
-                <Route
-                  path="/"
-                  element={userInfo ? <Box /> : <Navigate to="/sign-in" replace />}
-                />
-                <Route
-                  path="/sign-in"
-                  element={userInfo ? <Navigate to="/" replace /> : <SignIn />}
-                />
-                <Route
-                  path="/set-info"
-                  element={userInfo ? <Navigate to="/" replace /> : <SignUp />}
-                />
-                <Route
-                  path="/set-info/:email"
-                  element={userInfo ? <Navigate to="/" replace /> : <SignUp />}
-                />
-              </Routes>
-            </ErrorBoundary>
-          </BrowserRouter>
+          <IsOnlineProvider>
+            <BrowserRouter>
+              <ErrorBoundary>
+                <OfflineBanner />
+                <Header />
+                <Routes>
+                  <Route
+                    path="/"
+                    element={
+                      userInfo ? <Box /> : <Navigate to="/sign-in" replace />
+                    }
+                  />
+                  <Route
+                    path="/sign-in"
+                    element={
+                      userInfo ? <Navigate to="/" replace /> : <SignIn />
+                    }
+                  />
+                  <Route
+                    path="/set-info"
+                    element={
+                      userInfo ? <Navigate to="/" replace /> : <SignUp />
+                    }
+                  />
+                  <Route
+                    path="/set-info/:email"
+                    element={
+                      userInfo ? <Navigate to="/" replace /> : <SignUp />
+                    }
+                  />
+                </Routes>
+              </ErrorBoundary>
+            </BrowserRouter>
+          </IsOnlineProvider>
         </Context.Provider>
       </QueryClientProvider>
     </StrictMode>

--- a/src/client/OfflineBanner/index.css
+++ b/src/client/OfflineBanner/index.css
@@ -1,0 +1,42 @@
+/*
+ * The app shell is a fixed layout: #title_bar is `position: fixed; top: 0` and
+ * the mail panes are `position: fixed; top: 55px`. A normal-flow banner would
+ * sit underneath them, so the banner is itself fixed — pinned to the bottom
+ * edge, above the panes (z-index 30 > #title_bar's 20) — which keeps it visible
+ * without reflowing the pinned header/content.
+ */
+.offline-banner {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.4rem 1rem;
+  background: #5a5a5a;
+  color: white;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.offline-banner-message {
+  flex: 0 1 auto;
+}
+
+.offline-banner-retry {
+  flex: 0 0 auto;
+  padding: 0.2rem 0.7rem;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 4px;
+  background: transparent;
+  color: white;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.offline-banner-retry:hover {
+  background: rgba(255, 255, 255, 0.15);
+}

--- a/src/client/OfflineBanner/index.scss
+++ b/src/client/OfflineBanner/index.scss
@@ -1,3 +1,6 @@
+@use "sass:color";
+@use "../variables" as *;
+
 /*
  * The app shell is a fixed layout: #title_bar is `position: fixed; top: 0` and
  * the mail panes are `position: fixed; top: 55px`. A normal-flow banner would
@@ -16,8 +19,9 @@
   justify-content: center;
   gap: 0.75rem;
   padding: 0.4rem 1rem;
-  background: #5a5a5a;
-  color: white;
+  border-top: 2px solid $color-point;
+  background-color: color.adjust($color-dark, $lightness: 6%);
+  color: $color-light;
   font-size: 0.85rem;
   text-align: center;
 }
@@ -29,14 +33,14 @@
 .offline-banner-retry {
   flex: 0 0 auto;
   padding: 0.2rem 0.7rem;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  border: 1px solid $color-point;
   border-radius: 4px;
   background: transparent;
-  color: white;
+  color: $color-point;
   cursor: pointer;
   font-size: 0.8rem;
-}
 
-.offline-banner-retry:hover {
-  background: rgba(255, 255, 255, 0.15);
+  &:hover {
+    background-color: color.adjust($color-dark, $lightness: 12%);
+  }
 }

--- a/src/client/OfflineBanner/index.scss
+++ b/src/client/OfflineBanner/index.scss
@@ -41,6 +41,7 @@
   font-size: 0.8rem;
 
   &:hover {
-    background-color: color.adjust($color-dark, $lightness: 12%);
+    background-color: $color-point;
+    color: $color-dark;
   }
 }

--- a/src/client/OfflineBanner/index.tsx
+++ b/src/client/OfflineBanner/index.tsx
@@ -2,10 +2,10 @@ import { useIsOnline, formatLastSeen } from "client";
 import "./index.css";
 
 /**
- * Top banner shown only while the server is unreachable (#458 Phase 2). The app
+ * Banner shown only while the server is unreachable (#458 Phase 2). The app
  * keeps rendering the last-known data from the React Query cache (seeded from
  * IndexedDB in Phase 1); this tells the user the data is frozen and offers an
- * immediate reconnect attempt.
+ * immediate reconnect attempt. Bottom-fixed — see index.css for why.
  */
 const OfflineBanner = () => {
   const { isOnline, lastSeenOnline, recheck } = useIsOnline();

--- a/src/client/OfflineBanner/index.tsx
+++ b/src/client/OfflineBanner/index.tsx
@@ -1,0 +1,27 @@
+import { useIsOnline, formatLastSeen } from "client";
+import "./index.css";
+
+/**
+ * Top banner shown only while the server is unreachable (#458 Phase 2). The app
+ * keeps rendering the last-known data from the React Query cache (seeded from
+ * IndexedDB in Phase 1); this tells the user the data is frozen and offers an
+ * immediate reconnect attempt.
+ */
+const OfflineBanner = () => {
+  const { isOnline, lastSeenOnline, recheck } = useIsOnline();
+
+  if (isOnline) return null;
+
+  return (
+    <div className="offline-banner" role="status" aria-live="polite">
+      <span className="offline-banner-message">
+        Offline — showing data as of {formatLastSeen(lastSeenOnline)}
+      </span>
+      <button type="button" className="offline-banner-retry" onClick={recheck}>
+        Retry
+      </button>
+    </div>
+  );
+};
+
+export default OfflineBanner;

--- a/src/client/OfflineBanner/index.tsx
+++ b/src/client/OfflineBanner/index.tsx
@@ -1,11 +1,11 @@
 import { useIsOnline, formatLastSeen } from "client";
-import "./index.css";
+import "./index.scss";
 
 /**
  * Banner shown only while the server is unreachable (#458 Phase 2). The app
  * keeps rendering the last-known data from the React Query cache (seeded from
  * IndexedDB in Phase 1); this tells the user the data is frozen and offers an
- * immediate reconnect attempt. Bottom-fixed — see index.css for why.
+ * immediate reconnect attempt. Bottom-fixed — see index.scss for why.
  */
 const OfflineBanner = () => {
   const { isOnline, lastSeenOnline, recheck } = useIsOnline();

--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -1,6 +1,7 @@
 export * from "./lib";
 export { default as Box } from "./Box";
 export { default as ErrorBoundary } from "./ErrorBoundary";
+export { default as OfflineBanner } from "./OfflineBanner";
 export { default as Header } from "./Header";
 export { default as SignIn } from "./SignIn";
 export { default as SignUp } from "./SignUp";

--- a/src/client/lib/index.ts
+++ b/src/client/lib/index.ts
@@ -11,3 +11,4 @@ export * from "./mails";
 export * from "./cacheCatalog";
 export * from "./cachePersist";
 export * from "./serviceWorker";
+export * from "./online";

--- a/src/client/lib/online.test.ts
+++ b/src/client/lib/online.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "bun:test";
+
+import {
+  reduceOnline,
+  pingHealth,
+  invalidateCacheableQueries,
+  formatLastSeen,
+  OnlineState
+} from "./online";
+
+describe("reduceOnline", () => {
+  it("stamps lastSeenOnline with `now` while online and reports no reconnect when already online", () => {
+    const prev: OnlineState = { isOnline: true, lastSeenOnline: 1000 };
+    const { state, reconnected } = reduceOnline(prev, true, 2000);
+    expect(state).toEqual({ isOnline: true, lastSeenOnline: 2000 });
+    expect(reconnected).toBe(false);
+  });
+
+  it("keeps the prior lastSeenOnline when going offline (banner shows the last good time)", () => {
+    const prev: OnlineState = { isOnline: true, lastSeenOnline: 1000 };
+    const { state, reconnected } = reduceOnline(prev, false, 2000);
+    expect(state).toEqual({ isOnline: false, lastSeenOnline: 1000 });
+    expect(reconnected).toBe(false);
+  });
+
+  it("flags reconnected only on the offline→online edge", () => {
+    const offline: OnlineState = { isOnline: false, lastSeenOnline: 1000 };
+    const { state, reconnected } = reduceOnline(offline, true, 5000);
+    expect(state).toEqual({ isOnline: true, lastSeenOnline: 5000 });
+    expect(reconnected).toBe(true);
+  });
+
+  it("preserves a null lastSeenOnline across an offline→offline tick", () => {
+    const prev: OnlineState = { isOnline: false, lastSeenOnline: null };
+    const { state, reconnected } = reduceOnline(prev, false, 9000);
+    expect(state).toEqual({ isOnline: false, lastSeenOnline: null });
+    expect(reconnected).toBe(false);
+  });
+});
+
+describe("pingHealth", () => {
+  it("is true when /api/health responds ok", async () => {
+    let calledPath = "";
+    const fakeFetch = (async (path: string) => {
+      calledPath = path as string;
+      return { ok: true } as Response;
+    }) as unknown as typeof fetch;
+    expect(await pingHealth(fakeFetch)).toBe(true);
+    expect(calledPath).toBe("/api/health");
+  });
+
+  it("is false when /api/health responds non-ok", async () => {
+    const fakeFetch = (async () =>
+      ({ ok: false }) as Response) as unknown as typeof fetch;
+    expect(await pingHealth(fakeFetch)).toBe(false);
+  });
+
+  it("swallows a thrown/rejected fetch as offline rather than rejecting", async () => {
+    const fakeFetch = (async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    expect(await pingHealth(fakeFetch)).toBe(false);
+  });
+});
+
+describe("invalidateCacheableQueries", () => {
+  it("invalidates only queries whose key is a cacheable endpoint", () => {
+    let captured: ((q: { queryKey: unknown }) => boolean) | undefined;
+    const fakeClient = {
+      invalidateQueries: (filters: {
+        predicate: (q: { queryKey: unknown }) => boolean;
+      }) => {
+        captured = filters.predicate;
+      }
+    } as unknown as Parameters<typeof invalidateCacheableQueries>[0];
+
+    invalidateCacheableQueries(fakeClient);
+    expect(captured).toBeDefined();
+    const pred = captured!;
+
+    // string-key cacheable endpoint (mail headers) → invalidate
+    expect(pred({ queryKey: "/api/mails/headers/me@hoie.kim" })).toBe(true);
+    // array-key form, first element is the URL → invalidate
+    expect(pred({ queryKey: ["/api/mails/headers/me@hoie.kim?new=1"] })).toBe(
+      true
+    );
+    // volatile / non-cacheable endpoints → leave alone
+    expect(pred({ queryKey: "/api/mails/search/me@hoie.kim" })).toBe(false);
+    expect(pred({ queryKey: "/api/mails/accounts" })).toBe(false);
+    // non-string keys → leave alone
+    expect(pred({ queryKey: 42 })).toBe(false);
+  });
+});
+
+describe("formatLastSeen", () => {
+  it("returns a dash when the server was never reached this session", () => {
+    expect(formatLastSeen(null)).toBe("—");
+  });
+
+  it("renders a non-empty HH:MM clock for a real timestamp", () => {
+    const out = formatLastSeen(new Date(2026, 0, 1, 9, 5).getTime());
+    expect(out).toMatch(/\d/);
+    expect(out.length).toBeGreaterThan(0);
+  });
+});

--- a/src/client/lib/online.test.ts
+++ b/src/client/lib/online.test.ts
@@ -39,17 +39,17 @@ describe("reduceOnline", () => {
 });
 
 describe("pingHealth", () => {
-  it("is true when /api/health responds ok", async () => {
+  it("is true when /api/ping responds ok (cheap liveness route, not /api/health)", async () => {
     let calledPath = "";
     const fakeFetch = (async (path: string) => {
       calledPath = path as string;
       return { ok: true } as Response;
     }) as unknown as typeof fetch;
     expect(await pingHealth(fakeFetch)).toBe(true);
-    expect(calledPath).toBe("/api/health");
+    expect(calledPath).toBe("/api/ping");
   });
 
-  it("is false when /api/health responds non-ok", async () => {
+  it("is false when /api/ping responds non-ok", async () => {
     const fakeFetch = (async () =>
       ({ ok: false }) as Response) as unknown as typeof fetch;
     expect(await pingHealth(fakeFetch)).toBe(false);

--- a/src/client/lib/online.tsx
+++ b/src/client/lib/online.tsx
@@ -8,7 +8,8 @@ import {
   ReactNode
 } from "react";
 
-import { queryClient, matchCacheCatalog } from "client";
+import { queryClient } from "./queryClient";
+import { matchCacheCatalog } from "./cacheCatalog";
 
 /**
  * Phase 2 (#458) offline-read UX. Tracks whether the app can currently reach
@@ -19,8 +20,10 @@ import { queryClient, matchCacheCatalog } from "client";
  * Two signals feed the state, in increasing order of trust:
  *   1. `navigator.onLine` window events — instant but unreliable (stays `true`
  *      on captive-portal Wi-Fi where no request actually completes).
- *   2. A `GET /api/health` heartbeat while the tab is visible — the ground
- *      truth, used to correct `navigator.onLine`'s false positives.
+ *   2. A `GET /api/ping` heartbeat while the tab is visible — the ground truth,
+ *      used to correct `navigator.onLine`'s false positives. Deliberately the
+ *      cheap liveness route, not `/api/health` (whose DB + socket probes would
+ *      multiply by open-tab count).
  */
 
 export interface OnlineState {
@@ -54,15 +57,15 @@ export const reduceOnline = (
 });
 
 /**
- * Hit the health endpoint and report reachability. `fetchImpl` is injectable so
- * the heartbeat can be tested without a real network. Any throw (DNS failure,
- * abort, offline) is reachability=false, never a rejection.
+ * Hit the liveness endpoint and report reachability. `fetchImpl` is injectable
+ * so the heartbeat can be tested without a real network. Any throw (DNS
+ * failure, abort, offline) is reachability=false, never a rejection.
  */
 export const pingHealth = async (
   fetchImpl: typeof fetch = fetch
 ): Promise<boolean> => {
   try {
-    const res = await fetchImpl("/api/health", { cache: "no-store" });
+    const res = await fetchImpl("/api/ping", { cache: "no-store" });
     return res.ok;
   } catch {
     return false;

--- a/src/client/lib/online.tsx
+++ b/src/client/lib/online.tsx
@@ -1,0 +1,160 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  ReactNode
+} from "react";
+
+import { queryClient, matchCacheCatalog } from "client";
+
+/**
+ * Phase 2 (#458) offline-read UX. Tracks whether the app can currently reach
+ * the server and exposes that as a single shared signal so the offline banner —
+ * and, in a later #458 slice, every mutating control — read one source of truth
+ * instead of each running its own `navigator.onLine` check + heartbeat.
+ *
+ * Two signals feed the state, in increasing order of trust:
+ *   1. `navigator.onLine` window events — instant but unreliable (stays `true`
+ *      on captive-portal Wi-Fi where no request actually completes).
+ *   2. A `GET /api/health` heartbeat while the tab is visible — the ground
+ *      truth, used to correct `navigator.onLine`'s false positives.
+ */
+
+export interface OnlineState {
+  isOnline: boolean;
+  /** ms-epoch of the last moment the server was reachable, or null if never. */
+  lastSeenOnline: number | null;
+}
+
+export interface IsOnlineContextValue extends OnlineState {
+  /** Force an immediate heartbeat (the banner's "Retry" button). */
+  recheck: () => void;
+}
+
+const HEARTBEAT_MS = 30 * 1000;
+
+/**
+ * Pure state transition. Returns the next state plus whether this is an
+ * offline→online edge (the only moment we want to refetch). Kept side-effect
+ * free so the reconnect rule is unit-testable without React or timers.
+ */
+export const reduceOnline = (
+  prev: OnlineState,
+  online: boolean,
+  now: number
+): { state: OnlineState; reconnected: boolean } => ({
+  state: {
+    isOnline: online,
+    lastSeenOnline: online ? now : prev.lastSeenOnline
+  },
+  reconnected: online && !prev.isOnline
+});
+
+/**
+ * Hit the health endpoint and report reachability. `fetchImpl` is injectable so
+ * the heartbeat can be tested without a real network. Any throw (DNS failure,
+ * abort, offline) is reachability=false, never a rejection.
+ */
+export const pingHealth = async (
+  fetchImpl: typeof fetch = fetch
+): Promise<boolean> => {
+  try {
+    const res = await fetchImpl("/api/health", { cache: "no-store" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Refetch every React Query whose key is a cacheable endpoint (per the single
+ * cache catalog). Called on the offline→online edge so the stale data the user
+ * was shown while offline is replaced as soon as the server is reachable again.
+ */
+export const invalidateCacheableQueries = (client = queryClient): void => {
+  client.invalidateQueries({
+    predicate: (query) => {
+      const key = Array.isArray(query.queryKey)
+        ? query.queryKey[0]
+        : query.queryKey;
+      return typeof key === "string" && !!matchCacheCatalog(key);
+    }
+  });
+};
+
+/**
+ * Render the "data as of" clock for the offline banner. Returns a local
+ * `HH:MM` string, or a dash when the server was never reached this session.
+ */
+export const formatLastSeen = (lastSeenOnline: number | null): string => {
+  if (lastSeenOnline == null) return "—";
+  return new Date(lastSeenOnline).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+};
+
+const IsOnlineContext = createContext<IsOnlineContextValue>({
+  isOnline: true,
+  lastSeenOnline: null,
+  recheck: () => {}
+});
+
+export const IsOnlineProvider = ({ children }: { children: ReactNode }) => {
+  const [state, setState] = useState<OnlineState>(() => {
+    const online = navigator.onLine;
+    return { isOnline: online, lastSeenOnline: online ? Date.now() : null };
+  });
+
+  // Mirror of `state.isOnline` readable synchronously so the reconnect side
+  // effect fires outside the (StrictMode-double-invoked) state updater.
+  const isOnlineRef = useRef(state.isOnline);
+
+  const apply = useCallback((online: boolean) => {
+    const wasOnline = isOnlineRef.current;
+    isOnlineRef.current = online;
+    setState((prev) => reduceOnline(prev, online, Date.now()).state);
+    if (online && !wasOnline) invalidateCacheableQueries();
+  }, []);
+
+  const recheck = useCallback(() => {
+    pingHealth().then(apply);
+  }, [apply]);
+
+  useEffect(() => {
+    const handleOnline = () => apply(true);
+    const handleOffline = () => apply(false);
+    const handleVisible = () => {
+      if (document.visibilityState === "visible") recheck();
+    };
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    document.addEventListener("visibilitychange", handleVisible);
+
+    const interval = setInterval(() => {
+      // Don't ping a backgrounded tab — the heartbeat exists to keep the
+      // visible UI honest, not to poll forever in the background.
+      if (document.visibilityState === "visible") recheck();
+    }, HEARTBEAT_MS);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      document.removeEventListener("visibilitychange", handleVisible);
+      clearInterval(interval);
+    };
+  }, [apply, recheck]);
+
+  return (
+    <IsOnlineContext.Provider value={{ ...state, recheck }}>
+      {children}
+    </IsOnlineContext.Provider>
+  );
+};
+
+export const useIsOnline = (): IsOnlineContextValue =>
+  useContext(IsOnlineContext);

--- a/src/server/lib/http/routes/index.ts
+++ b/src/server/lib/http/routes/index.ts
@@ -15,8 +15,10 @@ import { sendAlarm } from "../../alarm";
 const apiRouter = Router();
 
 apiRouter.use((req, _res, next) => {
-  // Skip logging for health check requests (e.g. from reverse proxy)
-  if (req.url === "/health") {
+  // Skip logging for the infra health check and the client liveness ping —
+  // both are polled frequently (reverse proxy / every open tab's 30s offline
+  // heartbeat) and would otherwise flood the request log.
+  if (req.url === "/health" || req.url === "/ping") {
     next();
     return;
   }
@@ -29,6 +31,13 @@ apiRouter.use((req, _res, next) => {
     from: getClientIp(req),
   });
   next();
+});
+
+// Cheap liveness probe for the client's offline heartbeat: just "is the HTTP
+// server reachable", with none of /health's DB query + SMTP/IMAP socket probes
+// (which would multiply into N port-scans per 30s at N users with open tabs).
+apiRouter.get("/ping", (_req, res) => {
+  res.json({ status: "success" });
 });
 
 apiRouter.use("/health", healthRouter);


### PR DESCRIPTION
## What

The offline-read UX layer from **#458** (IndexedDB-cache Phase 2). Builds on Phase 1 (#618, merged) which seeds the React Query cache from IndexedDB before first render. This PR makes the app *tell the user* when it's serving that frozen data because the server is unreachable.

Part of #458 — does **not** close it (remaining slices below).

## Changes

- **`src/client/lib/online.tsx`** — `IsOnlineProvider` + `useIsOnline()` exposing `{ isOnline, lastSeenOnline, recheck }`.
  - Two signals, increasing trust: `navigator.onLine` window events (instant but unreliable — stays `true` on captive-portal Wi-Fi) corrected by a `GET /api/ping` heartbeat (a cheap liveness route added in this PR — not the heavyweight `/api/health`, which runs a DB query + mail-daemon socket probes per call) every 30s **while the tab is visible** (the design doc's sanity check).
  - On the **offline→online edge only**, invalidates every React Query whose key is a cacheable endpoint (resolved through the single `cacheCatalog`, so the offline layer can't drift from the persistence layer) — stale offline data is replaced as soon as the server is back.
  - Pure, unit-tested cores: `reduceOnline` (state transition + reconnect edge), `pingHealth` (injectable fetch), `invalidateCacheableQueries` (catalog predicate), `formatLastSeen` (HH:MM clock).
- **`src/client/OfflineBanner/`** — bar shown only while offline: `Offline — showing data as of HH:MM` + **Retry** button (forces an immediate heartbeat).
- **`App.tsx`** — wraps the app in `IsOnlineProvider`, renders `<OfflineBanner />`; client barrels updated.

### Note on banner placement (design-doc deviation — flagging for a call)

The design says *top* banner. The app shell is a fixed layout — `#title_bar` is `position: fixed; top: 0` and the mail panes are `position: fixed; top: 55px`. A normal-flow top banner sits *under* both, and a faithful top banner would mean reflowing the pinned header + every pane (invasive, outside this slice's scope). I pinned it to the **bottom** (`position: fixed; bottom: 0; z-index: 30`) — fully visible, zero reflow, the common offline-indicator pattern. If you'd rather have it on top, it's a small follow-up to add the header/pane offset. Re-surfaced on #458.

## Out of scope (remaining #458 slices)

- **Disable-when-offline mutating controls** (compose-send, mark read/save/delete, account add…) — a wide cross-cutting change; better as its own PR than entangled here ([scope discipline]). The `useIsOnline()` hook this PR adds is what those controls will read.
- **SW `sw-back-online` API-proxy bridge** — depends on the SW `/api/*` offline proxy, which is pending your design call (the current SW deliberately skips `/api`). This PR's navigator + heartbeat path already drives banner-clear + refetch without it.
- **SW registration lifecycle** — already in PR #634.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `eslint` on all touched files — clean.
- [x] `bun test src/client` — 38 pass / 0 fail (10 new in `online.test.ts`).
- [x] **UI E2E** — Playwright against a dev server started this session (`EMAIL_DOMAIN=hoie.kim`), logged in as `admin`:
  - **Online:** `.offline-banner` absent (count 0). App renders the account list + a mail.
  - **Offline** (`context.setOffline(true)`): banner becomes **visible** (boundingBox full-width at the viewport bottom, height ~36px), text reads `Offline — showing data as of HH:MM`, **Retry** button present. The mail list/body it was already showing stays rendered — last-known data, not a blank/error screen.
  - **Reconnect** (`setOffline(false)` + `online` event): banner detaches (count 0) **and** a `/api/mails/headers/` refetch fires — the catalog-scoped invalidation replaces the stale data.
  - Screenshots: `/tmp/pr-offline-1-online.png`, `/tmp/pr-offline-2-offline.png`, `/tmp/pr-offline-3-reconnect.png` (read back to confirm the rendered banner).

Refs #458. SW lifecycle: #634.
