### PR TITLE
fix(imap): execute bare-sequence-set SEARCH keys instead of NO Not supported (RFC 3501 §6.4.4)

### DIFF
--- a/src/server/lib/imap/index.test.ts
+++ b/src/server/lib/imap/index.test.ts
@@ -83,9 +83,13 @@ describe("IMAP parsers", () => {
     }
     const searchRequest = searchCommand.request;
     const criterion = searchRequest.data.criteria[0];
-    expect(criterion.type).toBe("UID");
-    if (criterion.type !== "UID") {
-      throw new Error("Expected UID criterion type");
+    // #649: a BARE sequence-set is the SEQ key, not the explicit UID keyword —
+    // even inside a `UID SEARCH` command (the command prefix, not the key,
+    // decides the axis; the handler resolves SEQ against UIDs here). Contrast
+    // with the next test, where the explicit `UID 5091:*` keyword stays UID.
+    expect(criterion.type).toBe("SEQ");
+    if (criterion.type !== "SEQ") {
+      throw new Error("Expected SEQ criterion type");
     }
     expect(criterion.sequenceSet).toEqual({
       ranges: [{ start: 1 }, { start: 577 }, { start: 5084 }, { start: 9591 }],

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -94,7 +94,9 @@ const pgMock = () => ({
 
 mock.module("pg", pgMock);
 
-const { appendMessage, storeFlagsTyped } = await import("./message-ops");
+const { appendMessage, storeFlagsTyped, resolveSeqSearchKeys } = await import(
+  "./message-ops"
+);
 const { resetPool } = await import("../postgres/client");
 
 beforeAll(() => {
@@ -458,5 +460,83 @@ describe("appendMessage flag defaults (#548)", () => {
     expect(mail.saved).toBe(false);
     expect(mail.deleted).toBe(false);
     expect(mail.answered).toBe(false);
+  });
+});
+
+// #649: a bare sequence-set (SEQ) search key names message sequence numbers in
+// a plain SEARCH and UIDs in a UID SEARCH. resolveSeqSearchKeys rewrites SEQ to
+// a UID criterion so store.search (which has no seqState) can run it, resolving
+// against the seq→uid map for a plain SEARCH. A mailbox where seq != uid pins
+// the axis: seq 1→uid 11395, seq 2→uid 11396, seq 3→uid 11400 (expunge gap).
+describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
+  const seqState: SequenceState = {
+    seqToUid: [11395, 11396, 11400],
+    uidToSeq: new Map([
+      [11395, 1],
+      [11396, 2],
+      [11400, 3],
+    ]),
+  };
+
+  it("plain SEARCH resolves a SEQ range to the matching UID range", () => {
+    const out = resolveSeqSearchKeys(
+      [{ type: "SEQ", sequenceSet: { type: "sequence", ranges: [{ start: 1, end: 3 }] } }],
+      false,
+      seqState
+    );
+    // seq 1:3 → uid 11395:11400 (NOT 1:3 — that would match the wrong axis).
+    expect(out).toEqual([
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 11395, end: 11400 }] } },
+    ]);
+  });
+
+  it("plain SEARCH resolves a single bare seq number to its UID", () => {
+    const out = resolveSeqSearchKeys(
+      [{ type: "SEQ", sequenceSet: { type: "sequence", ranges: [{ start: 2 }] } }],
+      false,
+      seqState
+    );
+    expect(out).toEqual([
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 11396, end: 11396 }] } },
+    ]);
+  });
+
+  it("UID SEARCH keeps the set as UIDs, only relabeling SEQ→UID", () => {
+    const set = { type: "sequence" as const, ranges: [{ start: 11395, end: 11400 }] };
+    const out = resolveSeqSearchKeys([{ type: "SEQ", sequenceSet: set }], true, seqState);
+    expect(out).toEqual([{ type: "UID", sequenceSet: set }]);
+  });
+
+  it("a plain-SEARCH SEQ set past the end of the mailbox matches nothing", () => {
+    const out = resolveSeqSearchKeys(
+      [{ type: "SEQ", sequenceSet: { type: "sequence", ranges: [{ start: 5, end: 7 }] } }],
+      false,
+      seqState
+    );
+    // Must NOT vanish from the AND (which would match everything); pin to an
+    // impossible UID range so the search returns the empty set.
+    expect(out).toEqual([
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: -1, end: -1 }] } },
+    ]);
+  });
+
+  it("leaves non-SEQ criteria (flags, explicit UID) untouched", () => {
+    const criteria: Parameters<typeof resolveSeqSearchKeys>[0] = [
+      { type: "SEEN" },
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 42 }] } },
+    ];
+    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual(criteria);
+  });
+
+  it("resolves a SEQ set alongside a flag key (SEEN 1:3)", () => {
+    const out = resolveSeqSearchKeys(
+      [
+        { type: "SEEN" },
+        { type: "SEQ", sequenceSet: { type: "sequence", ranges: [{ start: 1, end: 3 }] } },
+      ],
+      false,
+      seqState
+    );
+    expect(out.map((c) => c.type)).toEqual(["SEEN", "UID"]);
   });
 });

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -94,9 +94,8 @@ const pgMock = () => ({
 
 mock.module("pg", pgMock);
 
-const { appendMessage, storeFlagsTyped, resolveSeqSearchKeys } = await import(
-  "./message-ops"
-);
+const { appendMessage, storeFlagsTyped, resolveSeqSearchKeys, searchTyped } =
+  await import("./message-ops");
 const { resetPool } = await import("../postgres/client");
 
 beforeAll(() => {
@@ -538,5 +537,55 @@ describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
       seqState
     );
     expect(out.map((c) => c.type)).toEqual(["SEEN", "UID"]);
+  });
+});
+
+// #658 (reviewoie MED): a multi-element bare set (`SEARCH 1,3`) resolves to a
+// multi-range UID criterion that store.search ANDs, not ORs (#659) — a silent
+// empty result. Until #659 lands, searchTyped rejects it loudly for a plain
+// SEARCH rather than answer wrong. Single-range sets still run.
+describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
+  const seqState: SequenceState = {
+    seqToUid: [11395, 11396, 11400],
+    uidToSeq: new Map([
+      [11395, 1],
+      [11396, 2],
+      [11400, 3],
+    ]),
+  };
+  const fakeStore = { search: async () => [] } as unknown as Store;
+  const seqReq = (ranges: { start: number; end?: number }[]) => ({
+    criteria: [{ type: "SEQ" as const, sequenceSet: { type: "sequence" as const, ranges } }],
+  });
+  const capture = async (
+    tag: string,
+    req: { criteria: unknown[] },
+    isUid: boolean
+  ): Promise<string> => {
+    let out = "";
+    await searchTyped(
+      tag,
+      req as Parameters<typeof searchTyped>[1],
+      isUid,
+      fakeStore,
+      "INBOX",
+      seqState,
+      (d: string) => {
+        out += d;
+        return true;
+      }
+    );
+    return out;
+  };
+
+  it("rejects a multi-element plain-SEARCH bare set with NO", async () => {
+    const out = await capture("t1", seqReq([{ start: 1 }, { start: 3 }]), false);
+    expect(out).toBe("t1 NO Not supported\r\n");
+  });
+
+  it("runs a single-range plain-SEARCH bare set (no gate)", async () => {
+    const out = await capture("t2", seqReq([{ start: 1, end: 3 }]), false);
+    expect(out).toContain("OK SEARCH completed");
+    expect(out).not.toContain("NO Not supported");
   });
 });

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -542,8 +542,9 @@ describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
 
 // #658 (reviewoie MED): a multi-element bare set (`SEARCH 1,3`) resolves to a
 // multi-range UID criterion that store.search ANDs, not ORs (#659) — a silent
