### PR TITLE
feat: mark-as-spam / not-spam buttons + non-spam-view spam exclusion

### DIFF
--- a/src/client/Box/components/Mails/components/BanIcon.tsx
+++ b/src/client/Box/components/Mails/components/BanIcon.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+const BanIcon = (props: SVGProps<SVGSVGElement>) => (
+  // license = https://fontawesome.com/license
+  // ----------------from here----------------
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M367.2 412.5L99.5 144.8C77.1 176.1 64 214.5 64 256c0 106 86 192 192 192c41.5 0 79.9-13.1 111.2-35.5zm45.3-45.3C434.9 335.9 448 297.5 448 256c0-106-86-192-192-192c-41.5 0-79.9 13.1-111.2 35.5L412.5 367.2zM0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256z"
+    ></path>
+  </svg>
+  // ----------------until here---------------
+);
+
+export default BanIcon;

--- a/src/client/Box/components/Mails/components/CircleCheckIcon.tsx
+++ b/src/client/Box/components/Mails/components/CircleCheckIcon.tsx
@@ -1,0 +1,22 @@
+import { SVGProps } from "react";
+
+const CircleCheckIcon = (props: SVGProps<SVGSVGElement>) => (
+  // license = https://fontawesome.com/license
+  // ----------------from here----------------
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 512 512"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM369 209L241 337c-9.4 9.4-24.6 9.4-33.9 0l-64-64c-9.4-9.4-9.4-24.6 0-33.9s24.6-9.4 33.9 0l47 47L335 175c9.4-9.4 24.6-9.4 33.9 0s9.4 24.6 0 33.9z"
+    ></path>
+  </svg>
+  // ----------------until here---------------
+);
+
+export default CircleCheckIcon;

--- a/src/client/Box/components/Mails/components/index.ts
+++ b/src/client/Box/components/Mails/components/index.ts
@@ -9,3 +9,5 @@ export { default as EmptyStarIcon } from "./EmptyStarIcon";
 export { default as SolidStarIcon } from "./SolidStarIcon";
 export { default as RobotIcon } from "./RobotIcon";
 export { default as NewTabIcon } from "./NewTabIcon";
