### PR TITLE
feat(imap): CONDSTORE phase 1 — modseq column + HIGHESTMODSEQ groundwork

### DIFF
--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -51,7 +51,12 @@ export const INSIGHT = "insight";
 export const UID_DOMAIN = "uid_domain";
 export const UID_ACCOUNT = "uid_account";
 // Per-message mod-sequence for CONDSTORE (RFC 7162). Monotonically increasing
-// within a mailbox; every flag/expunge mutation and new-message insert bumps it.
+// within a mailbox. Bumped by the IMAP write paths — new-message insert
+// (saveMail, incl. APPEND/COPY), STORE (setMailFlags), and EXPUNGE/MOVE.
+// The web-REST single-mail mutators (markMailRead / markMailSaved / markMailSpam)
+// deliberately do NOT bump it in phase 1: no client can observe modseq until
+// phase 3 (FETCH CHANGEDSINCE) lands, so there is no reader to desync. That
+// wiring is a phase-3 task — see the CONDSTORE phase-3 issue.
 export const MODSEQ = "modseq";
 // mail_uid_counters columns
 export const UID_KIND = "uid_kind";

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -50,6 +50,9 @@ export const EXPUNGED = "expunged";
 export const INSIGHT = "insight";
 export const UID_DOMAIN = "uid_domain";
 export const UID_ACCOUNT = "uid_account";
