### PR TITLE
tech-debt(mails): stamp every `updated` write from the DB clock (DB_NOW sentinel)

### DIFF
--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -10,6 +10,16 @@ import {
   QueryData,
 } from "../database";
 
+/**
+ * Sentinel for a data-bag value that must be stamped from the DB clock
+ * (`CURRENT_TIMESTAMP`) rather than a bound parameter. Keeps every mutation on
+ * one timeline: the `?since=` delta cursor reads `as_of` from the DB clock, so
+ * an app-clock write (`new Date()`) on a host whose clock lags the DB's could
+ * stamp `updated` below a cursor the client already holds and drop the
+ * tombstone. Pass in an updateWhere data bag: `updateWhere(f, { updated: DB_NOW })`.
+ */
+export const DB_NOW: unique symbol = Symbol("DB_NOW");
+
 export class ModelValidationError extends Error {
   public readonly errors: string[];
 
@@ -101,7 +111,7 @@ export type TypeSafeFilters<TSchema extends Schema> = {
  * If notNull is true, an extra "col IS NOT NULL" clause is prepended.
  *
  * Example: deleteWhere({ cookie_expires: { op: '<=', value: now, notNull: true } })
- * Example: updateWhere({ mail_id: { op: 'IN', value: ids } }, { expunged: true, updated: new Date() })
+ * Example: updateWhere({ mail_id: { op: 'IN', value: ids } }, { expunged: true, updated: DB_NOW })
  */
 export interface FilterCondition {
   op: "=" | "<" | "<=" | ">" | ">=" | "IN";
@@ -275,8 +285,15 @@ export abstract class Table<
       return [];
     }
     let paramIdx = 1;
-    const setClauses = dataEntries.map(([k]) => `${k} = $${paramIdx++}`);
-    const dataValues = dataEntries.map(([, v]) => v as ParamValue);
+    const dataValues: ParamValue[] = [];
+    const setClauses = dataEntries.map(([k, v]) => {
+      // DB_NOW stamps the column from the DB clock (`CURRENT_TIMESTAMP`) as a
+      // SQL literal, consuming no bound parameter — keeps every mutation on one
+      // timeline for the delta cursor (see DB_NOW).
+      if (v === DB_NOW) return `${k} = CURRENT_TIMESTAMP`;
+      dataValues.push(v as ParamValue);
+      return `${k} = $${paramIdx++}`;
+    });
     const { whereSql, values: whereValues } = buildFilterClauses(filterEntries, paramIdx);
     const returningClause = returning?.length ? ` RETURNING ${returning.join(", ")}` : "";
     const sql = `UPDATE ${this.name} SET ${setClauses.join(", ")} WHERE ${whereSql}${returningClause}`;

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -115,7 +115,7 @@ export const saveMail = async (
         ];
         await mailsTable.updateWhere(
           { user_id: input.user_id, message_id: input.message_id },
-          { [ENVELOPE_TO]: JSON.stringify(merged) }
+          { [ENVELOPE_TO]: JSON.stringify(merged), updated: DB_NOW }
         );
       }
 

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { logger } from "../../../logger";
 import { pool } from "../../client";
 import { ParamValue } from "../../database";
-import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO } from "../../models";
+import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO, DB_NOW } from "../../models";
 import { getNextModseq } from "./counters";
 
 export interface SaveMailInput {
@@ -158,7 +158,7 @@ export const markMailRead = async (
   try {
     const rows = await mailsTable.updateWhere(
       { [MAIL_ID]: mail_id, [USER_ID]: user_id },
-      { read: true, updated: new Date() },
+      { read: true, updated: DB_NOW },
       [MAIL_ID]
     );
     return rows.length > 0;
@@ -176,7 +176,7 @@ export const markMailSaved = async (
   try {
     const rows = await mailsTable.updateWhere(
       { [MAIL_ID]: mail_id, [USER_ID]: user_id },
-      { saved, updated: new Date() },
+      { saved, updated: DB_NOW },
       [MAIL_ID]
     );
     return rows.length > 0;

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -312,6 +312,17 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456,
       (fnSource.match(/mailsTable\.updateWhere\(/g) ?? []).length;
     expect(updateWhereCount).toBe(2);
   });
+
+  it("no mutation path in mails.ts stamps `updated` from the app clock", () => {
+    // #614 acceptance, whole-file: not just expunge — markMailRead,
+    // markMailSaved, and the MOVE-path expungeMailsByUid must all use the
+    // DB_NOW sentinel too, so every `updated` write is on the DB clock. This
+    // guards against any future `updateWhere({ updated: new Date() })` sneaking
+    // back in.
+    expect(mailsSource).not.toMatch(/updated:\s*new Date\(\)/);
+    // And the sentinel is actually the shape in use.
+    expect(mailsSource).toMatch(/updated:\s*DB_NOW/);
+  });
 });
 
 describe("buildCriterionClause — flag criteria use schema columns", () => {

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -323,6 +323,21 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456,
     // And the sentinel is actually the shape in use.
     expect(mailsSource).toMatch(/updated:\s*DB_NOW/);
   });
+
+  it("saveMail envelope_to merge (23505 conflict) stamps DB-clock `updated`", () => {
+    // #614: the unique-violation merge branch mutates envelope_to, which feeds
+    // the received per-account address expansion in getMailHeadersDelta — so it
+    // is a delta-synced mutation. Without bumping `updated` the merge never
+    // advances the delta cursor: a client already holding the mail never
+    // re-fetches the newly-merged sub-address, so the mail silently misses that
+    // account's received view until a full resync.
+    const saveMatch = mailsSource.match(/export const saveMail[\s\S]*?\n};/);
+    if (!saveMatch) throw new Error("saveMail not found in mails/*.ts");
+    const saveSource = saveMatch[0];
+    expect(saveSource).toContain("mailsTable.updateWhere(");
+    expect(saveSource).toMatch(/\[ENVELOPE_TO\]:/);
+    expect(saveSource).toMatch(/updated:\s*DB_NOW/);
+  });
 });
 
 describe("buildCriterionClause — flag criteria use schema columns", () => {

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -256,12 +256,14 @@ describe("setMailFlags — no-op STORE skips the UPDATE (source regression for #
   });
 });
 
