### PR TITLE
fix(imap): OR a multi-element SEARCH sequence-set instead of ANDing to empty

### DIFF
--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -39,7 +39,7 @@ import {
 import { restoreLeaves } from "test-helpers";
 import type { MailType } from "common";
 import type { Store } from "./store";
-import type { StoreRequest, AppendRequest } from "./types";
+import type { StoreRequest, AppendRequest, SearchCriterion } from "./types";
 import type { SequenceState } from "./sequence-resolver";
 
 const STORED_UIDVALIDITY = 1716512400;
@@ -540,12 +540,11 @@ describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
   });
 });
 
-// #658 (reviewoie MED): a multi-element bare set (`SEARCH 1,3`) resolves to a
-// multi-range UID criterion that store.search ANDs, not ORs (#659) — a silent
-// empty result. Until #659 lands, searchTyped rejects it loudly on both the
-// plain and UID SEARCH forms rather than answer wrong. Single-range sets still
-// run on both.
-describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
+// #659: a multi-element bare set (`SEARCH 1,3`) resolves to a multi-range UID
+// criterion. store.search once ANDed its ranges (silent empty result), so #658
+// gated it with `NO Not supported`. Now the ranges OR among themselves, so the
+// set executes on both the plain and UID SEARCH forms — the gate is gone.
+describe("searchTyped — multi-element bare set executes (#659)", () => {
   const seqState: SequenceState = {
     seqToUid: [11395, 11396, 11400],
     uidToSeq: new Map([
@@ -554,21 +553,27 @@ describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
       [11400, 3],
     ]),
   };
-  const fakeStore = { search: async () => [] } as unknown as Store;
   const seqReq = (ranges: { start: number; end?: number }[]) => ({
     criteria: [{ type: "SEQ" as const, sequenceSet: { type: "sequence" as const, ranges } }],
   });
-  const capture = async (
+  const run = async (
     tag: string,
     req: { criteria: unknown[] },
     isUid: boolean
-  ): Promise<string> => {
+  ): Promise<{ out: string; passed: SearchCriterion[] | null }> => {
     let out = "";
+    let passed: SearchCriterion[] | null = null;
+    const store = {
+      search: async (_box: string, criteria: SearchCriterion[]) => {
+        passed = criteria;
+        return [];
+      },
+    } as unknown as Store;
     await searchTyped(
       tag,
       req as Parameters<typeof searchTyped>[1],
       isUid,
-      fakeStore,
+      store,
       "INBOX",
       seqState,
       (d: string) => {
@@ -576,27 +581,46 @@ describe("searchTyped — multi-element bare-set gate (#658/#659)", () => {
         return true;
       }
     );
-    return out;
+    return { out, passed };
   };
 
-  it("rejects a multi-element plain-SEARCH bare set with NO", async () => {
-    const out = await capture("t1", seqReq([{ start: 1 }, { start: 3 }]), false);
-    expect(out).toBe("t1 NO Not supported\r\n");
+  it("runs a multi-element plain-SEARCH bare set, resolving both seq→uid ranges", async () => {
+    const { out, passed } = await run("t1", seqReq([{ start: 1 }, { start: 3 }]), false);
+    expect(out).toContain("OK SEARCH completed");
+    expect(out).not.toContain("NO Not supported");
+    // seq 1 → uid 11395, seq 3 → uid 11400: both ranges reach store.search.
+    expect(passed).toEqual([
+      {
+        type: "UID",
+        sequenceSet: {
+          type: "sequence",
+          ranges: [
+            { start: 11395, end: 11395 },
+            { start: 11400, end: 11400 },
+          ],
+        },
+      },
+    ]);
   });
 
-  it("runs a single-range plain-SEARCH bare set (no gate)", async () => {
-    const out = await capture("t2", seqReq([{ start: 1, end: 3 }]), false);
+  it("runs a single-range plain-SEARCH bare set", async () => {
+    const { out } = await run("t2", seqReq([{ start: 1, end: 3 }]), false);
     expect(out).toContain("OK SEARCH completed");
     expect(out).not.toContain("NO Not supported");
   });
 
-  it("rejects a multi-element UID-SEARCH bare set with NO", async () => {
-    const out = await capture("t3", seqReq([{ start: 1 }, { start: 3 }]), true);
-    expect(out).toBe("t3 NO Not supported\r\n");
+  it("runs a multi-element UID-SEARCH bare set, keeping both ranges as UIDs", async () => {
+    const { out, passed } = await run("t3", seqReq([{ start: 1 }, { start: 3 }]), true);
+    expect(out).toContain("OK SEARCH completed");
+    expect(out).not.toContain("NO Not supported");
+    // UID SEARCH: the set already names UIDs, so relabel untouched.
+    expect(passed).toEqual([
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 1 }, { start: 3 }] } },
+    ]);
   });
 
-  it("runs a single-range UID-SEARCH bare set (no gate)", async () => {
-    const out = await capture("t4", seqReq([{ start: 1, end: 3 }]), true);
+  it("runs a single-range UID-SEARCH bare set", async () => {
+    const { out } = await run("t4", seqReq([{ start: 1, end: 3 }]), true);
     expect(out).toContain("OK SEARCH completed");
     expect(out).not.toContain("NO Not supported");
   });

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -248,20 +248,6 @@ export async function searchTyped(
     return;
   }
 
-  // A multi-element bare set (`SEARCH 1,3` or `UID SEARCH 1,3`) resolves to a
-  // multi-range UID criterion, which store.search currently ANDs rather than
-  // ORs (#659) — silently returning the empty set. Until #659 fixes the
-  // OR-combination, reject a multi-range bare set loudly on both the plain and
-  // UID SEARCH forms rather than answer wrong. Single-range sets (`SEARCH 1:3`,
-  // the common client form) are unaffected.
-  const hasMultiRangeSeq = searchRequest.criteria.some(
-    (c) => c.type === "SEQ" && c.sequenceSet.ranges.length > 1
-  );
-  if (hasMultiRangeSeq) {
-    write(`${tag} NO Not supported\r\n`);
-    return;
-  }
-
   const criteria = resolveSeqSearchKeys(
     searchRequest.criteria,
     isUidCommand,

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -136,14 +136,29 @@ describe("simplifyCriterion — NOT/OR operand normalisation (regression for #55
     });
   });
 
-  it("drops an OR whose operand cannot be expressed as a single value (UID)", () => {
+  it("normalises a multi-element UID set into one UID_SET carrying every range (#659)", () => {
+    expect(
+      simplifyCriterion({
+        type: "UID",
+        sequenceSet: { ranges: [{ start: 1 }, { start: 3, end: 5 }] },
+      } as never)
+    ).toEqual({ type: "UID_SET", value: [{ start: 1 }, { start: 3, end: 5 }] });
+  });
+
+  it("normalises a nested UID operand of an OR into a UID_SET (#659)", () => {
     expect(
       simplifyCriterion({
         type: "OR",
         left: { type: "FROM", value: "alice" },
-        right: { type: "UID", sequenceSet: { ranges: [{ start: 1 }] } },
+        right: { type: "UID", sequenceSet: { ranges: [{ start: 1 }, { start: 3 }] } },
       } as never)
-    ).toBeNull();
+    ).toEqual({
+      type: "OR",
+      value: {
+        left: { type: "FROM", value: "alice" },
+        right: { type: "UID_SET", value: [{ start: 1 }, { start: 3 }] },
+      },
+    });
   });
 
   it("normalises HEADER's field/value into { field, text }", () => {

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -47,9 +47,10 @@ type SimplifiedCriterion = { type: string; value?: unknown };
  * searchMailsByUid consumes. NOT/OR recurse so their operands are normalised too —
  * otherwise the SQL builder would read the wrong field off the raw parser shape
  * (e.g. `.date`/`.field` instead of `.value`) and silently mis-handle the nested
- * criterion. Returns null when the criterion imposes no constraint or can't be
- * expressed as a single flat value (UID, which expands to multiple entries, and is
- * handled by the caller). See #551.
+ * criterion. Returns null when the criterion imposes no constraint. A UID set
+ * normalises to one `UID_SET` entry carrying all its ranges, so the SQL builder
+ * ORs the ranges among themselves (a message is in the set if it falls in ANY
+ * range) — nested UID keys under NOT/OR resolve the same way. See #551, #659.
  */
 export const simplifyCriterion = (
   criterion: SearchCriterion
@@ -131,9 +132,12 @@ export const simplifyCriterion = (
       return null;
     }
 
-    // UID expands to multiple ranges; cannot collapse to a single value here.
-    case "UID":
-      return null;
+    // UID set: carry every range in one entry so the SQL builder ORs them —
+    // set membership means a message matches if it falls in ANY range (#659).
+    case "UID": {
+      const uidCriterion = criterion as UidCriterion;
+      return { type: "UID_SET", value: uidCriterion.sequenceSet.ranges };
+    }
 
     default:
       logger.warn("Unsupported search criterion", { component: "imap.store", type });
@@ -489,29 +493,12 @@ export class Store {
     try {
       const { accountName, isSent } = this.resolveBox(box);
 
-      // Convert criteria to a simpler flat format for searchMailsByUid.
-      // UID expands to one entry per range; everything else (including nested
-      // NOT/OR operands) normalises via simplifyCriterion.
+      // Convert criteria to a simpler flat format for searchMailsByUid. Every
+      // criterion — UID sets (one UID_SET entry per set), flags, text, dates,
+      // and nested NOT/OR operands — normalises through simplifyCriterion.
       const simplifiedCriteria: SimplifiedCriterion[] = [];
 
       for (const criterion of criteria) {
-        const type = criterion.type.toUpperCase();
-
-        if (type === "UID") {
-          const uidCriterion = criterion as UidCriterion;
-          for (const range of uidCriterion.sequenceSet.ranges) {
-            if (range.end === undefined) {
-              simplifiedCriteria.push({ type: "UID_EXACT", value: range.start });
-            } else {
-              simplifiedCriteria.push({
-                type: "UID_RANGE",
-                value: { start: range.start, end: range.end },
-              });
-            }
-          }
-          continue;
-        }
-
         const simplified = simplifyCriterion(criterion);
         if (simplified) simplifiedCriteria.push(simplified);
       }

--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -648,6 +648,89 @@ describe("buildCriterionClause — NOT/OR SQL generation (regression for #551)",
   });
 });
 
+describe("buildCriterionClause — UID_SET ORs its ranges (#659)", () => {
+  // A UID sequence-set's ranges are alternatives, so they must OR among
+  // themselves. Before #659 store.ts emitted one criterion per range and
+  // searchMailsByUid ANDed them, so `1,3` became `uid = 1 AND uid = 3` — an
+  // always-empty set. Now the whole set renders as a single OR-of-ranges.
+
+  it("renders a single exact element without an OR wrapper", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "UID_SET", value: [{ start: 5 }] },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("uid_account = $1");
+    expect(values).toEqual([5]);
+  });
+
+  it("ORs disjoint exact elements (`1,3`) instead of ANDing to empty", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "UID_SET", value: [{ start: 1 }, { start: 3 }] },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("(uid_account = $1 OR uid_account = $2)");
+    expect(values).toEqual([1, 3]);
+  });
+
+  it("ORs mixed exact + range elements (`2:3,5:7`) with parenthesised ranges", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "UID_SET", value: [{ start: 2, end: 3 }, { start: 5, end: 7 }] },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe(
+      "((uid_account >= $1 AND uid_account <= $2) OR (uid_account >= $3 AND uid_account <= $4))"
+    );
+    expect(values).toEqual([2, 3, 5, 7]);
+  });
+
+  it("renders a lone range without an OR wrapper (common `1:3` client form)", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    const frag = buildCriterionClause(
+      { type: "UID_SET", value: [{ start: 1, end: 3 }] },
+      "uid_account",
+      values as never
+    );
+    expect(frag).toBe("(uid_account >= $1 AND uid_account <= $2)");
+    expect(values).toEqual([1, 3]);
+  });
+
+  it("ANDs correctly against a sibling flag key (`SEEN 1,3`)", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    // Sibling keys are joined with AND by searchMailsByUid; the set stays a
+    // single OR-group so the intersection is `read AND (uid∈{1,3})`.
+    const values: unknown[] = [];
+    const flag = buildCriterionClause({ type: "SEEN" }, "uid_account", values as never);
+    const set = buildCriterionClause(
+      { type: "UID_SET", value: [{ start: 1 }, { start: 3 }] },
+      "uid_account",
+      values as never
+    );
+    expect([flag, set].join(" AND ")).toBe(
+      "read = TRUE AND (uid_account = $1 OR uid_account = $2)"
+    );
+    expect(values).toEqual([1, 3]);
+  });
+
+  it("imposes no constraint for an empty set (caller skips it)", async () => {
+    const { buildCriterionClause } = await import("./mails");
+    const values: unknown[] = [];
+    expect(
+      buildCriterionClause({ type: "UID_SET", value: [] }, "uid_account", values as never)
+    ).toBeNull();
+    expect(values).toHaveLength(0);
+  });
+});
+
 describe("searchMailsByUid — no result cap (#553)", () => {
   // A `LIMIT 10000` with `ORDER BY uid ASC` made SEARCH/UID SEARCH drop
   // the NEWEST messages once a mailbox exceeded 10000 — the worst-possible

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1344,14 +1344,22 @@ export const buildCriterionClause = (
     case "SMALLER":
       return null;
 
-    // UID ranges (already split from UidCriterion in store.ts)
-    case "UID_EXACT":
-      values.push(criterion.value as number);
-      return `${uidField} = $${values.length}`;
-    case "UID_RANGE": {
-      const range = criterion.value as { start: number; end: number };
-      values.push(range.start, range.end);
-      return `${uidField} >= $${values.length - 1} AND ${uidField} <= $${values.length}`;
+    // A UID sequence-set: its ranges are alternatives, so OR them among
+    // themselves (a message matches if it falls in ANY range) while the whole
+    // set still ANDs against sibling keys. An empty set imposes no constraint
+    // (caller skips it). See #659.
+    case "UID_SET": {
+      const ranges = criterion.value as { start: number; end?: number }[];
+      const parts = ranges.map((range) => {
+        if (range.end === undefined) {
+          values.push(range.start);
+          return `${uidField} = $${values.length}`;
+        }
+        values.push(range.start, range.end);
+        return `(${uidField} >= $${values.length - 1} AND ${uidField} <= $${values.length})`;
+      });
+      if (parts.length === 0) return null;
+      return parts.length === 1 ? parts[0] : `(${parts.join(" OR ")})`;
     }
 
     // Unsupported criterion — impose no constraint (caller skips it).


### PR DESCRIPTION
## What

`SEARCH` / `UID SEARCH` whose sequence-set has more than one element (`1,3`, `2:3,5:7`) matched **nothing** instead of the union of the ranges. `store.search` flattened a UID criterion into one criterion per range, and `searchMailsByUid` joins every criterion with `AND`, so `1,3` became `uid = 1 AND uid = 3` — unsatisfiable.

A sequence-set's ranges are alternatives (a message is in the set if it falls in ANY range). This PR makes the whole set render as one OR-of-ranges group that still ANDs against sibling keys.

## Changes

- **`store.ts` `simplifyCriterion`** — a `UID` criterion now normalises to a single `UID_SET` entry carrying all its ranges (was `null` + a special-case loop in `search()`). Routing UID through `simplifyCriterion` also fixes a **nested UID key under `NOT`/`OR`**, which previously dropped the whole disjunction (matched everything).
- **`store.ts` `search()`** — dropped the per-range UID special-case; every criterion now normalises through `simplifyCriterion`.
- **`mails.ts` `buildCriterionClause`** — new `UID_SET` case renders `(uid = a OR (uid >= b AND uid <= c) OR …)`; a lone element renders bare, an empty set imposes no constraint. Replaces `UID_EXACT`/`UID_RANGE` (now unreachable).
- **`message-ops.ts` `searchTyped`** — removed the interim `NO Not supported` gate for multi-range bare sets added in PR #658; both plain and UID SEARCH now execute.

## Test plan

Query-construction defect — verified at every layer, all green (`bun test src/server`: 1176 pass, 0 fail):

- **`mails.test.ts`** (SQL builder, exact fragment + bound-param assertions):
  - `1,3` → `(uid_account = $1 OR uid_account = $2)`, params `[1, 3]` (was AND → empty).
  - `2:3,5:7` → `((uid_account >= $1 AND uid_account <= $2) OR (uid_account >= $3 AND uid_account <= $4))`.
  - lone `5` / lone `1:3` render without an OR wrapper.
  - `SEEN 1,3` → `read = TRUE AND (uid_account = $1 OR uid_account = $2)` (set ORs internally, ANDs against the flag).
  - empty set → `null`.
- **`store.test.ts`** — `simplifyCriterion` maps a multi-element UID set and a nested UID-in-`OR` to `UID_SET`.
- **`message-ops.test.ts`** — `searchTyped` no longer rejects multi-element bare sets; asserts both seq→uid-resolved ranges (plain SEARCH) and the untouched UID ranges (UID SEARCH) reach `store.search`.

Typecheck clean; lint: 0 errors (pre-existing warnings only).

IMAP is a protocol surface with no browser UI path, so the E2E is the protocol-handler + SQL-builder assertions above rather than a Playwright drive.

Closes #659