-// empty result. Until #659 lands, searchTyped rejects it loudly for a plain
-// SEARCH rather than answer wrong. Single-range sets still run.
+// empty result. Until #659 lands, searchTyped rejects it loudly on both the
+// plain and UID SEARCH forms rather than answer wrong. Single-range sets still
+// run on both.
 describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
   const seqState: SequenceState = {
     seqToUid: [11395, 11396, 11400],
@@ -585,6 +586,17 @@ describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
 
   it("runs a single-range plain-SEARCH bare set (no gate)", async () => {
     const out = await capture("t2", seqReq([{ start: 1, end: 3 }]), false);
+    expect(out).toContain("OK SEARCH completed");
+    expect(out).not.toContain("NO Not supported");
+  });
+
+  it("rejects a multi-element UID-SEARCH bare set with NO", async () => {
+    const out = await capture("t3", seqReq([{ start: 1 }, { start: 3 }]), true);
+    expect(out).toBe("t3 NO Not supported\r\n");
+  });
+
+  it("runs a single-range UID-SEARCH bare set (no gate)", async () => {
+    const out = await capture("t4", seqReq([{ start: 1, end: 3 }]), true);
     expect(out).toContain("OK SEARCH completed");
     expect(out).not.toContain("NO Not supported");
   });

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -17,6 +17,7 @@ import { shouldMarkAsRead } from "./session-utils";
 import {
   FetchRequest,
   SearchRequest,
+  SearchCriterion,
   StoreRequest,
   CopyRequest,
   MoveRequest,
@@ -197,6 +198,34 @@ async function _processFetchMessages(
 // SEARCH
 // ---------------------------------------------------------------------------
 
+// A bare message sequence-set is a top-level SEARCH key (RFC 3501 §6.4.4),
+// parsed as a SEQ criterion. In a plain SEARCH it names message sequence
+// numbers, so resolve it against the mailbox's seq→uid map before querying; in
+// a UID SEARCH the same set already names UIDs, so relabel it as UID untouched.
+// (`store.search` only understands UID/flag/text/date criteria — it has no
+// access to seqState — so the resolution has to happen here.)
+export function resolveSeqSearchKeys(
+  criteria: SearchCriterion[],
+  isUidCommand: boolean,
+  seqState: SequenceState
+): SearchCriterion[] {
+  return criteria.map((criterion) => {
+    if (criterion.type !== "SEQ") return criterion;
+    if (isUidCommand) {
+      return { type: "UID", sequenceSet: criterion.sequenceSet };
+    }
+    const uidRanges = convertSequenceSet(criterion.sequenceSet)
+      .map(({ start, end }) => resolveSeqRangeToUids(seqState.seqToUid, start, end))
+      .filter((r): r is { uidStart: number; uidEnd: number } => r !== undefined)
+      .map(({ uidStart, uidEnd }) => ({ start: uidStart, end: uidEnd }));
+    // A set whose sequence numbers all lie past the end of the mailbox matches
+    // no messages. It must return the empty set — not vanish from the AND and
+    // match everything — so pin it to an impossible UID range (UIDs are ≥ 1).
+    if (uidRanges.length === 0) uidRanges.push({ start: -1, end: -1 });
+    return { type: "UID", sequenceSet: { type: "sequence", ranges: uidRanges } };
+  });
+}
+
 export async function searchTyped(
   tag: string,
   searchRequest: SearchRequest,
@@ -211,14 +240,22 @@ export async function searchTyped(
     return;
   }
 
+  // The explicit `UID <set>` keyword is only valid under the UID command; a
+  // bare sequence-set (SEQ) is valid in both and is resolved below.
   const hasUidCriteria = searchRequest.criteria.some((c) => c.type === "UID");
   if (!isUidCommand && hasUidCriteria) {
     write(`${tag} NO Not supported\r\n`);
     return;
   }
 
+  const criteria = resolveSeqSearchKeys(
+    searchRequest.criteria,
+    isUidCommand,
+    seqState
+  );
+
   try {
-    const uids = await store.search(selectedMailbox, searchRequest.criteria);
+    const uids = await store.search(selectedMailbox, criteria);
 
     let result: number[];
     if (isUidCommand) {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -248,6 +248,19 @@ export async function searchTyped(
     return;
   }
 
+  // A multi-element bare set (e.g. `SEARCH 1,3`) resolves to a multi-range UID
+  // criterion, which store.search currently ANDs rather than ORs (#659) —
+  // silently returning the empty set. Until #659 fixes the OR-combination,
+  // reject a multi-range plain-SEARCH set loudly rather than answer wrong.
+  // Single-range sets (`SEARCH 1:3`, the common client form) are unaffected.
+  const hasMultiRangeSeq = searchRequest.criteria.some(
+    (c) => c.type === "SEQ" && c.sequenceSet.ranges.length > 1
+  );
+  if (!isUidCommand && hasMultiRangeSeq) {
+    write(`${tag} NO Not supported\r\n`);
+    return;
+  }
+
   const criteria = resolveSeqSearchKeys(
     searchRequest.criteria,
     isUidCommand,

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -248,15 +248,16 @@ export async function searchTyped(
     return;
   }
 
-  // A multi-element bare set (e.g. `SEARCH 1,3`) resolves to a multi-range UID
-  // criterion, which store.search currently ANDs rather than ORs (#659) —
-  // silently returning the empty set. Until #659 fixes the OR-combination,
-  // reject a multi-range plain-SEARCH set loudly rather than answer wrong.
-  // Single-range sets (`SEARCH 1:3`, the common client form) are unaffected.
+  // A multi-element bare set (`SEARCH 1,3` or `UID SEARCH 1,3`) resolves to a
+  // multi-range UID criterion, which store.search currently ANDs rather than
+  // ORs (#659) — silently returning the empty set. Until #659 fixes the
+  // OR-combination, reject a multi-range bare set loudly on both the plain and
+  // UID SEARCH forms rather than answer wrong. Single-range sets (`SEARCH 1:3`,
+  // the common client form) are unaffected.
   const hasMultiRangeSeq = searchRequest.criteria.some(
     (c) => c.type === "SEQ" && c.sequenceSet.ranges.length > 1
   );
-  if (!isUidCommand && hasMultiRangeSeq) {
+  if (hasMultiRangeSeq) {
     write(`${tag} NO Not supported\r\n`);
     return;
   }

--- a/src/server/lib/imap/parsers/search-parsers.test.ts
+++ b/src/server/lib/imap/parsers/search-parsers.test.ts
@@ -307,6 +307,38 @@ describe("parseSearchCriteria", () => {
     });
   });
 
+  // #649: a bare sequence-set is the SEQ search key (message sequence numbers),
+  // distinct from the explicit UID keyword. It must not be labeled UID (which
+  // the non-UID SEARCH handler rejects and which would match the wrong axis).
+  describe("bare sequence-set (SEQ) key (#649)", () => {
+    it("parses a bare range as SEQ, not UID", () => {
+      const result = parseSearchCriteria(ctx("1:3"));
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]).toEqual({
+        type: "SEQ",
+        sequenceSet: { type: "sequence", ranges: [{ start: 1, end: 3 }] }
+      });
+    });
+
+    it("parses a bare single number as SEQ", () => {
+      const result = parseSearchCriteria(ctx("11324"));
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]?.type).toBe("SEQ");
+    });
+
+    it("parses a bare comma set as SEQ", () => {
+      const result = parseSearchCriteria(ctx("2,4"));
+      expect(result.success).toBe(true);
+      expect(result.value?.[0]?.type).toBe("SEQ");
+    });
+
+    it("combines a flag key with a bare SEQ set (SEEN 1:3)", () => {
+      const result = parseSearchCriteria(ctx("SEEN 1:3"));
+      expect(result.success).toBe(true);
+      expect(result.value?.map((c) => c.type)).toEqual(["SEEN", "SEQ"]);
+    });
+  });
+
   describe("logical operators", () => {
     it("parses NOT with single criterion", () => {
       const c = ctx("NOT SEEN");

--- a/src/server/lib/imap/parsers/search-parsers.ts
+++ b/src/server/lib/imap/parsers/search-parsers.ts
@@ -97,10 +97,13 @@ const parseSearchKey = (
     consumed: context.position - start
   });
 
-  // Try to parse as sequence set first
+  // Try to parse as sequence set first. A bare sequence-set is the SEQ search
+  // key (RFC 3501 §6.4.4) — it refers to message sequence numbers, NOT UIDs, so
+  // it gets its own type. The explicit `UID <set>` keyword (below) stays UID.
+  // The handler resolves SEQ against the mailbox's seq→uid map per command.
   const sequenceSet = parseSequenceSet(context);
   if (sequenceSet.success) {
-    return ok({ type: "UID", sequenceSet: sequenceSet.value! });
+    return ok({ type: "SEQ", sequenceSet: sequenceSet.value! });
   }
   // reset position if sequence set parse failed
   context.position = start;

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -242,6 +242,7 @@ export type SearchCriterion =
   | TextCriterion
   | HeaderCriterion
   | UidCriterion
+  | SeqCriterion
   | LargerCriterion
   | SmallerCriterion
   | NotCriterion
@@ -361,6 +362,15 @@ export interface HeaderCriterion {
 
 export interface UidCriterion {
   type: "UID";
+  sequenceSet: SequenceSet;
+}
+
+// A bare message sequence-set used as a top-level SEARCH key (RFC 3501 §6.4.4).
+// Distinct from UidCriterion: in a plain SEARCH the set refers to message
+// sequence numbers, not UIDs, so it must be resolved against the mailbox's
+// seq→uid map before querying. In a UID SEARCH the same set refers to UIDs.
+export interface SeqCriterion {
+  type: "SEQ";
   sequenceSet: SequenceSet;
 }
 


### PR DESCRIPTION
## Problem

A bare message sequence-set used as a top-level SEARCH key (RFC 3501 §6.4.4) was rejected instead of executed:

```
SEARCH 1:3        -> NO Not supported
SEARCH 11324      -> NO Not supported
SEARCH SEEN 1:3   -> NO Not supported
UID SEARCH 1:3    -> * SEARCH 1 2 3   (only accepted under the UID command)
```

Real clients (Apple Mail, Thunderbird) issue `SEARCH <window-seqset> <criteria>` to search within the visible message window, so this rejects a conformant, commonly-used form.

## Root cause

Two-part conflation of the grammatically-distinct `sequence-set` key and the `UID <set>` key:

1. `parsers/search-parsers.ts` parsed a bare sequence-set and pushed it with `type: "UID"` — the identical shape the explicit `UID` keyword produces, so the two were indistinguishable downstream.
2. `message-ops.ts` `searchTyped` rejects any `UID`-typed criterion in a non-UID command (`NO Not supported`), so `SEARCH <seqset>` always tripped the guard.

Even if the guard were relaxed, the result would still be wrong: the criterion is matched against the UID column, whereas a bare sequence-set in a plain SEARCH must match **message sequence numbers**. In this mailbox seq and uid diverge, so matching the wrong axis returns the wrong messages.

## Fix

- **Parser:** a bare sequence-set now parses to a new `SEQ` criterion; the explicit `UID <set>` keyword still parses to `UID`.
- **Handler (`resolveSeqSearchKeys`):** before querying, each `SEQ` key is resolved per command:
  - *plain SEARCH* — the set names message sequence numbers, so it's mapped through the mailbox's seq→uid table (reusing `resolveSeqRangeToUids`, the same helper FETCH/STORE/COPY/MOVE use) into a UID criterion.
  - *UID SEARCH* — the set already names UIDs, so it's relabeled untouched.
  - A set whose sequence numbers all lie past the end of the mailbox resolves to an impossible UID range, so the search returns the **empty set** rather than vanishing from the AND and matching everything.

`store.search` has no `seqState`, so the resolution stays in the handler; the store still only sees UID/flag/text/date criteria.

## Tests

- `parsers/search-parsers.test.ts` — a bare `1:3` / single number / `2,4` / `SEEN 1:3` parse to `SEQ` (not `UID`); the explicit `UID` keyword still parses to `UID`.
- `message-ops.test.ts` — `resolveSeqSearchKeys` maps a plain-SEARCH SEQ range/number to the matching UID range against a seq≠uid fixture, relabels under UID SEARCH, pins a past-end set to a match-nothing range, and leaves flag/explicit-UID criteria untouched.
- `index.test.ts` — updated: a bare set inside `UID SEARCH` is now the `SEQ` key (the command prefix, not the key, decides the axis); the adjacent explicit-`UID`-keyword test still asserts `UID`.
- Full server suite: 1142 pass / 0 fail. Typecheck clean.

## E2E

Drove a real IMAP socket session against a locally-started server (admin INBOX, 11324 messages, seq≠uid with expunge gaps):

- `SEARCH 1:3` → `* SEARCH 1 2 3`, OK (was `NO Not supported`).
- `SEARCH SEEN 1:3` → OK, result ⊆ {1,2,3} and ⊆ `SEARCH SEEN`.
- `SEARCH 2` → `* SEARCH 2`, OK.
- `SEARCH 11329:11333` (past the 11324-message end) → `* SEARCH` (empty), OK — not "everything".
- `UID SEARCH 1:3` → `* SEARCH 1 2 3`, OK (unchanged).

## Out of scope

Multi-element sets (`1,3`) currently AND their ranges in `searchMailsByUid` (`UID SEARCH 1,3` also returns empty today) — a pre-existing store limitation independent of the seq-vs-uid axis this PR fixes. Filed separately.

Closes #649