-describe("expungeDeletedMails — `updated` column refresh (regression for #456)", () => {
+describe("expungeDeletedMails — `updated` column refresh (regression for #456, #614)", () => {
   // Static source check: the expunge write paths must go through
-  // mailsTable.updateWhere with `updated: new Date()` in the data bag so the
-  // framework's own auto-`updated` is not bypassed. Source-text scanning is
-  // robust against module-mock interactions in the full suite — the
-  // alternative (mock pool.query) fails when other tests load the mails repository first.
+  // mailsTable.updateWhere with `updated: DB_NOW` in the data bag so the
+  // framework bumps `updated` from the DB clock (CURRENT_TIMESTAMP), not the
+  // app clock — one timeline for the delta cursor (#614). Source-text scanning
+  // is robust against module-mock interactions in the full suite — the
+  // alternative (mock pool.query) fails when other tests load the mails
+  // repository first.
   let mailsSource: string;
   let fnSource: string;
 
@@ -289,11 +291,15 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456)
     expect(fnSource).not.toMatch(/SET\s+expunged/);
   });
 
-  it("domain-wide branch uses mailsTable.updateWhere with `updated`", () => {
+  it("domain-wide branch uses mailsTable.updateWhere with DB-clock `updated`", () => {
     // The `account === null` branch must use updateWhere with equality filters.
     expect(fnSource).toContain("mailsTable.updateWhere(");
     expect(fnSource).toMatch(/\[EXPUNGED\]:\s*true/);
-    expect(fnSource).toMatch(/updated:\s*new Date\(\)/);
+    // #614: `updated` is stamped from the DB clock via the DB_NOW sentinel,
+    // never the app clock (`new Date()`), so it stays on the delta cursor's
+    // timeline.
+    expect(fnSource).toMatch(/updated:\s*DB_NOW/);
+    expect(fnSource).not.toMatch(/updated:\s*new Date\(\)/);
   });
 
   it("account-specific branch uses mailsTable.updateWhere with IN filter", () => {

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -14,6 +14,7 @@ import {
   SENT,
   DELETED,
   EXPUNGED,
+  DB_NOW,
 } from "../../models";
 import { getNextModseq } from "./counters";
 
@@ -660,7 +661,7 @@ export const expungeDeletedMails = async (
         { [USER_ID]: user_id, [SENT]: sent, [DELETED]: true, [EXPUNGED]: false },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
-        { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
+        { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
         [`${uidField} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -687,7 +688,7 @@ export const expungeDeletedMails = async (
       { [MAIL_ID]: { op: "IN", value: mailIds } },
       // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
       // resyncing CONDSTORE/QRESYNC client detects the removal.
-      { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
+      { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
       [`${uidField} as uid`]
     );
     return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -726,7 +727,7 @@ export const expungeMailsByUid = async (
         },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
-        { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
+        { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
         [`${uidField} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
@@ -759,7 +760,7 @@ export const expungeMailsByUid = async (
       { [MAIL_ID]: { op: "IN", value: mailIds } },
       // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
       // resyncing CONDSTORE/QRESYNC client detects the removal.
-      { [EXPUNGED]: true, updated: new Date(), [MODSEQ]: await getNextModseq(user_id) },
+      { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
       [`${uidField} as uid`]
     );
     return rows.map((row: Record<string, unknown>) => row.uid as number);


### PR DESCRIPTION
Closes #614.
Closes #676.

## Problem

`updated` was written on two different clocks across the mail-mutation paths, which is unsound for the `?since=` delta cursor (added for #457). The cursor reads its `as_of` from the **DB clock** (`now()`); an **app-clock** write (`new Date()`) on a host whose clock lags the DB's can stamp `updated` *below* an `as_of` the client already holds, so the expunge tombstone is `updated > since`-filtered out and the client never evicts the deleted mail (ghost row). #457's safety margin only papers over bounded skew.

## What drifted since the issue was filed

The issue said the flag-update paths already used `CURRENT_TIMESTAMP`. They don't anymore — the #456 data-bag migration moved `markMailRead` / `markMailSaved` onto `mailsTable.updateWhere` with `updated: new Date()` (app clock). So there were **six** app-clock writes, not two, all going through `updateWhere`:

- `markMailRead`, `markMailSaved`
- `expungeDeletedMails` (domain + account branches)
- `expungeMailsByUid` (the MOVE-path sibling, domain + account branches)

## Fix (issue's preferred option 1)

Add a `DB_NOW` sentinel to the data-bag `updateWhere` layer (`models/base.ts`). When a data-bag value is `DB_NOW`, the builder emits `col = CURRENT_TIMESTAMP` as a **SQL literal** (consuming no bound parameter) instead of binding `new Date()`. Every `updateWhere` mutation now stamps `updated` from the DB clock, matching the direct-SQL flag path (already `CURRENT_TIMESTAMP`) and the is_spam toggle (already `NOW()`). One timeline, no host-clock dependency.

Scope is the six app-clock `updated` writes + the shared sentinel + the flipped source guard. No behavior change beyond the clock source.

**Also folds in #676** (surfaced by reviewoie on this PR): the `saveMail` `23505` conflict-merge mutated the delta-synced `envelope_to` column via `updateWhere` but stamped **no** `updated` at all — a 7th mutation path on the same delta-cursor timeline. `envelope_to` feeds `getMailHeadersDelta`'s received per-account address expansion, so a merge that added a sub-address never advanced the cursor and the newly-merged account missed the mail until a full resync. Now stamps `updated: DB_NOW`, with a source-scan test pinning it — so the "every mutation path stamps `updated`" claim is genuinely complete, not narrowed.

## Verification

- **Typecheck**: clean (`tsc --noEmit`).
- **Full server suite**: 1163 pass / 0 fail (`bun test src/server`).
- **SQL-emission E2E** (drove the real `mailsTable.updateWhere` through a fake pool in an isolated process):
  - `updateWhere({...}, { expunged: true, updated: DB_NOW })` emits `UPDATE mails SET expunged = <param>, updated = CURRENT_TIMESTAMP WHERE ...` — `updated` is a literal, with **no `Date` bound value** in the params array.
  - Mixed bag `{ read: true, updated: DB_NOW, saved: false }` emits `read = <p1>, updated = CURRENT_TIMESTAMP, saved = <p2> WHERE user_id = <p3>` — placeholder numbering stays contiguous across the skipped sentinel, and the bound-values order is preserved.
- **Source guard** (`mails.test.ts`): flipped from asserting `updated: new Date()` to asserting `updated: DB_NOW` and **not** `new Date()` in the expunge paths.

## Acceptance

- [x] No mutation path stamps `updated` from the app clock.
- [x] Source guard asserts `expungeDeletedMails` does not use `new Date()` for `updated`.
