### PR TITLE
fix(imap): FETCH BODY[<part>.HEADER/.TEXT/.MIME] honors the sub-section

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -601,3 +601,87 @@ describe("convertSequenceSet normalizes descending ranges (#582)", () => {
     ]);
   });
 });
+
+describe("buildBodyResponsePart MIME part sub-sections (inbox #657)", () => {
+  // BODY[<part>.HEADER]/.MIME must return the part's MIME header fields; .TEXT
+  // (and a bare part number) the header-less body. Before the fix all three
+  // returned the base64 part body and the response was keyed BODY[<part>].
+  const mail: Partial<MailType> = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<mp@local>",
+    date: new Date("2026-07-08T00:00:00Z"),
+    text: "Plain body",
+    html: "<p>HTML body</p>",
+    attachments: []
+  };
+  const docId = "doc-mp";
+  const mailbox = "INBOX";
+
+  const partOf = async (fetch: BodyFetch) => {
+    const part = await buildBodyResponsePart(mail, fetch, docId, mailbox);
+    expect(part).not.toBeNull();
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    // The advertised {N} literal must equal the emitted octets.
+    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    return part!;
+  };
+
+  it("BODY[1.MIME] returns part 1 MIME header block, keyed BODY[1.MIME]", async () => {
+    const part = await partOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "MIME_PART", partNumber: "1", subSection: "MIME" }
+    });
+    expect(part.header).toBe("BODY[1.MIME]");
+    expect(part.content).toContain("Content-Type: text/plain; charset=utf-8");
+    expect(part.content).toContain("Content-Transfer-Encoding: base64");
+    // header block, not the base64 body
+    expect(part.content).not.toContain(
+      Buffer.from("Plain body", "utf8").toString("base64")
+    );
+    // exactly one delimiting blank line, no spurious second CRLF
+    expect(part.content.endsWith("\r\n\r\n")).toBe(true);
+    expect(part.content.endsWith("\r\n\r\n\r\n")).toBe(false);
+  });
+
+  it("BODY[1.HEADER] returns part 1 MIME header block, keyed BODY[1.HEADER]", async () => {
+    const part = await partOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "MIME_PART", partNumber: "1", subSection: "HEADER" }
+    });
+    expect(part.header).toBe("BODY[1.HEADER]");
+    expect(part.content).toContain("Content-Type: text/plain; charset=utf-8");
+  });
+
+  it("BODY[2.MIME] returns part 2 (html) MIME header block", async () => {
+    const part = await partOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "MIME_PART", partNumber: "2", subSection: "MIME" }
+    });
+    expect(part.header).toBe("BODY[2.MIME]");
+    expect(part.content).toContain("Content-Type: text/html; charset=utf-8");
+  });
+
+  it("BODY[1.TEXT] returns the header-less base64 body (same as BODY[1])", async () => {
+    const b64 = Buffer.from("Plain body", "utf8").toString("base64");
+    const withText = await partOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "MIME_PART", partNumber: "1", subSection: "TEXT" }
+    });
+    expect(withText.header).toBe("BODY[1.TEXT]");
+    expect(withText.content).toContain(b64);
+    expect(withText.content).not.toContain("Content-Type:");
+
+    const bare = await partOf({
+      type: "BODY",
+      peek: true,
+      section: { type: "MIME_PART", partNumber: "1" }
+    });
+    // Same body bytes, bare part is keyed without the sub-section.
+    expect(bare.header).toBe("BODY[1]");
+    expect(bare.content).toBe(withText.content);
+  });
+});

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -19,6 +19,7 @@ import {
   applyPartialFetch,
   buildFullMessage,
   getBodyPart,
+  getBodyPartHeaders,
   getBodySectionKey,
 } from "./session-utils";
 import {
@@ -97,7 +98,20 @@ export function getBodyContent(
     }
 
     case "MIME_PART":
-      return getBodyPart(mail, section.partNumber);
+      // RFC 3501 §6.4.5: `.HEADER`/`.MIME` return the part's MIME header fields;
+      // `.TEXT` (and a bare part number) return the part body without them. For
+      // this codebase's synthetic parts `getBodyPart` already yields the body
+      // sans MIME header, so `.TEXT` and no-subsection resolve identically.
+      switch (section.subSection) {
+        case "HEADER":
+        case "MIME": {
+          const headers = getBodyPartHeaders(mail, section.partNumber);
+          return headers === null ? null : headers + "\r\n\r\n";
+        }
+        case "TEXT":
+        default:
+          return getBodyPart(mail, section.partNumber);
+      }
 
     default:
       return null;
@@ -269,6 +283,18 @@ export function convertSequenceSet(
 // Response builders
 // ---------------------------------------------------------------------------
 
+// Sections whose `getBodyContent` output already ends in its own delimiting
+// blank line, so the builder must not append another trailing CRLF. Covers
+// HEADER, HEADER.FIELDS, and a MIME part's `.HEADER`/`.MIME` sub-section.
+function isHeaderLikeSection(section: BodySection): boolean {
+  return (
+    section.type === "HEADER" ||
+    section.type === "HEADER_FIELDS" ||
+    (section.type === "MIME_PART" &&
+      (section.subSection === "HEADER" || section.subSection === "MIME"))
+  );
+}
+
 export async function buildBodyResponsePart(
   mail: Partial<MailType>,
   bodyFetch: BodyFetch,
@@ -312,12 +338,12 @@ export async function buildBodyResponsePart(
     // CRLF. (The non-partial branch below appends one and recounts `length`;
     // doing that here would emit 2 octets more than the `{length}` literal
     // advertises, desyncing clients that read exactly `length` octets.)
-  } else if (section.type !== "HEADER" && section.type !== "HEADER_FIELDS") {
-    // Body sections (FULL / TEXT / MIME_PART) get a trailing CRLF here. Header
-    // sections already carry their own delimiting blank line from
+  } else if (!isHeaderLikeSection(section)) {
+    // Body sections (FULL / TEXT / bare MIME_PART) get a trailing CRLF here.
+    // Header sections already carry their own delimiting blank line from
     // `getBodyContent` (HEADER: `\r\n\r\n`; HEADER_FIELDS: last-field `\r\n` +
-    // blank line), so appending another `\r\n` would emit a spurious second
-    // blank line.
+    // blank line; MIME_PART `.HEADER`/`.MIME`: `\r\n\r\n`), so appending another
+    // `\r\n` would emit a spurious second blank line.
     finalContent += "\r\n";
     length = Buffer.byteLength(finalContent, "utf8");
   }

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -21,7 +21,8 @@ import {
   getBodySectionKey,
   shouldMarkAsRead,
   buildFullMessage,
-  getBodyPart
+  getBodyPart,
+  getBodyPartHeaders
 } from "./session-utils";
 import type {
   BodySection,
@@ -123,6 +124,35 @@ describe("getBodySectionKey", () => {
   it("returns BODY[nested partNumber] for nested MIME_PART section", () => {
     const section: BodySection = { type: "MIME_PART", partNumber: "1.2.3" };
     expect(getBodySectionKey(section)).toBe("BODY[1.2.3]");
+  });
+
+  // #657: the sub-section must survive in the response label, otherwise a
+  // client sees the reply keyed as BODY[1] for its BODY[1.HEADER] request.
+  it("returns BODY[1.HEADER] for MIME_PART with HEADER sub-section", () => {
+    const section: BodySection = {
+      type: "MIME_PART",
+      partNumber: "1",
+      subSection: "HEADER"
+    };
+    expect(getBodySectionKey(section)).toBe("BODY[1.HEADER]");
+  });
+
+  it("returns BODY[2.MIME] for MIME_PART with MIME sub-section", () => {
+    const section: BodySection = {
+      type: "MIME_PART",
+      partNumber: "2",
+      subSection: "MIME"
+    };
+    expect(getBodySectionKey(section)).toBe("BODY[2.MIME]");
+  });
+
+  it("returns BODY[1.2.TEXT] for nested MIME_PART with TEXT sub-section", () => {
+    const section: BodySection = {
+      type: "MIME_PART",
+      partNumber: "1.2",
+      subSection: "TEXT"
+    };
+    expect(getBodySectionKey(section)).toBe("BODY[1.2.TEXT]");
   });
 
   it("returns BODY[HEADER.FIELDS (...)] for HEADER_FIELDS section without not", () => {
@@ -530,5 +560,86 @@ describe("getBodyPart", () => {
     };
     // Part 3 would be attachment index 1 (0-based) but only 1 attachment exists
     expect(getBodyPart(mail, "3")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBodyPartHeaders (#657)
+// ---------------------------------------------------------------------------
+
+describe("getBodyPartHeaders", () => {
+  const TEXT_HDR =
+    "Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64";
+  const HTML_HDR =
+    "Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64";
+
+  it("returns null for empty mail", () => {
+    expect(getBodyPartHeaders({}, "1")).toBeNull();
+  });
+
+  it("returns text/plain headers for single-text mail, part 1", () => {
+    expect(getBodyPartHeaders({ text: "Hello" }, "1")).toBe(TEXT_HDR);
+  });
+
+  it("returns text/html headers for html-only mail, part 1", () => {
+    expect(getBodyPartHeaders({ html: "<p>Hi</p>" }, "1")).toBe(HTML_HDR);
+  });
+
+  it("returns per-part headers for text+html multipart/alternative", () => {
+    const mail: Partial<MailType> = { text: "Plain", html: "<p>H</p>" };
+    expect(getBodyPartHeaders(mail, "1")).toBe(TEXT_HDR);
+    expect(getBodyPartHeaders(mail, "2")).toBe(HTML_HDR);
+    expect(getBodyPartHeaders(mail, "3")).toBeNull();
+  });
+
+  it("returns nested-part headers for text+html+attachment multipart/mixed", () => {
+    const mail: Partial<MailType> = {
+      text: "Body",
+      html: "<p>Body</p>",
+      attachments: [
+        {
+          content: { data: "att-1" },
+          contentType: "application/pdf",
+          filename: "doc.pdf",
+          size: 100
+        }
+      ]
+    };
+    expect(getBodyPartHeaders(mail, "1.1")).toBe(TEXT_HDR);
+    expect(getBodyPartHeaders(mail, "1.2")).toBe(HTML_HDR);
+  });
+
+  it("returns attachment MIME headers with Content-Disposition for part 2", () => {
+    const mail: Partial<MailType> = {
+      text: "Body",
+      attachments: [
+        {
+          content: { data: "att-file" },
+          contentType: "image/png",
+          filename: "photo.png",
+          size: 200
+        }
+      ]
+    };
+    expect(getBodyPartHeaders(mail, "2")).toBe(
+      'Content-Type: image/png\r\n' +
+        'Content-Transfer-Encoding: base64\r\n' +
+        'Content-Disposition: attachment; filename="photo.png"'
+    );
+  });
+
+  it("returns null for out-of-range attachment index", () => {
+    const mail: Partial<MailType> = {
+      text: "Body",
+      attachments: [
+        {
+          content: { data: "att-1" },
+          contentType: "text/plain",
+          filename: "file.txt",
+          size: 10
+        }
+      ]
+    };
+    expect(getBodyPartHeaders(mail, "3")).toBeNull();
   });
 });

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -41,7 +41,9 @@ export const getBodySectionKey = (section: BodySection): string => {
     case "HEADER":
       return "BODY[HEADER]";
     case "MIME_PART":
-      return `BODY[${section.partNumber}]`;
+      return `BODY[${section.partNumber}${
+        section.subSection ? "." + section.subSection : ""
+      }]`;
     case "HEADER_FIELDS": {
       const hfs = section as HeaderFieldsSection;
       const fieldList = hfs.fields.join(" ");
@@ -239,6 +241,83 @@ export const getBodyPart = (
     const att = mail.attachments[attachmentIndex];
     const data = getAttachment(att.content.data);
     return data ? data.toString("base64") : null;
+  }
+
+  return null;
+};
+
+/**
+ * MIME header block for a specific body part (RFC 3501 §6.4.5 `BODY[<part>.MIME]`
+ * / `BODY[<part>.HEADER]`). Returns the part's `Content-Type` +
+ * `Content-Transfer-Encoding` (+ `Content-Disposition` for attachments) fields
+ * with no trailing CRLF — the caller appends the delimiting blank line. Mirrors
+ * `getBodyPart`'s part-numbering exactly so `BODY[1.MIME]` names the same part
+ * as `BODY[1]`.
+ */
+export const getBodyPartHeaders = (
+  mail: Partial<MailType>,
+  partNum: string
+): string | null => {
+  const parts = partNum.split(".");
+  const mainPart = parseInt(parts[0], 10);
+
+  const hasText = mail.text && mail.text.trim().length > 0;
+  const hasHtml = mail.html && mail.html.trim().length > 0;
+  const hasAttachments = mail.attachments && mail.attachments.length > 0;
+
+  if (!hasAttachments && !hasText && !hasHtml) {
+    return null;
+  }
+
+  const textHeaders =
+    "Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64";
+  const htmlHeaders =
+    "Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64";
+
+  if (!hasAttachments) {
+    if (hasText && hasHtml) {
+      // multipart/alternative
+      if (mainPart === 1) return textHeaders;
+      if (mainPart === 2) return htmlHeaders;
+    } else if (hasText && mainPart === 1) {
+      return textHeaders;
+    } else if (hasHtml && mainPart === 1) {
+      return htmlHeaders;
+    }
+    return null;
+  }
+
+  // multipart/mixed with attachments
+  let partIndex = 1;
+
+  // First part is the body content (possibly a nested multipart/alternative)
+  if (mainPart === partIndex) {
+    if (hasText && hasHtml) {
+      const subPart = parts[1] ? parseInt(parts[1], 10) : 1;
+      if (subPart === 1) return textHeaders;
+      if (subPart === 2) return htmlHeaders;
+    } else if (hasText) {
+      return textHeaders;
+    } else if (hasHtml) {
+      return htmlHeaders;
+    }
+  }
+
+  partIndex++;
+
+  // Subsequent parts are attachments
+  const attachmentIndex = mainPart - partIndex;
+  if (
+    mail.attachments &&
+    attachmentIndex >= 0 &&
+    attachmentIndex < mail.attachments.length
+  ) {
+    const att = mail.attachments[attachmentIndex];
+    return (
+      `Content-Type: ${att.contentType}\r\n` +
+      `Content-Transfer-Encoding: base64\r\n` +
+      `Content-Disposition: attachment; filename="${att.filename}"`
+    );
   }
 
   return null;


### PR DESCRIPTION
## What

`FETCH <set> BODY[<part>.HEADER]`, `BODY[<part>.TEXT]`, and `BODY[<part>.MIME]` all returned the **base64 part body** and labeled the response `BODY[<part>]` — the sub-section keyword was parsed but dropped by the response builder (#657, RFC 3501 §6.4.5).

## Root cause

- `getBodyContent`s `MIME_PART` case passed only `section.partNumber` to `getBodyPart`, ignoring `section.subSection`.
- `getBodySectionKey` rendered `BODY[${partNumber}]`, dropping the sub-section from the response label.

So `BODY[1.HEADER]` / `BODY[1.MIME]` / `BODY[1.TEXT]` were all indistinguishable from `BODY[1]`. A client fetching a parts MIME header (e.g. to read `Content-Type`/encoding before pulling the body) got the base64 body instead.

## Fix

- **`getBodyPartHeaders`** (session-utils) — new helper returning a parts MIME header block (`Content-Type` + `Content-Transfer-Encoding`, plus `Content-Disposition` for attachments), mirroring `getBodyPart`s part-numbering so `BODY[1.MIME]` names the same part as `BODY[1]`.
- **`getBodyContent` MIME_PART** — `.HEADER`/`.MIME` return the part header block (+ one delimiting blank line); `.TEXT` and a bare part number return the header-less body (for these synthetic parts `getBodyPart` already yields the body without its MIME header, so `.TEXT` ≡ bare part).
- **`getBodySectionKey`** — renders the sub-section, so the reply is keyed `BODY[1.HEADER]`, not `BODY[1]`.
- **`buildBodyResponsePart`** — `.HEADER`/`.MIME` are treated as header-like (new `isHeaderLikeSection`) so the builder does not append a spurious second blank line; the advertised `{N}` literal stays equal to the emitted octets.

## Tests

- `getBodyPartHeaders`: single-text, html-only, text+html multipart/alternative (parts 1/2), text+html+attachment multipart/mixed (parts 1.1/1.2), attachment MIME headers with `Content-Disposition`, out-of-range.
- `getBodySectionKey`: `BODY[1.HEADER]` / `BODY[2.MIME]` / `BODY[1.2.TEXT]` labels.
- `buildBodyResponsePart` end-to-end: `BODY[1.MIME]`/`BODY[1.HEADER]` emit the header block keyed correctly and are NOT the base64 body; exactly one delimiting blank line (no spurious second CRLF); `BODY[1.TEXT]` equals bare `BODY[1]` body bytes; `{N}` literal == emitted octets on every case.

## Verification

- `bun run typecheck` clean; `eslint` clean on changed files (0 errors).
- `bun test src/server/lib/imap` — 576 pass / 0 fail (24 files).
- IMAP E2E against a running dev server — see test plan below.

Closes #657