### PR TITLE
fix(client-error): capture error source location so opaque "Script error." reports are actionable

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,10 +12,18 @@ import "./index.scss";
 
 // Report unhandled JS errors to server
 window.addEventListener("error", (event) => {
+  // The browser sanitizes `message` to "Script error." and nulls `error` when
+  // the throw came from a cross-origin script (browser extension, CDN chunk).
+  // `filename`/`lineno`/`colno` survive that sanitization for same-origin code
+  // and expose the extension/CDN URL for cross-origin code, so an otherwise
+  // opaque report still says where it came from.
   const body = JSON.stringify({
     message: event.message,
     stack: event.error?.stack ?? "",
     url: window.location.href,
+    filename: event.filename || undefined,
+    lineno: event.lineno || undefined,
+    colno: event.colno || undefined,
   });
   navigator.sendBeacon("/api/client-error", new Blob([body], { type: "application/json" }));
 });

--- a/src/server/lib/http/routes/client-error.test.ts
+++ b/src/server/lib/http/routes/client-error.test.ts
@@ -128,4 +128,29 @@ describe("POST /api/client-error location enrichment (issue #631)", () => {
     const detail = mockSendAlarm.mock.calls[0][1] as string;
     expect(detail).toContain("**Source:** https://cdn.example.com/vendor.js");
   });
+
+  it("renders filename:lineno when the column is absent", async () => {
+    const res = await postClientError("203.0.113.13", {
+      message: "Script error.",
+      filename: "app.js",
+      lineno: 12,
+    });
+    expect(res.status).toBe(200);
+    const detail = mockSendAlarm.mock.calls[0][1] as string;
+    expect(detail).toContain("**Source:** app.js:12");
+    expect(detail).not.toContain("app.js:12:");
+  });
+
+  it("drops a column with no line (a bare column is meaningless without a line)", async () => {
+    const res = await postClientError("203.0.113.14", {
+      message: "Script error.",
+      filename: "app.js",
+      colno: 7,
+    });
+    expect(res.status).toBe(200);
+    const detail = mockSendAlarm.mock.calls[0][1] as string;
+    // No line → the column is discarded rather than rendered as `app.js:7`.
+    expect(detail).toContain("**Source:** app.js");
+    expect(detail).not.toContain("app.js:7");
+  });
 });

--- a/src/server/lib/http/routes/client-error.test.ts
+++ b/src/server/lib/http/routes/client-error.test.ts
@@ -92,3 +92,40 @@ describe("POST /api/client-error rate limiting (issue #517)", () => {
     expect(args[2]).toBe("client-error");
   });
 });
+
+describe("POST /api/client-error location enrichment (issue #631)", () => {
+  it("surfaces filename:lineno:colno so opaque 'Script error.' reports are actionable", async () => {
+    const res = await postClientError("203.0.113.10", {
+      message: "Script error.",
+      url: "https://mail.hoie.kim/",
+      filename: "chrome-extension://abcdef/inject.js",
+      lineno: 42,
+      colno: 7,
+    });
+    expect(res.status).toBe(200);
+    expect(mockSendAlarm).toHaveBeenCalledTimes(1);
+    const detail = mockSendAlarm.mock.calls[0][1] as string;
+    expect(detail).toContain("chrome-extension://abcdef/inject.js:42:7");
+    expect(detail).toContain("Script error.");
+  });
+
+  it("omits the Source line when no location is provided", async () => {
+    const res = await postClientError("203.0.113.11", {
+      message: "boom",
+      url: "https://mail.hoie.kim/",
+    });
+    expect(res.status).toBe(200);
+    const detail = mockSendAlarm.mock.calls[0][1] as string;
+    expect(detail).not.toContain("**Source:**");
+  });
+
+  it("tolerates a filename without line/column numbers", async () => {
+    const res = await postClientError("203.0.113.12", {
+      message: "Script error.",
+      filename: "https://cdn.example.com/vendor.js",
+    });
+    expect(res.status).toBe(200);
+    const detail = mockSendAlarm.mock.calls[0][1] as string;
+    expect(detail).toContain("**Source:** https://cdn.example.com/vendor.js");
+  });
+});