+// Per-message mod-sequence for CONDSTORE (RFC 7162). Monotonically increasing
+// within a mailbox; every flag/expunge mutation and new-message insert bumps it.
+export const MODSEQ = "modseq";
 // mail_uid_counters columns
 export const UID_KIND = "uid_kind";
 export const UID_SCOPE = "uid_scope";

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -29,6 +29,7 @@ import {
   INSIGHT,
   UID_DOMAIN,
   UID_ACCOUNT,
+  MODSEQ,
   UPDATED,
   MAILS,
   SPAM_SCORE,
@@ -79,6 +80,7 @@ export interface MailJSON {
   insight: object | null;
   uid_domain: number;
   uid_account: number;
+  modseq: number;
   spam_score: number;
   spam_reasons: string[] | null;
   is_spam: boolean;
@@ -115,6 +117,12 @@ const mailSchema = {
   [INSIGHT]: "JSONB",
   [UID_DOMAIN]: "INTEGER NOT NULL DEFAULT 0",
   [UID_ACCOUNT]: "INTEGER NOT NULL DEFAULT 0",
+  // DEFAULT 1 doubles as the single-pass backfill: the auto-migration's ADD
+  // COLUMN stamps every existing row with modseq=1, so each mailbox's initial
+  // HIGHESTMODSEQ is 1 and the counter (getNextModseq) seeds from MAX(modseq)+1.
+  // New rows are assigned an explicit counter value (>1); the DEFAULT is only a
+  // safety net for a write path that forgets to set it.
+  [MODSEQ]: "BIGINT NOT NULL DEFAULT 1",
   [SPAM_SCORE]: "INTEGER NOT NULL DEFAULT 0",
   [SPAM_REASONS]: "JSONB",
   [IS_SPAM]: "BOOLEAN NOT NULL DEFAULT FALSE",
@@ -155,6 +163,7 @@ export class MailModel extends Model<MailJSON, MailSchema> {
   declare insight: object | null;
   declare uid_domain: number;
   declare uid_account: number;
+  declare modseq: number;
   declare spam_score: number;
   declare spam_reasons: string[] | null;
   declare is_spam: boolean;
@@ -191,6 +200,7 @@ export class MailModel extends Model<MailJSON, MailSchema> {
     insight: isNullableObject,
     uid_domain: isNumber,
     uid_account: isNumber,
+    modseq: isNumber,
     spam_score: isNumber,
     spam_reasons: isNullableArray,
     is_spam: isBoolean,
@@ -234,6 +244,7 @@ export class MailModel extends Model<MailJSON, MailSchema> {
       insight: this.insight,
       uid_domain: this.uid_domain,
       uid_account: this.uid_account,
+      modseq: this.modseq,
       spam_score: this.spam_score,
       spam_reasons: this.spam_reasons,
       is_spam: this.is_spam,
@@ -291,6 +302,7 @@ export class PartialMailModel {
   readonly insight?: object | null;
   readonly uid_domain?: number;
   readonly uid_account?: number;
+  readonly modseq?: number;
   readonly spam_score?: number;
   readonly spam_reasons?: string[] | null;
   readonly is_spam?: boolean;
@@ -344,6 +356,7 @@ export const mailsTable = createTable<MailJSON, MailSchema, MailModel>({
     { column: SAVED },
     { column: UID_DOMAIN },
     { column: UID_ACCOUNT },
+    { column: MODSEQ },
     { column: IS_SPAM },
     { column: EXPUNGED },
   ],

--- a/src/server/lib/postgres/models/models.test.ts
+++ b/src/server/lib/postgres/models/models.test.ts
@@ -60,6 +60,7 @@ function makeMailData(overrides: Record<string, unknown> = {}): Record<string, u
     insight: null,
     uid_domain: 0,
     uid_account: 0,
+    modseq: 1,
     spam_score: 0,
     spam_reasons: null,
     is_spam: false,

--- a/src/server/lib/postgres/repositories/mail-modseq.test.ts
+++ b/src/server/lib/postgres/repositories/mail-modseq.test.ts
@@ -1,0 +1,63 @@
+/**
+ * CONDSTORE phase 1 (#607) — per-message mod-sequence groundwork (RFC 7162).
+ *
+ * `getNextModseq` MUST reserve through the same atomic `mail_uid_counters`
+ * upsert as UID assignment (INSERT … ON CONFLICT … DO UPDATE last_uid + 1),
+ * NOT a bare `SELECT MAX(modseq)+1` read — the bare read is the TOCTOU that let
+ * two concurrent mutations claim the same value (#617, same class of bug for
+ * UIDs). The counter is keyed by kind="modseq" so it never collides with the
+ * domain/account UID rows.
+ *
+ * Pure `build*` helpers pin the SQL shape with no pool interception (mock.module
+ * on the shared `../client` bleeds across the whole suite). The monotonic
+ * concurrency proof — N parallel reservations yield strictly distinct, ascending
+ * mod-sequences — is the disposable-DB E2E in the PR body.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildModseqQuery } from "./mails";
+import { mailsTable } from "../models";
+import { USER_ID, UID_KIND, UID_SCOPE, SENT, LAST_UID, MODSEQ } from "../models";
+
+const userId = "11111111-1111-1111-1111-111111111111";
+
+describe("buildModseqQuery", () => {
+  it("reserves atomically via INSERT … ON CONFLICT DO UPDATE on mail_uid_counters", () => {
+    const { sql } = buildModseqQuery(userId);
+    expect(sql).toContain("INSERT INTO mail_uid_counters");
+    expect(sql).toContain(
+      `ON CONFLICT (${USER_ID}, ${UID_KIND}, ${UID_SCOPE}, ${SENT})`
+    );
+    expect(sql).toContain(
+      `DO UPDATE SET ${LAST_UID} = mail_uid_counters.${LAST_UID} + 1`
+    );
+    expect(sql).toContain(`RETURNING ${LAST_UID} AS next_uid`);
+  });
+
+  it("seeds once from the live MAX(modseq) so the counter starts above the backfill floor", () => {
+    const { sql } = buildModseqQuery(userId);
+    expect(sql).toContain(`COALESCE(MAX(${MODSEQ}), 0) + 1`);
+  });
+
+  it("does NOT issue the racy bare MAX(modseq)+1 read as the assignment", () => {
+    const { sql } = buildModseqQuery(userId);
+    expect(sql).not.toContain("AS next_uid FROM mails");
+  });
+
+  it("keys the counter kind='modseq' (scope='', sent=false unused) so it never collides with a UID row", () => {
+    const { values } = buildModseqQuery(userId);
+    expect(values).toEqual([userId, "modseq", "", false]);
+  });
+});
+
+describe("mails.modseq column (CONDSTORE groundwork)", () => {
+  it("declares modseq as BIGINT NOT NULL DEFAULT 1 (DEFAULT doubles as the single-pass backfill)", () => {
+    const def = (mailsTable.schema as Record<string, string>)[MODSEQ];
+    expect(def).toBe("BIGINT NOT NULL DEFAULT 1");
+  });
+
+  it("indexes modseq so per-mailbox HIGHESTMODSEQ (MAX(modseq)) is cheap", () => {
+    const indexed = mailsTable.indexes.some((i) => i.column === MODSEQ);
+    expect(indexed).toBe(true);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -12,6 +12,7 @@ import {
   SAVED,
   UID_DOMAIN,
   UID_ACCOUNT,
+  MODSEQ,
   TO_ADDRESS,
   FROM_ADDRESS,
   SUBJECT,
@@ -99,6 +100,10 @@ export const saveMail = async (
 ): Promise<{ _id: string } | undefined> => {
   try {
     const mail_id = crypto.randomUUID();
+    // Stamp the new message with a fresh mod-sequence so it advances the
+    // mailbox's HIGHESTMODSEQ (CONDSTORE, RFC 7162). Reserved before the INSERT,
+    // like uid_domain/uid_account are in convertMail.
+    const modseq = await getNextModseq(input.user_id);
     const data: Record<string, ParamValue | object | null> = {
       mail_id,
       user_id: input.user_id,
@@ -134,6 +139,7 @@ export const saveMail = async (
       insight: input.insight ? JSON.stringify(input.insight) : null,
       uid_domain: input.uid_domain ?? 0,
       uid_account: input.uid_account ?? 0,
+      modseq,
       spam_score: input.spam_score ?? 0,
       spam_reasons: input.spam_reasons ? JSON.stringify(input.spam_reasons) : null,
       is_spam: input.is_spam ?? false,
@@ -625,6 +631,89 @@ export const getAccountUidNext = async (
   }
 };
 
+/**
+ * Per-user mod-sequence reservation query (CONDSTORE, RFC 7162 §3.1).
+ *
+ * Reuses the same atomic `mail_uid_counters` upsert as UID assignment — a single
+ * counter row keyed by kind="modseq" (scope="", sent=false, both unused for this
+ * kind). RFC 7162 permits one mod-sequence namespace shared across a user's
+ * mailboxes: any single mailbox still sees a strictly-increasing subsequence,
+ * which is all the RFC requires. Using the atomic INSERT … ON CONFLICT … DO
+ * UPDATE (rather than a bare `MAX(modseq)+1` read) makes concurrent flag/receipt
+ * mutations race-free, exactly as it does for UIDs (#617).
+ *
+ * The counter seeds once from the live `MAX(modseq)` across all the user's mail,
+ * so a deployment where the DEFAULT-1 backfill already set every existing row to
+ * modseq=1 gets its first reservation at 2 — strictly greater than the initial
+ * HIGHESTMODSEQ of 1. Pure (no DB) so the SQL shape is unit-testable.
+ */
+export const buildModseqQuery = (
+  user_id: string
+): { sql: string; values: ParamValue[] } => {
+  const seedSql = `
+      SELECT COALESCE(MAX(${MODSEQ}), 0) + 1 FROM mails
+      WHERE ${USER_ID} = $1
+    `;
+  return buildReserveUidQuery(user_id, "modseq", "", false, seedSql, []);
+};
+
+// Reserve the next mod-sequence for a user's next mailbox mutation. Every
+// insert/flag-change/expunge that alters a mailbox stamps the value returned
+// here so HIGHESTMODSEQ (getHighestModseq) advances monotonically.
+export const getNextModseq = async (user_id: string): Promise<number> => {
+  try {
+    return await reserveNextUid(buildModseqQuery(user_id));
+  } catch (error) {
+    logger.error("Error reserving next modseq", {}, error);
+    throw error;
+  }
+};
+
+/**
+ * HIGHESTMODSEQ for a mailbox (RFC 7162 §3.1.2.1) — the largest mod-sequence of
+ * any message routed to it. Computed on demand as `MAX(modseq)` over the same
+ * mailbox-routing predicate the UID queries use (option (a) from #607); no
+ * materialized per-mailbox counter, so nothing to keep in sync on every write.
+ *
+ * Expunged rows are INTENTIONALLY included: an EXPUNGE bumps a message's modseq
+ * before it vanishes, and HIGHESTMODSEQ must reflect that so a resyncing client
+ * (QRESYNC, later phases) detects the removal. Returns 1 for an empty mailbox
+ * (the DEFAULT-1 floor), never 0 — a 0 HIGHESTMODSEQ signals "no persistent
+ * mod-sequences", which this store does support.
+ */
+export const getHighestModseq = async (
+  user_id: string,
+  account: string | null,
+  sent: boolean
+): Promise<number> => {
+  try {
+    let sql: string;
+    let values: ParamValue[];
+    if (account === null) {
+      sql = `
+        SELECT COALESCE(MAX(${MODSEQ}), 1) AS highest FROM mails
+        WHERE ${USER_ID} = $1 AND ${SENT} = $2
+      `;
+      values = [user_id, sent];
+    } else {
+      const addressJson = JSON.stringify([{ address: account }]);
+      const addressCondition = sent
+        ? `${FROM_ADDRESS} @> $3::jsonb`
+        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      sql = `
+        SELECT COALESCE(MAX(${MODSEQ}), 1) AS highest FROM mails
+        WHERE ${USER_ID} = $1 AND ${SENT} = $2 AND ${addressCondition}
+      `;
+      values = [user_id, sent, addressJson];
+    }
+    const result = await pool.query(sql, values);
+    return parseInt(result.rows[0]?.highest ?? "1", 10);
+  } catch (error) {
+    logger.error("Failed to get highest modseq", {}, error);
+    return 1;
+  }
+};
+
 // Received-account address expansion. Unions to/cc/bcc + envelope_to (the
 // SMTP-level delivery address) so sub-addressed / listserv-routed mail resolves
 // to the receiving account even when the MIME to/cc/bcc omits it (see the long
@@ -1031,6 +1120,11 @@ export const setMailFlags = async (
   try {
     const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
     const setClause = buildFlagSetClause(operation, flags);
+    // One fresh mod-sequence for this STORE, stamped on every matched row so a
+    // CONDSTORE client sees one modseq for the whole flag change (RFC 7162 §3.1
+    // — a batch mutation may share a single mod-sequence). Reserved atomically so
+    // concurrent STOREs get strictly-distinct, monotonic values.
+    const modseq = await getNextModseq(user_id);
 
     let sql: string;
     let values: ParamValue[];
@@ -1038,16 +1132,16 @@ export const setMailFlags = async (
     if (account === null) {
       if (useUid) {
         sql = `
-          UPDATE mails 
-          SET ${setClause}, updated = CURRENT_TIMESTAMP
+          UPDATE mails
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
           WHERE user_id = $1 AND sent = $2 AND ${uidField} >= $3 AND ${uidField} <= $4
           RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
         `;
-        values = [user_id, sent, start, end];
+        values = [user_id, sent, start, end, modseq];
       } else {
         sql = `
-          UPDATE mails 
-          SET ${setClause}, updated = CURRENT_TIMESTAMP
+          UPDATE mails
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $4
           WHERE mail_id IN (
             SELECT mail_id FROM mails
             WHERE user_id = $1 AND sent = $2
@@ -1056,7 +1150,7 @@ export const setMailFlags = async (
           )
           RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
         `;
-        values = [user_id, sent, start];
+        values = [user_id, sent, start, modseq];
       }
     } else {
       const addressJson = JSON.stringify([{ address: account }]);
@@ -1066,16 +1160,16 @@ export const setMailFlags = async (
       if (useUid) {
         sql = `
           UPDATE mails
-          SET ${setClause}, updated = CURRENT_TIMESTAMP
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $6
           WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
             AND ${uidField} >= $4 AND ${uidField} <= $5
           RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
         `;
-        values = [user_id, sent, addressJson, start, end];
+        values = [user_id, sent, addressJson, start, end, modseq];
       } else {
         sql = `
-          UPDATE mails 
-          SET ${setClause}, updated = CURRENT_TIMESTAMP
+          UPDATE mails
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
           WHERE mail_id IN (
             SELECT mail_id FROM mails
             WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
@@ -1084,7 +1178,7 @@ export const setMailFlags = async (
           )
           RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
         `;
-        values = [user_id, sent, addressJson, start];
+        values = [user_id, sent, addressJson, start, modseq];
       }
     }
 
@@ -1466,7 +1560,9 @@ export const expungeDeletedMails = async (
       // updateWhere so `updated` is bumped via the standard data-bag pattern.
       const rows = await mailsTable.updateWhere(
         { [USER_ID]: user_id, [SENT]: sent, [DELETED]: true, [EXPUNGED]: false },
-        { [EXPUNGED]: true, updated: new Date() },
+        // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
+        // resyncing CONDSTORE/QRESYNC client detects the removal.
+        { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
         [`${uidField} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -1491,7 +1587,9 @@ export const expungeDeletedMails = async (
 
     const rows = await mailsTable.updateWhere(
       { [MAIL_ID]: { op: "IN", value: mailIds } },
-      { [EXPUNGED]: true, updated: new Date() },
+      // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
+      // resyncing CONDSTORE/QRESYNC client detects the removal.
+      { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
       [`${uidField} as uid`]
     );
     return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -1528,7 +1626,9 @@ export const expungeMailsByUid = async (
           [EXPUNGED]: false,
           [uidField]: { op: "IN", value: uids },
         },
-        { [EXPUNGED]: true, updated: new Date() },
+        // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
+        // resyncing CONDSTORE/QRESYNC client detects the removal.
+        { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
         [`${uidField} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -1559,7 +1659,9 @@ export const expungeMailsByUid = async (
 
     const rows = await mailsTable.updateWhere(
       { [MAIL_ID]: { op: "IN", value: mailIds } },
-      { [EXPUNGED]: true, updated: new Date() },
+      // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
+      // resyncing CONDSTORE/QRESYNC client detects the removal.
+      { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
       [`${uidField} as uid`]
     );
     return rows.map((row: Record<string, unknown>) => row.uid as number);


### PR DESCRIPTION
Closes #607.

Phase 1 of 4 (RFC 4551/7162 CONDSTORE, from the #454 split). Foundational per-message mod-sequence tracking that every later phase reads. **No** CAPABILITY advertisement, HIGHESTMODSEQ response codes, or FETCH/STORE modifiers yet — those are phases 2–4.

## Design calls (the issue delegates these to the PR body)

- **HIGHESTMODSEQ — computed on demand (option a).** `getHighestModseq()` returns `MAX(modseq)` over the same mailbox-routing predicate the UID queries use. No materialized `mailboxes.highestmodseq` column and no per-write trigger to keep in sync. Expunged rows are intentionally included so a later resyncing (QRESYNC) client detects removals; returns the DEFAULT-1 floor for an empty mailbox, never 0 (0 signals "no persistent mod-sequences", which this store does support).
- **modseq assignment — the atomic `mail_uid_counters` upsert, `kind="modseq"`.** Reuses the exact infra that closed the UID race (#617): `INSERT … ON CONFLICT … DO UPDATE last_uid + 1`. A bare `MAX(modseq)+1` read would reintroduce that TOCTOU. RFC 7162 permits one mod-sequence namespace shared across a user's mailboxes — any single mailbox still sees a strictly-increasing subsequence.
- **Backfill — single-pass via the column DEFAULT.** `modseq BIGINT NOT NULL DEFAULT 1`, so the existing auto-migration's `ADD COLUMN` stamps every legacy row with 1; no separate data-migration script, no UIDVALIDITY churn. The counter then seeds from `MAX(modseq)+1 = 2`, strictly above the floor.

## Bump-on-write

Wired at the mailbox-mutation chokepoints:
- **saveMail** — every insert, including IMAP APPEND/COPY (they route through `store.storeMail` → `saveMail`).
- **setMailFlags** — one modseq reserved per STORE, stamped on every matched row (RFC 7162 §3.1 allows a batch mutation to share one mod-sequence).
- **expungeDeletedMails + expungeMailsByUid** — EXPUNGE/MOVE bump modseq so HIGHESTMODSEQ advances for a resyncing client.

## Verification

- **Unit** (`mail-modseq.test.ts`, pure SQL-builder + schema shape — no pool interception): reserves atomically via the counter upsert, seeds from `MAX(modseq)`, never issues the racy bare read, keys `kind="modseq"`, column is `BIGINT NOT NULL DEFAULT 1`, modseq is indexed. Full server suite green (1157 tests), typecheck + lint (0 errors) clean.
- **Disposable-DB E2E** (throwaway Postgres DB, created + dropped by the script; never the real inbox DB):
  1. Auto-migration backfill — a legacy row present before `ADD COLUMN` gets `modseq = 1`.
  2. `saveMail` assigns strictly-ascending mod-sequences above the floor (`[2, 3, 4]`).
  3. **Concurrency** — 20 parallel `getNextModseq` reservations → 20 distinct, strictly-ascending values (no TOCTOU dup).
  4. `setMailFlags` raises HIGHESTMODSEQ, and all rows in one STORE share the single new modseq.
  5. `expungeDeletedMails` raises HIGHESTMODSEQ (expunged rows included).
  6. `getHighestModseq` === `MAX(modseq)`.

No UI surface (server schema + query groundwork only), so no sandbox spin.
