### PR TITLE
fix(mails): debounce toggle-handler resize with double rAF to stop ResizeObserver loop alarm

### DIFF
--- a/src/client/Box/components/Mails/components/MailBody.tsx
+++ b/src/client/Box/components/Mails/components/MailBody.tsx
@@ -47,12 +47,15 @@ const MailBody = ({ mailId }: Props) => {
 
   const iframeElement = useRef<HTMLIFrameElement>(null);
   const pendingTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const pendingFrames = useRef<number[]>([]);
 
-  // Cancel all pending timers when the component unmounts
+  // Cancel all pending timers/frames when the component unmounts
   useEffect(() => {
     return () => {
       pendingTimers.current.forEach(clearTimeout);
       pendingTimers.current = [];
+      pendingFrames.current.forEach(cancelAnimationFrame);
+      pendingFrames.current = [];
     };
   }, []);
 
@@ -236,8 +239,22 @@ const MailBody = ({ mailId }: Props) => {
       // content, so `scrollHeight` read in the handler reflects the new
       // size — robust under keyboard activation and slow renders, where
       // the body-level click listener's setTimeout(50) heuristic misses.
+      // Defer the resize past the current layout pass with a double
+      // requestAnimationFrame: mutating the iframe height synchronously
+      // inside `toggle` re-enters the browser's ResizeObserver
+      // notification cycle within the same frame, which it cannot
+      // complete and reports as a global "ResizeObserver loop completed
+      // with undelivered notifications" error.
       Array.from(content.querySelectorAll("details")).forEach((det) => {
-        det.addEventListener("toggle", () => adjustMailContentSize(iframeDom));
+        det.addEventListener("toggle", () => {
+          const outer = requestAnimationFrame(() => {
+            const inner = requestAnimationFrame(() =>
+              adjustMailContentSize(iframeDom)
+            );
+            pendingFrames.current.push(inner);
+          });
+          pendingFrames.current.push(outer);
+        });
       });
 
       adjustMailContentSize(iframeDom);


### PR DESCRIPTION
## Problem

`src/client/Box/components/Mails/components/MailBody.tsx` attaches a `toggle` listener to every quoted-reply `<details>` element inside the mail-body iframe (added in PR #627). The listener called `adjustMailContentSize` **synchronously**, mutating `iframe.style.height` inside the browser's ResizeObserver notification cycle in the same frame. The browser cannot complete that cycle in one frame and emits the global `ResizeObserver loop completed with undelivered notifications` error, which the client-error handler forwards to Shepherd as a paging alarm (issue #632, Shepherd alarm 2026-06-29 03:10 UTC).

Per Hoie's 2026-07-07 decision on the closed PR #651, the alarm must keep paging — the fix is to stop the loop **at the source**, not filter the message at the alarm boundary. This is the accepted "Option B".

## Fix

Defer the toggle-triggered resize past the current layout pass with a double `requestAnimationFrame`. The inner frame runs after the layout the `toggle` event itself triggered has settled, so the height mutation no longer re-enters the same-frame ResizeObserver cycle. Frame handles are tracked in a `pendingFrames` ref and cancelled on unmount, mirroring the existing `pendingTimers` cleanup.

Scope is limited to the `toggle` handler — the body-level click listener already defers via `setTimeout(50)`, and the initial `onLoad` calls run before any observer is watching.

## Verification

- `bun run typecheck` — clean.
- `bun run lint` — 0 errors (pre-existing warnings only; none in MailBody).
- E2E (sandbox, mobile viewport): open a mail whose quoted reply renders as a `<details>`, expand/collapse it via a real click, confirm the iframe still resizes to fit the expanded content and no `pageerror` is thrown. Note: the ResizeObserver-loop error is timing-dependent and does not reproduce deterministically headless — see the PR comment for the exact assertions run and their limits.

Closes #632