### PR TITLE
fix(imap): terminate FETCH BODY[HEADER]/[HEADER.FIELDS] with exactly one blank line (RFC 3501 §6.4.5)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -223,6 +223,44 @@ describe("buildBodyResponsePart header terminators (inbox #645)", () => {
     });
     expect(content).toBe("\r\n");
   });
+
+  it("BODY[HEADER.FIELDS.NOT (...)] ends in exactly one delimiting blank line", async () => {
+    // HEADER.FIELDS.NOT excludes the named fields and keeps the rest; it goes
+    // through the same self-terminating HEADER_FIELDS branch, so it must also
+    // end in exactly one blank line.
+    const content = await contentOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "HEADER_FIELDS", fields: ["Subject"], not: true }
+    });
+    expect(content).not.toContain("Subject: Hello"); // excluded
+    expect(content).toContain("From: alice@example.com"); // kept
+    expect(content.endsWith("\r\n\r\n")).toBe(true);
+    expect(content.endsWith("\r\n\r\n\r\n")).toBe(false);
+  });
+
+  it("partial fetch on BODY[HEADER] keeps {N} literal == emitted octets", async () => {
+    // The partial branch slices `content` (which already carries the delimiting
+    // blank line) and recomputes `length`, so the header path must not desync
+    // the literal from the wire bytes.
+    const part = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "HEADER" },
+        partial: { start: 0, length: 10 }
+      },
+      docId,
+      mailbox
+    );
+    expect(part).not.toBeNull();
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    expect(part!.length).toBe(10);
+    expect(part!.header).toContain("<0>");
+    expect(part!.header).not.toMatch(/<\d+\.\d+>/);
+  });
 });
 
 describe("buildFetchResponsePart ENVELOPE", () => {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -162,6 +162,69 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
   });
 });
 
