### PR TITLE
fix(imap): dedupe source UIDs so overlapping COPY/MOVE ranges clone once (#626)

### DIFF
--- a/src/server/lib/imap/copy.test.ts
+++ b/src/server/lib/imap/copy.test.ts
@@ -352,6 +352,81 @@ describe("COPY COPYUID positional pairing — out-of-order set (#624, RFC 4315 �
   });
 });
 
+describe("COPY overlapping ranges — dedupe by source UID (#626, RFC 4315 §3)", () => {
+  it("clones each distinct source UID once and keeps COPYUID src/dest set lengths equal", async () => {
+    // `UID COPY 3:5,4:6` — the ranges overlap on UIDs 4 and 5. The handler
+    // calls getMessages once per range, so an overlapping UID is materialized
+    // twice. Without the dedupe, each such UID is cloned twice (a duplicate
+    // stored message) AND the COPYUID response desyncs: `formatUidSet`
+    // collapses the source set via `new Set` but the dest set keeps every
+    // clone, so srcSet.length < destSet.length and the positional pairing is
+    // unparseable. The fix drops repeats so each distinct source UID is
+    // copied exactly once.
+    const all = [
+      sourceMail({ domain: 3, account: 30 }),
+      sourceMail({ domain: 4, account: 40 }),
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 6, account: 60 }),
+    ];
+    const { store, stored } = makeCopyStore(["Archive"], all);
+    // Range-aware getMessages so only the overlap (4,5) is returned twice —
+    // faithfully modeling the wire behavior rather than duplicating everything.
+    store.getMessages = async (
+      _box: never,
+      start: never,
+      end: never
+    ) => {
+      const map = new Map<number, Partial<MailType>>();
+      all
+        .filter((m) => m.uid!.domain >= (start as number) && m.uid!.domain <= (end as number))
+        .forEach((m, i) => map.set(i, m));
+      return map as never;
+    };
+
+    const lines = await runCopy(
+      copyReq("Archive", {
+        type: "uid",
+        ranges: [
+          { start: 3, end: 5 },
+          { start: 4, end: 6 },
+        ],
+      }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+
+    // One clone per distinct source UID — pre-#626 stored 6 (4,5 twice).
+    expect(stored.length).toBe(4);
+    const storedSubjects = stored.map((c) => c.subject).sort();
+    expect(storedSubjects).toEqual(["src-3", "src-4", "src-5", "src-6"]);
+
+    const tagged = lines.find((l) => l.startsWith("A1 OK [COPYUID"))!;
+    const m = tagged.match(/\[COPYUID \d+ ([\d,:]+) ([\d,:]+)\]/)!;
+    const expand = (set: string): number[] =>
+      set.split(",").flatMap((part) => {
+        if (!part.includes(":")) return [Number(part)];
+        const [a, b] = part.split(":").map(Number);
+        const out: number[] = [];
+        for (let i = a; i <= b; i++) out.push(i);
+        return out;
+      });
+    const srcSet = expand(m[1]);
+    const destSet = expand(m[2]);
+    // Pre-#626: srcSet dedupes to 4, destSet keeps 6 → lengths diverge.
+    expect(srcSet.length).toBe(destSet.length);
+    expect(srcSet.length).toBe(4);
+
+    // Positional COPYUID mapping resolves to the real stored dest UID.
+    const claimedPairing = new Map<number, number>();
+    srcSet.forEach((s, i) => claimedPairing.set(s, destSet[i]));
+    const actualDestOf = (srcUid: number): number =>
+      stored.find((c) => c.subject === `src-${srcUid}`)!.uid!.account;
+    [3, 4, 5, 6].forEach((u) =>
+      expect(claimedPairing.get(u)).toBe(actualDestOf(u))
+    );
+  });
+});
+
 describe("COPY dispatch — sequence vs UID semantics (#520)", () => {
   it("UID COPY consumes the sequenceSet as UIDs (no seqState lookup)", async () => {
     const ctx = buildStore({ existsBoxes: ["Archive"] });

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -482,6 +482,24 @@ export async function copyMessageTyped(
     // ascending, and `formatUidSet`'s independent sorts stay aligned.
     sourceMails.sort((a, b) => srcUidOf(a) - srcUidOf(b));
 
+    // De-duplicate by source UID. A client may send overlapping ranges
+    // (`UID COPY 3:5,4:6`); `getMessages` runs once per range, so a UID
+    // that falls in two ranges is materialized twice. Cloning it twice
+    // would both store a duplicate message and desync the COPYUID sets:
+    // `formatUidSet` collapses the source set via `new Set` while the dest
+    // set keeps every clone, so `sourceSet.length !== destSet.length` and
+    // the positional n-th-source ↔ n-th-dest correspondence the response
+    // promises is broken. Keep the first occurrence of each source UID so
+    // each is copied exactly once (RFC 4315 copies a message set, not a
+    // bag). The array is already ascending, so dups are adjacent.
+    const seenSourceUids = new Set<number>();
+    const uniqueSourceMails = sourceMails.filter((mail) => {
+      const uid = srcUidOf(mail);
+      if (seenSourceUids.has(uid)) return false;
+      seenSourceUids.add(uid);
+      return true;
+    });
+
     const sourceUids: number[] = [];
     const destUids: number[] = [];
 
@@ -493,7 +511,7 @@ export async function copyMessageTyped(
     // leaves the already-stored copies in the destination. Documented as
     // a limitation; a follow-up can promote this to a multi-row INSERT
     // or transaction.
-    for (const sourceMail of sourceMails) {
+    for (const sourceMail of uniqueSourceMails) {
       // The mails table has UNIQUE(user_id, message_id); the copy must
       // carry a fresh message_id so the INSERT actually creates a new
       // row (otherwise saveMail merges into the source row and the
@@ -743,6 +761,19 @@ export async function moveMessageTyped(
     // explicit high→low sort below, so it is unaffected by this.)
     sourceMails.sort((a, b) => srcUidOf(a) - srcUidOf(b));
 
+    // De-duplicate by source UID before cloning. Overlapping ranges
+    // (`UID MOVE 3:5,4:6`) materialize a UID twice; see copyMessageTyped
+    // for the full rationale (duplicate clone + COPYUID set-length desync).
+    // Deduping here also keeps `sourceUids` — and therefore the EXPUNGE
+    // set below — one entry per distinct source UID.
+    const seenSourceUids = new Set<number>();
+    const uniqueSourceMails = sourceMails.filter((mail) => {
+      const uid = srcUidOf(mail);
+      if (seenSourceUids.has(uid)) return false;
+      seenSourceUids.add(uid);
+      return true;
+    });
+
     const sourceUids: number[] = [];
     const destUids: number[] = [];
 
@@ -750,7 +781,7 @@ export async function moveMessageTyped(
     const getRandomId = (await import("common")).getRandomId;
 
     // === COPY phase (mirrors copyMessageTyped's fixed shape) ===
-    for (const sourceMail of sourceMails) {
+    for (const sourceMail of uniqueSourceMails) {
       const newMail = new Mail({
         subject: sourceMail.subject,
         date: sourceMail.date,

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -366,6 +366,62 @@ describe("MOVE happy path — INBOX → non-INBOX dest (#453, RFC 6851 §3.2-§3
   });
 });
 
+describe("MOVE overlapping ranges — dedupe by source UID (#626, RFC 4315 §3 via RFC 6851)", () => {
+  it("clones each distinct source UID once, keeps COPYUID sets aligned, and expunges each UID once", async () => {
+    // `UID MOVE 3:5,4:6` — overlap on 4,5. Same defect as COPY plus the
+    // expunge set: without the dedupe, `sourceUids` (and therefore the
+    // targeted EXPUNGE set) carries 4 and 5 twice.
+    const all = [
+      sourceMail({ domain: 3, account: 30 }),
+      sourceMail({ domain: 4, account: 40 }),
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 6, account: 60 }),
+    ];
+    const { store, stored, getExpungeArg } = makeMoveStore(["Archive"], all);
+    // Range-aware getMessages: only the overlap is returned twice.
+    store.getMessages = (async (
+      _box: string,
+      start: number,
+      end: number
+    ) => {
+      const map = new Map<number, Partial<MailType>>();
+      all
+        .filter((m) => m.uid!.domain >= start && m.uid!.domain <= end)
+        .forEach((m, i) => map.set(i, m));
+      return map;
+    }) as never;
+    const seqState: SequenceState = {
+      seqToUid: [3, 4, 5, 6],
+      uidToSeq: new Map([
+        [3, 1],
+        [4, 2],
+        [5, 3],
+        [6, 4],
+      ]),
+    };
+
+    await runMove(
+      moveReq("Archive", {
+        type: "uid",
+        ranges: [
+          { start: 3, end: 5 },
+          { start: 4, end: 6 },
+        ],
+      }),
+      true,
+      store,
+      false,
+      "INBOX",
+      seqState
+    );
+
+    // One clone per distinct source UID — pre-#626 stored 6 (4,5 twice).
+    expect(stored.length).toBe(4);
+    // The targeted expunge hits each source UID exactly once, ascending.
+    expect(getExpungeArg()).toEqual([3, 4, 5, 6]);
+  });
+});
+
 describe("MOVE happy path — non-INBOX source → INBOX dest (#453, address-clear invariant)", () => {
   it("clears to/envelopeTo/cc/bcc routing so the moved copy does not re-surface in the source account view", async () => {
     // Source is a per-account mailbox (Archive). The source row carries


### PR DESCRIPTION
## What

`UID COPY 3:5,4:6` / `UID MOVE 3:5,4:6` — a sequence-set with **overlapping ranges** — cloned a source UID that falls in two ranges **twice** and produced a malformed RFC 4315 `[COPYUID …]` response.

`copyMessageTyped` / `moveMessageTyped` call `store.getMessages` **once per range object**, appending each batch to `sourceMails`. An overlapping UID is therefore materialized twice → two clones → two dest UIDs. The COPYUID response then builds its two sets with `formatUidSet`, which dedupes via `new Set`: the source set collapses the repeat to one entry while the dest set keeps both, so `srcSet.length !== destSet.length` and the positional n-th-source ↔ n-th-dest correspondence the response promises is broken — under a tagged `OK`.

## Fix

De-duplicate `sourceMails` by source UID (keep the first occurrence) right after the existing ascending sort, in both `copyMessageTyped` and `moveMessageTyped`. Each distinct source UID is then copied exactly once (RFC 4315 copies a message *set*, not a bag). For MOVE this also keeps the targeted EXPUNGE set (`sourceUids`) one entry per source UID.

Orthogonal to #624/PR #625 (that fixed the source/dest *ordering* desync for non-ascending sets via the sort); this fixes the *duplication* desync for overlapping sets. Both live identically on `main` before their respective fixes. Surfaced by reviewoie on PR #625.

Closes #626

## Scope

3 files, +~55 LOC (2 source blocks + 2 regression tests):
- `message-ops.ts` — dedupe filter after the sort in both functions.
- `copy.test.ts`, `move.test.ts` — overlapping-range regression tests.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — no new warnings from the changed files
- [x] `bun test src/server` — **1113 pass / 0 fail** (confirms no `mock.module` bleed from the new range-aware `getMessages` overrides)
- [x] **Baseline-reproduces → fix-corrects** (FakePool-driven, real `copyMessageTyped`/`moveMessageTyped` — only the `pg` Pool is faked so dest-UID assignment is deterministic; the real range-loop + dedupe + COPYUID-build code runs). Range-aware `getMessages` returns only the overlap (UIDs 4,5) twice, faithfully modeling the wire behavior for `3:5,4:6`:
  - **COPY** — `UID COPY 3:5,4:6` over source UIDs {3,4,5,6}. **Baseline (fix stashed, tests kept):** `stored.length === 6` (UIDs 4,5 cloned twice) → assertion fails, proving the duplication. **Fix:** `stored.length === 4`, one clone per distinct UID (`src-3..src-6`), COPYUID `srcSet.length === destSet.length === 4`, and each claimed positional pair resolves to the real stored dest UID.
  - **MOVE** — same set. **Baseline:** `stored.length === 6` → fails. **Fix:** 4 clones + the targeted EXPUNGE set is `[3,4,5,6]` (each source UID expunged exactly once, not twice).

**Why this surface (no Playwright UI):** no browser screen consumes IMAP COPYUID; live-IMAP COPY/MOVE against the local sandbox is write-unsafe (it inserts + expunges rows, and the sandbox server reads the real local DB), and the defect is invisible in the COPYUID string alone — it only surfaces by correlating each stored clone to its assigned dest UID + counting clones, exactly what the FakePool tests do against the production functions (the same surface #619/#625 used and reviewoie approved).
