### PR TITLE
fix(imap): partial BODY[…] FETCH response emits single origin octet, not origin.length

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -237,7 +237,12 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
     // A <0.10> partial returns exactly 10 octets — no trailing CRLF.
     expect(part!.length).toBe(10);
-    expect(part!.header).toContain("<0.10>");
+    // inbox #640: the response partial marker is the single origin octet only
+    // (RFC 3501 §9 / §7.4.2 `"BODY" section ["<" number ">"]`). The request's
+    // `<start.length>` form must NOT be echoed into the response.
+    expect(part!.header).toContain("<0>");
+    expect(part!.header).not.toContain("<0.10>");
+    expect(part!.header).not.toMatch(/<\d+\.\d+>/);
     expect(part!.content.endsWith("\r\n")).toBe(false);
   });
 
@@ -255,7 +260,10 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     if (part!.type !== "literal") throw new Error("expected literal part");
     expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
     expect(part!.length).toBe(8);
-    expect(part!.header).toContain("<5.8>");
+    // inbox #640: single origin octet only — not the request's `<start.length>`.
+    expect(part!.header).toContain("<5>");
+    expect(part!.header).not.toContain("<5.8>");
+    expect(part!.header).not.toMatch(/<\d+\.\d+>/);
   });
 });
 

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -292,12 +292,16 @@ export async function buildBodyResponsePart(
       finalContent = applyPartialFetch(content, partial);
       length = Buffer.byteLength(finalContent, "utf8");
     }
-    header += `<${start}.${Math.min(partialLength, length)}>`;
+    // Response partial marker is the single origin octet only — RFC 3501 §9
+    // `msg-att-static` / §7.4.2 allow `"BODY" section ["<" number ">"]`. The
+    // `<start.length>` form is request-only grammar (`fetch-att`); echoing the
+    // length back is non-conformant. The `{length}` literal already tells the
+    // client how many octets follow.
+    header += `<${start}>`;
     // A partial fetch returns exactly the requested substring — no trailing
     // CRLF. (The non-partial branch below appends one and recounts `length`;
     // doing that here would emit 2 octets more than the `{length}` literal
-    // and the `<start.length>` annotation both advertise, desyncing clients
-    // that read exactly `length` octets.)
+    // advertises, desyncing clients that read exactly `length` octets.)
   } else if (section.type !== "HEADER") {
     finalContent += "\r\n";
     length = Buffer.byteLength(finalContent, "utf8");


### PR DESCRIPTION
Closes #640.

## Problem

The FETCH response for a **partial** body fetch (`BODY[…]<start.length>`) echoed the request's `origin.length` pair into the response section identifier — e.g. `BODY[TEXT]<0.10>`.

Per RFC 3501 §9 (`msg-att-static`) and §7.4.2, the response partial marker is a **single origin octet**: `"BODY" section ["<" number ">"]` → the correct form is `BODY[TEXT]<0>`. The `number "." number` form appears only in the **command** grammar (`fetch-att`), which is why the request parser correctly accepts `<0.10>` — but the response builder must not echo the length back. The `{length}` literal already advertises how many octets follow, so the length in the section identifier is both redundant and non-conformant; a strict client parsing per the §9 grammar expects `>` immediately after the origin `number` and fails on the unexpected `.`.

This affects **every** partial body fetch — the mechanism clients use to progressively download large messages / preview the first N bytes (`BODY[]<0.2048>`, `BODY[TEXT]<0.4096>`, …).

## Fix

`buildBodyResponsePart` (`fetch-helpers.ts`): emit `<${start}>` instead of `<${start}.${Math.min(partialLength, length)}>`. No change to #581's literal-length (`{N}`) accounting — the CRLF-suppression logic and byte counting are untouched.

## Why the tests didn't catch it

Two assertions in `fetch-helpers.test.ts` **pinned the wrong shape** (`<0.10>`, `<5.8>`). They were added for #581 (partial-fetch literal-length accounting) and locked in the `<start.length>` header format alongside the length fix, so the non-conformant origin format was enshrined rather than caught. Updated both to expect the single origin octet (`<0>`, `<5>`) and added a regression assertion that the marker contains no `<N.N>` form.

## Scope

Two files, both server-side:
- `src/server/lib/imap/fetch-helpers.ts` — the one-line fix + clarifying comment.
- `src/server/lib/imap/fetch-helpers.test.ts` — corrected + hardened assertions.

No schema, route, or client change.

## Test plan (E2E at the response-builder layer — the layer the bug lives in)

Deterministic response-builder defect; verified by driving the real `buildBodyResponsePart` (the same function the issue reproduced against):

| Request | Before (header) | After (header) | Literal |
|---|---|---|---|
| `BODY[TEXT]<0.10>` | `BODY[TEXT]<0.10>` ❌ | `BODY[TEXT]<0>` ✅ | `{10}` |
| `BODY[TEXT]<5.8>` | `BODY[TEXT]<5.8>` ❌ | `BODY[TEXT]<5>` ✅ | `{8}` |

- [x] `bun test src/server/lib/imap/fetch-helpers.test.ts` — 19 pass / 0 fail.
- [x] `bun test src/server/lib/imap` — 519 pass / 0 fail (no regressions).
- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (pre-existing warnings only, unrelated).

Literal-length invariant from #581 (`byteLength(content) === length`) still asserted and green, confirming this change is orthogonal to that fix.

No PII (purely structural, synthetic body slices).