### PR TITLE
fix(imap): make FETCH RFC822.SIZE equal the BODY[] octet count (RFC 3501 §2.3.4)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -162,6 +162,70 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
   });
 });
 
+describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)", () => {
+  const docId = "doc-654";
+  const mailbox = "INBOX";
+  const base = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<size@local>",
+    date: new Date("2026-07-07T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "size check",
+  };
+
+  // Each shape exercises a different buildFullMessage branch (single part,
+  // multipart/alternative, attachments). RFC 3501 §2.3.4: RFC822.SIZE must
+  // equal the octet count BODY[] returns for the same message.
+  const shapes: Array<[string, Partial<MailType>]> = [
+    ["text only", { ...base, text: "line one\r\nline two", html: "", attachments: [] }],
+    ["html only", { ...base, text: "", html: "<p>hi there</p>", attachments: [] }],
+    [
+      "multipart/alternative (text+html)",
+      { ...base, text: "plain body", html: "<p>rich body</p>", attachments: [] },
+    ],
+    [
+      "with attachment",
+      {
+        ...base,
+        text: "see attached",
+        html: "",
+        attachments: [
+          {
+            filename: "a.txt",
+            contentType: "text/plain",
+            size: 11,
+            content: { data: "aGVsbG8gd29ybGQ=" },
+          },
+        ] as unknown as MailType["attachments"],
+      },
+    ],
+  ];
+
+  for (const [label, mail] of shapes) {
+    it(`RFC822.SIZE equals BODY[] length for ${label}`, async () => {
+      const size = await buildFetchResponsePart(
+        mail,
+        { type: "RFC822.SIZE" },
+        docId,
+        mailbox
+      );
+      const body = await buildFetchResponsePart(
+        mail,
+        { type: "BODY", peek: true, section: { type: "FULL" } },
+        docId,
+        mailbox
+      );
+      expect(size!.type).toBe("simple");
+      expect(body!.type).toBe("literal");
+      if (size!.type === "simple" && body!.type === "literal") {
+        const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
+        expect(reported).toBe(body!.length);
+      }
+    });
+  }
+});
+
 describe("buildBodyResponsePart header terminators (inbox #645)", () => {
   // RFC 3501 §6.4.5: every header fetch ends with exactly one RFC-2822
   // delimiting blank line after the last header field — i.e. `…field\r\n\r\n`.

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -96,6 +96,33 @@ describe("getRequestedFields", () => {
       expect(rfc.has("text")).toBe(true);
     });
   });
+
+  describe("RFC822.SIZE (inbox #654)", () => {
+    it("requests the full-message columns its size computation serializes", () => {
+      // RFC822.SIZE is derived from the FULL-body serializer, so a bare
+      // `FETCH n RFC822.SIZE` must load the header columns too — otherwise
+      // formatHeaders omits those lines and the size under-reports vs BODY[].
+      const size = getRequestedFields([{ type: "RFC822.SIZE" }]);
+      const body = getRequestedFields([
+        { type: "BODY", peek: true, section: { type: "FULL" } }
+      ]);
+      expect([...size].sort()).toEqual([...body].sort());
+      for (const f of [
+        "text",
+        "html",
+        "subject",
+        "from",
+        "to",
+        "cc",
+        "bcc",
+        "date",
+        "messageId",
+        "attachments",
+      ] as const) {
+        expect(size.has(f)).toBe(true);
+      }
+    });
+  });
 });
 
 describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -227,6 +227,18 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
         ] as unknown as MailType["attachments"],
       },
     ],
