### PR TITLE
fix(imap): space-pad single-digit INTERNALDATE day (RFC 3501 date-day-fixed)

### DIFF
--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -176,10 +176,16 @@ describe("IMAP util", () => {
       expect(result).toMatch(/^\d{2}-\w{3}-\d{4} \d{2}:\d{2}:\d{2} [+-]\d{4}$/);
     });
 
-    it("should pad single-digit day", () => {
+    it("should space-pad single-digit day (RFC 3501 date-day-fixed)", () => {
       const date = new Date("2024-01-05T10:30:45Z");
       const result = formatInternalDate(date);
-      expect(result).toMatch(/^05-Jan-/);
+      expect(result).toMatch(/^ 5-Jan-/);
+    });
+
+    it("should render two-digit day without padding", () => {
+      const date = new Date("2024-01-15T10:30:45Z");
+      const result = formatInternalDate(date);
+      expect(result).toMatch(/^15-Jan-/);
     });
 
     it("should use correct month abbreviation", () => {

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -177,13 +177,15 @@ describe("IMAP util", () => {
     });
 
     it("should space-pad single-digit day (RFC 3501 date-day-fixed)", () => {
-      const date = new Date("2024-01-05T10:30:45Z");
+      // Local-constructor form so the asserted day is timezone-invariant
+      // (formatInternalDate reads local getDate()).
+      const date = new Date(2024, 0, 5, 10, 30, 45);
       const result = formatInternalDate(date);
       expect(result).toMatch(/^ 5-Jan-/);
     });
 
     it("should render two-digit day without padding", () => {
-      const date = new Date("2024-01-15T10:30:45Z");
+      const date = new Date(2024, 0, 15, 10, 30, 45);
       const result = formatInternalDate(date);
       expect(result).toMatch(/^15-Jan-/);
     });

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -344,7 +344,9 @@ export const formatInternalDate = (d: Date): string => {
   ];
   const pad = (n: number) => String(n).padStart(2, "0");
 
-  const day = pad(d.getDate());
+  // RFC 3501 §9 date-day-fixed: single-digit days are space-padded (" 9"),
+  // not zero-padded. Only the day uses this rule; time fields are 2DIGIT.
+  const day = String(d.getDate()).padStart(2, " ");
   const month = months[d.getMonth()];
   const year = d.getFullYear();
   const time = [d.getHours(), d.getMinutes(), d.getSeconds()]


### PR DESCRIPTION
## Summary

`formatInternalDate` zero-padded single-digit days (`09-Mar-2026`), but RFC 3501 §9 `date-day-fixed` requires a **space-padded** day for values 1–9 (`" 9-Mar-2026"`). `INTERNALDATE` is emitted as `date-time` (§7.4.2), so the FETCH `INTERNALDATE` response was formally non-conformant for every message whose local day-of-month is 1–9 (~30% of dates). A strict client parsing the fixed-format grammar (`SP DIGIT / 2DIGIT`) can mis-parse or reject it.

Closes #661.

## Root cause

The shared `pad` helper (`padStart(2, "0")`) is correct for the `time` fields (RFC 3501 `time = 2DIGIT`) but conflates them with the day, which follows the distinct `date-day-fixed` rule. Only the day needs the space-pad.

## Fix

`src/server/lib/imap/util.ts` — split the day out:

```ts
const day = String(d.getDate()).padStart(2, " ");  // date-day-fixed: SP DIGIT / 2DIGIT
```

Time components keep `pad` (zero-pad). Two-digit days (10–31) are unchanged.

**Scope note — output-only.** The inbound `parseDate` used by SEARCH (`date-day = 1*2DIGIT`, a non-fixed grammar) is a separate code path and is deliberately untouched. No schema, no data, no user choice involved.

## Test plan

- `src/server/lib/imap/util.test.ts`:
  - Updated the test that pinned the zero-padded form (`/^05-Jan-/` → `/^ 5-Jan-/`).
  - Added a two-digit-day case (`/^15-Jan-/`) so both branches of `date-day-fixed` are locked against a future refactor of `pad`.
- `bun test src/server/lib/imap/util.test.ts` → 49 pass / 0 fail.
- `bun run typecheck` → clean.
- Grep confirmed no other test asserts the old `0N-Mon` INTERNALDATE output; the `01-Jan-2024` assertions in `search-parsers.test.ts` / `primitive-parsers.test.ts` are the inbound SEARCH `date` grammar (`parseDate`), which this PR does not touch.
- IMAP protocol E2E (socket-level FETCH INTERNALDATE): see follow-up comment.