+export { default as BanIcon } from "./BanIcon";
+export { default as CircleCheckIcon } from "./CircleCheckIcon";

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -16,7 +16,9 @@ import {
   MarkMailPostBody,
   MarkMailPostResponse,
   SearchGetResponse,
-  MailDeleteResponse
+  MailDeleteResponse,
+  SpamMarkPostBody,
+  SpamMarkPostResponse
 } from "server";
 
 import {
@@ -30,7 +32,9 @@ import {
   TrashIcon,
   EmptyStarIcon,
   SolidStarIcon,
-  RobotIcon
+  RobotIcon,
+  BanIcon,
+  CircleCheckIcon
 } from "./components";
 
 import {
@@ -80,6 +84,10 @@ interface RenderedMailProps {
   requestDeleteMail: (
     mail: MailHeaderData
   ) => Promise<ApiResponse<MailDeleteResponse>>;
+  requestMarkSpam: (
+    mail: MailHeaderData,
+    isSpam: boolean
+  ) => Promise<ApiResponse<SpamMarkPostResponse>>;
   selectedAccount: string;
   domainName: string;
   accountsCache: AccountsCache;
@@ -101,6 +109,7 @@ const RenderedMail = ({
   markReadInQueryData,
   setReplyData,
   requestDeleteMail,
+  requestMarkSpam,
   selectedAccount,
   domainName,
   accountsCache,
@@ -254,6 +263,66 @@ const RenderedMail = ({
     markSavedInQueryData(mail, !mail.saved);
   };
 
+  const isSpamView = selectedCategory === Category.SpamMails;
+
+  const onClickSpam = () => {
+    if (!isOnline) return;
+
+    // In the spam view the button un-marks (Not Spam); everywhere else it
+    // marks as spam. Either way the mail leaves the current list.
+    const nextIsSpam = !isSpamView;
+
+    requestMarkSpam(mail, nextIsSpam)
+      .then(({ status, message }) => {
+        if (status !== "success") throw new Error(message);
+      })
+      .catch(() => {
+        // The optimistic removal below already took the row out of the view.
+        // If the server rejected the mark, re-fetch so the row comes back
+        // rather than silently vanishing.
+        queryClient.invalidateQueries(
+          getMailsQueryUrl(selectedAccount, selectedCategory)
+        );
+      });
+
+    // Optimistically evict from the current view, mirroring onClickTrash:
+    // decrement the matching account bucket, then splice the row out of this
+    // category's cached list.
+    accountsCache.set((oldData) => {
+      if (!oldData) return oldData;
+
+      const newData = { ...oldData };
+
+      const arrayKey =
+        selectedCategory === Category.SentMails
+          ? "sent"
+          : isSpamView
+          ? "spam"
+          : "received";
+      newData[arrayKey].find((account) => {
+        const { key, unread_doc_count } = account;
+        const found = key === selectedAccount;
+        if (found) {
+          if (!mail.read && unread_doc_count) account.unread_doc_count -= 1;
+          account.doc_count -= 1;
+        }
+        return found;
+      });
+
+      return newData;
+    });
+
+    const mailsCache = new MailsCache(selectedAccount, selectedCategory);
+
+    mailsCache.set((oldData) => {
+      if (!oldData) return oldData;
+      const newData = [...oldData];
+      newData.splice(i, 1);
+      if (!newData.length) removeAccountFromQueryData();
+      return newData;
+    });
+  };
+
   const onClickRobot = () => {
     setIsSummaryOpen((v) => !v);
   };
@@ -388,6 +457,18 @@ const RenderedMail = ({
               <ShareIcon />
             </div>
             <div
+              key="spam"
+              className={"iconBox cursor" + offlineClass}
+              title={
+                offlineTitle ?? (isSpamView ? "Not spam" : "Mark as spam")
+              }
+              onClick={onClickSpam}
+              onTouchStart={(e) => e.stopPropagation()}
+              onMouseEnter={() => setOpenedKebab(mail.id)}
+            >
+              {isSpamView ? <CircleCheckIcon /> : <BanIcon />}
+            </div>
+            <div
               key="trash"
               className={"iconBox cursor" + offlineClass}
               title={offlineTitle}
@@ -496,6 +577,13 @@ const RenderedMails = ({ page }: { page: number }) => {
     return call.delete<MailDeleteResponse>(`/api/mails/${mail.id}`);
   };
 
+  const requestMarkSpam = (mail: MailHeaderData, isSpam: boolean) => {
+    type Response = SpamMarkPostResponse;
+    type Body = SpamMarkPostBody;
+    const body: Body = { mail_id: mail.id, is_spam: isSpam };
+    return call.post<Response, Body>("/api/mails/spam/mark", body);
+  };
+
   const requestMarkRead = async (mail: MailHeaderData) => {
     type Response = MarkMailPostResponse;
     type Body = MarkMailPostBody;
@@ -515,7 +603,12 @@ const RenderedMails = ({ page }: { page: number }) => {
       if (!oldData) return oldData;
 
       const newData = { ...oldData };
-      const key = selectedCategory === Category.SentMails ? "sent" : "received";
+      const key =
+        selectedCategory === Category.SentMails
+          ? "sent"
+          : selectedCategory === Category.SpamMails
+          ? "spam"
+          : "received";
       newData[key].find((account, i) => {
         const found = account.key === selectedAccount;
         if (found) newData[key].splice(i, 1);
@@ -628,6 +721,7 @@ const RenderedMails = ({ page }: { page: number }) => {
           markReadInQueryData={markReadInQueryData}
           setReplyData={setReplyData}
           requestDeleteMail={requestDeleteMail}
+          requestMarkSpam={requestMarkSpam}
           selectedAccount={selectedAccount}
           domainName={domainName}
           accountsCache={accountsCache}

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -272,17 +272,35 @@ const RenderedMail = ({
     // marks as spam. Either way the mail leaves the current list.
     const nextIsSpam = !isSpamView;
 
+    const listUrl = getMailsQueryUrl(selectedAccount, selectedCategory);
+    // Where the mail lands: the Spam view when marking, the All Mails view
+    // when un-marking. Refreshing it on navigation avoids a stale destination.
+    const destUrl = getMailsQueryUrl(
+      selectedAccount,
+      nextIsSpam ? Category.SpamMails : Category.AllMails
+    );
+
     requestMarkSpam(mail, nextIsSpam)
       .then(({ status, message }) => {
         if (status !== "success") throw new Error(message);
+        // The mail moved buckets — refresh the destination list so it shows
+        // up fresh instead of relying on whatever was cached there.
+        queryClient.invalidateQueries(destUrl);
       })
       .catch(() => {
         // The optimistic removal below already took the row out of the view.
         // If the server rejected the mark, re-fetch so the row comes back
         // rather than silently vanishing.
-        queryClient.invalidateQueries(
-          getMailsQueryUrl(selectedAccount, selectedCategory)
-        );
+        queryClient.invalidateQueries(listUrl);
+      })
+      .finally(() => {
+        // Spam is a MOVE between account buckets, not a delete. The optimistic
+        // update below only decrements the source bucket; rather than
+        // hand-maintain the destination's spam count (and create a spam
+        // account row when the account had none), reconcile the whole sidebar
+        // from the authoritative accounts payload. Also restores the source
+        // count if the mark failed. Cheap — accounts is one small response.
+        queryClient.invalidateQueries(accountsCache.key);
       });
 
     // Optimistically evict from the current view, mirroring onClickTrash:

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -264,6 +264,11 @@ const RenderedMail = ({
   };
 
   const isSpamView = selectedCategory === Category.SpamMails;
+  // Spam is a received-mail concept only. A sent mail (in the Sent view, or a
+  // sent mail surfaced in the Saved/Search views) must not get the spam button:
+  // is_spam=TRUE + sent=TRUE is excluded from BOTH the Sent view and the Spam
+  // view, so it would orphan the mail with no un-mark path.
+  const canToggleSpam = !isSentMail(mail, domainName);
 
   const onClickSpam = () => {
     if (!isOnline) return;
@@ -474,18 +479,20 @@ const RenderedMail = ({
             >
               <ShareIcon />
             </div>
-            <div
-              key="spam"
-              className={"iconBox cursor" + offlineClass}
-              title={
-                offlineTitle ?? (isSpamView ? "Not spam" : "Mark as spam")
-              }
-              onClick={onClickSpam}
-              onTouchStart={(e) => e.stopPropagation()}
-              onMouseEnter={() => setOpenedKebab(mail.id)}
-            >
-              {isSpamView ? <CircleCheckIcon /> : <BanIcon />}
-            </div>
+            {canToggleSpam ? (
+              <div
+                key="spam"
+                className={"iconBox cursor" + offlineClass}
+                title={
+                  offlineTitle ?? (isSpamView ? "Not spam" : "Mark as spam")
+                }
+                onClick={onClickSpam}
+                onTouchStart={(e) => e.stopPropagation()}
+                onMouseEnter={() => setOpenedKebab(mail.id)}
+              >
+                {isSpamView ? <CircleCheckIcon /> : <BanIcon />}
+              </div>
+            ) : null}
             <div
               key="trash"
               className={"iconBox cursor" + offlineClass}

--- a/src/server/lib/postgres/repositories/mails/http.test.ts
+++ b/src/server/lib/postgres/repositories/mails/http.test.ts
@@ -385,3 +385,40 @@ describe("spam-exclusion invariant — non-spam views hide is_spam mail (#461)",
     expect(evictMatch[1]).toContain("is_spam = TRUE");
   });
 });
+
+describe("getAccountStats + getUnreadNotifications — mirror the is_spam exclusion (#461)", () => {
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = (
+      await Promise.all(
+        (await fs.readdir(import.meta.dir)).sort()
+          .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+          .map((f) => fs.readFile(path.join(import.meta.dir, f), "utf8"))
+      )
+    ).join("\n");
+  });
+
+  it("getAccountStats excludes is_spam from the non-spam (received/sent) counts", () => {
+    // The sidebar count must match the spam-excluding headers list, or an
+    // account with spam would show a doc_count higher than its listed mails.
+    const fnMatch = mailsSource.match(/export const getAccountStats[\s\S]*?\n};/);
+    if (!fnMatch) throw new Error("getAccountStats not found in mails/*.ts");
+    const src = fnMatch[0];
+    const spamMatch = src.match(
+      /const\s+spamCondition\s*=\s*spamOnly[\s\S]*?:\s*`([^`]*)`/
+    );
+    if (!spamMatch) throw new Error("spamCondition not found");
+    expect(spamMatch[1]).toContain("is_spam = FALSE");
+  });
+
+  it("getUnreadNotifications excludes is_spam so spam does not ring the new-mail badge", () => {
+    const fnMatch = mailsSource.match(
+      /export const getUnreadNotifications[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getUnreadNotifications not found in mails/*.ts");
+    expect(fnMatch[0]).toContain("is_spam = FALSE");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/http.test.ts
+++ b/src/server/lib/postgres/repositories/mails/http.test.ts
@@ -339,3 +339,49 @@ describe("getMailHeaders — saved query spans both folders (#568)", () => {
     expect(expr).toContain(": receivedCondition");
   });
 });
+
+describe("spam-exclusion invariant — non-spam views hide is_spam mail (#461)", () => {
+  // The spam folder is a per-account view of is_spam = TRUE received mail. Its
+  // complement — every non-spam view (New / All / Saved / Sent) — must hide any
+  // is_spam mail, whether auto-classified on receipt or user-marked via
+  // /spam/mark. Without this the "Mark as spam" button is cosmetic (the row
+  // reappears on the next refetch) and auto-classified spam leaks into the
+  // inbox. Source-scan style, matching the delta / draft-exclusion guards above.
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = (
+      await Promise.all(
+        (await fs.readdir(import.meta.dir)).sort()
+          .filter((f) => f.endsWith(".ts") && !f.endsWith(".test.ts"))
+          .map((f) => fs.readFile(path.join(import.meta.dir, f), "utf8"))
+      )
+    ).join("\n");
+  });
+
+  it("getMailHeaders excludes is_spam mail from non-spam views", () => {
+    const fnMatch = mailsSource.match(/export const getMailHeaders[\s\S]*?\n};/);
+    if (!fnMatch) throw new Error("getMailHeaders not found in mails/*.ts");
+    const src = fnMatch[0];
+    // Spam view includes is_spam = TRUE; the else (every other view) excludes it.
+    expect(src).toMatch(/if \(options\.spam\)[\s\S]*is_spam = TRUE[\s\S]*else[\s\S]*is_spam = FALSE/);
+  });
+
+  it("getMailHeadersDelta evicts a mail from a non-spam view when it becomes spam", () => {
+    const fnMatch = mailsSource.match(
+      /export const getMailHeadersDelta[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("getMailHeadersDelta not found in mails/*.ts");
+    const src = fnMatch[0];
+    // Non-spam eviction mirrors the spam side: tombstone on expunge OR when the
+    // row is marked spam (is_spam flips to TRUE), so delta-sync clients evict it.
+    const evictMatch = src.match(
+      /evictionCondition\s*=\s*options\.spam[\s\S]*?:\s*`([^`]*)`/
+    );
+    if (!evictMatch) throw new Error("evictionCondition not found");
+    expect(evictMatch[1]).toContain("expunged = TRUE");
+    expect(evictMatch[1]).toContain("is_spam = TRUE");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/http.ts
+++ b/src/server/lib/postgres/repositories/mails/http.ts
@@ -128,6 +128,13 @@ export const getMailHeaders = async (
       // Spam mail is always received, never sent — matches the (sent = FALSE)
       // guard the standalone spam query carried before spam became per-account.
       sql += ` AND is_spam = TRUE AND sent = FALSE`;
+    } else {
+      // Every non-spam view (New / All / Saved / Sent) is the complement of the
+      // spam folder: a mail flagged spam — whether auto-classified on receipt or
+      // marked by the user via /spam/mark — belongs only in the spam folder, not
+      // here. Without this the "Mark as spam" action is cosmetic: the row would
+      // reappear on the next refetch because the inbox query still returned it.
+      sql += ` AND is_spam = FALSE`;
     }
 
     if (options.since !== undefined) {
@@ -214,10 +221,12 @@ export const getMailHeadersDelta = async (
     const addressCondition = buildHeaderAddressCondition(options);
     // A row leaves the spam folder either by expunge OR by being un-marked
     // (is_spam flips to FALSE); both must tombstone so a cached client evicts
-    // it. Non-spam views only evict on expunge.
+    // it. A non-spam view is the mirror: a row leaves it on expunge OR by being
+    // marked spam (is_spam flips to TRUE), so a delta-sync client evicts a mail
+    // the user just moved to the spam folder instead of leaving it cached.
     const evictionCondition = options.spam
       ? `(expunged = TRUE OR is_spam = FALSE)`
-      : `expunged = TRUE`;
+      : `(expunged = TRUE OR is_spam = TRUE)`;
     const expungedSql = `
       SELECT ${MAIL_ID} FROM mails
       WHERE user_id = $1

--- a/src/server/lib/postgres/repositories/mails/http.ts
+++ b/src/server/lib/postgres/repositories/mails/http.ts
@@ -375,7 +375,13 @@ export const getAccountStats = async (
       : RECEIVED_ADDRESS_NOT_NULL;
 
     // Match the per-account spam-folder query (is_spam received mail only).
-    const spamCondition = spamOnly ? `AND is_spam = TRUE AND sent = FALSE` : "";
+    // Spam is a separate per-account folder: the spam view counts only is_spam
+    // received mail; every other view (received/sent counts + New badge) is its
+    // complement and must exclude is_spam, so the sidebar count matches the
+    // spam-excluding headers list rather than over-counting by the spam total.
+    const spamCondition = spamOnly
+      ? `AND is_spam = TRUE AND sent = FALSE`
+      : `AND is_spam = FALSE`;
 
     // Use address matching (from_address for sent, to/cc/bcc for received) rather
     // than the `sent` boolean flag, so self-emails appear in both views correctly.
@@ -509,7 +515,9 @@ export const getUnreadNotifications = async (
       -- draft = FALSE: a user's own unsent draft must not ring the new-mail
       -- push badge. Mirrors getMailHeaders / getAccountStats so the badge count
       -- matches the headers list view (drafts live in the Drafts folder).
-      WHERE user_id IN (${placeholders}) AND sent = FALSE AND expunged = FALSE AND draft = FALSE
+      -- is_spam = FALSE: spam is quarantined to the spam folder, so it must not
+      -- ring the new-mail badge either (same mirror — the New view excludes it).
+      WHERE user_id IN (${placeholders}) AND sent = FALSE AND is_spam = FALSE AND expunged = FALSE AND draft = FALSE
       GROUP BY user_id
     `;
 


### PR DESCRIPTION
Closes #461.

## What

Adds the user-facing spam-feedback affordance from the signed-off spam-filter design ([doc](https://doc.hoie.kim/p/LhRUYyC1OR) → "User Feedback") and the server-side inbox/spam separation it depends on. The backend `POST /api/mails/spam/mark` endpoint and the `Category.SpamMails` view (PR #621) already existed; this wires the UI to them and closes the list-exclusion gap that made the mark cosmetic.

### Client — the buttons

- **"Mark as spam"** button (ban icon) in the kebab actions of any non-spam view. POSTs `{ mail_id, is_spam: true }` — flips the flag and trains the per-user Bayesian classifier.
- **"Not spam"** button (check icon) in the Spam view. POSTs `{ mail_id, is_spam: false }`.
- Both **optimistically remove** the row from the current list; a **rejected mark re-fetches** so an optimistically-removed row returns instead of vanishing.
- Spam is a **move**, not a delete, so after the mark settles the sidebar account counts are reconciled from the authoritative `/api/mails/accounts` payload (and the destination list is refreshed) rather than hand-maintaining a cross-bucket count.
- Offline-gated exactly like the star/trash controls.
- The button is gated to **received mail only** (`!isSentMail`): spam is a received-mail concept, so a sent mail (Sent view, or a sent mail in Saved/Search) never shows it — marking one would orphan it (excluded from both the Sent and Spam views).

### Server — the exclusion (why the button wasn't a no-op)

The headers query only added `is_spam = TRUE` for the spam view and **never excluded `is_spam = TRUE` from the non-spam views** (New / All / Saved / Sent). So a mail marked spam reappeared in the inbox on the next refetch, and auto-classified spam leaked into the inbox too. Fixed:

- `getMailHeaders` non-spam branch now adds `AND is_spam = FALSE`.
- `getMailHeadersDelta` non-spam eviction mirrors the spam side — tombstone on `expunged = TRUE OR is_spam = TRUE` — so a delta-sync (IDB-cache) client evicts a mail the user just moved to spam.
- Source-scan tests pin both (matching the existing draft-exclusion / delta guards).
- **Count paths mirror the exclusion:** `getAccountStats` (sidebar per-account `doc_count`) and `getUnreadNotifications` (new-mail push badge) now also exclude `is_spam`, so the count matches the spam-excluding list instead of over-counting by the spam total — and spam no longer rings the new-mail badge.

## Scope note

The issue's acceptance criteria mention a **toast + Undo**. That is not in the signed-off design (which specifies just the two buttons) and needs a toast primitive the client does not have — deferred as a follow-up. The rejected-mark re-fetch covers the failure case without a toast.

## Verification

- typecheck clean · lint clean (0 errors) · client build green · **full server suite `bun test src/server` green (1153 pass, 0 fail)** including the 2 new spam-exclusion tests.
- E2E (Playwright, 390x844 mobile viewport) on the per-PR sandbox, real UI click-chains (hamburger → category → account → kebab → action), asserting POST payloads + DB state:
  - **Mark as spam** from an inbox account (8 mails): kebab → ban button → `POST {is_spam:true}` 200; list 8 -> 7; DB row flips `is_spam=true`. **After a hard page reload the count stays 7** — the mail actually left the inbox server-side, not just optimistically hidden.
  - **Not spam** from the Spam view: kebab → check button → `POST {is_spam:false}` 200; spam list 1 -> 0; DB row flips `is_spam=false`.
  - Eye-checked screenshots per screen: the ban icon (mark) and filled-check icon (not-spam) render at the right size/position in the action row alongside star/reply/share/trash.
  - Sandbox DB state restored after each write.

---

Also closes #705. That issue reports the same defect from the data side (spam appearing in the received All/New views, the per-account badge, and the push-unread count) and its proposed fix is exactly the three query paths changed here. Filed independently before this PR existed; recording the link so the two do not get worked twice.

#705's open scope question — "the IMAP layer has no spam concept at all, should quarantine extend there?" — is answered separately by #740, which excludes spam from the IMAP INBOX tree.