+    // Multibyte UTF-8: octet count != character count, so any path that
+    // measured string `.length` instead of `Buffer.byteLength` would diverge.
+    [
+      "multibyte utf-8 (octet != char count)",
+      {
+        ...base,
+        subject: "größe 日本語 ✉",
+        text: "café ☕ 日本語 — first line\r\nemoji 😀 tail",
+        html: "",
+        attachments: [],
+      },
+    ],
   ];
 
   for (const [label, mail] of shapes) {

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -145,10 +145,12 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<keyof MailTy
         fields.add("date");
         break;
 
+      // RFC822.SIZE is derived from the full-message serializer (it must equal
+      // len(BODY[]) per §2.3.4), so it needs every column that serializer
+      // reads — headers included, not just the body parts. Request the same
+      // columns a FULL body fetch does.
       case "RFC822.SIZE":
-        fields.add("text");
-        fields.add("html");
-        fields.add("attachments");
+        addBodyFields({ type: "BODY", peek: true, section: { type: "FULL" } }, fields);
         break;
 
       // RFC822* alias the matching BODY[...] sections (§6.4.5); request the

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -8,7 +8,6 @@
 import { MailType } from "common";
 import { logger } from "server";
 import {
-  encodeText,
   formatBodyStructure,
   formatEnvelope,
   formatFlags,
@@ -345,15 +344,21 @@ export async function buildFetchResponsePart(
     }
 
     case "RFC822.SIZE": {
-      const encodedText = encodeText(mail.text || "");
-      const textSize = Buffer.byteLength(encodedText, "utf-8");
-      const encodedHtml = encodeText(mail.html || "");
-      const htmlSize = Buffer.byteLength(encodedHtml, "utf-8");
-      const attachmentSize = (mail.attachments ?? []).reduce(
-        (acc, { size }) => acc + (size ? Math.ceil(size / 3) * 4 : 0),
-        0
+      // RFC 3501 §2.3.4: RFC822.SIZE is the octet count of the message in RFC
+      // 2822 format — i.e. it must equal the number of octets BODY[] / RFC822
+      // returns for the same message. Deriving it from the same FULL-body
+      // serializer BODY[] uses (buildBodyResponsePart) makes the two agree by
+      // construction, including the RFC-2822 header block, all MIME framing,
+      // and the exact base64 encoding of every part. The previous ad-hoc
+      // formula summed only the base64 body parts (no headers, no boundaries),
+      // so it under-reported and drifted from BODY[] in both directions.
+      const fullBody = await buildBodyResponsePart(
+        mail,
+        { type: "BODY", peek: true, section: { type: "FULL" } },
+        docId,
+        selectedMailbox
       );
-      const size = textSize + htmlSize + attachmentSize;
+      const size = fullBody?.type === "literal" ? fullBody.length : 0;
       return { type: "simple", content: `RFC822.SIZE ${size}` };
     }
 


### PR DESCRIPTION
## What

`FETCH … RFC822.SIZE` reported a byte count that did **not** equal the octet length of the message the server returns for `FETCH … BODY[]` / `RFC822`. RFC 3501 §2.3.4 defines `RFC822.SIZE` as the number of octets in the message in RFC 2822 format — i.e. it must equal `len(BODY[])`. It didn't, and it diverged in both directions:

- text+html multipart: under-reported by ~570–590 octets (the header block, `--boundary` delimiters, per-part `Content-Type`/`Content-Transfer-Encoding` headers, closing `--boundary--`, and inter-part CRLFs were never counted).
- with attachments: drifted by the full attachment framing, since the estimate used the declared `attachment.size` rather than the actual base64 the serializer emits.

Impact: clients that bound a full-message fetch on the advertised size (`BODY.PEEK[]<0.{RFC822.SIZE}>`) truncate the tail of the message; validators may flag corruption or re-download.

Closes #654.

## Root cause

`src/server/lib/imap/fetch-helpers.ts`, the `RFC822.SIZE` case, computed an independent estimate (`textSize + htmlSize + attachmentSize`) that never touched `buildFullMessage` — the exact serializer `BODY[]` / `RFC822` / `BODY[TEXT]` all go through. Two different code paths cannot agree.

## Fix

Derive `RFC822.SIZE` from the **same** FULL-body computation `BODY[]` uses — `buildBodyResponsePart(mail, { section: FULL })` — and report its literal `.length`. The header block, MIME boundaries, per-part headers, and the exact base64 encoding of every part are now all accounted for identically, so `RFC822.SIZE` and `BODY[]` agree **by construction** and cannot drift again. (Also drops the now-unused `encodeText` import.)

## Tests

`src/server/lib/imap/fetch-helpers.test.ts` — new `RFC822.SIZE == BODY[] octet count` block asserting the invariant across four `buildFullMessage` branches: text-only, html-only, multipart/alternative, and an attachment message. `bun test src/server/lib/imap` → 556 pass (560 incl. the 4 new), 0 fail. `tsc --noEmit` clean.

## E2E (live IMAP socket, dev server)

`LOGIN admin` → `SELECT INBOX`, then `FETCH <seq> (RFC822.SIZE BODY.PEEK[])` across a spread of real messages (seq 1, 2, 3, 50, 500, 2000 — small to large):

| | before | after |
|---|---|---|
| `RFC822.SIZE` vs `BODY[] {n}` | under-reported (e.g. 2496 vs 3063) | **equal on every message tested** |

Confirmed `RFC822.SIZE == BODY[]` literal octet count for all sampled messages.

## Performance note (per the scalability lens)

Sizing now serializes the full body (including base64-encoding attachments) per request, so metadata-only fetches — `FETCH 1:* FAST` / `ALL` list views — pay that cost where the old estimate was cheap-but-wrong. The durable O(1) fix is a persisted `size` column computed at ingest; filing that as a follow-up so the correctness fix lands now without waiting on a schema change.
