### PR TITLE
fix(test): align push.test.ts expectations with removed badge-count increment (fa305b1)

### DIFF
--- a/src/server/lib/push.test.ts
+++ b/src/server/lib/push.test.ts
@@ -257,7 +257,7 @@ describe("notifyNewMails", () => {
     expect(sendArgs[0]).toBe(subscription);
     const payload = JSON.parse(sendArgs[1] as string);
     expect(payload.title).toBe("You have a new mail");
-    expect(payload.badge_count).toBe(2);
+    expect(payload.badge_count).toBe(1);
     expect(payload.push_subscription_id).toBe("sub-1");
     expect(m.repo.updateLastNotified).toHaveBeenCalledTimes(1);
     expect(m.repo.updateLastNotified.mock.calls[0]).toEqual(["sub-1"] as never);
@@ -279,8 +279,8 @@ describe("notifyNewMails", () => {
 
     const sendArgs = m.sendNotification.mock.calls[0] as unknown as unknown[];
     const payload = JSON.parse(sendArgs[1] as string);
-    expect(payload.title).toBe("You have 5 new mails");
-    expect(payload.badge_count).toBe(5);
+    expect(payload.title).toBe("You have 4 new mails");
+    expect(payload.badge_count).toBe(4);
   });
 
   it("skips notification when no fresh unread mail (latest <= lastNotified)", async () => {


### PR DESCRIPTION
## Summary

Fixes the CD failure on `main` from `fa305b1` (`Update push.ts to remove badge count incrementation logic`). That commit dropped the `badgeCount + 1` increment inside `notifyNewMails`, but the two `push.test.ts` assertions still expected the pre-increment values.

## Changes

- `notifyNewMails > sends a push, then updates lastNotified` (count=1 input): `badge_count: 2 → 1`. Title unchanged — the singular branch fires on `!(badgeCount > 1)` regardless of the increment.
- `notifyNewMails > uses plural message when count > 1` (count=4 input): `title: "You have 5 new mails" → "You have 4 new mails"`, `badge_count: 5 → 4`.

## Test plan

- [x] `bun test src/server/lib/push.test.ts` — 24 pass / 0 fail
🤖 Generated with [Claude Code](https://claude.com/claude-code)
