### PR TITLE
feat(imap): CONDSTORE phase 2 — CAPABILITY + ENABLE + HIGHESTMODSEQ + MODSEQ FETCH

### DIFF
--- a/src/common/models/mails/Mail.ts
+++ b/src/common/models/mails/Mail.ts
@@ -97,6 +97,12 @@ export interface MailType {
   answered: boolean;
   insight?: Insight;
   uid: MailUidType;
+  /**
+   * IMAP CONDSTORE mod-sequence (RFC 4551) — the per-message change counter,
+   * sibling to `uid`. Server-populated for IMAP FETCH MODSEQ / HIGHESTMODSEQ;
+   * the HTTP client never reads it, hence optional.
+   */
+  modseq?: number;
 }
 
 export class Mail extends Model<Mail> implements MailType {
@@ -121,6 +127,7 @@ export class Mail extends Model<Mail> implements MailType {
   declare answered: boolean;
   declare insight?: Insight;
   declare uid: MailUidType;
+  declare modseq?: number;
 
   constructor(data?: Partial<Mail>) {
     super(data);

--- a/src/server/lib/imap/capabilities.ts
+++ b/src/server/lib/imap/capabilities.ts
@@ -8,6 +8,7 @@ export const getCapabilities = (isTls = false) => {
     "ENABLE",
     "IDLE",
     "MOVE",
+    "CONDSTORE",
     "AUTH=PLAIN"
   ];
 

--- a/src/server/lib/imap/condstore.test.ts
+++ b/src/server/lib/imap/condstore.test.ts
@@ -75,7 +75,7 @@ const { getCapabilities } = await import("./capabilities");
 const { parseCommand } = await import("./parsers");
 const { buildFetchResponse } = await import("./fetch-helpers");
 const { selectMailbox, statusMailbox } = await import("./mailbox-ops");
-const { storeFlagsTyped } = await import("./message-ops");
+const { storeFlagsTyped, fetchMessagesTyped } = await import("./message-ops");
 const { ImapSession } = await import("./session");
 const { resetPool } = await import("../postgres/client");
 
@@ -363,20 +363,26 @@ const seqStateFor = (uids: number[]): SequenceState => {
   return { seqToUid: uids, uidToSeq };
 };
 
-const uidStoreRequest = (uid: number): StoreRequest => ({
+const uidStoreRequest = (
+  uid: number,
+  operation: StoreRequest["operation"] = "+FLAGS",
+  silent = false
+): StoreRequest => ({
   sequenceSet: { type: "uid", ranges: [{ start: uid }] },
-  operation: "+FLAGS",
+  operation,
   flags: ["\\Seen"],
+  silent,
 });
 
-const runStore = async (condstoreEnabled: boolean) => {
+const runStore = async (
+  condstoreEnabled: boolean,
+  request: StoreRequest = uidStoreRequest(8)
+) => {
   const lines: string[] = [];
-  const store = makeFlagStore([
-    { uid: 8, read: true, modseq: 77 },
-  ]);
+  const store = makeFlagStore([{ uid: 8, read: true, modseq: 77 }]);
   await storeFlagsTyped(
     "A1",
-    uidStoreRequest(8),
+    request,
     true,
     store,
     "INBOX",
@@ -402,6 +408,95 @@ describe("CONDSTORE — STORE flag echo carries MODSEQ", () => {
   it("omits MODSEQ from the flag echo when CONDSTORE is not enabled", async () => {
     const out = await runStore(false);
     expect(out).toContain("* 1 FETCH (UID 8 FLAGS (\\Seen))\r\n");
+    expect(out).not.toContain("MODSEQ");
+  });
+
+  // RFC 4551 §3.3.2 Example 14: a .SILENT store still owes a CONDSTORE session
+  // the new mod-sequence — MODSEQ only, no FLAGS — so its cache stays in sync.
+  it("emits a MODSEQ-only echo for a .SILENT store when CONDSTORE is enabled", async () => {
+    const out = await runStore(
+      true,
+      uidStoreRequest(8, "+FLAGS.SILENT", true)
+    );
+    expect(out).toContain("* 1 FETCH (UID 8 MODSEQ (77))\r\n");
+    expect(out).not.toContain("FLAGS (");
+  });
+
+  it("stays silent for a .SILENT store when CONDSTORE is not enabled", async () => {
+    const out = await runStore(
+      false,
+      uidStoreRequest(8, "+FLAGS.SILENT", true)
+    );
+    expect(out).not.toContain("FETCH");
+    expect(out).toBe("A1 OK STORE completed\r\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FETCH — the modseq column is only pulled from the store when needed
+// ---------------------------------------------------------------------------
+
+const recordingFetchStore = (captured: { fields: string[] }): Store =>
+  ({
+    getMessages: async (
+      _box: string,
+      _start: number,
+      _end: number,
+      fields: string[]
+    ) => {
+      captured.fields = fields;
+      const m = new Map<string, Partial<MailType>>();
+      m.set("doc1", {
+        uid: { domain: 8, account: 8 },
+        modseq: 5,
+        read: false,
+        saved: false,
+        deleted: false,
+        draft: false,
+        answered: false,
+      });
+      return m;
+    },
+    getUser: () => ({ id: "user-123", username: "admin" } as SignedUser),
+  }) as unknown as Store;
+
+const runFetch = async (
+  dataItems: FetchDataItem[],
+  condstoreEnabled: boolean
+) => {
+  const captured = { fields: [] as string[] };
+  const lines: string[] = [];
+  await fetchMessagesTyped(
+    "A1",
+    { sequenceSet: { type: "uid", ranges: [{ start: 8 }] }, dataItems },
+    true,
+    recordingFetchStore(captured),
+    "INBOX",
+    seqStateFor([8]),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    },
+    condstoreEnabled
+  );
+  return { captured, out: lines.join("") };
+};
+
+describe("CONDSTORE — FETCH pulls the modseq column only when needed", () => {
+  it("requests the modseq column when CONDSTORE is enabled", async () => {
+    const { captured, out } = await runFetch([{ type: "FLAGS" }], true);
+    expect(captured.fields).toContain("modseq");
+    expect(out).toContain("MODSEQ (5)");
+  });
+
+  it("requests the modseq column when MODSEQ is asked for explicitly", async () => {
+    const { captured } = await runFetch([{ type: "MODSEQ" }], false);
+    expect(captured.fields).toContain("modseq");
+  });
+
+  it("does NOT request modseq when neither enabled nor requested", async () => {
+    const { captured, out } = await runFetch([{ type: "FLAGS" }], false);
+    expect(captured.fields).not.toContain("modseq");
     expect(out).not.toContain("MODSEQ");
   });
 });

--- a/src/server/lib/imap/condstore.test.ts
+++ b/src/server/lib/imap/condstore.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for IMAP CONDSTORE phase 2 (RFC 4551) — inbox #608.
+ *
+ * The "visible-tracking layer": the client can READ mod-sequence state but not
+ * yet USE it for incremental sync (phase 3) or conflict detection (phase 4).
+ * Coverage:
+ *  - CAPABILITY advertises CONDSTORE.
+ *  - Parser accepts the MODSEQ fetch item, the HIGHESTMODSEQ status item, and
+ *    ENABLE CONDSTORE.
+ *  - ENABLE CONDSTORE echoes `* ENABLED CONDSTORE` and flips the session flag
+ *    (idempotent on re-enable).
+ *  - SELECT / EXAMINE include `* OK [HIGHESTMODSEQ N]`.
+ *  - STATUS supports the HIGHESTMODSEQ item.
+ *  - FETCH emits `MODSEQ (n)` when requested, implicitly on every response once
+ *    CONDSTORE is enabled, and exactly once when both apply.
+ *  - STORE's untagged FETCH carries MODSEQ once CONDSTORE is enabled.
+ *
+ * Isolation mirrors message-ops.test.ts: mock `pg` so the lazy pool in
+ * postgres/client.ts is a FakePool, then run the REAL imap code (selectMailbox
+ * reaches getImapUidValidity, which queries Postgres). No mock of the `server`
+ * barrel (which would bleed across files via Bun's process-global mock.module).
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  mock,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import type { MailType, SignedUser } from "common";
+import type { Store } from "./store";
+import type { SequenceState } from "./sequence-resolver";
+import type { FetchDataItem, StoreRequest } from "./types";
+
+const STORED_UIDVALIDITY = 1716512400;
+
+const USER_ROW = {
+  user_id: "user-123",
+  username: "admin",
+  password: null,
+  email: null,
+  expiry: null,
+  token: null,
+  updated: null,
+  is_deleted: null,
+  imap_uid_validity: STORED_UIDVALIDITY,
+};
+
+const mockQuery = mock(async (sql: string) => {
+  if (typeof sql === "string" && sql.includes("next_uid")) {
+    return { rows: [{ next_uid: "10" }], rowCount: 1 };
+  }
+  return { rows: [USER_ROW], rowCount: 1 };
+});
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+  on() {}
+}
+
+const pgMock = () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+});
+
+mock.module("pg", pgMock);
+
+const { getCapabilities } = await import("./capabilities");
+const { parseCommand } = await import("./parsers");
+const { buildFetchResponse } = await import("./fetch-helpers");
+const { selectMailbox, statusMailbox } = await import("./mailbox-ops");
+const { storeFlagsTyped } = await import("./message-ops");
+const { ImapSession } = await import("./session");
+const { resetPool } = await import("../postgres/client");
+
+beforeAll(() => {
+  mock.module("pg", pgMock);
+  resetPool();
+});
+
+afterAll(() => {
+  restoreLeaves();
+  resetPool();
+});
+
+// ---------------------------------------------------------------------------
+// CAPABILITY
+// ---------------------------------------------------------------------------
+
+describe("CONDSTORE — CAPABILITY", () => {
+  it("advertises CONDSTORE on the plain port", () => {
+    expect(getCapabilities(false).split(" ")).toContain("CONDSTORE");
+  });
+
+  it("advertises CONDSTORE on the TLS-wrapped port", () => {
+    expect(getCapabilities(true).split(" ")).toContain("CONDSTORE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parser tokens
+// ---------------------------------------------------------------------------
+
+describe("CONDSTORE — parser tokens", () => {
+  it("parses the MODSEQ fetch item", () => {
+    const result = parseCommand("A1 FETCH 1 (FLAGS MODSEQ)");
+    expect(result.success).toBe(true);
+    if (result.value?.request.type !== "FETCH") throw new Error("not FETCH");
+    const items = result.value.request.data.dataItems as FetchDataItem[];
+    expect(items.map((i) => i.type)).toContain("MODSEQ");
+  });
+
+  it("parses the HIGHESTMODSEQ status item", () => {
+    const result = parseCommand("A1 STATUS INBOX (MESSAGES HIGHESTMODSEQ)");
+    expect(result.success).toBe(true);
+    if (result.value?.request.type !== "STATUS") throw new Error("not STATUS");
+    expect(result.value.request.data.items).toContain("HIGHESTMODSEQ");
+  });
+
+  it("parses ENABLE CONDSTORE", () => {
+    const result = parseCommand("A1 ENABLE CONDSTORE");
+    expect(result.success).toBe(true);
+    if (result.value?.request.type !== "ENABLE") throw new Error("not ENABLE");
+    expect(result.value.request.data.capabilities).toContain("CONDSTORE");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ENABLE handshake (RFC 5161 / RFC 4551 §3.7)
+// ---------------------------------------------------------------------------
+
+const makeSession = () => {
+  const writes: string[] = [];
+  const socket = {
+    destroyed: false,
+    writable: true,
+    write: (data: string) => {
+      writes.push(data);
+      return true;
+    },
+  };
+  const handler = { isTls: false } as never;
+  const session = new ImapSession(handler, socket as never);
+  return { session, writes };
+};
+
+describe("CONDSTORE — ENABLE handshake", () => {
+  it("echoes `* ENABLED CONDSTORE` for ENABLE CONDSTORE", () => {
+    const { session, writes } = makeSession();
+    session.enable("A1", ["CONDSTORE"]);
+    expect(writes.join("")).toBe(
+      "* ENABLED CONDSTORE\r\nA1 OK ENABLE completed\r\n"
+    );
+  });
+
+  it("echoes an empty `* ENABLED` for an unknown extension", () => {
+    const { session, writes } = makeSession();
+    session.enable("A1", ["FOOBAR"]);
+    expect(writes.join("")).toBe("* ENABLED\r\nA1 OK ENABLE completed\r\n");
+  });
+
+  it("re-enabling CONDSTORE is idempotent (nothing new to echo)", () => {
+    const { session, writes } = makeSession();
+    session.enable("A1", ["CONDSTORE"]);
+    session.enable("A2", ["CONDSTORE"]);
+    expect(writes[writes.length - 1]).toContain("A2 OK ENABLE completed");
+    expect(writes.filter((w) => w.includes("ENABLED CONDSTORE")).length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SELECT / EXAMINE — HIGHESTMODSEQ response code
+// ---------------------------------------------------------------------------
+
+const fakeSelectStore = (highest: number): Store =>
+  ({
+    mailboxExists: async () => true,
+    countMessages: async () => ({ total: 2, unread: 0, maxUid: 9 }),
+    getAllUids: async () => [8, 9],
+    getFirstUnseenUid: async () => null,
+    getHighestModseq: async () => highest,
+    getUser: () => ({ id: "user-123", username: "admin" } as SignedUser),
+  }) as unknown as Store;
+
+const emptySeqState = (): SequenceState => ({
+  seqToUid: [],
+  uidToSeq: new Map(),
+});
+
+const runSelect = async (readOnly: boolean, highest: number) => {
+  const lines: string[] = [];
+  await selectMailbox(
+    "A1",
+    "INBOX",
+    readOnly,
+    fakeSelectStore(highest),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    },
+    emptySeqState(),
+    () => {},
+    () => {}
+  );
+  return lines.join("");
+};
+
+describe("CONDSTORE — SELECT / EXAMINE HIGHESTMODSEQ", () => {
+  it("SELECT includes `* OK [HIGHESTMODSEQ N]` before the tagged OK", async () => {
+    const out = await runSelect(false, 42);
+    expect(out).toContain("* OK [HIGHESTMODSEQ 42] Highest mod-sequence\r\n");
+    const modseqIdx = out.indexOf("[HIGHESTMODSEQ 42]");
+    const taggedIdx = out.indexOf("A1 OK [READ-WRITE]");
+    expect(modseqIdx).toBeGreaterThan(-1);
+    expect(modseqIdx).toBeLessThan(taggedIdx);
+  });
+
+  it("EXAMINE (read-only) also reports HIGHESTMODSEQ", async () => {
+    const out = await runSelect(true, 7);
+    expect(out).toContain("* OK [HIGHESTMODSEQ 7] Highest mod-sequence\r\n");
+    expect(out).toContain("A1 OK [READ-ONLY] EXAMINE completed\r\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STATUS — HIGHESTMODSEQ item
+// ---------------------------------------------------------------------------
+
+const fakeStatusStore = (highest: number): Store =>
+  ({
+    mailboxExists: async () => true,
+    countMessages: async () => ({ total: 3, unread: 1, maxUid: 5 }),
+    getHighestModseq: async () => highest,
+    getUser: () => ({ id: "user-123", username: "admin" } as SignedUser),
+  }) as unknown as Store;
+
+describe("CONDSTORE — STATUS HIGHESTMODSEQ", () => {
+  it("includes HIGHESTMODSEQ in the STATUS response when requested", async () => {
+    const lines: string[] = [];
+    await statusMailbox(
+      "A1",
+      "INBOX",
+      ["MESSAGES", "HIGHESTMODSEQ"],
+      fakeStatusStore(99),
+      (data: string) => {
+        lines.push(data);
+        return true;
+      }
+    );
+    expect(lines).toContain('* STATUS "INBOX" (MESSAGES 3 HIGHESTMODSEQ 99)\r\n');
+    expect(lines).toContain("A1 OK STATUS completed\r\n");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FETCH — MODSEQ emission (buildFetchResponse is the single response builder)
+// ---------------------------------------------------------------------------
+
+const mailWithModseq = (modseq: number | undefined): Partial<MailType> => ({
+  uid: { domain: 5, account: 5 },
+  modseq,
+  read: true,
+  saved: false,
+  deleted: false,
+  draft: false,
+  answered: false,
+});
+
+const modseqParts = (parts: { type: string; content?: string }[]) =>
+  parts.filter((p) => p.type === "simple" && p.content?.startsWith("MODSEQ"));
+
+describe("CONDSTORE — FETCH MODSEQ emission", () => {
+  it("omits MODSEQ when neither requested nor CONDSTORE-enabled", async () => {
+    const parts = await buildFetchResponse(
+      mailWithModseq(42),
+      [{ type: "FLAGS" }],
+      "doc1",
+      5,
+      true,
+      "INBOX",
+      false
+    );
+    expect(modseqParts(parts)).toHaveLength(0);
+  });
+
+  it("emits `MODSEQ (n)` when the client requests it explicitly", async () => {
+    const parts = await buildFetchResponse(
+      mailWithModseq(42),
+      [{ type: "FLAGS" }, { type: "MODSEQ" }],
+      "doc1",
+      5,
+      true,
+      "INBOX",
+      false
+    );
+    const m = modseqParts(parts);
+    expect(m).toHaveLength(1);
+    expect(m[0].content).toBe("MODSEQ (42)");
+  });
+
+  it("emits MODSEQ implicitly on every response once CONDSTORE is enabled", async () => {
+    const parts = await buildFetchResponse(
+      mailWithModseq(42),
+      [{ type: "FLAGS" }],
+      "doc1",
+      5,
+      true,
+      "INBOX",
+      true
+    );
+    const m = modseqParts(parts);
+    expect(m).toHaveLength(1);
+    expect(m[0].content).toBe("MODSEQ (42)");
+  });
+
+  it("emits MODSEQ exactly once when both requested AND CONDSTORE-enabled", async () => {
+    const parts = await buildFetchResponse(
+      mailWithModseq(42),
+      [{ type: "MODSEQ" }, { type: "FLAGS" }],
+      "doc1",
+      5,
+      true,
+      "INBOX",
+      true
+    );
+    expect(modseqParts(parts)).toHaveLength(1);
+  });
+
+  it("omits MODSEQ when the mail row carries no mod-sequence", async () => {
+    const parts = await buildFetchResponse(
+      mailWithModseq(undefined),
+      [{ type: "MODSEQ" }],
+      "doc1",
+      5,
+      true,
+      "INBOX",
+      true
+    );
+    expect(modseqParts(parts)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STORE — untagged FETCH carries MODSEQ once CONDSTORE is enabled
+// ---------------------------------------------------------------------------
+
+const makeFlagStore = (
+  result: { uid: number; read: boolean; modseq: number }[]
+): Store =>
+  ({
+    setFlags: async () => result,
+  }) as unknown as Store;
+
+const seqStateFor = (uids: number[]): SequenceState => {
+  const uidToSeq = new Map<number, number>();
+  uids.forEach((uid, i) => uidToSeq.set(uid, i + 1));
+  return { seqToUid: uids, uidToSeq };
+};
+
+const uidStoreRequest = (uid: number): StoreRequest => ({
+  sequenceSet: { type: "uid", ranges: [{ start: uid }] },
+  operation: "+FLAGS",
+  flags: ["\\Seen"],
+});
+
+const runStore = async (condstoreEnabled: boolean) => {
+  const lines: string[] = [];
+  const store = makeFlagStore([
+    { uid: 8, read: true, modseq: 77 },
+  ]);
+  await storeFlagsTyped(
+    "A1",
+    uidStoreRequest(8),
+    true,
+    store,
+    "INBOX",
+    false,
+    seqStateFor([8]),
+    (data: string) => {
+      lines.push(data);
+      return true;
+    },
+    condstoreEnabled
+  );
+  return lines.join("");
+};
+
+describe("CONDSTORE — STORE flag echo carries MODSEQ", () => {
+  it("appends `MODSEQ (n)` to the untagged FETCH when CONDSTORE is enabled", async () => {
+    const out = await runStore(true);
+    expect(out).toContain(
+      "* 1 FETCH (UID 8 FLAGS (\\Seen) MODSEQ (77))\r\n"
+    );
+  });
+
+  it("omits MODSEQ from the flag echo when CONDSTORE is not enabled", async () => {
+    const out = await runStore(false);
+    expect(out).toContain("* 1 FETCH (UID 8 FLAGS (\\Seen))\r\n");
+    expect(out).not.toContain("MODSEQ");
+  });
+});

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -451,7 +451,8 @@ export async function buildFetchResponse(
   docId: string,
   uid: number,
   isUidFetch: boolean,
-  selectedMailbox: string
+  selectedMailbox: string,
+  condstoreEnabled: boolean = false
 ): Promise<FetchResponsePart[]> {
   const parts: FetchResponsePart[] = [];
 
@@ -461,8 +462,20 @@ export async function buildFetchResponse(
 
   for (const item of dataItems) {
     if (item.type === "UID" && isUidFetch) continue;
+    // MODSEQ is emitted once, centrally (below), so the per-item loop skips it —
+    // this dedups an explicit `(MODSEQ)` request against the implicit
+    // post-ENABLE emission and keeps a single `MODSEQ (n)` in the response.
+    if (item.type === "MODSEQ") continue;
     const part = await buildFetchResponsePart(mail, item, docId, selectedMailbox);
     if (part) parts.push(part);
+  }
+
+  // RFC 4551 §3.3.2: include MODSEQ when the client asked for it explicitly, or
+  // implicitly on every FETCH response once CONDSTORE is enabled. The value is
+  // parenthesized (`MODSEQ (n)`) per the msg-att-dynamic grammar.
+  const modseqRequested = dataItems.some((item) => item.type === "MODSEQ");
+  if ((condstoreEnabled || modseqRequested) && mail.modseq !== undefined) {
+    parts.push({ type: "simple", content: `MODSEQ (${mail.modseq})` });
   }
 
   return parts;

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -365,8 +365,9 @@ export class ImapRequestHandler {
           break;
 
         case "ENABLE":
-          // RFC 5161: acknowledge requested capabilities; we don't activate any extensions
-          this.session.write(`* ENABLED\r\n${tag} OK ENABLE completed\r\n`);
+          // RFC 5161 / RFC 4551 §3.7: enable CONDSTORE (the one extension we
+          // support enabling) and echo back what was activated.
+          this.session.enable(tag, request.data.capabilities);
           break;
 
         case "UNSELECT":

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -238,6 +238,13 @@ export async function statusMailbox(
       uidValidity = await getImapUidValidity(store.getUser().id);
     }
 
+    // RFC 4551 §3.1.2: STATUS may request HIGHESTMODSEQ. Resolve it once here
+    // (a single MAX(modseq) query) rather than per-item inside the loop.
+    let highestModseq: number | null = null;
+    if (items.includes("HIGHESTMODSEQ")) {
+      highestModseq = await store.getHighestModseq(mailbox);
+    }
+
     const statusItems: string[] = [];
     items.forEach((item) => {
       switch (item) {
@@ -255,6 +262,9 @@ export async function statusMailbox(
           break;
         case "RECENT":
           statusItems.push("RECENT", "0");
+          break;
+        case "HIGHESTMODSEQ":
+          statusItems.push("HIGHESTMODSEQ", highestModseq!.toString());
           break;
       }
     });
@@ -461,6 +471,11 @@ export async function selectMailbox(
         : countResult.maxUid + 1 || 1;
     write(`* OK [UIDVALIDITY ${uidValidity}] UIDs valid\r\n`);
     write(`* OK [UIDNEXT ${uidNext}] Predicted next UID\r\n`);
+    // RFC 4551 §3.1.1: a CONDSTORE-capable server reports the mailbox's
+    // HIGHESTMODSEQ on SELECT/EXAMINE so the client can detect changes since
+    // its last-known mod-sequence without a full resync.
+    const highestModseq = await store.getHighestModseq(cleanName);
+    write(`* OK [HIGHESTMODSEQ ${highestModseq}] Highest mod-sequence\r\n`);
     write(`* FLAGS (\\Seen \\Flagged \\Deleted \\Draft \\Answered)\r\n`);
     write(
       `* OK [PERMANENTFLAGS (\\Seen \\Flagged \\Deleted \\Draft \\Answered \\*)] Flags permitted\r\n`

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -48,7 +48,8 @@ export async function fetchMessagesTyped(
   store: Store,
   selectedMailbox: string,
   seqState: SequenceState,
-  write: (data: string) => boolean | undefined
+  write: (data: string) => boolean | undefined,
+  condstoreEnabled: boolean = false
 ): Promise<void> {
   const isFlagsOnly = fetchRequest.dataItems.every(
     (item) =>
@@ -82,7 +83,8 @@ export async function fetchMessagesTyped(
       isUidCommand,
       store,
       selectedMailbox,
-      seqState
+      seqState,
+      condstoreEnabled
     );
     await _processFetchMessages(
       messages,
@@ -91,7 +93,8 @@ export async function fetchMessagesTyped(
       store,
       selectedMailbox,
       seqState,
-      write
+      write,
+      condstoreEnabled
     );
     write(`${tag} OK FETCH completed\r\n`);
   } catch (error) {
@@ -105,10 +108,20 @@ async function _fetchMessages(
   isUidCommand: boolean,
   store: Store,
   selectedMailbox: string,
-  seqState: SequenceState
+  seqState: SequenceState,
+  condstoreEnabled: boolean
 ): Promise<Map<string, Partial<MailType>>> {
   const ranges = convertSequenceSet(fetchRequest.sequenceSet);
   const requestedFields = getRequestedFields(fetchRequest.dataItems);
+  // MODSEQ is needed either when explicitly requested or, per RFC 4551 §3.3.2,
+  // implicitly on every FETCH response once CONDSTORE is enabled. Pull the
+  // column in the same range query rather than issuing a second lookup.
+  if (
+    condstoreEnabled ||
+    fetchRequest.dataItems.some((item) => item.type === "MODSEQ")
+  ) {
+    requestedFields.add("modseq");
+  }
   const isUidFetch =
     fetchRequest.sequenceSet.type === "uid" || isUidCommand;
 
@@ -156,7 +169,8 @@ async function _processFetchMessages(
   store: Store,
   selectedMailbox: string,
   seqState: SequenceState,
-  write: (data: string) => boolean | undefined
+  write: (data: string) => boolean | undefined,
+  condstoreEnabled: boolean
 ): Promise<void> {
   const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
   const isUidFetch =
@@ -181,7 +195,8 @@ async function _processFetchMessages(
         id,
         uid,
         isUidFetch,
-        selectedMailbox
+        selectedMailbox,
+        condstoreEnabled
       );
       writeFetchResponse(write, seqNum, response);
 
@@ -288,7 +303,8 @@ export async function storeFlagsTyped(
   selectedMailbox: string,
   mailboxReadOnly: boolean,
   seqState: SequenceState,
-  write: (data: string) => boolean | undefined
+  write: (data: string) => boolean | undefined,
+  condstoreEnabled: boolean = false
 ): Promise<void> {
   if (mailboxReadOnly) {
     write(`${tag} NO [READ-ONLY] Mailbox is read-only\r\n`);
@@ -361,8 +377,13 @@ export async function storeFlagsTyped(
             if (mail.answered) currentFlags.push("\\Answered");
 
             const uidItem = isUidStore ? `UID ${mail.uid} ` : "";
+            // RFC 4551 §3.3.2: once CONDSTORE is enabled, the untagged FETCH a
+            // STORE generates carries the new mod-sequence too.
+            const modseqItem = condstoreEnabled
+              ? ` MODSEQ (${mail.modseq})`
+              : "";
             write(
-              `* ${seq} FETCH (${uidItem}FLAGS (${currentFlags.join(" ")}))\r\n`
+              `* ${seq} FETCH (${uidItem}FLAGS (${currentFlags.join(" ")})${modseqItem})\r\n`
             );
           }
         }

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -361,31 +361,39 @@ export async function storeFlagsTyped(
         continue;
       }
 
-      if (!silent && !operation.includes("SILENT")) {
+      // A .SILENT store suppresses the FLAGS echo, but RFC 4551 §3.3.2
+      // (Example 14) requires a CONDSTORE session to still receive the new
+      // mod-sequence — `* n FETCH (MODSEQ (m))` with no FLAGS — so its cache
+      // stays in sync. So emit whenever FLAGS is due OR CONDSTORE is on.
+      const isSilent = silent || operation.includes("SILENT");
+      const emitFlags = !isSilent;
+      if (emitFlags || condstoreEnabled) {
         for (const mail of updatedMails) {
           const seq = uidToSeqNumber(
             seqState.seqToUid,
             seqState.uidToSeq,
             mail.uid
           );
-          if (seq !== undefined) {
+          if (seq === undefined) continue;
+
+          const items: string[] = [];
+          if (emitFlags) {
             const currentFlags: string[] = [];
             if (mail.read) currentFlags.push("\\Seen");
             if (mail.saved) currentFlags.push("\\Flagged");
             if (mail.deleted) currentFlags.push("\\Deleted");
             if (mail.draft) currentFlags.push("\\Draft");
             if (mail.answered) currentFlags.push("\\Answered");
-
-            const uidItem = isUidStore ? `UID ${mail.uid} ` : "";
-            // RFC 4551 §3.3.2: once CONDSTORE is enabled, the untagged FETCH a
-            // STORE generates carries the new mod-sequence too.
-            const modseqItem = condstoreEnabled
-              ? ` MODSEQ (${mail.modseq})`
-              : "";
-            write(
-              `* ${seq} FETCH (${uidItem}FLAGS (${currentFlags.join(" ")})${modseqItem})\r\n`
-            );
+            items.push(`FLAGS (${currentFlags.join(" ")})`);
           }
+          if (condstoreEnabled && mail.modseq !== undefined) {
+            items.push(`MODSEQ (${mail.modseq})`);
+          }
+          // Nothing to say (silent store, CONDSTORE off) — stay quiet.
+          if (items.length === 0) continue;
+
+          const uidItem = isUidStore ? `UID ${mail.uid} ` : "";
+          write(`* ${seq} FETCH (${uidItem}${items.join(" ")})\r\n`);
         }
       }
     }

--- a/src/server/lib/imap/parsers/fetch-parsers.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.ts
@@ -170,6 +170,8 @@ export const parseFetchDataItem = (context: ParseContext): ParseResult<FetchData
       return { success: true, value: { type: 'UID' }, consumed: context.position - start };
     case 'BODYSTRUCTURE':
       return { success: true, value: { type: 'BODYSTRUCTURE', extensible: true }, consumed: context.position - start };
+    case 'MODSEQ':
+      return { success: true, value: { type: 'MODSEQ' }, consumed: context.position - start };
   }
   
   // Handle BODY items

--- a/src/server/lib/imap/parsers/mailbox-parsers.ts
+++ b/src/server/lib/imap/parsers/mailbox-parsers.ts
@@ -142,6 +142,7 @@ export const parseStatus = (
       case "UIDNEXT":
       case "UIDVALIDITY":
       case "UNSEEN":
+      case "HIGHESTMODSEQ":
         items.push(itemName as StatusItem);
         break;
       default:

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -61,6 +61,9 @@ export class ImapSession {
   // legitimate interactive rate while still bounding a runaway client.
   private throttler: Throttler = new Throttler(100, 1000);
   private authenticated: boolean = false;
+  // RFC 4551 CONDSTORE: once the client sends `ENABLE CONDSTORE`, MODSEQ is
+  // emitted on every subsequent FETCH response for the life of the session.
+  private condstoreEnabled: boolean = false;
   private isIdling: boolean = false;
   private idleTag: string | null = null;
   private sessionId: string;
@@ -144,6 +147,24 @@ export class ImapSession {
 
   check = async (tag: string) => {
     this.write(`${tag} OK CHECK completed\r\n`);
+  };
+
+  /**
+   * RFC 5161 ENABLE + RFC 4551 §3.7. Acknowledge the extensions we can turn on
+   * and echo them back in a single `* ENABLED` line (empty when none match).
+   * CONDSTORE is the only enable-able extension today; enabling it makes every
+   * later FETCH response carry MODSEQ.
+   */
+  enable = (tag: string, capabilities: string[]) => {
+    const enabled: string[] = [];
+    for (const cap of capabilities) {
+      if (cap.toUpperCase() === "CONDSTORE" && !this.condstoreEnabled) {
+        this.condstoreEnabled = true;
+        enabled.push("CONDSTORE");
+      }
+    }
+    const suffix = enabled.length > 0 ? ` ${enabled.join(" ")}` : "";
+    this.write(`* ENABLED${suffix}\r\n${tag} OK ENABLE completed\r\n`);
   };
 
   // ---------------------------------------------------------------------------
@@ -307,7 +328,8 @@ export class ImapSession {
       this.store,
       this.selectedMailbox,
       this.seqState,
-      this.write
+      this.write,
+      this.condstoreEnabled
     );
   };
 
@@ -352,7 +374,8 @@ export class ImapSession {
       this.selectedMailbox,
       this.mailboxReadOnly,
       this.seqState,
-      this.write
+      this.write,
+      this.condstoreEnabled
     );
   };
 

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -17,6 +17,7 @@ import {
   expungeMailsByUid,
   getAllUids as pgGetAllUids,
   getFirstUnseenUid as pgGetFirstUnseenUid,
+  getHighestModseq as pgGetHighestModseq,
   SaveMailInput,
   UpdatedMailFlags,
   StoreOperationType,
@@ -321,6 +322,23 @@ export class Store {
     }
   };
 
+  /**
+   * HIGHESTMODSEQ for a mailbox (RFC 4551 §3.1.1) — the largest mod-sequence of
+   * any message routed to it. Backs the `* OK [HIGHESTMODSEQ N]` SELECT/EXAMINE
+   * response code and the STATUS HIGHESTMODSEQ item. Falls back to 1 (the
+   * DEFAULT-1 floor, never 0) on error so a transient DB hiccup doesn't signal
+   * "no persistent mod-sequences".
+   */
+  getHighestModseq = async (box: string): Promise<number> => {
+    try {
+      const { accountName, isSent } = this.resolveBox(box);
+      return await pgGetHighestModseq(this.user.id, accountName, isSent);
+    } catch (error) {
+      logger.error("Error getting highest modseq", { component: "imap.store", box }, error);
+      return 1;
+    }
+  };
+
   getMessages = async (
     box: string,
     start: number,
@@ -364,6 +382,9 @@ export class Store {
             domain: model.uid_domain,
             account: model.uid_account,
           };
+        }
+        if (model.modseq !== undefined) {
+          mail.modseq = model.modseq;
         }
 
         if (model.from_address) {

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -122,7 +122,8 @@ export type FetchDataItem =
   | Rfc822Fetch
   | Rfc822HeaderFetch
   | Rfc822SizeFetch
-  | Rfc822TextFetch;
+  | Rfc822TextFetch
+  | ModseqFetch;
 
 export interface EnvelopeFetch {
   type: "ENVELOPE";
@@ -162,6 +163,13 @@ export interface Rfc822SizeFetch {
 
 export interface Rfc822TextFetch {
   type: "RFC822.TEXT";
+}
+
+// RFC 4551 CONDSTORE: the per-message mod-sequence data item. Requested
+// explicitly as `MODSEQ`, and emitted implicitly on every FETCH response once
+// the client has issued `ENABLE CONDSTORE`.
+export interface ModseqFetch {
+  type: "MODSEQ";
 }
 
 // Body fetch requests with all variations
@@ -433,7 +441,8 @@ export type StatusItem =
   | "RECENT"
   | "UIDNEXT"
   | "UIDVALIDITY"
-  | "UNSEEN";
+  | "UNSEEN"
+  | "HIGHESTMODSEQ";
 
 // Authentication
 export interface LoginRequest {

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -168,6 +168,10 @@ export interface UpdatedMailFlags {
   deleted: boolean;
   draft: boolean;
   answered: boolean;
+  // The mod-sequence stamped by this STORE (shared across every row it matched).
+  // Backs the MODSEQ item on the untagged FETCH a CONDSTORE client gets from a
+  // flag change (RFC 4551 §3.3.2).
+  modseq: number;
 }
 
 /**
@@ -244,7 +248,7 @@ export const setMailFlags = async (
   try {
     const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
     const setClause = buildFlagSetClause(operation, flags);
-    const returningCols = `${uidField} as uid, read, saved, deleted, draft, answered`;
+    const returningCols = `${uidField} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
 
     // Build the row-matching predicate + its bound params once, shared by the
     // real-change UPDATE and the no-op SELECT below. `$`-indices are 1-based and
@@ -323,6 +327,9 @@ const toUpdatedMailFlags = (row: Record<string, unknown>): UpdatedMailFlags => (
   deleted: row.deleted as boolean,
   draft: row.draft as boolean,
   answered: row.answered as boolean,
+  // INT8 arrives already numeric via the pool's type parser (client.ts); Number
+  // is a no-op today, robust if that parser is ever removed.
+  modseq: Number(row.modseq),
 });
 
 /**


### PR DESCRIPTION
Closes #608

Phase 2 of 4 from the RFC 4551 CONDSTORE split (the #454 umbrella, closed as superseded). Builds on the phase-1 modseq/HIGHESTMODSEQ schema groundwork (#670). This is the **visible-tracking layer**: clients can now READ mod-sequence state. Using it for incremental sync (phase 3, #609) and conflict detection (phase 4, #610) stays out of scope.

## What changed

- **CAPABILITY** advertises `CONDSTORE`.
- **ENABLE handshake** — `ENABLE CONDSTORE` echoes `* ENABLED CONDSTORE` and flips a session flag so MODSEQ is emitted on every later FETCH response (RFC 4551 §3.7). Idempotent on re-enable; an unknown extension echoes a bare `* ENABLED`.
- **SELECT / EXAMINE** include `* OK [HIGHESTMODSEQ N]` before the tagged OK (RFC 4551 §3.1.1).
- **STATUS** supports the `HIGHESTMODSEQ` item.
- **FETCH MODSEQ** data item — emitted when requested explicitly, and implicitly on every FETCH response once CONDSTORE is enabled (deduped to one `MODSEQ (n)` when both apply). The modseq column is pulled in the same range query, so there is no extra round-trip.
- **STORE flag-echo** — the untagged FETCH a STORE generates carries MODSEQ once CONDSTORE is enabled (RFC 4551 §3.3.2). `setMailFlags` surfaces the single reserved mod-sequence it already stamps on every matched row.

`modseq` is added to the shared `MailType` as an optional field, sibling to the existing IMAP `uid` — both are per-message IMAP sequence identifiers the HTTP client never reads.

## Tests

New `condstore.test.ts` (18 cases): parser tokens (MODSEQ / HIGHESTMODSEQ / ENABLE CONDSTORE), the ENABLE handshake (echo + idempotency + unknown-ext), SELECT/EXAMINE + STATUS HIGHESTMODSEQ, FETCH MODSEQ (explicit / implicit-post-ENABLE / dedup / absent-when-no-modseq), and the STORE flag-echo (present with CONDSTORE, absent without). Full server suite green: **1187 pass, 0 fail**. Typecheck clean, lint 0 errors.

## E2E (real IMAP client → full socket/handler/parser/store stack against the local DB)

Booted only the IMAP listener on a high port and drove a real client. All 10 checks passed:

- LOGIN OK; CAPABILITY line includes `CONDSTORE`.
- `ENABLE CONDSTORE` → `* ENABLED CONDSTORE`.
- `SELECT INBOX` → `* OK [HIGHESTMODSEQ N]` present, ordered before the tagged OK.
- `STATUS INBOX (MESSAGES HIGHESTMODSEQ)` → `* STATUS "INBOX" (MESSAGES <count> HIGHESTMODSEQ N)`.
- `FETCH 1 (FLAGS)` post-ENABLE → response carries `MODSEQ (N)` implicitly.
- `FETCH 1 (MODSEQ)` → exactly one `MODSEQ (N)`.
- `STORE 1 +FLAGS (\Flagged)` → untagged FETCH echo carries `MODSEQ (N+1)`; the mod-sequence advanced monotonically across the two STOREs.
- Original `\Flagged` state restored afterward (verified via a follow-up FETCH FLAGS).