### PR TITLE
perf(cache): revalidate IDB-seeded header queries on mount, and label retained data

### DIFF
--- a/src/client/Box/components/Mails/index.scss
+++ b/src/client/Box/components/Mails/index.scss
@@ -38,6 +38,15 @@
     padding-top: 0.5rem;
   }
 
+  .mails_stale_notice {
+    margin-bottom: 0.5rem;
+    padding: 0.35rem 0.6rem;
+    border-left: 3px solid $color-point;
+    background-color: color.adjust($color-dark, $lightness: 6%);
+    color: $color-midium;
+    font-size: 0.8rem;
+  }
+
   .content {
     margin: 0;
   }

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -45,7 +45,8 @@ import {
   isSentMail,
   processHtmlForViewer,
   useIsOnline,
-  matchCacheCatalog
+  revalidateOnMountPolicy,
+  formatDataAge
 } from "client";
 import { AccountsCache } from "client/Box/components/Accounts";
 import { getMailsQueryUrl } from "./mailsQuery";
@@ -555,6 +556,7 @@ const RenderedMails = ({ page }: { page: number }) => {
 
   const [activeMailId, setActiveMailId] = useState<ActiveMailMap>({});
   const [openedKebab, setOpenedKebab] = useState("");
+  const { isOnline } = useIsOnline();
 
   const accountsCache = new AccountsCache();
 
@@ -581,16 +583,8 @@ const RenderedMails = ({ page }: { page: number }) => {
       return body?.map((d) => new MailHeaderData(d)) || [];
     } else throw new Error(message);
   };
-  // Header lists are seeded from IndexedDB before first render (#618), so a hard
-  // reload paints last session's cache without hitting the network. Revalidate
-  // those seeded keys on mount so the paint can't stay stale inside the count-
-  // heuristic's blind spot (a net-zero count change — read-elsewhere, or a
-  // delete + new arrival) until the 10-min interval fires. A failed revalidation
-  // keeps the seeded paint (see the render guards below). Search results aren't
-  // seeded, so they keep the global refetchOnMount: false. (#622)
-  const revalidateOnMount = matchCacheCatalog(queryUrl) ? "always" : false;
   const query = useQuery<MailHeaderData[]>(queryUrl, getMails, {
-    refetchOnMount: revalidateOnMount
+    refetchOnMount: revalidateOnMountPolicy(queryUrl)
   });
 
   if (query.isLoading) {
@@ -603,11 +597,10 @@ const RenderedMails = ({ page }: { page: number }) => {
     );
   }
 