--- a/src/server/lib/http/routes/client-error.ts
+++ b/src/server/lib/http/routes/client-error.ts
@@ -16,6 +16,9 @@ type ClientErrorBody = {
   message?: string;
   stack?: string;
   url?: string;
+  filename?: string;
+  lineno?: number;
+  colno?: number;
 };
 
 /**
@@ -37,12 +40,25 @@ clientErrorRouter.post("/", clientErrorLimiter.middleware, async (req, res) => {
   const message = typeof body.message === "string" ? body.message : "(no message)";
   const stack = typeof body.stack === "string" ? body.stack : "";
   const url = typeof body.url === "string" ? body.url : "";
+  const filename = typeof body.filename === "string" ? body.filename : "";
+  const lineno = typeof body.lineno === "number" ? body.lineno : undefined;
+  const colno = typeof body.colno === "number" ? body.colno : undefined;
 
-  console.error("Client error reported:", { url, message });
+  // When the message is the opaque "Script error." (cross-origin throw), the
+  // source location is the only way to tell an extension/CDN chunk from our
+  // own code — surface it so the alarm is actionable.
+  const location = filename
+    ? `${filename}${lineno !== undefined ? `:${lineno}` : ""}${
+        colno !== undefined ? `:${colno}` : ""
+      }`
+    : "";
+
+  console.error("Client error reported:", { url, message, location });
 
   const detail = [
     url ? `**URL:** ${url}` : null,
     `**Message:** ${message}`,
+    location ? `**Source:** ${location}` : null,
     stack ? `\`\`\`\n${stack.slice(0, 1000)}\n\`\`\`` : null,
   ]
     .filter(Boolean)

--- a/src/server/lib/http/routes/client-error.ts
+++ b/src/server/lib/http/routes/client-error.ts
@@ -47,9 +47,13 @@ clientErrorRouter.post("/", clientErrorLimiter.middleware, async (req, res) => {
   // When the message is the opaque "Script error." (cross-origin throw), the
   // source location is the only way to tell an extension/CDN chunk from our
   // own code — surface it so the alarm is actionable.
+  // Only append the column once a line is known — `filename::7` / a bare column
+  // in the line slot would misread as a line number.
   const location = filename
-    ? `${filename}${lineno !== undefined ? `:${lineno}` : ""}${
-        colno !== undefined ? `:${colno}` : ""
+    ? `${filename}${
+        lineno !== undefined
+          ? `:${lineno}${colno !== undefined ? `:${colno}` : ""}`
+          : ""
       }`
     : "";
 

--- a/src/server/lib/http/routes/client-error.ts
+++ b/src/server/lib/http/routes/client-error.ts
@@ -47,8 +47,8 @@ clientErrorRouter.post("/", clientErrorLimiter.middleware, async (req, res) => {
   // When the message is the opaque "Script error." (cross-origin throw), the
   // source location is the only way to tell an extension/CDN chunk from our
   // own code — surface it so the alarm is actionable.
-  // Only append the column once a line is known — `filename::7` / a bare column
-  // in the line slot would misread as a line number.
+  // Only append the column once a line is known — a column-without-line report
+  // would otherwise render `filename:7` and misread the column as a line number.
   const location = filename
     ? `${filename}${
         lineno !== undefined


### PR DESCRIPTION
## What

The global `window` `"error"` handler in `src/index.tsx` reported only `message` + `error.stack` to `/api/client-error`. When a throw comes from a **cross-origin script** (browser extension, CDN chunk), the browser sanitizes `message` to the opaque `"Script error."` and nulls `error` — so the alarm arrived with no message, no stack, and no origin, indistinguishable from a real in-app crash (the 2026-06-29 Shepherd alarm in this issue).

This PR captures `event.filename` / `event.lineno` / `event.colno` — which survive the cross-origin sanitization for same-origin code and expose the extension/CDN URL for cross-origin code — and renders them as a **Source** line in the alarm detail. Opaque reports are now triageable at a glance.

## Investigation (per issue acceptance criteria — root-cause the `"Script error."`)

- `index.html` has **no external `<script>` tags** — all scripts self-hosted.
- `public/service-worker.js` has **no `importScripts`** and loads no cross-origin resources (same-origin cache-first for `/assets/*` only).
- **No runtime CDN `import()`** in `src/client` (no `import("https://…")` / `from "https://…"`).

With no first-party cross-origin script surface, the sanitized `"Script error."` is most consistent with a **browser-extension-injected script** (or, rarely, a Safari async-context quirk) — neither of which is fixable from app code. The right lever is **observability**: the enriched `Source` line makes an extension throw self-identify via its `chrome-extension://…` / `moz-extension://…` URL, and makes any genuine in-app error point at the exact `assets/*.js` chunk. That's this PR.

## Changes

- `src/index.tsx` — enrich the `"error"` beacon payload with `filename`/`lineno`/`colno` (only when present). `unhandledrejection` unchanged (it carries no location).
- `src/server/lib/http/routes/client-error.ts` — accept the three fields, compose a `filename:lineno:colno` location, add a `**Source:**` line to the alarm detail. Backward-compatible: reports without the fields render exactly as before.
- `client-error.test.ts` — 3 tests: enriched `"Script error."` surfaces the location; no-location report omits the `Source` line; filename-without-line/col tolerated.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (17 pre-existing warnings, none in touched files)
- [x] `bun run build` — clean
- [x] `bun test src/server` — **1172 pass / 0 fail** (no mock-bleed; +3 new route tests)
- [x] **E2E — real client handler → real route round-trip** (built server `bun build/server/bundle.js` on `:3999`, Playwright driving the actual `src/index.tsx` `window "error"` listener; the listener is registered pre-auth so the sign-in screen exercises it):
  - Dispatched an opaque cross-origin `ErrorEvent` (`message:"Script error."`, `filename:"chrome-extension://…/inject.js"`, `lineno:42`, `colno:7`, `error:null`) → server logged `location: "chrome-extension://…/inject.js:42:7"` — **the extension throw self-identifies** (was a bare `"Script error."`).
  - Dispatched a same-origin real error (`filename:"…/assets/index-abc.js"`, `lineno:100`, `colno:25`, real `Error`) → server logged `location: "…/assets/index-abc.js:100:25"` + stack preserved.
  - Both beacons observed hitting `POST /api/client-error`; the real Express route parsed the Blob body and computed the `location` shown above.

No currency/UI surface touched; behavioral proof via the round-trip log above.

Closes #631.