+describe("buildBodyResponsePart header terminators (inbox #645)", () => {
+  // RFC 3501 §6.4.5: every header fetch ends with exactly one RFC-2822
+  // delimiting blank line after the last header field — i.e. `…field\r\n\r\n`.
+  // The no-match HEADER.FIELDS case is the sole exception: a single `\r\n`.
+  const mail: Partial<MailType> = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<term@local>",
+    date: new Date("2026-07-03T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "Hello",
+    text: "body line",
+    html: "",
+    attachments: []
+  };
+  const docId = "doc-term";
+  const mailbox = "INBOX";
+
+  const contentOf = async (fetch: BodyFetch): Promise<string> => {
+    const part = await buildBodyResponsePart(mail, fetch, docId, mailbox);
+    expect(part).not.toBeNull();
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    // The advertised {N} literal must equal the emitted octets.
+    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    return part!.content;
+  };
+
+  it("BODY[HEADER] ends in exactly one delimiting blank line", async () => {
+    const content = await contentOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "HEADER" }
+    });
+    // last field's CRLF + one blank line, and NOT a spurious second blank line.
+    expect(content.endsWith("\r\n\r\n")).toBe(true);
+    expect(content.endsWith("\r\n\r\n\r\n")).toBe(false);
+    // sanity: the last header line is present immediately before the blank line.
+    expect(content).toContain("Content-Transfer-Encoding: base64\r\n\r\n");
+  });
+
+  it("BODY[HEADER.FIELDS (...)] ends in exactly one delimiting blank line", async () => {
+    const content = await contentOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "HEADER_FIELDS", fields: ["From", "Subject"], not: false }
+    });
+    expect(content).toContain("From: alice@example.com");
+    expect(content).toContain("Subject: Hello");
+    expect(content).not.toContain("To: bob@example.com"); // not requested
+    expect(content.endsWith("\r\n\r\n")).toBe(true);
+    expect(content.endsWith("\r\n\r\n\r\n")).toBe(false);
+  });
+
+  it("BODY[HEADER.FIELDS (no match)] is exactly a single blank line", async () => {
+    const content = await contentOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "HEADER_FIELDS", fields: ["X-Nonexistent"], not: false }
+    });
+    expect(content).toBe("\r\n");
+  });
+});
+
 describe("buildFetchResponsePart ENVELOPE", () => {
   const mail: Partial<MailType> = {
     date: "2024-01-15T10:30:00Z",

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -59,7 +59,12 @@ export function getBodyContent(
     }
 
     case "HEADER":
-      return formatHeaders(mail, docId) + "\r\n";
+      // RFC 3501 §6.4.5: a HEADER fetch includes the RFC-2822 delimiting blank
+      // line between the header block and the body. `formatHeaders` joins the
+      // header lines with `\r\n` and adds no trailing CRLF, so the first `\r\n`
+      // terminates the last header line and the second is the delimiting blank
+      // line.
+      return formatHeaders(mail, docId) + "\r\n\r\n";
 
     case "HEADER_FIELDS": {
       const allHeaders = formatHeaders(mail, docId);
@@ -302,7 +307,12 @@ export async function buildBodyResponsePart(
     // CRLF. (The non-partial branch below appends one and recounts `length`;
     // doing that here would emit 2 octets more than the `{length}` literal
     // advertises, desyncing clients that read exactly `length` octets.)
-  } else if (section.type !== "HEADER") {
+  } else if (section.type !== "HEADER" && section.type !== "HEADER_FIELDS") {
+    // Body sections (FULL / TEXT / MIME_PART) get a trailing CRLF here. Header
+    // sections already carry their own delimiting blank line from
+    // `getBodyContent` (HEADER: `\r\n\r\n`; HEADER_FIELDS: last-field `\r\n` +
+    // blank line), so appending another `\r\n` would emit a spurious second
+    // blank line.
     finalContent += "\r\n";
     length = Buffer.byteLength(finalContent, "utf8");
   }


### PR DESCRIPTION
## Problem

`FETCH BODY[HEADER]` and `FETCH BODY[HEADER.FIELDS (...)]` mishandled the RFC-2822 delimiting blank line that RFC 3501 §6.4.5 requires in every header fetch — in opposite directions:

| Fetch | Correct terminator | Before |
|---|---|---|
| `BODY[HEADER]` | `…lastField\r\n` + blank line | `…lastField\r\n` (missing blank line) |
| `BODY[HEADER.FIELDS (a b)]` | `…b\r\n` + blank line | `…b\r\n\r\n\r\n` (extra blank line) |
| `BODY[HEADER.FIELDS (no match)]` | `\r\n` | `\r\n\r\n` (extra blank line) |

Real clients (Apple Mail, Thunderbird) fetch `BODY[HEADER.FIELDS (...)]` for the message list and `BODY[HEADER]` for full-header display, so nearly every rendered message hit one of these paths. `RFC822.HEADER` (aliases `BODY[HEADER]`) inherited the same defect.

## Root cause

`src/server/lib/imap/fetch-helpers.ts`:
- `getBodyContent` `HEADER` returned `formatHeaders(...) + "\r\n"`. `formatHeaders` joins header lines with `\r\n` and adds no trailing CRLF, so the single `\r\n` only terminated the last header line — no delimiting blank line.
- `getBodyContent` `HEADER_FIELDS` already terminates itself correctly (`…\r\n\r\n`, or `\r\n` for no-match), but `buildBodyResponsePart`'s trailing-CRLF append guard only excluded `HEADER`, so it appended a second `\r\n` on top of the already-correct `HEADER_FIELDS` terminator.

The `{N}` literal was self-consistent with the malformed content in each case, so the length/literal contract was never violated — the defect was the byte content of the header block.

## Fix

- `HEADER` content now carries its own `\r\n\r\n` (last-field CRLF + delimiting blank line).
- `buildBodyResponsePart` excludes both `HEADER` and `HEADER_FIELDS` from the body-section trailing-CRLF append. `FULL` / `TEXT` / `MIME_PART` keep their trailing CRLF unchanged.

## Tests

`fetch-helpers.test.ts` — new `buildBodyResponsePart header terminators` block pins the exact terminator bytes for `BODY[HEADER]`, `BODY[HEADER.FIELDS (From Subject)]` (both end in exactly `…\r\n\r\n`), and the no-match `HEADER.FIELDS` (exactly `\r\n`), each asserting `{N}` literal == emitted octets. Confirmed the 3 new tests FAIL on `upstream/main` and PASS with the fix. Full server suite green (1135 pass, 0 fail). Typecheck clean.

## E2E

Drove a real IMAP socket session against a locally-started server (`IMAP_PORT` high port, admin INBOX, 11324 messages):

- `FETCH 1 (BODY.PEEK[HEADER])` → tail `…base64\r\n\r\n`, one blank line; literal {351} == 351 octets captured.
- `FETCH 1 (BODY.PEEK[HEADER.FIELDS (FROM SUBJECT)])` → tail `…\r\n\r\n`, one blank line; literal {95} == 95 octets.
- `FETCH 1 (BODY.PEEK[HEADER.FIELDS (X-NONEXISTENT)])` → content exactly `\r\n` (2 octets).

All three now carry exactly one delimiting blank line, and each literal length matches the octets on the wire.

Closes #645