-  // A failed revalidation must not blow away the IndexedDB-seeded paint
-  // (#618/#622): with retry:false + refetchOnReconnect:false, an offline or
-  // transient-error refetch sets query.error while the seeded query.data
-  // survives, so only surface the error screen when there's no cached list to
-  // fall back on.
+  // react-query v3's `error` action keeps `data`, so a failed revalidation
+  // leaves the IndexedDB-seeded list intact — fall back to it instead of
+  // blanking the pane, and only show the error screen when there is nothing to
+  // fall back on. The retained list is labelled by staleNotice below.
   if (query.error && !query.data) {
     return (
       <div className="mails_container error">Mails List Request Failed</div>
@@ -749,6 +742,17 @@ const RenderedMails = ({ page }: { page: number }) => {
   // Paired with the error guard above: gating on isSuccess alone would blank
   // the pane the instant a revalidation failed, so render retained data too.
   if (query.isSuccess || query.data) {
+    // A revalidation that failed while the server is reachable (expired
+    // session, 5xx) has no other signal — the offline banner doesn't apply and
+    // every list action is optimistic — so retained data must not render as if
+    // it were fresh. While offline the banner already says this.
+    const staleNotice =
+      query.error && query.data && isOnline ? (
+        <div className="mails_stale_notice" role="status" aria-live="polite">
+          Couldn&apos;t refresh — showing mail as of{" "}
+          {formatDataAge(query.dataUpdatedAt)}
+        </div>
+      ) : null;
     const mails = Array.isArray(query.data) ? query.data : [];
     const pagedMails = mails.slice(0, 4 + 8 * page);
 
@@ -798,12 +802,18 @@ const RenderedMails = ({ page }: { page: number }) => {
       })();
       return (
         <div className="mails_container empty">
+          {staleNotice}
           <p className="empty_state">{emptyMessage}</p>
         </div>
       );
     }
 
-    return <div className="mails_container">{result}</div>;
+    return (
+      <div className="mails_container">
+        {staleNotice}
+        {result}
+      </div>
+    );
   }
 
   return <></>;

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -585,7 +585,8 @@ const RenderedMails = ({ page }: { page: number }) => {
   // reload paints last session's cache without hitting the network. Revalidate
   // those seeded keys on mount so the paint can't stay stale inside the count-
   // heuristic's blind spot (a net-zero count change — read-elsewhere, or a
-  // delete + new arrival) until the 10-min interval fires. Search results aren't
+  // delete + new arrival) until the 10-min interval fires. A failed revalidation
+  // keeps the seeded paint (see the render guards below). Search results aren't
   // seeded, so they keep the global refetchOnMount: false. (#622)
   const revalidateOnMount = matchCacheCatalog(queryUrl) ? "always" : false;
   const query = useQuery<MailHeaderData[]>(queryUrl, getMails, {
@@ -602,7 +603,12 @@ const RenderedMails = ({ page }: { page: number }) => {
     );
   }
 
-  if (query.error) {
+  // A failed revalidation must not blow away the IndexedDB-seeded paint
+  // (#618/#622): with retry:false + refetchOnReconnect:false, an offline or
+  // transient-error refetch sets query.error while the seeded query.data
+  // survives, so only surface the error screen when there's no cached list to
+  // fall back on.
+  if (query.error && !query.data) {
     return (
       <div className="mails_container error">Mails List Request Failed</div>
     );
@@ -740,7 +746,12 @@ const RenderedMails = ({ page }: { page: number }) => {
     });
   };
 
-  if (query.isSuccess) {
+  // Render whatever list we have — a fresh success, OR the IndexedDB-seeded /
+  // last-good data retained through a failed background revalidation (v3 keeps
+  // query.data on error; only a genuine no-data error reaches the screen above).
+  // Gating on isSuccess alone would blank the pane the instant a revalidation
+  // failed, defeating the offline-read paint. (#618/#622)
+  if (query.isSuccess || query.data) {
     const mails = Array.isArray(query.data) ? query.data : [];
     const pagedMails = mails.slice(0, 4 + 8 * page);
 

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -746,11 +746,8 @@ const RenderedMails = ({ page }: { page: number }) => {
     });
   };
 
-  // Render whatever list we have — a fresh success, OR the IndexedDB-seeded /
-  // last-good data retained through a failed background revalidation (v3 keeps
-  // query.data on error; only a genuine no-data error reaches the screen above).
-  // Gating on isSuccess alone would blank the pane the instant a revalidation
-  // failed, defeating the offline-read paint. (#618/#622)
+  // Paired with the error guard above: gating on isSuccess alone would blank
+  // the pane the instant a revalidation failed, so render retained data too.
   if (query.isSuccess || query.data) {
     const mails = Array.isArray(query.data) ? query.data : [];
     const pagedMails = mails.slice(0, 4 + 8 * page);

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -46,7 +46,8 @@ import {
   processHtmlForViewer,
   useIsOnline,
   revalidateOnMountPolicy,
-  formatDataAge
+  formatDataAge,
+  isShowingStaleData
 } from "client";
 import { AccountsCache } from "client/Box/components/Accounts";
 import { getMailsQueryUrl } from "./mailsQuery";
@@ -556,7 +557,6 @@ const RenderedMails = ({ page }: { page: number }) => {
 
   const [activeMailId, setActiveMailId] = useState<ActiveMailMap>({});
   const [openedKebab, setOpenedKebab] = useState("");
-  const { isOnline } = useIsOnline();
 
   const accountsCache = new AccountsCache();
 
@@ -742,12 +742,13 @@ const RenderedMails = ({ page }: { page: number }) => {
   // Paired with the error guard above: gating on isSuccess alone would blank
   // the pane the instant a revalidation failed, so render retained data too.
   if (query.isSuccess || query.data) {
-    // A revalidation that failed while the server is reachable (expired
-    // session, 5xx) has no other signal — the offline banner doesn't apply and
-    // every list action is optimistic — so retained data must not render as if
-    // it were fresh. While offline the banner already says this.
+    // Retained data must not render as if it were fresh: a failed revalidation
+    // leaves a list that can be a week old, and every action on it is
+    // fire-and-forget optimistic. The offline banner reports connectivity and
+    // can only say "—" for the age on a cold offline start, so this carries the
+    // age the banner can't know rather than duplicating it.
     const staleNotice =
-      query.error && query.data && isOnline ? (
+      query.data && isShowingStaleData(query) ? (
         <div className="mails_stale_notice" role="status" aria-live="polite">
           Couldn&apos;t refresh — showing mail as of{" "}
           {formatDataAge(query.dataUpdatedAt)}

--- a/src/client/Box/components/Mails/index.tsx
+++ b/src/client/Box/components/Mails/index.tsx
@@ -44,7 +44,8 @@ import {
   call,
   isSentMail,
   processHtmlForViewer,
-  useIsOnline
+  useIsOnline,
+  matchCacheCatalog
 } from "client";
 import { AccountsCache } from "client/Box/components/Accounts";
 import { getMailsQueryUrl } from "./mailsQuery";
@@ -580,7 +581,16 @@ const RenderedMails = ({ page }: { page: number }) => {
       return body?.map((d) => new MailHeaderData(d)) || [];
     } else throw new Error(message);
   };
-  const query = useQuery<MailHeaderData[]>(queryUrl, getMails);
+  // Header lists are seeded from IndexedDB before first render (#618), so a hard
+  // reload paints last session's cache without hitting the network. Revalidate
+  // those seeded keys on mount so the paint can't stay stale inside the count-
+  // heuristic's blind spot (a net-zero count change — read-elsewhere, or a
+  // delete + new arrival) until the 10-min interval fires. Search results aren't
+  // seeded, so they keep the global refetchOnMount: false. (#622)
+  const revalidateOnMount = matchCacheCatalog(queryUrl) ? "always" : false;
+  const query = useQuery<MailHeaderData[]>(queryUrl, getMails, {
+    refetchOnMount: revalidateOnMount
+  });
 
   if (query.isLoading) {
     return (

--- a/src/client/lib/cache.ts
+++ b/src/client/lib/cache.ts
@@ -12,7 +12,14 @@ export class QueryCache<T> {
 
   public set = (callback: Updater<T | undefined, T | undefined>) => {
     if (!this.get()) return;
-    return queryClient.setQueryData<T | undefined>(this.key, callback);
+    // An optimistic local edit is not a server fetch. Carry the existing
+    // dataUpdatedAt forward — left to default it would stamp `now`, dating the
+    // data to the edit and telling every freshness consumer the server was
+    // just heard from.
+    const updatedAt = queryClient.getQueryState(this.key)?.dataUpdatedAt;
+    return queryClient.setQueryData<T | undefined>(this.key, callback, {
+      updatedAt
+    });
   };
 }
 

--- a/src/client/lib/cacheCatalog.test.ts
+++ b/src/client/lib/cacheCatalog.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "bun:test";
 import { MailHeaderData } from "common";
-import { matchCacheCatalog, cacheCatalog } from "./cacheCatalog";
+import {
+  matchCacheCatalog,
+  cacheCatalog,
+  revalidateOnMountPolicy,
+} from "./cacheCatalog";
 
 describe("cacheCatalog", () => {
   it("matches the mail-headers list endpoints (all category variants)", () => {
@@ -16,6 +20,9 @@ describe("cacheCatalog", () => {
     expect(
       matchCacheCatalog("/api/mails/headers/me@hoie.kim?saved=1")?.id
     ).toBe("mail-headers");
+    expect(matchCacheCatalog("/api/mails/headers/me@hoie.kim?spam=1")?.id).toBe(
+      "mail-headers"
+    );
   });
 
   it("does not match volatile or unrelated endpoints", () => {
@@ -58,5 +65,39 @@ describe("cacheCatalog", () => {
     for (const entry of cacheCatalog) {
       expect(entry.maxAgeMs).toBeGreaterThan(0);
     }
+  });
+});
+
+describe("revalidateOnMountPolicy", () => {
+  it("forces a mount refetch for every seeded header list, including spam", () => {
+    const seeded = [
+      "/api/mails/headers/me@hoie.kim",
+      "/api/mails/headers/me@hoie.kim?sent=1",
+      "/api/mails/headers/me@hoie.kim?new=1",
+      "/api/mails/headers/me@hoie.kim?saved=1",
+      "/api/mails/headers/me@hoie.kim?spam=1",
+    ];
+    expect(seeded.map(revalidateOnMountPolicy)).toEqual([
+      "always",
+      "always",
+      "always",
+      "always",
+      "always",
+    ]);
+  });
+
+  it("leaves un-seeded keys on the client-wide refetchOnMount: false", () => {
+    const unseeded = [
+      "/api/mails/search/me@hoie.kim",
+      "/api/mails/body/abc",
+      "/api/mails/accounts",
+      "/api/users/login",
+    ];
+    expect(unseeded.map(revalidateOnMountPolicy)).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
   });
 });

--- a/src/client/lib/cacheCatalog.ts
+++ b/src/client/lib/cacheCatalog.ts
@@ -54,3 +54,13 @@ export const matchCacheCatalog = (
   queryKey: string
 ): CacheCatalogEntry | undefined =>
   cacheCatalog.find((entry) => entry.matches(queryKey));
+
+/**
+ * React Query's `refetchOnMount` for a query key. Cataloged keys paint from
+ * IndexedDB before the first render, so they need `"always"` — which refetches
+ * regardless of `staleTime` — or a seeded paint can outlive the new-mail count
+ * heuristic's blind spot (a net-zero count change) until the 10-min interval
+ * fires. Everything else keeps the client-wide `refetchOnMount: false`. (#622)
+ */
+export const revalidateOnMountPolicy = (queryKey: string): "always" | false =>
+  matchCacheCatalog(queryKey) ? "always" : false;

--- a/src/client/lib/cachePersist.test.ts
+++ b/src/client/lib/cachePersist.test.ts
@@ -9,6 +9,7 @@ import {
   startCachePersistence,
 } from "./cachePersist";
 import { idbGetAllQueries, idbPutQuery, idbClearQueries } from "./idbStore";
+import { QueryCache } from "./cache";
 
 const HEADERS_KEY = "/api/mails/headers/me@hoie.kim";
 const flush = () => new Promise((r) => setTimeout(r, 10));
@@ -118,6 +119,47 @@ describe("startCachePersistence", () => {
     ]);
     await flush();
     expect(await idbGetAllQueries()).toHaveLength(0);
+    unsubscribe();
+  });
+
+  it("re-persists a seed at its original fetch time, so an over-age entry still expires", async () => {
+    // Bootstrap order: startCachePersistence() runs before login, so the
+    // hydrate-time setQueryData fires this subscription. Stamping `now` here
+    // would re-date the seed on every login and re-arm its maxAge forever.
+    const sixDaysAgo = Date.now() - 6 * 24 * 60 * 60 * 1000;
+    await idbPutQuery({
+      key: HEADERS_KEY,
+      payload: [{ id: "m1", subject: "hi" }],
+      userId: "u1",
+      lastFetchedAt: sixDaysAgo,
+    });
+    setCacheUser("u1");
+    const unsubscribe = startCachePersistence();
+    await hydrateQueryCache("u1");
+    await flush();
+    const [stored] = await idbGetAllQueries();
+    expect(stored.lastFetchedAt).toBe(sixDaysAgo);
+    unsubscribe();
+  });
+
+  it("carries the fetch time through an optimistic write, so a local edit is not a refresh", async () => {
+    setCacheUser("u1");
+    const unsubscribe = startCachePersistence();
+    await queryClient.fetchQuery(HEADERS_KEY, async () => [
+      new MailHeaderData({ id: "m1", subject: "hi", read: false }),
+    ]);
+    await flush();
+    const fetchedAt = (await idbGetAllQueries())[0].lastFetchedAt;
+
+    await new Promise((r) => setTimeout(r, 20));
+    new QueryCache<MailHeaderData[]>(HEADERS_KEY).set((old) =>
+      old?.map((m) => new MailHeaderData({ ...m, read: true }))
+    );
+    await flush();
+
+    const [stored] = await idbGetAllQueries();
+    expect((stored.payload as MailHeaderData[])[0].read).toBe(true);
+    expect(stored.lastFetchedAt).toBe(fetchedAt);
     unsubscribe();
   });
 });

--- a/src/client/lib/cachePersist.ts
+++ b/src/client/lib/cachePersist.ts
@@ -52,7 +52,12 @@ export const hydrateQueryCache = async (userId?: string): Promise<void> => {
       void idbDeleteQuery(entry.key);
       continue;
     }
-    queryClient.setQueryData(entry.key, catalog.revive(entry.payload));
+    // Stamp the seed with when it was actually fetched, not now — the stale-
+    // data notice reads dataUpdatedAt, and the default (hydration time) would
+    // report week-old mail as just-fetched.
+    queryClient.setQueryData(entry.key, catalog.revive(entry.payload), {
+      updatedAt: entry.lastFetchedAt,
+    });
   }
 };
 

--- a/src/client/lib/cachePersist.ts
+++ b/src/client/lib/cachePersist.ts
@@ -80,7 +80,11 @@ export const startCachePersistence = (): (() => void) =>
       key: url,
       payload: query.state.data,
       userId: currentUserId,
-      lastFetchedAt: Date.now(),
+      // The query's own fetch stamp, not `now`. This subscription also fires
+      // for hydration seeds and for optimistic setQueryData writes, both of
+      // which carry an older dataUpdatedAt — stamping `now` would re-date a
+      // week-old seed on every login and re-arm its maxAge expiry forever.
+      lastFetchedAt: query.state.dataUpdatedAt,
     });
   });
 

--- a/src/client/lib/online.test.ts
+++ b/src/client/lib/online.test.ts
@@ -5,6 +5,7 @@ import {
   pingHealth,
   invalidateCacheableQueries,
   formatLastSeen,
+  formatDataAge,
   OnlineState
 } from "./online";
 
@@ -101,5 +102,25 @@ describe("formatLastSeen", () => {
     const out = formatLastSeen(new Date(2026, 0, 1, 9, 5).getTime());
     expect(out).toMatch(/\d/);
     expect(out.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatDataAge", () => {
+  const now = new Date(2026, 0, 8, 14, 0).getTime();
+
+  it("renders same-day data as a bare clock", () => {
+    const out = formatDataAge(new Date(2026, 0, 8, 9, 5).getTime(), now);
+    expect(out).toBe(formatLastSeen(new Date(2026, 0, 8, 9, 5).getTime()));
+  });
+
+  it("carries the date once the data predates today, so week-old mail can't read as today", () => {
+    const out = formatDataAge(new Date(2026, 0, 1, 9, 5).getTime(), now);
+    expect(out).not.toBe(formatLastSeen(new Date(2026, 0, 1, 9, 5).getTime()));
+    expect(out).toContain(formatLastSeen(new Date(2026, 0, 1, 9, 5).getTime()));
+  });
+
+  it("treats yesterday-late as a different day even when it is under 24h old", () => {
+    const yesterday = new Date(2026, 0, 7, 23, 30).getTime();
+    expect(formatDataAge(yesterday, now)).toContain("Jan");
   });
 });

--- a/src/client/lib/online.test.ts
+++ b/src/client/lib/online.test.ts
@@ -6,6 +6,7 @@ import {
   invalidateCacheableQueries,
   formatLastSeen,
   formatDataAge,
+  isShowingStaleData,
   OnlineState
 } from "./online";
 
@@ -122,5 +123,35 @@ describe("formatDataAge", () => {
   it("treats yesterday-late as a different day even when it is under 24h old", () => {
     const yesterday = new Date(2026, 0, 7, 23, 30).getTime();
     expect(formatDataAge(yesterday, now)).toContain("Jan");
+  });
+});
+
+describe("isShowingStaleData", () => {
+  it("classifies each react-query stamp pairing", () => {
+    const cases = [
+      // never errored (errorUpdatedAt is 0 on a fresh query)
+      { dataUpdatedAt: 5000, errorUpdatedAt: 0 },
+      // a fetch failed after the data landed — the seeded-paint-plus-401 case
+      { dataUpdatedAt: 5000, errorUpdatedAt: 6000 },
+      // a later fetch succeeded, so the failure is history
+      { dataUpdatedAt: 7000, errorUpdatedAt: 6000 },
+      // an optimistic setQueryData that carried dataUpdatedAt forward keeps
+      // the signal up even though it cleared `error`
+      { dataUpdatedAt: 5000, errorUpdatedAt: 6000 },
+      // ...and one that did NOT carry it forward would lose the signal, which
+      // is exactly why QueryCache.set passes updatedAt
+      { dataUpdatedAt: 8000, errorUpdatedAt: 6000 },
+      // simultaneous stamps resolve to "not stale" — a success at the same ms
+      // is the newer fact, since the error is what triggered the refetch
+      { dataUpdatedAt: 6000, errorUpdatedAt: 6000 },
+    ];
+    expect(cases.map(isShowingStaleData)).toEqual([
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+    ]);
   });
 });

--- a/src/client/lib/online.tsx
+++ b/src/client/lib/online.tsx
@@ -100,6 +100,28 @@ export const formatLastSeen = (lastSeenOnline: number | null): string => {
   });
 };
 
+/**
+ * Render the "as of" clock for cached data, which — unlike the banner's
+ * session-scoped `lastSeenOnline` — can be up to `maxAgeMs` old (a week for the
+ * header catalog). A bare `HH:MM` on week-old data reads as today, so anything
+ * fetched before `now`'s calendar day carries its date.
+ */
+export const formatDataAge = (
+  dataUpdatedAt: number,
+  now: number = Date.now()
+): string => {
+  const fetched = new Date(dataUpdatedAt);
+  const time = fetched.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+  if (fetched.toDateString() === new Date(now).toDateString()) return time;
+  return `${fetched.toLocaleDateString([], {
+    month: "short",
+    day: "numeric"
+  })} ${time}`;
+};
+
 const IsOnlineContext = createContext<IsOnlineContextValue>({
   isOnline: true,
   lastSeenOnline: null,

--- a/src/client/lib/online.tsx
+++ b/src/client/lib/online.tsx
@@ -101,6 +101,20 @@ export const formatLastSeen = (lastSeenOnline: number | null): string => {
 };
 
 /**
+ * Is the data a query is currently rendering older than the last thing that
+ * happened to that query? True exactly when a fetch has failed and no
+ * successful one has landed since — including after an optimistic
+ * `setQueryData`, which clears `error` but leaves `errorUpdatedAt` standing
+ * (and, via `QueryCache.set`, carries `dataUpdatedAt` forward). Reading the
+ * two stamps rather than `error` is what keeps the signal alive across a local
+ * edit made while the server is unreachable.
+ */
+export const isShowingStaleData = (query: {
+  dataUpdatedAt: number;
+  errorUpdatedAt: number;
+}): boolean => query.errorUpdatedAt > query.dataUpdatedAt;
+
+/**
  * Render the "as of" clock for cached data, which — unlike the banner's
  * session-scoped `lastSeenOnline` — can be up to `maxAgeMs` old (a week for the
  * header catalog). A bare `HH:MM` on week-old data reads as today, so anything


### PR DESCRIPTION
## What

Closes #622. Cataloged mail-header list queries are seeded from IndexedDB before first render (#618), so a hard reload paints last session's cache without a network round-trip. But with the global `refetchOnMount: false` (`queryClient.ts`), the seeded list never revalidated on mount — freshness rode on two backstops:

1. the `MailsSynchronizer` count heuristic, which only refetches when a per-account count *changes*, and
2. the 10-minute `refetchInterval`.

When a cross-device mutation leaves the per-account count unchanged (a mail read-elsewhere in AllMails, or a delete + new arrival that nets zero), the synchronizer stays quiet and the seeded list showed stale read/saved/deleted state for up to ~10 minutes.

## Fix

`Box/components/Mails/index.tsx`, three tightly-coupled changes:

1. **Revalidate seeded keys on mount.** Gate `refetchOnMount` on cache-catalog membership: cataloged (IDB-seeded) header keys → `"always"`; non-seeded search results (`/api/mails/search/...`, excluded from the catalog) → keep the global `refetchOnMount: false`. The decision is `revalidateOnMountPolicy(queryKey)` in `lib/cacheCatalog.ts`, so it is a pure function pinned by `cacheCatalog.test.ts` rather than an inline ternary.
2. **Only show the error screen when there's no cached list** — `query.error && !query.data` instead of `query.error`.
3. **Render the list whenever data is present** — `query.isSuccess || query.data` instead of `query.isSuccess`.

Scope note on the search path: change 1 excludes search, but changes 2 and 3 are unconditional render guards, so they apply to the search pane too. A search whose 10-minute `refetchInterval` re-run fails now keeps the previous result set on screen (with the stale notice below) instead of flipping to the error screen. That is a deliberate consequence, not an oversight — an earlier revision of this body claimed "search behavior is unchanged" without that qualification.

4. **Label retained data instead of passing it off as fresh.** When `query.data` is present and the query's last recorded event was a failure, the pane renders a stale notice — `Couldn't refresh — showing mail as of <time>`. The gap this closes: an expired session returns `401 {status:"failed"}`, which `call.ts` parses without throwing, so the app is genuinely online (the offline banner does not apply), the seeded list can be up to a week old (`maxAgeMs`), and every list action is fire-and-forget optimistic — so the diverged read-state gets persisted back into IndexedDB. Before this the pane was indistinguishable from a live one.

   The gate is `isShowingStaleData(query)` in `lib/online.tsx` — `errorUpdatedAt > dataUpdatedAt`, extracted as a pure function and pinned in `online.test.ts`. It reads the two stamps rather than `query.error` on purpose: an optimistic `setQueryData` dispatches v3's `success` action, which clears `error` but leaves `errorUpdatedAt` standing, so a local edit made while the server is unreachable no longer erases the notice. An earlier revision of this branch gated on `query.error && query.data && isOnline` and had exactly that defect (reviewoie, Med 1).

   **There is no `isOnline` term in the gate.** An earlier revision of this body claimed the notice "stays suppressed" while offline — that is no longer true and was the wrong behavior anyway: `OfflineBanner` renders `Offline — showing data as of {formatLastSeen(lastSeenOnline)}`, and on a cold offline start `lastSeenOnline` is `null`, so the banner can only say `—`. Offline therefore shows both messages by design: the banner reports connectivity, the notice carries the date the banner cannot know.

   For that timestamp to be honest, `hydrateQueryCache` now stamps each seed with `{ updatedAt: entry.lastFetchedAt }`. `setQueryData` otherwise defaults `dataUpdatedAt` to the moment of hydration, which would report week-old mail as fetched just now. `staleTime` is 0 client-wide, so backdating changes no refetch decision. `formatDataAge` (next to `formatLastSeen` in `lib/online.tsx`) carries the date once the data predates today, because a bare `HH:MM` on week-old mail reads as today.

Changes 2+3 exist because the forced revalidation can now fail (offline / server 5xx / transient blip): with `retry:false` + `refetchOnReconnect:false`, react-query v3 sets `query.error` while *keeping* `query.data` (verified in the vendored reducer — the `error` action never clears `data`). Without these two guards, a failed revalidation flipped the seeded pane to the full-screen "Mails List Request Failed" (change 2) or blanked it to an empty fragment via the `isSuccess`-only gate (change 3) — discarding the exact cached mails the #618 paint exists to deliver. This was caught by reviewoie on the first commit (HIGH) and is fixed here.

New freshness bound: **immediate revalidate-on-mount** for seeded header lists (stale paint for one render frame, then server truth within ~1s), and a failed revalidation now leaves the seeded/last-good list on screen instead of an error.

### Why not the issue's approach (A) (`invalidateQueries` after hydrate)

Approach (A) as written cannot fire the refetch: `hydrateQueryCache` runs *before* `root.render()` (`src/index.tsx`), so at seed time there are **zero query observers**. A query created via `setQueryData` has **no `queryFn`** until its `useQuery` observer mounts, so `invalidateQueries({refetchInactive:true})` has no function to call; and once the observer mounts, the global `refetchOnMount:false` suppresses the mount refetch anyway. The per-query `refetchOnMount` override (issue's option B) is the shape that actually revalidates.

## E2E (local dev, real UI clicks, admin account with real cached mail)

Driving the Playwright UI (login → select account → reload/refetch), asserting on network + IndexedDB + rendered DOM:

| scenario | result |
|---|---|
| **online revalidation** — reload with seeded IDB, re-select account | `GET /api/mails/headers/<acct>` fires on mount (was **0** on main → stale window) |
| **transient 500 during revalidation** — seeded list, forced refetch 500s | list stays rendered (12 → 12 rows), no error screen |
| **offline refetch** — seeded list, go offline, force reconnect-edge refetch | list preserved (12 → 12), no error screen |
| **genuine no-data failure** — never-fetched account, headers 500 | "Mails List Request Failed" shown (correct — nothing to fall back on) |
| **A/B vs main** — reload + failing refetch | main: error screen over cached data · this branch: cached list preserved |

- **Seeded precondition verified**: read IndexedDB (`inbox-query-cache/queries`) — the selected account's header key is persisted, so the reload path genuinely hydrates-then-mounts.
- **v3 data-retention verified** by instrumenting `query.data` through a failed refetch: `dataUpdatedAt`/`data` survive the `error` transition.

### Stale-notice sweep (sandbox at `inbox-pr-685`, Playwright at 390x844, screenshots eye-checked)

Click chain from login each time - `admin` login -> list pane -> hamburger -> category. No `page.goto` deep links.

| scenario | result |
|---|---|
| cold login | app shell + list rendered, stale notice absent |
| warm reload (IDB seed) | rows painted inside 500 ms, then 1 `GET /api/mails/headers/...` mount revalidation; notice absent after it succeeds |
| **401 during revalidation** | seeded rows retained, error screen absent, exactly 1 notice: `Couldn't refresh - showing mail as of <time>` |
| **open a mail while the notice is up** (optimistic mark-read) | notice still present with unchanged text, row count unchanged, and the IDB row's age preserved rather than re-dated |
| recovery reload with a healthy revalidation | notice clears |
| offline mid-session (first 10 min) | offline banner shown; no notice yet, because no fetch had been attempted and so nothing had failed. This holds only until the first `refetchInterval` tick — with `refetchIntervalInBackground: true` that background refetch fails and raises the notice alongside the banner, which is the intended end state |
| Spam category reached by clicking through the nav | `?spam=1` key seeded, and it force-revalidates on the next reload |
| **seeded-but-empty list + 500 revalidation** | empty-state copy renders *below* the notice; no error screen |

Zero `pageerror` events across the run.

Visual check at 390x844 (screenshots read and described): the notice is a full-width strip immediately under the title bar - orange left rule, muted grey ~0.8rem text - and the mail card / empty-state copy below it sits exactly where it does on the no-notice baseline screenshot. No reflow of existing rows.

Not verified: the cold-offline-reload case. Playwright's offline mode blocks the app bundle too, so nothing paints at all and the seeded-paint path can't be reached that way. By inspection that path renders the banner (`Offline — showing data as of —`) and the notice (`Couldn't refresh — showing mail as of <date>`) together, which is the case the notice exists for.

## Checks

- `bun run tsc --noEmit` — clean.
- `bunx eslint` on the eight lintable changed files (the diff also touches `Mails/index.scss`, which eslint does not cover) — 0 problems.
- `bun test src/client` — 99 pass / 0 fail (was 91).
- New coverage, no DOM harness needed: `revalidateOnMountPolicy` is pinned in `cacheCatalog.test.ts` over all five seeded header variants (spam included) and the four un-seeded keys, asserting the full mapped array rather than a predicate; `formatDataAge` is pinned in `online.test.ts` for same-day, older-than-today, and the under-24h-but-yesterday boundary. Each new assertion was mutation-tested — collapsing `formatDataAge` to the bare clock fails 2, forcing `revalidateOnMountPolicy` to always return `"always"` fails 1.
- An earlier revision of this body said a render-level assertion "would need a testing-library harness inbox doesn't have yet (tracked separately)". That was wrong on both counts — `@testing-library/react` and `@happy-dom/global-registrator` are already devDependencies with a working per-file precedent in `src/client/lib/html.test.ts`, and there is no issue tracking a client render harness. The pure-function coverage above is the cheaper of the two routes, not a fallback forced by a missing harness.



