### PR TITLE
feat(client): disable mutating controls when offline (#458 Phase 2)

### DIFF
--- a/src/client/Box/components/Accounts/components/Allowlist/index.scss
+++ b/src/client/Box/components/Accounts/components/Allowlist/index.scss
@@ -128,6 +128,11 @@
       font-size: 1.3rem;
       line-height: 1;
 
+      &:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
       &:focus-visible {
         outline: 2px solid currentColor;
         outline-offset: 2px;

--- a/src/client/Box/components/Accounts/components/Allowlist/index.tsx
+++ b/src/client/Box/components/Accounts/components/Allowlist/index.tsx
@@ -8,7 +8,7 @@ import {
   AllowlistAddBody,
   AllowlistDeleteResponse
 } from "server";
-import { call, onKeyboardActivate, queryClient } from "client";
+import { call, onKeyboardActivate, queryClient, useIsOnline } from "client";
 import { isValidAllowlistPattern } from "./pattern";
 
 import "./index.scss";
@@ -19,6 +19,13 @@ const Allowlist = ({ onClose }: { onClose: () => void }) => {
   const [input, setInput] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
+
+  // The allowlist stays viewable from cache while offline, but its add/remove
+  // mutations are disabled — they'd silently fail against an unreachable server.
+  const { isOnline } = useIsOnline();
+  const offlineTitle = isOnline
+    ? undefined
+    : "You're offline — reconnect to change the allowlist";
 
   const query = useQuery<AllowlistGetResponse>(
     queryUrl,
@@ -124,7 +131,8 @@ const Allowlist = ({ onClose }: { onClose: () => void }) => {
                 <button
                   className="text-button danger"
                   onClick={() => deleteMutation.mutate(entry.pattern)}
-                  disabled={deleteMutation.isLoading}
+                  disabled={deleteMutation.isLoading || !isOnline}
+                  title={offlineTitle}
                 >
                   Remove
                 </button>
@@ -139,7 +147,8 @@ const Allowlist = ({ onClose }: { onClose: () => void }) => {
               <button
                 className="icon-button"
                 aria-label={`Remove ${entry.pattern}`}
-                title="Remove"
+                title={offlineTitle || "Remove"}
+                disabled={!isOnline}
                 onClick={() => {
                   setError(null);
                   setConfirmingId(entry.id);
@@ -196,7 +205,8 @@ const Allowlist = ({ onClose }: { onClose: () => void }) => {
           <button
             className="text-button"
             onClick={handleAdd}
-            disabled={addMutation.isLoading || !input.trim()}
+            disabled={addMutation.isLoading || !input.trim() || !isOnline}
+            title={offlineTitle}
           >
             Add
           </button>

--- a/src/client/Box/components/Accounts/components/Allowlist/index.tsx
+++ b/src/client/Box/components/Accounts/components/Allowlist/index.tsx
@@ -91,6 +91,9 @@ const Allowlist = ({ onClose }: { onClose: () => void }) => {
   }, [onClose]);
 
   const handleAdd = () => {
+    // Guard the shared handler, not just the button — the input's Enter key
+    // (onInputKeyDown) routes here too and would otherwise fire the POST offline.
+    if (!isOnline) return;
     const pattern = input.trim();
     if (!isValidAllowlistPattern(pattern)) {
       setError(

--- a/src/client/Box/components/Accounts/index.scss
+++ b/src/client/Box/components/Accounts/index.scss
@@ -97,6 +97,18 @@
               height: 22px;
             }
 
+            // Offline-disabled control (e.g. logout): dim it and suppress the
+            // hover/active grow so it doesn't read as interactive.
+            &:disabled {
+              opacity: 0.4;
+              cursor: not-allowed;
+
+              &:hover svg,
+              &:active svg {
+                height: 20px;
+              }
+            }
+
             &:focus-visible {
               outline: 2px solid currentColor;
               outline-offset: 2px;

--- a/src/client/Box/components/Accounts/index.tsx
+++ b/src/client/Box/components/Accounts/index.tsx
@@ -32,7 +32,8 @@ import {
   call,
   onKeyboardActivate,
   clearCachedQueries,
-  unregisterServiceWorker
+  unregisterServiceWorker,
+  useIsOnline
 } from "client";
 import { MailsSynchronizer } from "client/Box";
 import { mergeSavedAccounts } from "./savedAccounts";
@@ -89,6 +90,8 @@ const Accounts = ({
     newMailsTotal,
     setNewMailsTotal
   } = useContext(Context);
+
+  const { isOnline } = useIsOnline();
 
   const getAccounts = async () => {
     isFetched = false;
@@ -426,7 +429,12 @@ const Accounts = ({
                 className="icon-button"
                 onClick={onClickLogout}
                 aria-label="Logout"
-                title="Logout"
+                disabled={!isOnline}
+                title={
+                  isOnline
+                    ? "Logout"
+                    : "You're offline — reconnect to log out"
+                }
               >
                 <LogoutIcon />
               </button>

--- a/src/client/Box/components/Mails/index.scss
+++ b/src/client/Box/components/Mails/index.scss
@@ -181,6 +181,19 @@
           height: 22px;
         }
 
+        // Offline-disabled control: dim it and suppress the hover/active grow
+        // so it doesn't read as interactive while mutations are unavailable.
+        &.disabled {
+          cursor: not-allowed;
+          opacity: 0.4;
+
+          &:hover > svg,
+          &:active > svg {
+            width: 20px;
+            height: 20px;
+          }
+        }
+
         .star {
           color: $color-point;
         }

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -303,8 +303,8 @@ const RenderedMail = ({
 
   const isKebabOpen = openedKebab === mail.id;
 
-  // Mutating controls (save, delete) are disabled while offline per the #458
-  // Behavior Matrix; the handlers also early-return as a backstop.
+  // Mutating controls (save, delete) are disabled while offline; the handlers
+  // also early-return as a backstop against a stray click.
   const offlineClass = isOnline ? "" : " disabled";
   const offlineTitle = isOnline
     ? undefined

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -39,7 +39,8 @@ import {
   QueryCache,
   call,
   isSentMail,
-  processHtmlForViewer
+  processHtmlForViewer,
+  useIsOnline
 } from "client";
 import { AccountsCache } from "client/Box/components/Accounts";
 
@@ -136,6 +137,8 @@ const RenderedMail = ({
 
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
 
+  const { isOnline } = useIsOnline();
+
   const queryClient = useQueryClient();
 
   const onClickOpenInNewTab = async () => {
@@ -182,7 +185,10 @@ const RenderedMail = ({
       delete clonedActiveMailId[mail.id];
       setActiveMailId(clonedActiveMailId);
     } else {
-      if (!mail.read) {
+      // Auto-mark-read is a side effect of opening, not a user-clicked
+      // control — so gate the request itself when offline rather than
+      // disabling a button. The mail still opens and renders cached body.
+      if (!mail.read && isOnline) {
         requestMarkRead(mail);
         markReadInQueryData(mail);
         mail.read = true;
@@ -219,6 +225,7 @@ const RenderedMail = ({
   };
 
   const onClickTrash = () => {
+    if (!isOnline) return;
     if (window.confirm("Do you want to delete this mail?")) {
       requestDeleteMail(mail);
 
@@ -259,6 +266,7 @@ const RenderedMail = ({
   };
 
   const onClickStar = () => {
+    if (!isOnline) return;
     requestMarkSaved(mail, !mail.saved);
     markSavedInQueryData(mail, !mail.saved);
   };
@@ -294,6 +302,13 @@ const RenderedMail = ({
   }
 
   const isKebabOpen = openedKebab === mail.id;
+
+  // Mutating controls (save, delete) are disabled while offline per the #458
+  // Behavior Matrix; the handlers also early-return as a backstop.
+  const offlineClass = isOnline ? "" : " disabled";
+  const offlineTitle = isOnline
+    ? undefined
+    : "You're offline — reconnect to make changes";
 
   const summary = ("insight" in mail ? mail.insight?.summary : undefined)?.map(
     (e, i) => {
@@ -349,7 +364,8 @@ const RenderedMail = ({
           <>
             <div
               key="star"
-              className="iconBox cursor"
+              className={"iconBox cursor" + offlineClass}
+              title={offlineTitle}
               onClick={onClickStar}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
@@ -390,7 +406,8 @@ const RenderedMail = ({
             </div>
             <div
               key="trash"
-              className="iconBox cursor"
+              className={"iconBox cursor" + offlineClass}
+              title={offlineTitle}
               onClick={onClickTrash}
               onTouchStart={(e) => e.stopPropagation()}
               onMouseEnter={() => setOpenedKebab(mail.id)}
@@ -410,7 +427,12 @@ const RenderedMail = ({
               </div>
             ) : null}
             {mail.saved ? (
-              <div key="star" className="iconBox cursor" onClick={onClickStar}>
+              <div
+                key="star"
+                className={"iconBox cursor" + offlineClass}
+                title={offlineTitle}
+                onClick={onClickStar}
+              >
                 <SolidStarIcon className="star" />
               </div>
             ) : null}

--- a/src/client/Box/components/Writer/index.scss
+++ b/src/client/Box/components/Writer/index.scss
@@ -153,6 +153,11 @@
       svg {
         margin-right: 0.5rem;
       }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
     }
   }
 

--- a/src/client/Box/components/Writer/index.tsx
+++ b/src/client/Box/components/Writer/index.tsx
@@ -19,7 +19,8 @@ import {
   useLocalStorage,
   getDateForMailHeader,
   processHtmlToSendMail,
-  call
+  call,
+  useIsOnline
 } from "client";
 
 import { CcIcon, SendIcon, AttachIcon, EraserIcon } from "./components";
@@ -81,6 +82,8 @@ const Writer = () => {
     replyData,
     setReplyData
   } = useContext(Context);
+
+  const { isOnline } = useIsOnline();
 
   const [isCcOpen, setIsCcOpen] = useLocalStorage("isCcOpen", false);
 
@@ -414,7 +417,13 @@ const Writer = () => {
         </div>
       </div>
       <div className="writer-buttons">
-        <button onClick={onClickSend}>
+        <button
+          onClick={onClickSend}
+          disabled={!isOnline}
+          title={
+            isOnline ? undefined : "You're offline — reconnect to send mail"
+          }
+        >
           <SendIcon />
           <span>Send</span>
         </button>


### PR DESCRIPTION
## What

Final Phase 2 slice of the IndexedDB offline-read UX (#458). Every mutating control now reads the shared `useIsOnline()` signal (shipped in #638) and becomes unavailable while the server is unreachable, matching the approved design doc's Behavior Matrix ("Mutations: disabled in UI with tooltip").

Before this, no control read `useIsOnline` — a user could hit Send / delete / star while offline and the request would silently fail.

## Changes

- **Writer send button** (`Writer/index.tsx`) — native `disabled` + tooltip when `!isOnline`.
- **Mail save / star** and **delete / trash** (`Mails/index.tsx`, `RenderedMail`) — dimmed + `not-allowed` cursor + tooltip via a `.disabled` class; the `onClickStar` / `onClickTrash` handlers also early-return as a backstop.
- **Auto-mark-read on open** — *gated* (the mark-read request is skipped when offline) rather than disabling a control, because it is an implicit side effect of opening a mail, not a user-clicked button. The mail still opens and renders its cached body.

Purely client-side; no server or SW change. `isOnline` defaults to `true`, so online behavior is unchanged.

## Scope note

This closes the last unshipped item in #458's Behavior Matrix. The remaining open design fork on #458 (SW `/api/*` offline proxy, option (a) vs (b)) is independent and still pending your call — Phase 1 hydrate-before-render + the #638 heartbeat already cover cold-load and mid-session reconnect without it.

Part of #458 (not closing — the SW-proxy design decision remains).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (pre-existing warnings only, unrelated files)
- [x] `bun run build` — server + client build succeed
- [x] `bun test src/client/lib/online.test.ts` — 10 pass / 0 fail
- [x] **UI E2E** — Playwright against sandbox, logged in as admin, `navigator.onLine` forced offline + `/api/ping` aborted:
  - **Online baseline:** Send button enabled; kebab star/trash have no `.disabled` class.
  - **Offline** (banner "Offline — showing data as of HH:MM" appears): Send button `disabled` with tooltip "You're offline — reconnect to send mail"; kebab **star + trash** both carry `.disabled` (dimmed, `not-allowed`) with tooltip "You're offline — reconnect to make changes"; reply/share/open-in-new-tab stay enabled (not mutations). Clicking the disabled trash does nothing (mailcard count unchanged, no confirm dialog).
  - **Mark-read gating:** opening a mail while offline fired **zero** `POST /api/mails/mark` requests, and the mail still opened + rendered its cached body. Control test: opening an *unread* mail while online fired exactly one mark request — so the offline suppression is meaningful, not a no-op.
  - **Reconnect** (`online` event): banner cleared, Send re-enabled.
  - Screenshots: `/tmp/pr-646-online-kebab.png`, `/tmp/pr-646-offline-kebab.png`, `/tmp/pr-646-reconnected.png`.

### Post-review verification (reviewoie round 1 fixes)

- [x] **Allowlist gating** — modal opens + stays viewable offline; **Add** disabled with tooltip "You're offline — reconnect to change the allowlist" (clicking it fires no mutation); added an entry online, went offline → **remove (×)** trigger disabled with the same tooltip, entry not removed. Reconnect re-enables.
- [x] **Logout gating** — offline: logout icon disabled with tooltip "You're offline — reconnect to log out"; reconnect re-enables.
- Screenshots: `/tmp/pr-646v2-allowlist-offline.png`, `/tmp/pr-646v2-logout-offline.png`, `/tmp/pr-646-remove-offline.png`.

### reviewoie round 2 fix

- [x] **Allowlist Enter-key path** — round-1 fix gated the Add *button* but not the shared `handleAdd` handler, so pressing Enter in the input still fired the POST offline. Added an `!isOnline` guard at the handler choke point. E2E: online Enter fires exactly one `POST /api/mails/spam-allowlist` (control); offline Enter fires **zero** and adds no entry.
