### PR TITLE
fix(imap): emit absent ENVELOPE address members as bare NIL, not (NIL) (#636)

### DIFF
--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -254,6 +254,37 @@ describe("IMAP util", () => {
       const result = formatEnvelope(mail);
       expect(result).toContain('"John Doe" NIL "john" "example.com"');
     });
+
+    it("emits absent address-list members as bare NIL, not (NIL) (RFC 3501 §7.4.2)", () => {
+      // Empty mail: every one of the six address slots (from, sender,
+      // reply-to, to, cc, bcc) must be the bare atom NIL. `(NIL)` matches
+      // neither `nil` nor `"(" 1*address ")"` in the §9 grammar.
+      const result = formatEnvelope({});
+      expect(result).not.toContain("(NIL)");
+      // date subject from sender reply-to to cc bcc in-reply-to message-id,
+      // all absent → ten bare NILs wrapped in one outer paren.
+      expect(result).toBe("(NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL)");
+    });
+
+    it("keeps populated address slots parenthesized while absent ones stay bare NIL", () => {
+      // Typical received mail: From + To present, no Cc/Bcc/Reply-To.
+      const mail: Partial<MailType> = {
+        from: {
+          text: "John <john@example.com>",
+          value: [{ name: "John", address: "john@example.com" }]
+        },
+        to: {
+          text: "Jane <jane@example.com>",
+          value: [{ name: "Jane", address: "jane@example.com" }]
+        }
+      };
+      const result = formatEnvelope(mail);
+      // Populated from/sender/to keep their single wrapping paren...
+      expect(result).toContain('(("John" NIL "john" "example.com"))');
+      expect(result).toContain('(("Jane" NIL "jane" "example.com"))');
+      // ...and the absent reply-to/cc/bcc are bare NIL, not (NIL).
+      expect(result).not.toContain("(NIL)");
+    });
   });
 
   describe("formatHeaders", () => {

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -117,7 +117,13 @@ export const formatEnvelope = (mail: Partial<MailType>): string => {
   const inReplyTo = "NIL"; // Not implemented
   const messageId = mail.messageId ? `"${mail.messageId}"` : "NIL";
 
-  return `(${date} ${subject} (${from}) (${sender}) (${replyTo}) (${to}) (${cc}) (${bcc}) ${inReplyTo} ${messageId})`;
+  // RFC 3501 §7.4.2 / §9: each address-list envelope member is either the
+  // bare atom `NIL` (its header is absent) or a parenthesized `1*address`
+  // list — never `(NIL)`. `formatAddressList` already returns bare "NIL" for
+  // an empty/absent list, so only the populated case gets the parentheses.
+  const addressList = (list: string) => (list === "NIL" ? "NIL" : `(${list})`);
+
+  return `(${date} ${subject} ${addressList(from)} ${addressList(sender)} ${addressList(replyTo)} ${addressList(to)} ${addressList(cc)} ${addressList(bcc)} ${inReplyTo} ${messageId})`;
 };
 
 export const formatBodyStructure = (mail: Partial<MailType>): string => {


### PR DESCRIPTION
## What

`FETCH ENVELOPE` (and `FETCH ALL` / `FETCH FULL`, which embed ENVELOPE) rendered each **absent** address-list member as `(NIL)` instead of the bare atom `NIL` that RFC 3501 §7.4.2 / §9 require. Because the vast majority of real emails have no `Cc`, `Bcc`, or `Reply-To` header, nearly every `FETCH ENVELOPE` produced a structurally invalid response that a strict IMAP client (or any client that round-trips/validates the ENVELOPE) rejects.

## Root cause

`formatAddressList` (`src/server/lib/imap/util.ts:9`) already returns the bare string `"NIL"` for an empty/absent list. But `formatEnvelope` (`util.ts:120`) unconditionally wrapped all six address slots in parentheses — turning that bare `NIL` into `(NIL)`. Per the §9 grammar, `env-cc = "(" 1*address ")" / nil`: `(NIL)` matches neither alternative (it isn't the atom `NIL`, and a paren list whose only token is `NIL` is not a valid `1*address`).

Non-address members (date, subject, in-reply-to, message-id) were already emitted correctly as bare `NIL` — only the six address members carried the spurious wrap.

## Fix

Introduce a local `addressList` helper that parenthesizes **only** the populated case and passes bare `NIL` through unwrapped. The populated path is byte-for-byte unchanged (`formatAddressList` returns the inner `("Name" NIL "local" "host")` with no outer paren, so the helper still adds the single required pair).

```
const addressList = (list) => (list === "NIL" ? "NIL" : `(${list})`);
```

Purely a response-serializer fix. Server-only, no schema/API-shape change.

## Why existing tests missed it

- `util.test.ts` empty-envelope case only asserted the `"NIL NIL"` substring (matching the correct date/subject NILs) and never inspected the address slots.
- The populated-address tests only exercise non-empty lists, where the wrap is correct.

No test fed an empty `cc`/`bcc`/`reply-to` and asserted a bare `NIL`.

## Test plan

- [x] `bun test src/server/lib/imap/util.test.ts` — 48 pass / 0 fail (2 new regressions):
  - empty envelope renders exactly ten bare NILs `(NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL)` — asserts `not.toContain("(NIL)")`.
  - a From+To mail keeps its populated `from`/`sender`/`to` slots parenthesized while the absent `reply-to`/`cc`/`bcc` stay bare `NIL`.
- [x] `bun test src/server/lib/imap` — 521 pass / 0 fail (no existing test asserted the old `(NIL)` output, so nothing regressed; the four ENVELOPE-touching suites — `fetch-helpers`, `index`, `session-utils`, `util` — all stay green).
- [x] `bun run typecheck` — clean.
- [x] `eslint` on the two changed files — clean.

This is a server-side wire-format fix with no browser surface, so E2E is the `bun test` execution of the real `formatEnvelope` (a pure function) shown above — not a Playwright path.

Closes #636
