### PR TITLE
feat(logging): switch container log driver to journald

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,18 @@ services:
       retries: 3
       start_period: 60s
     restart: always
+    # journald log driver so container stdout persists across restart /
+    # `compose down`/recreate. json-file (the docker default) is keyed by
+    # container-id, so the previous container's logs become unreachable
+    # via `docker logs` the moment compose replaces the container — every
+    # OOM triage today loses history that way. journald keeps everything
+    # under systemd-journald's retention (SystemMaxUse / MaxRetentionSec
+    # in /etc/systemd/journald.conf on the host). Read live or historical:
+    #   journalctl CONTAINER_NAME=hoie-inbox-1 --since '1 hour ago'
+    logging:
+      driver: journald
+      options:
+        tag: "hoie-inbox"
     volumes:
       - attachments:/app/attachments
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     # OOM triage today loses history that way. journald keeps everything
     # under systemd-journald's retention (SystemMaxUse / MaxRetentionSec
     # in /etc/systemd/journald.conf on the host). Read live or historical:
-    #   journalctl CONTAINER_NAME=hoie-inbox-1 --since '1 hour ago'
+    #   journalctl CONTAINER_TAG=hoie-inbox --since '1 hour ago'
     logging:
       driver: journald
       options:


### PR DESCRIPTION
## Summary (updated 2026-07-01)

Switch the inbox container to the `journald` docker log driver. Docker's default `json-file` driver keys logs by container-id, so a `compose down/up` or an image rebuild strands the previous container's history on disk — unreachable via `docker logs`. Every OOM triage today loses history for that reason. journald keeps everything host-side, independent of container lifecycle.

The first draft of this PR also added an app-side memory heartbeat. Per Hoie's feedback (2026-07-01) that shape muddles metrics with events — memory monitoring belongs at the docker/host layer, not in the app log stream. The heartbeat is dropped; the companion monitor PR polls memory via the Docker stats API instead.

## Changes

`docker-compose.yml` — new `logging:` block on the inbox service:

```yaml
logging:
  driver: journald
  options:
    tag: "hoie-inbox"
```

That's the whole PR.

## Companion PR

- hoiekim/monitor #13 — swaps `/logs/:container` to `journalctl` and adds Docker-stats-based memory polling (`GET /stats/:container` + optional `MEMORY_PRESSURE` early-warning alarm).

Deploy order: land + deploy this PR (compose applies the log driver switch) → then land + `pm2 restart monitor` for the companion PR. Monitor's log endpoint will return empty for inbox until the compose side is deployed.

## Host-layer steps (one-time, at deploy)

1. **Journald persists to disk** — needs `/var/log/journal/`:
   ```
   sudo mkdir -p /var/log/journal
   sudo systemctl restart systemd-journald
   ```
   Without this, journald is memory-only and doesn't survive a host reboot.
2. **Retention** in `/etc/systemd/journald.conf` (optional but recommended):
   ```
   Storage=persistent
   SystemMaxUse=2G
   MaxRetentionSec=30day
   ```
   Then `sudo systemctl restart systemd-journald`.

## Test plan

- [x] Diff is a `docker-compose.yml`-only change; `bun run typecheck` unaffected.
- [ ] Post-deploy: `journalctl CONTAINER_NAME=hoie-inbox-1 -f` should stream inbox's stdout live. Confirm at least one log line lands after a normal request (e.g. `curl https://mail.hoie.kim/api/health`).
- [ ] After a `docker compose up -d --build inbox`, confirm `journalctl CONTAINER_NAME=hoie-inbox-1 --since '10 minutes ago'` includes log lines from BOTH the pre-rebuild and post-rebuild container instances — that's the persistence-across-recreate that we're paying for.
