### PR TITLE
fix(imap): map reply_to_address onto mail.replyTo so FETCH surfaces Reply-To

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -52,6 +52,41 @@ describe("getRequestedFields", () => {
       expect(fields.has("from")).toBe(true);
       expect(fields.has("messageId")).toBe(true);
     });
+
+    // #667: the reply-to member of the §7.4.2 envelope needs its column
+    // selected, else it always renders NIL.
+    it("requests replyTo so the envelope reply-to member is populated", () => {
+      expect(getRequestedFields([{ type: "ENVELOPE" }]).has("replyTo")).toBe(true);
+    });
+  });
+
+  // #667: the served RFC-2822 header block must carry Reply-To when present,
+  // so every body fetch that serializes headers selects the replyTo column.
+  describe("replyTo column selection (#667)", () => {
+    it("BODY[] (FULL) requests replyTo", () => {
+      const fields = getRequestedFields([
+        { type: "BODY", peek: false, section: { type: "FULL" } },
+      ]);
+      expect(fields.has("replyTo")).toBe(true);
+    });
+
+    it("BODY[HEADER] requests replyTo", () => {
+      const fields = getRequestedFields([
+        { type: "BODY", peek: true, section: { type: "HEADER" } },
+      ]);
+      expect(fields.has("replyTo")).toBe(true);
+    });
+
+    it("HEADER.FIELDS.NOT includes replyTo in the 'all-except' set", () => {
+      const fields = getRequestedFields([
+        {
+          type: "BODY",
+          peek: true,
+          section: { type: "HEADER_FIELDS", not: true, fields: ["SUBJECT"] },
+        },
+      ]);
+      expect(fields.has("replyTo")).toBe(true);
+    });
   });
 
   it("always includes uid", () => {

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -119,6 +119,7 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<keyof MailTy
         fields.add("to");
         fields.add("cc");
         fields.add("bcc");
+        fields.add("replyTo");
         fields.add("date");
         fields.add("messageId");
         break;
@@ -185,6 +186,7 @@ export function addBodyFields(
       fields.add("to");
       fields.add("cc");
       fields.add("bcc");
+      fields.add("replyTo");
       fields.add("date");
       fields.add("messageId");
       fields.add("attachments");
@@ -202,6 +204,7 @@ export function addBodyFields(
       fields.add("to");
       fields.add("cc");
       fields.add("bcc");
+      fields.add("replyTo");
       fields.add("date");
       fields.add("messageId");
       break;
@@ -224,6 +227,7 @@ export function addBodyFields(
         fields.add("to");
         fields.add("cc");
         fields.add("bcc");
+        fields.add("replyTo");
         fields.add("date");
         fields.add("messageId");
       } else {

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -180,3 +180,48 @@ describe("Store.getFirstUnseenUid", () => {
     expect(await store.getFirstUnseenUid("INBOX")).toBeNull();
   });
 });
+
+describe("Store.getMessages — replyTo mapping (#667)", () => {
+  beforeEach(() => {
+    mockGetMailsByRange.mockClear();
+    mockGetMailsByRange.mockResolvedValue(new Map());
+  });
+
+  it("maps reply_to_address/reply_to_text onto mail.replyTo", async () => {
+    const replyToValue = [{ address: "noreply@vendor.example", name: "Vendor" }];
+    mockGetMailsByRange.mockResolvedValue(
+      new Map([
+        [
+          "doc-1",
+          {
+            message_id: "<m1>",
+            from_address: [{ address: "sender@vendor.example", name: "Vendor" }],
+            from_text: "Vendor <sender@vendor.example>",
+            reply_to_address: replyToValue,
+            reply_to_text: "Vendor <noreply@vendor.example>",
+          },
+        ],
+      ]) as never
+    );
+
+    const store = new Store(makeUser());
+    const mails = await store.getMessages("INBOX", 1, 1, ["replyTo", "from"]);
+    const mail = mails.get("doc-1");
+
+    expect(mail?.replyTo).toEqual({
+      value: replyToValue,
+      text: "Vendor <noreply@vendor.example>",
+    });
+  });
+
+  it("leaves replyTo undefined when the column is absent (no spurious NIL-vs-value flip)", async () => {
+    mockGetMailsByRange.mockResolvedValue(
+      new Map([["doc-2", { message_id: "<m2>", from_address: [] }]]) as never
+    );
+
+    const store = new Store(makeUser());
+    const mails = await store.getMessages("INBOX", 1, 1, ["from"]);
+
+    expect(mails.get("doc-2")?.replyTo).toBeUndefined();
+  });
+});

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -386,6 +386,12 @@ export class Store {
             text: model.bcc_text || "",
           };
         }
+        if (model.reply_to_address) {
+          mail.replyTo = {
+            value: model.reply_to_address as MailAddressValueType[],
+            text: model.reply_to_text || "",
+          };
+        }
         if (model.envelope_from) {
           mail.envelopeFrom = model.envelope_from as MailAddressValueType[];
         }


### PR DESCRIPTION
## What

`store.getMessages` — the single loader that turns a DB row into the `Partial<Mail>` the FETCH/render pipeline consumes — mapped `from`/`to`/`cc`/`bcc`/`envelope_*`/`attachments`/`insight` but **never mapped `reply_to_address`/`reply_to_text` → `mail.replyTo`**. Every consumer (`formatEnvelope`, `formatHeaders`, the COPY cloner) already reads `mail.replyTo`, so with it always `undefined` the server dropped Reply-To on every FETCH path:

1. `FETCH ENVELOPE` → reply-to member always `NIL`.
2. `FETCH BODY[]` / `RFC822` / `BODY[HEADER]` → served RFC-2822 message missing its `Reply-To:` line.
3. `FETCH BODY[HEADER.FIELDS (REPLY-TO)]` → empty block.
4. `COPY` / `MOVE` → destination copy permanently loses Reply-To (data loss).

A real client hitting "Reply" sends to `From` instead of the intended `Reply-To` — wrong for mailing lists, no-reply-vs-support split senders, and transactional mail routing replies elsewhere.

## Fix

- `store.getMessages`: add the missing `reply_to_address → mail.replyTo` branch alongside the other address mappings.
- `getRequestedFields` / `addBodyFields`: add `replyTo` to the column set on the **ENVELOPE**, **BODY[] (FULL)**, **BODY[HEADER]**, and **HEADER.FIELDS.NOT** paths, so the `reply_to_*` columns are actually SELECTed where a header block or envelope needs them. (`HEADER.FIELDS (REPLY-TO)` already requested `replyTo`, but the loader gap meant it still came back empty.)

Left out of scope (issue notes it as optional/separate): defaulting the envelope reply-to member to `From` when the header is *absent* per RFC 3501 §7.4.2. This PR only stops **dropping** a present Reply-To.

4 files, +14/-0 across product code (store.ts, fetch-helpers.ts) + regression tests.

## Test plan — disposition

**E2E** (live IMAP loader against the local inbox DB, admin INBOX): drove the REAL `store.getMessages("INBOX", <uid>, <uid>, ["replyTo", ...], useUid=true)` on a received message whose Reply-To (`no-reply@…`) differs from its From (`postmaster@…`), then formatted the envelope + header block:
- `mail.replyTo` is populated (loader maps the column). ✅
- `formatEnvelope` carries the reply-to address (no longer `NIL`). ✅
- `formatHeaders` emits a `Reply-To:` line. ✅

**Unit / regression:**
- `store.test.ts` — `getMessages` maps `reply_to_address`/`reply_to_text` onto `mail.replyTo` (round-trips through the loader, closing the gap the isolated `util.test.ts` cases missed); and leaves `replyTo` undefined when the column is absent.
- `fetch-helpers.test.ts` — ENVELOPE, BODY[] (FULL), BODY[HEADER], and HEADER.FIELDS.NOT all request the `replyTo` column.

**CI:** `tsc --noEmit` clean · `eslint` 0 errors on changed files (pre-existing warnings only) · `bun test src/server` 1175 pass / 0 fail (full suite, mock.module-bleed guard).

Closes #667