### PR TITLE
fix(imap): bound NOT/OR search operands so trailing keys parse

### DIFF
--- a/src/server/lib/imap/parsers/search-parsers.test.ts
+++ b/src/server/lib/imap/parsers/search-parsers.test.ts
@@ -465,6 +465,25 @@ describe("parseSearchCriteria", () => {
       expect(result.value).toEqual([]);
     });
   });
+
+  // An atom that matches no known search-key is skipped and the loop continues
+  // (historical lenient behavior). Pins that invariant plus the no-infinite-loop
+  // guarantee — parseSearchKey must advance past the unknown atom.
+  describe("unknown search key", () => {
+    it("skips an unknown atom and continues to the next key", () => {
+      const c = ctx("FOO SEEN");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual([{ type: "SEEN" }]);
+    });
+
+    it("returns empty (still success) for a sole unknown atom", () => {
+      const c = ctx("FOO");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value).toEqual([]);
+    });
+  });
 });
 
 describe("parseSearch", () => {

--- a/src/server/lib/imap/parsers/search-parsers.test.ts
+++ b/src/server/lib/imap/parsers/search-parsers.test.ts
@@ -350,6 +350,81 @@ describe("parseSearchCriteria", () => {
         expect(criterion.right.type).toBe("DELETED");
       }
     });
+
+    // Regression: an operator followed by MORE top-level keys used to be
+    // rejected because NOT/OR recursed into the unbounded criteria parser,
+    // which greedily consumed every remaining key into the operand and then
+    // failed the operand-length guard (#637).
+    it("parses NOT SEEN followed by another ANDed key", () => {
+      const c = ctx("NOT SEEN SINCE 1-Jan-2026");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.length).toBe(2);
+      expect(result.value?.[0]).toEqual({
+        type: "NOT",
+        criterion: { type: "SEEN" },
+      });
+      expect(result.value?.[1]?.type).toBe("SINCE");
+    });
+
+    it("parses NOT SEEN FROM bob (NOT bounds to one key)", () => {
+      const c = ctx("NOT SEEN FROM bob");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.length).toBe(2);
+      expect(result.value?.[0]).toEqual({
+        type: "NOT",
+        criterion: { type: "SEEN" },
+      });
+      expect(result.value?.[1]).toEqual({ type: "FROM", value: "bob" });
+    });
+
+    it("parses OR SEEN ANSWERED followed by another ANDed key", () => {
+      const c = ctx("OR SEEN ANSWERED FROM bob");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.length).toBe(2);
+      expect(result.value?.[0]).toEqual({
+        type: "OR",
+        left: { type: "SEEN" },
+        right: { type: "ANSWERED" },
+      });
+      expect(result.value?.[1]).toEqual({ type: "FROM", value: "bob" });
+    });
+
+    it("parses an operator that appears before other keys (SINCE … NOT SEEN)", () => {
+      const c = ctx("SINCE 1-Jan-2026 NOT SEEN");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.length).toBe(2);
+      expect(result.value?.[0]?.type).toBe("SINCE");
+      expect(result.value?.[1]).toEqual({
+        type: "NOT",
+        criterion: { type: "SEEN" },
+      });
+    });
+
+    it("parses nested NOT NOT SEEN", () => {
+      const c = ctx("NOT NOT SEEN");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({
+        type: "NOT",
+        criterion: { type: "NOT", criterion: { type: "SEEN" } },
+      });
+    });
+
+    it("parses OR with a NOT operand (OR NOT SEEN FLAGGED)", () => {
+      const c = ctx("OR NOT SEEN FLAGGED");
+      const result = parseSearchCriteria(c);
+      expect(result.success).toBe(true);
+      expect(result.value?.length).toBe(1);
+      expect(result.value?.[0]).toEqual({
+        type: "OR",
+        left: { type: "NOT", criterion: { type: "SEEN" } },
+        right: { type: "FLAGGED" },
+      });
+    });
   });
 
   describe("multiple criteria", () => {

--- a/src/server/lib/imap/parsers/search-parsers.ts
+++ b/src/server/lib/imap/parsers/search-parsers.ts
@@ -46,406 +46,21 @@ export const parseSearchCriteria = (
   const start = context.position;
   const criteria: SearchCriterion[] = [];
 
+  // A top-level SEARCH is `1*(SP search-key)` — space-separated keys ANDed
+  // together (RFC 3501 §6.4.4). Parse them one key at a time; NOT/OR each
+  // consume a bounded number of following keys via parseSearchKey and hand
+  // control back here for the rest.
   while (context.position < context.length) {
     skipWhitespace(context);
     if (context.position >= context.length) break;
-    const { position } = context;
-    // Try to parse as sequence set first
-    const sequenceSet = parseSequenceSet(context);
-    if (sequenceSet.success) {
-      criteria.push({ type: "UID", sequenceSet: sequenceSet.value! });
-    } else {
-      // reset position if sequence set parse failed
-      context.position = position;
 
-      const atom = parseAtom(context);
-      const itemName = atom.value!.toUpperCase();
-
-      // Handle simple items
-      switch (itemName) {
-        case "ALL":
-          criteria.push({ type: "ALL" });
-          break;
-        case "ANSWERED":
-          criteria.push({ type: "ANSWERED" });
-          break;
-        case "DELETED":
-          criteria.push({ type: "DELETED" });
-          break;
-        case "FLAGGED":
-          criteria.push({ type: "FLAGGED" });
-          break;
-        case "NEW":
-          criteria.push({ type: "NEW" });
-          break;
-        case "OLD":
-          criteria.push({ type: "OLD" });
-          break;
-        case "RECENT":
-          criteria.push({ type: "RECENT" });
-          break;
-        case "SEEN":
-          criteria.push({ type: "SEEN" });
-          break;
-        case "UNANSWERED":
-          criteria.push({ type: "UNANSWERED" });
-          break;
-        case "UNDELETED":
-          criteria.push({ type: "UNDELETED" });
-          break;
-        case "UNFLAGGED":
-          criteria.push({ type: "UNFLAGGED" });
-          break;
-        case "UNSEEN":
-          criteria.push({ type: "UNSEEN" });
-          break;
-        case "DRAFT":
-          criteria.push({ type: "DRAFT" });
-          break;
-        case "UNDRAFT":
-          criteria.push({ type: "UNDRAFT" });
-          break;
-        case "KEYWORD":
-          skipWhitespace(context);
-          const keywordFlag = parseAtom(context);
-          if (keywordFlag.success) {
-            criteria.push({ type: "KEYWORD", flag: keywordFlag.value! });
-          } else {
-            return {
-              success: false,
-              error: "Expected flag after KEYWORD",
-              consumed: 0
-            };
-          }
-          break;
-        case "UNKEYWORD":
-          skipWhitespace(context);
-          const unkeywordFlag = parseAtom(context);
-          if (unkeywordFlag.success) {
-            criteria.push({
-              type: "UNKEYWORD",
-              flag: unkeywordFlag.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected flag after UNKEYWORD",
-              consumed: 0
-            };
-          }
-          break;
-        case "BEFORE":
-          skipWhitespace(context);
-          const beforeDate = parseDate(context);
-          if (beforeDate.success) {
-            criteria.push({
-              type: "BEFORE",
-              date: beforeDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after BEFORE",
-              consumed: 0
-            };
-          }
-          break;
-        case "ON":
-          skipWhitespace(context);
-          const onDate = parseDate(context);
-          if (onDate.success) {
-            criteria.push({
-              type: "ON",
-              date: onDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after ON",
-              consumed: 0
-            };
-          }
-          break;
-        case "SINCE":
-          skipWhitespace(context);
-          const sinceDate = parseDate(context);
-          if (sinceDate.success) {
-            criteria.push({
-              type: "SINCE",
-              date: sinceDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after SINCE",
-              consumed: 0
-            };
-          }
-          break;
-        case "SENTBEFORE":
-          skipWhitespace(context);
-          const sentBeforeDate = parseDate(context);
-          if (sentBeforeDate.success) {
-            criteria.push({
-              type: "SENTBEFORE",
-              date: sentBeforeDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after SENTBEFORE",
-              consumed: 0
-            };
-          }
-          break;
-        case "SENTON":
-          skipWhitespace(context);
-          const sentOnDate = parseDate(context);
-          if (sentOnDate.success) {
-            criteria.push({
-              type: "SENTON",
-              date: sentOnDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after SENTON",
-              consumed: 0
-            };
-          }
-          break;
-        case "SENTSINCE":
-          skipWhitespace(context);
-          const sentSinceDate = parseDate(context);
-          if (sentSinceDate.success) {
-            criteria.push({
-              type: "SENTSINCE",
-              date: sentSinceDate.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected date after SENTSINCE",
-              consumed: 0
-            };
-          }
-          break;
-        case "FROM":
-          skipWhitespace(context);
-          const fromValue = parseString(context);
-          if (fromValue.success) {
-            criteria.push({
-              type: "FROM",
-              value: fromValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after FROM",
-              consumed: 0
-            };
-          }
-          break;
-        case "TO":
-          skipWhitespace(context);
-          const toValue = parseString(context);
-          if (toValue.success) {
-            criteria.push({
-              type: "TO",
-              value: toValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after TO",
-              consumed: 0
-            };
-          }
-          break;
-        case "CC":
-          skipWhitespace(context);
-          const ccValue = parseString(context);
-          if (ccValue.success) {
-            criteria.push({
-              type: "CC",
-              value: ccValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after CC",
-              consumed: 0
-            };
-          }
-          break;
-        case "BCC":
-          skipWhitespace(context);
-          const bccValue = parseString(context);
-          if (bccValue.success) {
-            criteria.push({
-              type: "BCC",
-              value: bccValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after BCC",
-              consumed: 0
-            };
-          }
-          break;
-        case "SUBJECT":
-          skipWhitespace(context);
-          const subjectValue = parseString(context);
-          if (subjectValue.success) {
-            criteria.push({
-              type: "SUBJECT",
-              value: subjectValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after SUBJECT",
-              consumed: 0
-            };
-          }
-          break;
-        case "BODY":
-          skipWhitespace(context);
-          const bodyValue = parseString(context);
-          if (bodyValue.success) {
-            criteria.push({
-              type: "BODY",
-              value: bodyValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after BODY",
-              consumed: 0
-            };
-          }
-          break;
-        case "TEXT":
-          skipWhitespace(context);
-          const textValue = parseString(context);
-          if (textValue.success) {
-            criteria.push({
-              type: "TEXT",
-              value: textValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected text value after TEXT",
-              consumed: 0
-            };
-          }
-          break;
-        case "HEADER":
-          skipWhitespace(context);
-          const headerField = parseString(context);
-          skipWhitespace(context);
-          const headerValue = parseString(context);
-          if (headerField.success && headerValue.success) {
-            criteria.push({
-              type: "HEADER",
-              field: headerField.value!,
-              value: headerValue.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected field & value after HEADER",
-              consumed: 0
-            };
-          }
-          break;
-        case "UID":
-          skipWhitespace(context);
-          const uidSequenceSet = parseSequenceSet(context);
-          if (uidSequenceSet.success) {
-            criteria.push({
-              type: "UID",
-              sequenceSet: uidSequenceSet.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected sequence set after UID",
-              consumed: 0
-            };
-          }
-          break;
-        case "LARGER":
-          skipWhitespace(context);
-          const largerSize = parseNumber(context);
-          if (largerSize.success) {
-            criteria.push({
-              type: "LARGER",
-              size: largerSize.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected size after LARGER",
-              consumed: 0
-            };
-          }
-          break;
-        case "SMALLER":
-          skipWhitespace(context);
-          const smallerSize = parseNumber(context);
-          if (smallerSize.success) {
-            criteria.push({
-              type: "SMALLER",
-              size: smallerSize.value!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected size after SMALLER",
-              consumed: 0
-            };
-          }
-          break;
-        case "NOT":
-          skipWhitespace(context);
-          const notCriteria = parseSearchCriteria(context);
-          if (notCriteria.success && notCriteria.value?.length === 1) {
-            criteria.push({
-              type: "NOT",
-              criterion: notCriteria.value[0]!
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected exactly 1 search criterion after NOT",
-              consumed: 0
-            };
-          }
-          break;
-        case "OR":
-          skipWhitespace(context);
-          const orCriteria = parseSearchCriteria(context);
-          if (orCriteria.success && orCriteria.value?.length === 2) {
-            const orCriteriaLeft = orCriteria.value![0];
-            const orCriteriaRight = orCriteria.value![1];
-            criteria.push({
-              type: "OR",
-              left: orCriteriaLeft,
-              right: orCriteriaRight
-            });
-          } else {
-            return {
-              success: false,
-              error: "Expected exactly 2 search criteria after OR",
-              consumed: 0
-            };
-          }
-          break;
-      }
+    const key = parseSearchKey(context);
+    if (!key.success) {
+      return { success: false, error: key.error, consumed: 0 };
     }
+    // A recognized atom that matches no known key yields `null` — skip it and
+    // continue, preserving the loop's historical lenient behavior.
+    if (key.value) criteria.push(key.value);
   }
 
   return {
@@ -453,4 +68,340 @@ export const parseSearchCriteria = (
     value: criteria,
     consumed: context.position - start
   };
+};
+
+/**
+ * Parse exactly one top-level search-key (RFC 3501 §6.4.4). Leading whitespace
+ * must already be skipped by the caller.
+ *
+ * Returning a single criterion (rather than looping to end-of-line as
+ * parseSearchCriteria does) is what lets the bounded operators consume the
+ * right number of operands: `NOT SP search-key` takes one following key, `OR
+ * SP search-key SP search-key` takes two. Both then return control to the
+ * top-level loop for any remaining ANDed keys — so `NOT SEEN SINCE 1-Jan-2026`
+ * parses as `[NOT SEEN] AND [SINCE …]` instead of failing the old operand
+ * length guard.
+ *
+ * Returns `null` (still `success`) for an atom that matches no known key,
+ * mirroring the top-level loop's historical skip-and-continue behavior.
+ */
+const parseSearchKey = (
+  context: ParseContext
+): ParseResult<SearchCriterion | null> => {
+  const start = context.position;
+  const ok = (
+    value: SearchCriterion | null
+  ): ParseResult<SearchCriterion | null> => ({
+    success: true,
+    value,
+    consumed: context.position - start
+  });
+
+  // Try to parse as sequence set first
+  const sequenceSet = parseSequenceSet(context);
+  if (sequenceSet.success) {
+    return ok({ type: "UID", sequenceSet: sequenceSet.value! });
+  }
+  // reset position if sequence set parse failed
+  context.position = start;
+
+  const atom = parseAtom(context);
+  const itemName = atom.value!.toUpperCase();
+
+  // Handle simple items
+  switch (itemName) {
+    case "ALL":
+      return ok({ type: "ALL" });
+    case "ANSWERED":
+      return ok({ type: "ANSWERED" });
+    case "DELETED":
+      return ok({ type: "DELETED" });
+    case "FLAGGED":
+      return ok({ type: "FLAGGED" });
+    case "NEW":
+      return ok({ type: "NEW" });
+    case "OLD":
+      return ok({ type: "OLD" });
+    case "RECENT":
+      return ok({ type: "RECENT" });
+    case "SEEN":
+      return ok({ type: "SEEN" });
+    case "UNANSWERED":
+      return ok({ type: "UNANSWERED" });
+    case "UNDELETED":
+      return ok({ type: "UNDELETED" });
+    case "UNFLAGGED":
+      return ok({ type: "UNFLAGGED" });
+    case "UNSEEN":
+      return ok({ type: "UNSEEN" });
+    case "DRAFT":
+      return ok({ type: "DRAFT" });
+    case "UNDRAFT":
+      return ok({ type: "UNDRAFT" });
+    case "KEYWORD": {
+      skipWhitespace(context);
+      const keywordFlag = parseAtom(context);
+      if (keywordFlag.success) {
+        return ok({ type: "KEYWORD", flag: keywordFlag.value! });
+      }
+      return {
+        success: false,
+        error: "Expected flag after KEYWORD",
+        consumed: 0
+      };
+    }
+    case "UNKEYWORD": {
+      skipWhitespace(context);
+      const unkeywordFlag = parseAtom(context);
+      if (unkeywordFlag.success) {
+        return ok({ type: "UNKEYWORD", flag: unkeywordFlag.value! });
+      }
+      return {
+        success: false,
+        error: "Expected flag after UNKEYWORD",
+        consumed: 0
+      };
+    }
+    case "BEFORE": {
+      skipWhitespace(context);
+      const beforeDate = parseDate(context);
+      if (beforeDate.success) {
+        return ok({ type: "BEFORE", date: beforeDate.value! });
+      }
+      return {
+        success: false,
+        error: "Expected date after BEFORE",
+        consumed: 0
+      };
+    }
+    case "ON": {
+      skipWhitespace(context);
+      const onDate = parseDate(context);
+      if (onDate.success) {
+        return ok({ type: "ON", date: onDate.value! });
+      }
+      return { success: false, error: "Expected date after ON", consumed: 0 };
+    }
+    case "SINCE": {
+      skipWhitespace(context);
+      const sinceDate = parseDate(context);
+      if (sinceDate.success) {
+        return ok({ type: "SINCE", date: sinceDate.value! });
+      }
+      return {
+        success: false,
+        error: "Expected date after SINCE",
+        consumed: 0
+      };
+    }
+    case "SENTBEFORE": {
+      skipWhitespace(context);
+      const sentBeforeDate = parseDate(context);
+      if (sentBeforeDate.success) {
+        return ok({ type: "SENTBEFORE", date: sentBeforeDate.value! });
+      }
+      return {
+        success: false,
+        error: "Expected date after SENTBEFORE",
+        consumed: 0
+      };
+    }
+    case "SENTON": {
+      skipWhitespace(context);
+      const sentOnDate = parseDate(context);
+      if (sentOnDate.success) {
+        return ok({ type: "SENTON", date: sentOnDate.value! });
+      }
+      return {
+        success: false,
+        error: "Expected date after SENTON",
+        consumed: 0
+      };
+    }
+    case "SENTSINCE": {
+      skipWhitespace(context);
+      const sentSinceDate = parseDate(context);
+      if (sentSinceDate.success) {
+        return ok({ type: "SENTSINCE", date: sentSinceDate.value! });
+      }
+      return {
+        success: false,
+        error: "Expected date after SENTSINCE",
+        consumed: 0
+      };
+    }
+    case "FROM": {
+      skipWhitespace(context);
+      const fromValue = parseString(context);
+      if (fromValue.success) {
+        return ok({ type: "FROM", value: fromValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after FROM",
+        consumed: 0
+      };
+    }
+    case "TO": {
+      skipWhitespace(context);
+      const toValue = parseString(context);
+      if (toValue.success) {
+        return ok({ type: "TO", value: toValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after TO",
+        consumed: 0
+      };
+    }
+    case "CC": {
+      skipWhitespace(context);
+      const ccValue = parseString(context);
+      if (ccValue.success) {
+        return ok({ type: "CC", value: ccValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after CC",
+        consumed: 0
+      };
+    }
+    case "BCC": {
+      skipWhitespace(context);
+      const bccValue = parseString(context);
+      if (bccValue.success) {
+        return ok({ type: "BCC", value: bccValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after BCC",
+        consumed: 0
+      };
+    }
+    case "SUBJECT": {
+      skipWhitespace(context);
+      const subjectValue = parseString(context);
+      if (subjectValue.success) {
+        return ok({ type: "SUBJECT", value: subjectValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after SUBJECT",
+        consumed: 0
+      };
+    }
+    case "BODY": {
+      skipWhitespace(context);
+      const bodyValue = parseString(context);
+      if (bodyValue.success) {
+        return ok({ type: "BODY", value: bodyValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after BODY",
+        consumed: 0
+      };
+    }
+    case "TEXT": {
+      skipWhitespace(context);
+      const textValue = parseString(context);
+      if (textValue.success) {
+        return ok({ type: "TEXT", value: textValue.value! });
+      }
+      return {
+        success: false,
+        error: "Expected text value after TEXT",
+        consumed: 0
+      };
+    }
+    case "HEADER": {
+      skipWhitespace(context);
+      const headerField = parseString(context);
+      skipWhitespace(context);
+      const headerValue = parseString(context);
+      if (headerField.success && headerValue.success) {
+        return ok({
+          type: "HEADER",
+          field: headerField.value!,
+          value: headerValue.value!
+        });
+      }
+      return {
+        success: false,
+        error: "Expected field & value after HEADER",
+        consumed: 0
+      };
+    }
+    case "UID": {
+      skipWhitespace(context);
+      const uidSequenceSet = parseSequenceSet(context);
+      if (uidSequenceSet.success) {
+        return ok({ type: "UID", sequenceSet: uidSequenceSet.value! });
+      }
+      return {
+        success: false,
+        error: "Expected sequence set after UID",
+        consumed: 0
+      };
+    }
+    case "LARGER": {
+      skipWhitespace(context);
+      const largerSize = parseNumber(context);
+      if (largerSize.success) {
+        return ok({ type: "LARGER", size: largerSize.value! });
+      }
+      return {
+        success: false,
+        error: "Expected size after LARGER",
+        consumed: 0
+      };
+    }
+    case "SMALLER": {
+      skipWhitespace(context);
+      const smallerSize = parseNumber(context);
+      if (smallerSize.success) {
+        return ok({ type: "SMALLER", size: smallerSize.value! });
+      }
+      return {
+        success: false,
+        error: "Expected size after SMALLER",
+        consumed: 0
+      };
+    }
+    case "NOT": {
+      skipWhitespace(context);
+      const operand = parseSearchKey(context);
+      if (operand.success && operand.value) {
+        return ok({ type: "NOT", criterion: operand.value });
+      }
+      return {
+        success: false,
+        error: "Expected exactly 1 search criterion after NOT",
+        consumed: 0
+      };
+    }
+    case "OR": {
+      skipWhitespace(context);
+      const left = parseSearchKey(context);
+      if (!left.success || !left.value) {
+        return {
+          success: false,
+          error: "Expected exactly 2 search criteria after OR",
+          consumed: 0
+        };
+      }
+      skipWhitespace(context);
+      const right = parseSearchKey(context);
+      if (!right.success || !right.value) {
+        return {
+          success: false,
+          error: "Expected exactly 2 search criteria after OR",
+          consumed: 0
+        };
+      }
+      return ok({ type: "OR", left: left.value, right: right.value });
+    }
+    default:
+      return ok(null);
+  }
 };


### PR DESCRIPTION
Closes #637.

## Problem

Any `SEARCH` / `UID SEARCH` where a `NOT` or `OR` key appears as **anything other than the last top-level key** was rejected with a tagged `BAD Invalid search criteria` instead of being executed.

`NOT`/`OR` parsed their operands by recursing into `parseSearchCriteria`, whose `while` loop consumes **every** remaining search-key to end-of-line. When more ANDed keys followed the operator, the returned operand array had length > 1 (NOT) or ≠ 2 (OR), the length guard failed, and the whole parse returned `success: false` → tagged `BAD`.

Per RFC 3501 §6.4.4, a top-level search is `1*(SP search-key)` (keys ANDed together); `"NOT" SP search-key` takes exactly one following key and `"OR" SP search-key SP search-key` exactly two. So `NOT SEEN SINCE 1-Jan-2026` is two top-level keys — `[NOT SEEN]` AND `[SINCE …]` — not one greedy operand.

These shapes are common: Apple Mail / Thunderbird smart-mailbox filters compile to `is-unread AND not-in-trash` / `(flagged OR recent) since <date>`.

## Fix

Extract one iteration of the top-level loop into `parseSearchKey(context)`, which parses **exactly one** search-key and returns a single criterion. The top-level `parseSearchCriteria` now loops over it; `NOT` calls it once and `OR` twice, then control returns to the top-level loop for the remaining ANDed keys.

- Unknown atoms still yield "null-and-continue" at the top level, so the loop's lenient skip behavior is unchanged (no unrelated behavior change).
- Nested operators (`NOT NOT SEEN`, `OR NOT SEEN FLAGGED`) now parse correctly as a natural consequence of the bounded recursion.

## Scope

Two files, both server-side:
- `src/server/lib/imap/parsers/search-parsers.ts` — the fix (extract `parseSearchKey`, bound NOT/OR operands).
- `src/server/lib/imap/parsers/search-parsers.test.ts` — regression tests.

No schema, route, or client change.

## Test plan (E2E at the parser layer — the layer the bug lives in)

This is a pure deterministic parser defect; the issue itself reproduced it by driving the parser through `bun test`. Verified the exact repro table now behaves per RFC (the operator followed by more keys used to fail; sole/final operator already worked):

| Command criteria | RFC-correct | Before | After |
|---|---|---|---|
| `NOT SEEN` | 1 key | ✅ pass | ✅ pass |
| `NOT SEEN SINCE 1-Jan-2026` | `[NOT SEEN] AND [SINCE …]` | ❌ BAD | ✅ 2 keys |
| `NOT SEEN FROM bob` | `[NOT SEEN] AND [FROM bob]` | ❌ BAD | ✅ 2 keys |
| `OR SEEN ANSWERED FROM bob` | `[OR …] AND [FROM bob]` | ❌ BAD | ✅ 2 keys |
| `OR FROM a@x.com TO b@x.com` | 1 key | ✅ pass | ✅ pass |
| `SINCE 1-Jan-2026 NOT SEEN` | `[SINCE …] AND [NOT SEEN]` | ✅ pass | ✅ pass |
| `NOT NOT SEEN` (nested) | nested NOT | — | ✅ pass |
| `OR NOT SEEN FLAGGED` (operator operand) | OR(NOT SEEN, FLAGGED) | — | ✅ pass |

- [x] `bun test src/server/lib/imap/parsers/search-parsers.test.ts` — 56 pass / 0 fail (+8 new regression tests).
- [x] `bun test src/server/lib/imap/parsers` — 261 pass / 0 fail.
- [x] `bun test src/server` — 1117 pass / 0 fail (no regressions).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (pre-existing warnings only, unrelated files).

No PII (purely structural, synthetic criteria).