### PR TITLE
fix(client-error): skip alarm on benign ResizeObserver browser messages

### DIFF
--- a/src/server/lib/http/routes/client-error.test.ts
+++ b/src/server/lib/http/routes/client-error.test.ts
@@ -92,3 +92,34 @@ describe("POST /api/client-error rate limiting (issue #517)", () => {
     expect(args[2]).toBe("client-error");
   });
 });
+
+describe("POST /api/client-error benign-message denylist (issue #629)", () => {
+  // The ResizeObserver "loop" messages are a benign Chrome quirk — no stack, no
+  // user-visible failure. They should be accepted (200) but never paged.
+  it("does not alarm on 'ResizeObserver loop completed with undelivered notifications'", async () => {
+    const res = await postClientError("203.0.113.10", {
+      message: "ResizeObserver loop completed with undelivered notifications.",
+      url: "https://mail.example.com/",
+    });
+    expect(res.status).toBe(200);
+    expect(mockSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it("does not alarm on 'ResizeObserver loop limit exceeded'", async () => {
+    const res = await postClientError("203.0.113.11", {
+      message: "ResizeObserver loop limit exceeded",
+    });
+    expect(res.status).toBe(200);
+    expect(mockSendAlarm).not.toHaveBeenCalled();
+  });
+
+  it("still alarms on a real error that merely mentions ResizeObserver elsewhere", async () => {
+    const res = await postClientError("203.0.113.12", {
+      message:
+        "TypeError: cannot read 'observe' of undefined in ResizeObserver setup",
+      stack: "at setup (app.js:10)",
+    });
+    expect(res.status).toBe(200);
+    expect(mockSendAlarm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/lib/http/routes/client-error.ts
+++ b/src/server/lib/http/routes/client-error.ts
@@ -18,6 +18,20 @@ type ClientErrorBody = {
   url?: string;
 };
 
+// Browser-emitted messages that are benign quirks, not real errors. The
+// ResizeObserver "loop" messages fire when a ResizeObserver callback can't
+// settle within a single animation frame during rapid layout changes — a
+// Chrome diagnostic with no stack, no user-visible failure, and no server
+// fault. They are still logged, but never forwarded to the alarm webhook so a
+// benign frontend quirk can't page an operator (issue #629).
+const BENIGN_CLIENT_MESSAGES = [
+  "ResizeObserver loop completed with undelivered notifications",
+  "ResizeObserver loop limit exceeded",
+];
+
+const isBenignClientMessage = (message: string): boolean =>
+  BENIGN_CLIENT_MESSAGES.some((benign) => message.includes(benign));
+
 /**
  * POST /client-error
  *
@@ -39,6 +53,13 @@ clientErrorRouter.post("/", clientErrorLimiter.middleware, async (req, res) => {
   const url = typeof body.url === "string" ? body.url : "";
 
   console.error("Client error reported:", { url, message });
+
+  // A benign browser quirk (logged above) is not an alarm-worthy event. Skip
+  // the webhook forward but still ack so the beacon doesn't retry.
+  if (isBenignClientMessage(message)) {
+    res.json({ status: "success" });
+    return;
+  }
 
   const detail = [
     url ? `**URL:** ${url}` : null,


### PR DESCRIPTION
## Summary

`POST /api/client-error` forwarded **every** reported message to the Discord alarm webhook, including the benign Chrome quirk:

> `ResizeObserver loop completed with undelivered notifications.`

This fires when a ResizeObserver callback can't settle within a single animation frame during rapid layout changes (e.g. opening a mail body while the pane resizes). No stack, no user-visible failure, no server fault — but it paged an operator (real alarm 1520903653701980454 on 2026-06-28).

## Fix

Add a small benign-message denylist in the route handler. Matched messages are **still logged** (`console.error`) but skip the `sendAlarm` forward and ack normally so the beacon doesn't retry. The rate-limit slot is still consumed (an attacker can't bypass the volume cap by sending benign strings).

Denylist (substring match on the full phrase):
- `ResizeObserver loop completed with undelivered notifications`
- `ResizeObserver loop limit exceeded`

A real error that merely *mentions* `ResizeObserver` still alarms — the match is on the full benign phrase, not the word.

Scope: the one route handler + its test. This is the defensive filter at the alarm boundary; fixing the ResizeObserver loop at its source (`adjustMailContentSize`) is the separate, still-open #632.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/server` — 1114 pass / 0 fail (whole tree, no mock-module bleed)
- [x] `bunx eslint` on changed files — clean
- [x] Unit (`client-error.test.ts`, 3 new): benign "completed" + "limit exceeded" → 200, `sendAlarm` not called; real error mentioning ResizeObserver → 200, `sendAlarm` called once.
- [x] **Live-route E2E** — drove the **real** router + **real** `sendAlarm` against a local webhook-capture server (the actual forward path, not a mock). No browser UI consumes this route, so `/api/client-error` is the correct surface:
  - `ResizeObserver loop completed with undelivered notifications.` → http 200, **0** webhook captures.
  - `ResizeObserver loop limit exceeded` → http 200, **0** webhook captures.
  - `TypeError: undefined is not a function` → http 200, **1** webhook capture (still alarms).
  - `TypeError in ResizeObserver setup handler` → http 200, **1** webhook capture (word-mention still alarms).

Closes #629
