### PR TITLE
fix(imap): resolve a bare `*` sequence-set to the last message (RFC 3501 §9)

### DIFF
--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -127,6 +127,33 @@ describe("resolveSeqRangeToUids (inbox #588)", () => {
   it("returns undefined on an empty mailbox", () => {
     expect(resolveSeqRangeToUids([], 1, 10)).toBeUndefined();
   });
+
+  // inbox #660: a bare `*` (both endpoints MAX_SAFE_INTEGER) targets the last
+  // message, not nothing. The `*` sentinel start is exempt from the
+  // out-of-range guard; a concrete past-end start still matches nothing.
+  it("resolves a bare `*` (start and end are `*`) to the last message", () => {
+    expect(
+      resolveSeqRangeToUids(uids, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    ).toEqual({ uidStart: 50, uidEnd: 50 });
+  });
+
+  it("resolves `*` to the last message on a single-message mailbox", () => {
+    expect(
+      resolveSeqRangeToUids([10], Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    ).toEqual({ uidStart: 10, uidEnd: 10 });
+  });
+
+  it("returns undefined for `*` on an empty mailbox", () => {
+    expect(
+      resolveSeqRangeToUids([], Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    ).toBeUndefined();
+  });
+
+  it("still returns undefined for a concrete past-end start (not the `*` sentinel)", () => {
+    // `6:*` on a 5-message mailbox: the start (6) is a real number past the
+    // end, so it matches nothing — only `*` itself is treated as the last msg.
+    expect(resolveSeqRangeToUids(uids, 6, Number.MAX_SAFE_INTEGER)).toBeUndefined();
+  });
 });
 
 describe("uidToSeqNumber", () => {

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -64,6 +64,12 @@ export function seqToUidNumber(seqToUid: number[], seq: number): number | undefi
  * messages match) or the mailbox is empty. '*' (MAX_SAFE_INTEGER) clamps to the
  * last message. Endpoint ordering is left as-is; descending ranges are handled
  * separately in convertSequenceSet (issue #582).
+ *
+ * '*' means "the highest message in the mailbox" (RFC 3501 §9), so a `*` start
+ * clamps to the last message like `end` does — `SEARCH *` / `FETCH *` target
+ * the final message. This is exempt from the out-of-range guard: a *concrete*
+ * sequence number past the end (e.g. `SEARCH 99999` on a 3-message mailbox)
+ * must still match nothing, so only the sentinel is let through (issue #660).
  */
 export function resolveSeqRangeToUids(
   seqToUid: number[],
@@ -71,7 +77,8 @@ export function resolveSeqRangeToUids(
   end: number
 ): { uidStart: number; uidEnd: number } | undefined {
   const maxSeq = seqToUid.length;
-  if (maxSeq === 0 || start > maxSeq) return undefined;
+  if (maxSeq === 0) return undefined;
+  if (start !== Number.MAX_SAFE_INTEGER && start > maxSeq) return undefined;
   const uidStart = seqToUidNumber(seqToUid, Math.min(start, maxSeq));
   const uidEnd = seqToUidNumber(seqToUid, Math.min(end, maxSeq));
   if (uidStart === undefined || uidEnd === undefined) return undefined;


### PR DESCRIPTION
## What

`SEARCH *` / `FETCH *` / `STORE *` / `COPY *` / `MOVE *` (bare `*` sequence-set) resolved to **no messages** instead of the last message in the mailbox. Per RFC 3501 §9, `*` is "the highest message number in the mailbox", so a bare `*` must target the final message.

Closes #660.

## Root cause

The parser encodes `*` as `Number.MAX_SAFE_INTEGER`. `resolveSeqRangeToUids` (`src/server/lib/imap/sequence-resolver.ts`) guarded the start endpoint with `start > maxSeq` **before** the `Math.min(start, maxSeq)` clamp could map it to the last message:

```ts
if (maxSeq === 0 || start > maxSeq) return undefined;   // rejects the `*` sentinel
```

For a bare `*`, both `start` and `end` are `MAX_SAFE_INTEGER`, so `start > maxSeq` fired and the whole range collapsed to empty. `1:*` worked only because its `end` (not `start`) is the sentinel, and `end` was already clamped. The helper is shared, so every sequence-number command (SEARCH/FETCH/STORE/COPY/MOVE) mishandled bare `*` identically.

## Fix

Exempt the `*` sentinel from the out-of-range guard so it clamps to the last message like `end` already does. A **concrete** sequence number past the end still matches nothing — only the sentinel is let through:

```ts
if (maxSeq === 0) return undefined;
if (start !== Number.MAX_SAFE_INTEGER && start > maxSeq) return undefined;
```

## Verification

- `bun test src/server/lib/imap/sequence-resolver.test.ts` — added regression tests: bare `*` -> last message; `*` on a single-message and empty mailbox; a concrete past-end start still returns undefined; existing `n:*` and full-range cases unchanged.
- Full server suite `bun test src/server` green (1155 pass, 0 fail).
- **Live IMAP E2E** against a locally-started server (admin INBOX), real IMAP session:
  - `SEARCH *`  -> the last message (single seq, matching the mailbox `EXISTS` count) — was empty before.
  - `FETCH * (UID)`  -> one untagged FETCH for the last message with its UID.
  - `SEARCH 1:*`  -> the full range, unchanged (control).
  - `SEARCH <past-end concrete number>`  -> empty, unchanged (control — a concrete out-of-range start is not the `*` sentinel).

## Scope note

This fixes the **sequence-set** resolver (the SEARCH/FETCH/STORE/COPY/MOVE variants #660 lists). While verifying, I noticed `UID SEARCH *` also returns empty — but that flows through the separate UID-criterion path (`store.ts` / `searchMailsByUid`), not `resolveSeqRangeToUids`, so it is out of scope here. Filed as #678 so it is not lost.