### PR TITLE
feat(client): search side-tab lists accounts matching the keyword

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -10,7 +10,7 @@ import {
 import { QueryClientProvider } from "react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
-import { Account, SignedUser, ReplyData } from "common";
+import { SignedUser, ReplyData } from "common";
 import { DomainGetResponse } from "server";
 
 import {
@@ -57,8 +57,6 @@ export interface ContextType {
   setSelectedCategory: Dispatch<
     SetStateAction<ContextType["selectedCategory"]>
   >;
-  searchHistory: Account[];
-  setSearchHistory: Dispatch<SetStateAction<ContextType["searchHistory"]>>;
   newMailsTotal: number;
   setNewMailsTotal: Dispatch<SetStateAction<ContextType["newMailsTotal"]>>;
 }
@@ -102,9 +100,6 @@ const App = ({ user: session }: Props) => {
     // the account address as the search term, producing confusing sort order.
     (v) => (v === Category.Search ? Category.AllMails : v)
   );
-  const [searchHistory, setSearchHistory] = useState<
-    ContextType["searchHistory"]
-  >([]);
   const [newMailsTotal, setNewMailsTotal] = useState(0);
 
   // On mount: if the app reloaded while in search mode, exit search state.
@@ -179,7 +174,6 @@ const App = ({ user: session }: Props) => {
       setIsWriterOpen(false);
       setIsAccountsOpen(window.innerWidth > 750);
       setReplyData({});
-      setSearchHistory([]);
       setNewMailsTotal(0);
     } else {
       // Register the SW for every authenticated session, not just push opt-ins,
@@ -194,7 +188,6 @@ const App = ({ user: session }: Props) => {
     setIsWriterOpen,
     setIsAccountsOpen,
     setReplyData,
-    setSearchHistory,
     setNewMailsTotal
   ]);
 
@@ -214,8 +207,6 @@ const App = ({ user: session }: Props) => {
     setSelectedAccount,
     selectedCategory,
     setSelectedCategory,
-    searchHistory,
-    setSearchHistory,
     newMailsTotal,
     setNewMailsTotal
   };

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -152,13 +152,21 @@ const Accounts = ({
   }, [searchInputDom, isAccountsOpen, isWriterOpen]);
 
   // Auto-select the first received account on fresh login when no account is
-  // stored in localStorage (e.g., first visit or cleared storage).
+  // stored in localStorage (e.g., first visit or cleared storage). Skipped in
+  // Search mode, where an empty selectedAccount is the empty search term (a
+  // fresh, not-yet-typed search) — auto-selecting an account there would turn
+  // that account's address into a stray search keyword.
   useEffect(() => {
-    if (!selectedAccount && query.isSuccess && query.data?.received?.length) {
+    if (
+      !selectedAccount &&
+      selectedCategory !== Category.Search &&
+      query.isSuccess &&
+      query.data?.received?.length
+    ) {
       const firstKey = query.data.received[0].key;
       if (firstKey) setSelectedAccount(firstKey);
     }
-  }, [selectedAccount, query.isSuccess, query.data]);
+  }, [selectedAccount, selectedCategory, query.isSuccess, query.data]);
 
   const touchStartHandler = () => setShowSortOptions(false);
 
@@ -305,24 +313,28 @@ const Accounts = ({
           setSelectedAccount("");
           return;
         }
-        if (selectedCategory === Category.Search) {
-          // Leaving search: restore the pre-search account if we have one
-          // (preSearchAccount is a ref and won't survive a page reload)
-          if (preSearchAccount.current) {
-            setSelectedAccount(preSearchAccount.current);
-          }
-        }
-        setSelectedCategory(e);
-        // Reset selectedAccount if it doesn't exist in the new category's account list
+
+        // The account to keep selected in the destination category. Leaving
+        // search restores the pre-search account (selectedAccount currently
+        // holds the search term, so we can't read it here); otherwise we keep
+        // the current account.
+        const candidate =
+          selectedCategory === Category.Search
+            ? preSearchAccount.current
+            : selectedAccount;
+
+        // The destination category's account list — used to fall back to its
+        // first account when the candidate isn't present in it.
         let targetAccounts: Account[];
         if (e === Category.SentMails) targetAccounts = sent;
         else if (e === Category.NewMails) targetAccounts = received.filter((a) => a.unread_doc_count);
         else if (e === Category.SavedMails) targetAccounts = mergeSavedAccounts(received, sent);
         else targetAccounts = received;
-        if (
-          targetAccounts.length > 0 &&
-          !targetAccounts.some((a) => a.key === selectedAccount)
-        ) {
+
+        setSelectedCategory(e);
+        if (candidate && targetAccounts.some((a) => a.key === candidate)) {
+          if (candidate !== selectedAccount) setSelectedAccount(candidate);
+        } else if (targetAccounts.length > 0) {
           setSelectedAccount(targetAccounts[0].key);
         }
       };

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -23,7 +23,11 @@ import {
 } from "./components";
 
 import { Account } from "common";
-import { AccountsGetResponse, LoginDeleteResponse } from "server";
+import {
+  AccountsGetResponse,
+  LoginDeleteResponse,
+  SearchAccountsGetResponse
+} from "server";
 import {
   Context,
   Category,
@@ -81,8 +85,6 @@ const Accounts = ({
     setSelectedAccount,
     selectedCategory,
     setSelectedCategory,
-    searchHistory,
-    setSearchHistory,
     isAccountsOpen,
     setIsAccountsOpen,
     isWriterOpen,
@@ -124,6 +126,25 @@ const Accounts = ({
     refetchOnReconnect: false,
     retry: false
   });
+
+  // In search mode `selectedAccount` holds the search term. Fetch the accounts
+  // that own a matching mail so the side-tab can list them (clicking one jumps
+  // to that account's All view). Empty term → disabled, so the tab stays empty
+  // until the user types.
+  const searchValue =
+    selectedCategory === Category.Search ? selectedAccount : "";
+  const searchAccountsQuery = useQuery<SearchAccountsGetResponse>(
+    ["/api/mails/search-accounts", searchValue],
+    async () => {
+      const { status, body, message } =
+        await call.get<SearchAccountsGetResponse>(
+          `/api/mails/search-accounts/${encodeURIComponent(searchValue)}`
+        );
+      if (status === "success") return body as SearchAccountsGetResponse;
+      throw new Error(message);
+    },
+    { enabled: !!searchValue, cacheTime: 0, retry: false }
+  );
 
   useEffect(() => {
     if (searchInputDom && isAccountsOpen && !isWriterOpen)
@@ -196,6 +217,16 @@ const Accounts = ({
       const accountName = data.key;
       const unreadNo = data.unread_doc_count;
       const onClickAccount = () => {
+        // A found account in the search side-tab jumps to that account's All
+        // view (the search term lives in selectedAccount, so we must switch
+        // category as well as the account).
+        if (selectedCategory === Category.Search) {
+          setPage(1);
+          setSelectedCategory(Category.AllMails);
+          setSelectedAccount(accountName);
+          if (viewSize.width <= 750) setIsAccountsOpen(false);
+          return;
+        }
         if (selectedAccount !== accountName) {
           setPage(1);
           setSelectedAccount(accountName);
@@ -235,8 +266,8 @@ const Accounts = ({
       sortedAccountData = mergeSavedAccounts(received, sent);
     } else if (selectedCategory === Category.SentMails) {
       sortedAccountData = sent;
-    } else if (selectedCategory === Category.Search && searchHistory) {
-      sortedAccountData = searchHistory;
+    } else if (selectedCategory === Category.Search) {
+      sortedAccountData = searchAccountsQuery.data || [];
     }
 
     const sortingFactor = 2 * +sortAscending - 1;
@@ -266,9 +297,15 @@ const Accounts = ({
     const categoryComponents = Object.values(Category).map((e, i) => {
       const onClickCategory = () => {
         if (e === Category.Search) {
-          // Entering search: save current account so we can restore it later
+          // Entering search: remember the current account to restore on exit,
+          // and start from an empty term so the side-tab (found accounts) and
+          // the mails list stay empty until the user types a keyword.
           preSearchAccount.current = selectedAccount;
-        } else if (selectedCategory === Category.Search) {
+          setSelectedCategory(e);
+          setSelectedAccount("");
+          return;
+        }
+        if (selectedCategory === Category.Search) {
           // Leaving search: restore the pre-search account if we have one
           // (preSearchAccount is a ref and won't survive a page reload)
           if (preSearchAccount.current) {
@@ -281,7 +318,6 @@ const Accounts = ({
         if (e === Category.SentMails) targetAccounts = sent;
         else if (e === Category.NewMails) targetAccounts = received.filter((a) => a.unread_doc_count);
         else if (e === Category.SavedMails) targetAccounts = mergeSavedAccounts(received, sent);
-        else if (e === Category.Search) targetAccounts = searchHistory;
         else targetAccounts = received;
         if (
           targetAccounts.length > 0 &&
@@ -354,16 +390,8 @@ const Accounts = ({
     const onKeyDownSearch: KeyboardEventHandler<HTMLInputElement> = (e) => {
       if (e.key === "Enter") {
         const target = e.target as HTMLInputElement;
-        setSearchHistory([
-          new Account({
-            key: target.value,
-            doc_count: 0,
-            unread_doc_count: 0,
-            saved_doc_count: 0,
-            updated: new Date()
-          }),
-          ...searchHistory
-        ]);
+        // Search immediately instead of waiting out the debounce.
+        clearTimeout(searchDelay);
         setSelectedAccount(target.value);
         if (viewSize.width <= 750) setIsAccountsOpen(false);
       }

--- a/src/server/lib/http/routes/mails/get-search-accounts.ts
+++ b/src/server/lib/http/routes/mails/get-search-accounts.ts
@@ -1,0 +1,18 @@
+import { Account } from "common";
+import { searchAccounts } from "server";
+import { Route } from "../route";
+
+export type SearchAccountsGetResponse = Account[];
+
+export const getSearchAccountsRoute = new Route<SearchAccountsGetResponse>(
+  "GET",
+  "/search-accounts/:value",
+  async (req) => {
+    const user = req.session.user!;
+
+    const value = req.params.value;
+    const result = await searchAccounts(user, value);
+
+    return { status: "success", body: result };
+  }
+);

--- a/src/server/lib/http/routes/mails/index.ts
+++ b/src/server/lib/http/routes/mails/index.ts
@@ -6,6 +6,7 @@ import { getHeadersRoute } from "./get-headers";
 import { getBodyRoute } from "./get-body";
 import { getAttachmentRoute } from "./get-attachment";
 import { getSearchRoute } from "./get-search";
+import { getSearchAccountsRoute } from "./get-search-accounts";
 import { postMarkMailRoute } from "./post-mark";
 import { postSendMailRoute } from "./post-send";
 import { deleteMailRoute } from "./delete";
@@ -30,6 +31,7 @@ const routes = [
   getBodyRoute,
   getAttachmentRoute,
   getSearchRoute,
+  getSearchAccountsRoute,
   postMarkMailRoute,
   postSendMailRoute,
   deleteMailRoute,
@@ -50,6 +52,7 @@ export * from "./get-headers";
 export * from "./get-body";
 export * from "./get-attachment";
 export * from "./get-search";
+export * from "./get-search-accounts";
 export * from "./post-mark";
 export * from "./post-send";
 export * from "./delete";

--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -29,6 +29,7 @@ export {
   addressToUsername,
   saveBuffer,
   getAccounts,
+  searchAccounts,
   getText,
   ATTACHMENT_FOLDER,
   getAttachmentId,

--- a/src/server/lib/mails/accounts.test.ts
+++ b/src/server/lib/mails/accounts.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { SignedUser } from "common";
 
 const mockGetAccountStats = mock(() => Promise.resolve([]));
+const mockSearchAccountStats = mock(() => Promise.resolve([]));
 
 mock.module("../postgres/repositories/mails", () => ({
   getAccountStats: mockGetAccountStats,
+  searchAccountStats: mockSearchAccountStats,
 }));
 
 // Mock getUserDomain from "server" — only mock what accounts.ts actually imports
@@ -13,7 +15,7 @@ mock.module("server", () => ({
     username === "admin" ? "example.com" : `${username}.example.com`,
 }));
 
-import { getAccounts } from "./accounts";
+import { getAccounts, searchAccounts } from "./accounts";
 
 const mockUser = new SignedUser({
   id: "user-123",
@@ -124,5 +126,55 @@ describe("getAccounts", () => {
     expect(result.sent).toHaveLength(1);
     expect(result.received[0].key).toBe("recv@example.com");
     expect(result.sent[0].key).toBe("sent@example.com");
+  });
+});
+
+describe("searchAccounts", () => {
+  beforeEach(() => {
+    mockSearchAccountStats.mockClear();
+    mockSearchAccountStats.mockResolvedValue([]);
+  });
+
+  it("should short-circuit an empty/whitespace term without querying", async () => {
+    expect(await searchAccounts(mockUser, "")).toEqual([]);
+    expect(await searchAccounts(mockUser, "   ")).toEqual([]);
+    expect(mockSearchAccountStats).not.toHaveBeenCalled();
+  });
+
+  it("should query with the trimmed term, user id, and user domain", async () => {
+    await searchAccounts(mockUser, "  invoice  ");
+    expect(mockSearchAccountStats).toHaveBeenCalledWith(
+      "user-123",
+      "invoice",
+      "testuser.example.com"
+    );
+  });
+
+  it("should use the base domain for the admin user", async () => {
+    await searchAccounts(adminUser, "invoice");
+    expect(mockSearchAccountStats).toHaveBeenCalledWith(
+      "admin-1",
+      "invoice",
+      "example.com"
+    );
+  });
+
+  it("should map matching stats to Account objects", async () => {
+    mockSearchAccountStats.mockResolvedValueOnce([
+      { address: "shop@testuser.example.com", count: 4, unread: 2, saved: 1, latest: "2024-02-01" },
+    ]);
+
+    const result = await searchAccounts(mockUser, "invoice");
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("shop@testuser.example.com");
+    expect(result[0].doc_count).toBe(4);
+    expect(result[0].unread_doc_count).toBe(2);
+    expect(result[0].saved_doc_count).toBe(1);
+    expect(result[0].updated).toBe("2024-02-01");
+  });
+
+  it("should return an empty array when no account matches", async () => {
+    const result = await searchAccounts(mockUser, "nomatch");
+    expect(result).toEqual([]);
   });
 });

--- a/src/server/lib/mails/accounts.ts
+++ b/src/server/lib/mails/accounts.ts
@@ -1,5 +1,8 @@
 import { Account, SignedUser } from "common";
-import { getAccountStats } from "../postgres/repositories/mails";
+import {
+  getAccountStats,
+  searchAccountStats,
+} from "../postgres/repositories/mails";
 import { getUserDomain } from "server";
 
 export interface AccountsGetResponse {
@@ -38,4 +41,28 @@ export const getAccounts = async (
   });
 
   return { received, sent };
+};
+
+// Received accounts that own at least one mail matching `value`. Backs the
+// search side-tab: the user types a keyword, this lists the accounts whose mail
+// appears in the results, and clicking one jumps to that account's All view.
+export const searchAccounts = async (
+  user: SignedUser,
+  value: string
+): Promise<Account[]> => {
+  value = value.trim();
+  if (!value) return [];
+
+  const userDomain = getUserDomain(user.username);
+  const stats = await searchAccountStats(user.id, value, userDomain);
+
+  return stats.map((stat) => {
+    return new Account({
+      key: stat.address,
+      doc_count: stat.count,
+      unread_doc_count: stat.unread,
+      saved_doc_count: stat.saved,
+      updated: stat.latest,
+    });
+  });
 };

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -244,31 +244,52 @@ describe("getAccountStats — envelope_to inclusion in received address expansio
   });
 
   it("received-branch address expansion unions envelope_to with to/cc/bcc", () => {
-    // Locate the addressExpansion ternary's received branch — everything
-    // between `addressExpansion = sent ? <sent SQL>` and the final `;`,
-    // dropping the sent SQL portion via the backtick boundary.
-    const exprMatch = fnSource.match(
-      /const\s+addressExpansion\s*=\s*sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+    // The received-branch expansion lives in the shared
+    // RECEIVED_ADDRESS_EXPANSION constant (reused by getAccountStats and
+    // searchAccountStats so the two never drift). getAccountStats' received
+    // branch must reference it.
+    const constMatch = mailsSource.match(
+      /const\s+RECEIVED_ADDRESS_EXPANSION\s*=\s*`([^`]*)`/
     );
-    if (!exprMatch) throw new Error("addressExpansion ternary not found");
-    const receivedSql = exprMatch[1];
+    if (!constMatch) throw new Error("RECEIVED_ADDRESS_EXPANSION not found");
+    const receivedSql = constMatch[1];
     expect(receivedSql).toContain("to_address");
     expect(receivedSql).toContain("cc_address");
     expect(receivedSql).toContain("bcc_address");
     expect(receivedSql).toContain("envelope_to");
+    expect(fnSource).toContain("RECEIVED_ADDRESS_EXPANSION");
   });
 
   it("received-branch null-check includes envelope_to", () => {
     // Otherwise rows with only envelope_to populated (no MIME recipient
     // headers, which happens for some listserv-style senders) would be
-    // filtered out before the address expansion even fires.
-    const exprMatch = fnSource.match(
-      /const\s+addressNotNull\s*=\s*sent\s*\?\s*`[^`]*`\s*:\s*`([^`]*)`\s*;/
+    // filtered out before the address expansion even fires. Also a shared
+    // constant so searchAccountStats inherits the same null-check.
+    const constMatch = mailsSource.match(
+      /const\s+RECEIVED_ADDRESS_NOT_NULL\s*=\s*`([^`]*)`/
     );
-    if (!exprMatch) throw new Error("addressNotNull ternary not found");
-    const receivedSql = exprMatch[1];
+    if (!constMatch) throw new Error("RECEIVED_ADDRESS_NOT_NULL not found");
+    const receivedSql = constMatch[1];
     expect(receivedSql).toContain("to_address IS NOT NULL");
     expect(receivedSql).toContain("envelope_to IS NOT NULL");
+    expect(fnSource).toContain("RECEIVED_ADDRESS_NOT_NULL");
+  });
+
+  it("searchAccountStats reuses the shared received-address constants + full-text predicate", () => {
+    // The search side-tab must list exactly the accounts whose mail appears in
+    // the search results, so searchAccountStats' account attribution has to
+    // match getAccountStats' received path (same envelope_to union) AND filter
+    // to the search term via the same tsquery searchMails uses.
+    const fnMatch = mailsSource.match(
+      /export const searchAccountStats[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("searchAccountStats not found in mails.ts");
+    const src = fnMatch[0];
+    expect(src).toContain("RECEIVED_ADDRESS_EXPANSION");
+    expect(src).toContain("RECEIVED_ADDRESS_NOT_NULL");
+    expect(src).toContain("search_vector @@ plainto_tsquery('english', $2)");
+    expect(src).toContain("expunged = FALSE");
+    expect(src).toContain("draft = FALSE");
   });
 
   it("sent-branch address expansion remains from_address only", () => {

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -607,6 +607,19 @@ export const getAccountUidNext = async (
   }
 };
 
+// Received-account address expansion. Unions to/cc/bcc + envelope_to (the
+// SMTP-level delivery address) so sub-addressed / listserv-routed mail resolves
+// to the receiving account even when the MIME to/cc/bcc omits it (see the long
+// comment in getAccountStats and PR #525). Shared by getAccountStats and
+// searchAccountStats so the two never drift.
+const RECEIVED_ADDRESS_EXPANSION = `jsonb_array_elements(
+  COALESCE(to_address, '[]'::jsonb) ||
+  COALESCE(cc_address, '[]'::jsonb) ||
+  COALESCE(bcc_address, '[]'::jsonb) ||
+  COALESCE(envelope_to, '[]'::jsonb)
+)->>'address' as address`;
+const RECEIVED_ADDRESS_NOT_NULL = `(to_address IS NOT NULL OR cc_address IS NOT NULL OR bcc_address IS NOT NULL OR envelope_to IS NOT NULL)`;
+
 export const getAccountStats = async (
   user_id: string,
   sent: boolean,
@@ -633,16 +646,11 @@ export const getAccountStats = async (
     // FE shows 0 / badge shows N.
     const addressExpansion = sent
       ? `jsonb_array_elements(from_address)->>'address' as address`
-      : `jsonb_array_elements(
-          COALESCE(to_address, '[]'::jsonb) ||
-          COALESCE(cc_address, '[]'::jsonb) ||
-          COALESCE(bcc_address, '[]'::jsonb) ||
-          COALESCE(envelope_to, '[]'::jsonb)
-        )->>'address' as address`;
+      : RECEIVED_ADDRESS_EXPANSION;
 
     const addressNotNull = sent
       ? `from_address IS NOT NULL`
-      : `(to_address IS NOT NULL OR cc_address IS NOT NULL OR bcc_address IS NOT NULL OR envelope_to IS NOT NULL)`;
+      : RECEIVED_ADDRESS_NOT_NULL;
 
     // Use address matching (from_address for sent, to/cc/bcc for received) rather
     // than the `sent` boolean flag, so self-emails appear in both views correctly.
@@ -692,6 +700,69 @@ export const getAccountStats = async (
     }));
   } catch (error) {
     logger.error("Failed to get account stats", {}, error);
+    return [];
+  }
+};
+
+// Received accounts that own at least one mail matching a full-text search
+// term. Mirrors getAccountStats' received path (same address expansion +
+// envelope_to union + domain filter) with the full-text predicate from
+// searchMails added, so the search side-tab lists exactly the accounts whose
+// mails appear in the search results — including sub-addressed deliveries the
+// client payload can't see (envelope_to is server-only). counts/unread/saved
+// reflect only the matching mails.
+export const searchAccountStats = async (
+  user_id: string,
+  searchTerm: string,
+  domainFilter?: string
+): Promise<
+  {
+    address: string;
+    count: number;
+    unread: number;
+    saved: number;
+    latest: Date;
+  }[]
+> => {
+  try {
+    const domainCondition = domainFilter ? `AND address ILIKE '%@' || $3` : "";
+    const sql = `
+      WITH expanded_mails AS (
+        SELECT DISTINCT
+          mail_id, read, saved, date,
+          ${RECEIVED_ADDRESS_EXPANSION}
+        FROM mails
+        WHERE user_id = $1
+          AND expunged = FALSE
+          AND draft = FALSE
+          AND ${RECEIVED_ADDRESS_NOT_NULL}
+          AND search_vector @@ plainto_tsquery('english', $2)
+      )
+      SELECT
+        address,
+        COUNT(*) as count,
+        SUM(CASE WHEN read = FALSE THEN 1 ELSE 0 END) as unread,
+        SUM(CASE WHEN saved = TRUE THEN 1 ELSE 0 END) as saved_count,
+        MAX(date) as latest
+      FROM expanded_mails
+      WHERE address IS NOT NULL
+      ${domainCondition}
+      GROUP BY address
+      ORDER BY latest DESC
+    `;
+    const values: ParamValue[] = domainFilter
+      ? [user_id, searchTerm, domainFilter]
+      : [user_id, searchTerm];
+    const result = await pool.query(sql, values);
+    return result.rows.map((row: Record<string, unknown>) => ({
+      address: row.address as string,
+      count: parseInt(row.count as string, 10),
+      unread: parseInt(row.unread as string, 10),
+      saved: parseInt(row.saved_count as string, 10),
+      latest: new Date(row.latest as string),
+    }));
+  } catch (error) {
+    logger.error("Failed to search account stats", {}, error);
     return [];
   }
 };


### PR DESCRIPTION
Closes #642

## What
Reworks the Search tab's side panel. Previously it showed search **history**; now, when the user types a keyword, the side panel lists the **accounts that own matching mail** and the mails list shows the matching mails (as before).

- **Side tab** → receiving accounts whose mail matches the keyword. Clicking one navigates to the **All** tab with that account selected.
- **Mails list** → the mails matching the keyword (unchanged behavior, still `GET /api/mails/search/:value`).
- Entering Search starts from an empty term (empty side-tab + list until you type); leaving Search restores the pre-search account.

## Why server-side attribution
Account attribution uses `envelope_to` (the SMTP delivery address) in addition to MIME to/cc/bcc — sub-addressed / listserv-routed mail (e.g. GitHub notifications) only names the receiving account in `envelope_to`, which is server-only and never reaches the client search payload. So the found-accounts list can't be derived client-side; it needs a server query.

New `GET /api/mails/search-accounts/:value` → `searchAccountStats`, which mirrors `getAccountStats`' received path (same address expansion + envelope_to union + domain filter) plus the same `plainto_tsquery` full-text predicate `searchMails` uses. The received-path address-expansion SQL is now a shared constant (`RECEIVED_ADDRESS_EXPANSION` / `RECEIVED_ADDRESS_NOT_NULL`) so the stats path and the search path can't drift. Single query per keystroke (debounced), O(matching-rows) — no N+1.

Client: `Accounts` fetches the found accounts via react-query keyed on the term (disabled while the term is empty); `searchHistory` state removed from `Context`.

## Tests
- `accounts.test.ts`: new `searchAccounts` block — empty/whitespace short-circuit (no query), trimmed-term + domain args, admin base-domain, stat→Account mapping, empty result.
- `mails.test.ts`: envelope_to-inclusion guards repointed to the shared constants + assert both `getAccountStats` and `searchAccountStats` reference them; new guard that `searchAccountStats` reuses the constants + full-text/expunged/draft predicates.
- Full server suite: 1117 pass / 0 fail. Client suite: 82 pass / 0 fail. `tsc --noEmit` clean, eslint clean.

## E2E (Playwright, admin login, real mail data — read-only)

Driven against a locally-started dev server. All assertions pass.

**Main flow**
- Login → Search tab → search input renders; side-tab is empty before typing.
- Type `notifications` → server returns 90 found accounts; side-tab renders all 90 (each tag matches a server-returned account key).
- Mails list populates with matching mails.
- Click a found account → jumps to All Mails with that account selected; search input gone; account's headers fetched.

**Entry/exit correctness (regression checks)**
- Entering search: empty side-tab, **zero** `search-accounts` queries fired (no stray fetch on the previously-selected account).
- Leaving search without typing: restores the pre-search account even when it's mid-list (`koreasim@hoie.kim`, not `received[0]`) — not the first account.

**Server-side attribution necessity, verified against real data**
- For `notifications`: 90 found accounts, of which **49 are `envelope_to`-only** (sub-addressed / listserv-routed deliveries whose receiving account never appears in the MIME to/cc/bcc the client search payload carries). Client-side derivation would miss 54% of the accounts — this is why the side-tab is a server query, not a client fold over the search results.
- Spot-checked `searchAccountStats` returns exactly the accounts owning matching mail, with per-account match counts.

Suites: server 1117 pass / 0 fail, client 82 pass / 0 fail, `tsc --noEmit` clean, eslint clean.
