### PR TITLE
fix(imap): bare BODY returns non-extensible BODYSTRUCTURE, not content (RFC 3501 §6.4.5)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -189,6 +189,57 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
   });
 });
 
+describe("buildFetchResponsePart bare BODY vs BODYSTRUCTURE (#666)", () => {
+  const mail: Partial<MailType> = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    text: "Hello",
+    attachments: [
+      {
+        content: { data: "att1" },
+        filename: "document.pdf",
+        size: 1024,
+        contentType: "application/pdf"
+      }
+    ] as unknown as MailType["attachments"]
+  };
+  const docId = "doc-666";
+  const mailbox = "INBOX";
+
+  it("bare BODY emits a `BODY (...)` structure line, not BODY[] content", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "BODYSTRUCTURE", extensible: false },
+      docId,
+      mailbox
+    );
+    expect(part).not.toBeNull();
+    // A structure line is a simple part, not a literal content download.
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      expect(part!.content.startsWith("BODY ")).toBe(true);
+      expect(part!.content.startsWith("BODY[")).toBe(false);
+      // Non-extensible: extension data dropped.
+      expect(part!.content).not.toContain('"ATTACHMENT"');
+      expect(part!.content).toContain('"mixed")');
+    }
+  });
+
+  it("BODYSTRUCTURE emits a `BODYSTRUCTURE (...)` line with the extension data", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      expect(part!.content.startsWith("BODYSTRUCTURE ")).toBe(true);
+      expect(part!.content).toContain('"ATTACHMENT"');
+      expect(part!.content).toContain('"mixed" NIL NIL NIL NIL)');
+    }
+  });
+});
+
 describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)", () => {
   const docId = "doc-654";
   const mailbox = "INBOX";

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -370,8 +370,11 @@ export async function buildFetchResponsePart(
     }
 
     case "BODYSTRUCTURE": {
-      const bodyStructure = formatBodyStructure(mail);
-      return { type: "simple", content: `BODYSTRUCTURE ${bodyStructure}` };
+      // extensible=false is the bare `BODY` data item: non-extensible structure
+      // labelled `BODY` (RFC 3501 §6.4.5). extensible=true is full BODYSTRUCTURE.
+      const bodyStructure = formatBodyStructure(mail, item.extensible);
+      const label = item.extensible ? "BODYSTRUCTURE" : "BODY";
+      return { type: "simple", content: `${label} ${bodyStructure}` };
     }
 
     case "BODY":

--- a/src/server/lib/imap/parsers/fetch-parsers.test.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.test.ts
@@ -192,6 +192,10 @@ describe("fetch-parsers > real-world FETCH patterns", () => {
     expect(types).toContain("FLAGS");
     expect(types).toContain("ENVELOPE");
     expect(types).toContain("BODYSTRUCTURE");
+    // The BODYSTRUCTURE token is the extensible form (carries the extension data).
+    const structure = data.dataItems.find((i) => i.type === "BODYSTRUCTURE");
+    if (structure?.type !== "BODYSTRUCTURE") throw new Error("expected BODYSTRUCTURE");
+    expect(structure.extensible).toBe(true);
   });
 
   it("should parse (UID BODY.PEEK[]) — full message fetch", () => {

--- a/src/server/lib/imap/parsers/fetch-parsers.test.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.test.ts
@@ -99,13 +99,16 @@ describe("fetch-parsers > parenthesized lists", () => {
 // ---------------------------------------------------------------------------
 
 describe("fetch-parsers > BODY data items", () => {
-  it("should parse BODY as full body fetch", () => {
+  it("should parse bare BODY as the non-extensible BODYSTRUCTURE, not content (#666)", () => {
+    // RFC 3501 §6.4.5: `BODY` (no section, no .PEEK) is the non-extensible form
+    // of BODYSTRUCTURE — a structure line, NOT BODY[] content. It must not parse
+    // to a content BODY item (which would stream the whole message and set \Seen).
     const data = parseFetch("1 BODY");
     expect(data.dataItems).toHaveLength(1);
-    expect(data.dataItems[0].type).toBe("BODY");
-    const bodyItem = data.dataItems[0];
-    if (bodyItem.type !== "BODY") throw new Error("expected BODY");
-    expect(bodyItem.peek).toBe(false);
+    const item = data.dataItems[0];
+    expect(item.type).toBe("BODYSTRUCTURE");
+    if (item.type !== "BODYSTRUCTURE") throw new Error("expected BODYSTRUCTURE");
+    expect(item.extensible).toBe(false);
   });
 
   it("should parse BODY[] as full body fetch", () => {
@@ -246,6 +249,10 @@ describe("fetch-parsers > macros", () => {
     ]);
     // Guard against a regression back to the full-content BODY[] shape.
     expect(data.dataItems.some((i) => i.type === "BODY")).toBe(false);
+    // FULL's structure item is the non-extensible form (labelled `BODY`).
+    const structure = data.dataItems.find((i) => i.type === "BODYSTRUCTURE");
+    if (structure?.type !== "BODYSTRUCTURE") throw new Error("expected BODYSTRUCTURE");
+    expect(structure.extensible).toBe(false);
   });
 
   it("should be case-insensitive (fast / all / full)", () => {

--- a/src/server/lib/imap/parsers/fetch-parsers.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.ts
@@ -2,7 +2,7 @@
  * FETCH command parsing
  */
 
-import { ParseContext, ParseResult, ImapRequest, FetchDataItem, BodyFetch, BodySection, PartialRange } from '../types';
+import { ParseContext, ParseResult, ImapRequest, FetchDataItem, BodyFetch, BodyStructureFetch, BodySection, PartialRange } from '../types';
 import { parseSequenceSet, skipWhitespace, peek, parseAtom } from './primitive-parsers';
 
 /**
@@ -57,18 +57,18 @@ const expandFetchMacro = (name: string): FetchDataItem[] | null => {
         { type: 'RFC822.SIZE' },
       ];
     // FULL = (FLAGS INTERNALDATE RFC822.SIZE ENVELOPE BODY)
-    // The BODY here is the non-extensible BODYSTRUCTURE (a compact structure
-    // line), NOT BODY[] (the full message content) — RFC 3501 §6.4.5 defines
-    // the bare `BODY` data item as "Non-extensible form of BODYSTRUCTURE".
-    // Expanding it to BODY[] would make `FETCH 1:* FULL` stream every message's
-    // entire body, which is the opposite of the lightweight listing FULL is for.
+    // The trailing BODY is the bare `BODY` data item — the non-extensible form
+    // of BODYSTRUCTURE (RFC 3501 §6.4.5), a compact structure line labelled
+    // `BODY`, NOT BODY[] (the full message content). Expanding it to BODY[]
+    // would make `FETCH 1:* FULL` stream every message's entire body, the
+    // opposite of the lightweight listing FULL is for.
     case 'FULL':
       return [
         { type: 'FLAGS' },
         { type: 'INTERNALDATE' },
         { type: 'RFC822.SIZE' },
         { type: 'ENVELOPE' },
-        { type: 'BODYSTRUCTURE' },
+        { type: 'BODYSTRUCTURE', extensible: false },
       ];
     default:
       return null;
@@ -169,7 +169,7 @@ export const parseFetchDataItem = (context: ParseContext): ParseResult<FetchData
     case 'UID':
       return { success: true, value: { type: 'UID' }, consumed: context.position - start };
     case 'BODYSTRUCTURE':
-      return { success: true, value: { type: 'BODYSTRUCTURE' }, consumed: context.position - start };
+      return { success: true, value: { type: 'BODYSTRUCTURE', extensible: true }, consumed: context.position - start };
   }
   
   // Handle BODY items
@@ -219,17 +219,15 @@ export const parseFetchDataItem = (context: ParseContext): ParseResult<FetchData
 /**
  * Parse BODY fetch expressions
  */
-export const parseBodyFetch = (bodyExpr: string, _context: ParseContext): ParseResult<BodyFetch> => {
-  // Handle BODY (without section)
+export const parseBodyFetch = (bodyExpr: string, _context: ParseContext): ParseResult<BodyFetch | BodyStructureFetch> => {
+  // Bare `BODY` (no `[section]`, no `.PEEK`) is the non-extensible form of
+  // BODYSTRUCTURE (RFC 3501 §6.4.5) — a structure line labelled `BODY`, NOT
+  // BODY[] content. It is non-destructive: it never sets \Seen.
   if (bodyExpr === 'BODY') {
-    return { 
-      success: true, 
-      value: { 
-        type: 'BODY', 
-        peek: false, 
-        section: { type: 'FULL' } 
-      }, 
-      consumed: 0 
+    return {
+      success: true,
+      value: { type: 'BODYSTRUCTURE', extensible: false },
+      consumed: 0
     };
   }
   

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -178,6 +178,13 @@ describe("shouldMarkAsRead", () => {
     expect(shouldMarkAsRead(items)).toBe(false);
   });
 
+  it("returns false for the bare BODY structure item (non-destructive, #666)", () => {
+    // Bare `BODY` parses to a non-extensible BODYSTRUCTURE, not a content BODY,
+    // so it must not set \Seen — unlike the old `{type:'BODY', peek:false}` shape.
+    const items: FetchDataItem[] = [{ type: "BODYSTRUCTURE", extensible: false }];
+    expect(shouldMarkAsRead(items)).toBe(false);
+  });
+
   it("returns false when BODY item has peek=true", () => {
     const items: FetchDataItem[] = [
       {

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -179,8 +179,8 @@ describe("shouldMarkAsRead", () => {
   });
 
   it("returns false for the bare BODY structure item (non-destructive, #666)", () => {
-    // Bare `BODY` parses to a non-extensible BODYSTRUCTURE, not a content BODY,
-    // so it must not set \Seen — unlike the old `{type:'BODY', peek:false}` shape.
+    // A structure fetch (BODYSTRUCTURE, incl. the non-extensible bare `BODY`)
+    // never sets \Seen — only BODY[...] content without .PEEK does.
     const items: FetchDataItem[] = [{ type: "BODYSTRUCTURE", extensible: false }];
     expect(shouldMarkAsRead(items)).toBe(false);
   });

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -134,6 +134,10 @@ export interface FlagsFetch {
 
 export interface BodyStructureFetch {
   type: "BODYSTRUCTURE";
+  // false is the bare `BODY` data item — the non-extensible form of BODYSTRUCTURE
+  // (RFC 3501 §6.4.5): labelled `BODY` and omitting the extension fields
+  // (body-fld-md5/disposition/language/location). true is the full BODYSTRUCTURE.
+  extensible: boolean;
 }
 
 export interface UidFetch {

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -428,5 +428,52 @@ describe("IMAP util", () => {
       expect(result).toContain("TEXT");
       expect(result).toContain("PLAIN");
     });
+
+    // Non-extensible form (the bare `BODY` data item, RFC 3501 §6.4.5) drops the
+    // extension data: md5/disposition/language/location on single parts and
+    // param-list/disposition/language/location on the multipart wrappers (#666).
+    describe("non-extensible form (extensible=false)", () => {
+      it("leaves a leaf text part identical (it carries no extension data)", () => {
+        const mail: Partial<MailType> = { text: "Hello, World!" };
+        expect(formatBodyStructure(mail, false)).toBe(
+          formatBodyStructure(mail, true)
+        );
+      });
+
+      it("drops the multipart/alternative extension tail", () => {
+        const mail: Partial<MailType> = { text: "Hello", html: "<p>Hello</p>" };
+        const ext = formatBodyStructure(mail, true);
+        const nonExt = formatBodyStructure(mail, false);
+        expect(ext).toContain('"alternative" NIL NIL NIL NIL)');
+        expect(nonExt).toContain('"alternative")');
+        expect(nonExt).not.toContain('"alternative" NIL');
+      });
+
+      it("drops md5/disposition/language/location from an attachment part and the mixed tail", () => {
+        const mail: Partial<MailType> = {
+          text: "Hello",
+          attachments: [
+            {
+              content: { data: "att1" },
+              filename: "document.pdf",
+              size: 1024,
+              contentType: "application/pdf"
+            }
+          ]
+        };
+        const ext = formatBodyStructure(mail, true);
+        const nonExt = formatBodyStructure(mail, false);
+        // Extension data present in BODYSTRUCTURE, absent in the bare BODY form.
+        expect(ext).toContain('"ATTACHMENT"');
+        expect(ext).toContain('"mixed" NIL NIL NIL NIL)');
+        expect(nonExt).not.toContain('"ATTACHMENT"');
+        expect(nonExt).toContain('"mixed")');
+        expect(nonExt).not.toContain('"mixed" NIL');
+        // The attachment part itself now ends at the size field (BASE64 <size>).
+        const attachmentSize = Math.ceil(1024 / 3) * 4;
+        expect(nonExt).toContain(`"application" "pdf"`);
+        expect(nonExt).toContain(`BASE64 ${attachmentSize})`);
+      });
+    });
   });
 });

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -126,11 +126,19 @@ export const formatEnvelope = (mail: Partial<MailType>): string => {
   return `(${date} ${subject} ${addressList(from)} ${addressList(sender)} ${addressList(replyTo)} ${addressList(to)} ${addressList(cc)} ${addressList(bcc)} ${inReplyTo} ${messageId})`;
 };
 
-export const formatBodyStructure = (mail: Partial<MailType>): string => {
+export const formatBodyStructure = (
+  mail: Partial<MailType>,
+  extensible = true
+): string => {
   /**
    * IMAP BODYSTRUCTURE format:
    * For single part: (type subtype (param-list) id description encoding size [lines] [md5] [disposition] [language] [location])
    * For multipart: ((part1)(part2)...(partN) subtype (param-list) [disposition] [language] [location])
+   *
+   * The bracketed tail (md5/disposition/language/location on single parts,
+   * param-list/disposition/language/location on multiparts) is the extension
+   * data — present only in BODYSTRUCTURE. The bare `BODY` data item is the
+   * non-extensible form (RFC 3501 §6.4.5): pass extensible=false to drop it.
    */
 
   const buildTextPart = (
@@ -176,17 +184,27 @@ export const formatBodyStructure = (mail: Partial<MailType>): string => {
       "NIL", // body ID
       "NIL", // body description
       "BASE64", // encoding
-      size.toString(),
-      "NIL", // MD5
-      `("${disposition.type}" (${Object.entries(disposition.params)
-        .map(([k, v]) => `"${k}" "${v}"`)
-        .join(" ")}))`,
-      "NIL", // language
-      "NIL" // location
+      size.toString()
     ];
+
+    if (extensible) {
+      parts.push(
+        "NIL", // MD5
+        `("${disposition.type}" (${Object.entries(disposition.params)
+          .map(([k, v]) => `"${k}" "${v}"`)
+          .join(" ")}))`,
+        "NIL", // language
+        "NIL" // location
+      );
+    }
 
     return `(${parts.join(" ")})`;
   };
+
+  // Multipart wrapper tail: `subtype` alone (non-extensible) or `subtype` plus
+  // the extension data — body-fld-param, disposition, language, location.
+  const multipartTail = (subtype: string): string =>
+    extensible ? `"${subtype}" NIL NIL NIL NIL` : `"${subtype}"`;
 
   const hasText = mail.text && mail.text.trim().length > 0;
   const hasHtml = mail.html && mail.html.trim().length > 0;
@@ -206,7 +224,7 @@ export const formatBodyStructure = (mail: Partial<MailType>): string => {
   if (hasText && hasHtml && !hasAttachments) {
     const textPart = buildTextPart("plain", mail.text!);
     const htmlPart = buildTextPart("html", mail.html!);
-    return `(${textPart} ${htmlPart} "alternative" NIL NIL NIL NIL)`;
+    return `(${textPart} ${htmlPart} ${multipartTail("alternative")})`;
   }
 
   // Case 4: Content with attachments (multipart/mixed)
@@ -217,7 +235,9 @@ export const formatBodyStructure = (mail: Partial<MailType>): string => {
     if (hasText && hasHtml) {
       const textPart = buildTextPart("plain", mail.text!);
       const htmlPart = buildTextPart("html", mail.html!);
-      const alternativePart = `(${textPart} ${htmlPart} "alternative" NIL NIL NIL NIL)`;
+      const alternativePart = `(${textPart} ${htmlPart} ${multipartTail(
+        "alternative"
+      )})`;
       bodyParts.push(alternativePart);
     } else if (hasText) {
       bodyParts.push(buildTextPart("plain", mail.text!));
@@ -230,7 +250,7 @@ export const formatBodyStructure = (mail: Partial<MailType>): string => {
       bodyParts.push(buildAttachmentPart(attachment));
     });
 
-    return `(${bodyParts.join(" ")} "mixed" NIL NIL NIL NIL)`;
+    return `(${bodyParts.join(" ")} ${multipartTail("mixed")})`;
   }
 
   // Default case: empty text part


### PR DESCRIPTION
## What

`FETCH n BODY` (the bare `BODY` data item — no `[section]`, no `.PEEK`) returned the **full message content** as `BODY[]` instead of the compact structure line. RFC 3501 §6.4.5 defines bare `BODY` as the **non-extensible form of BODYSTRUCTURE**: same shape as `BODYSTRUCTURE` but without the extension fields (disposition, language, location), labelled `BODY (...)`, not the message body.

Two concrete defects, both fixed here:

1. **Streamed content instead of structure.** `parseBodyFetch` mapped bare `BODY` to `{ type:'BODY', section:{type:'FULL'} }`, which resolves downstream to a `BODY[]` full-content download. A client asking for a one-line structure got the whole message.
2. **Wrongly set `\Seen`.** Because bare `BODY` parsed to `{ type:'BODY', peek:false }`, `shouldMarkAsRead` treated it as a non-peek content fetch and marked the message read. A structure fetch must be non-destructive (only `BODY[...]` without `.PEEK` sets `\Seen`).

The FULL macro (`= FLAGS INTERNALDATE RFC822.SIZE ENVELOPE BODY`) previously aliased its `BODY` to the **extensible** `BODYSTRUCTURE` as a stopgap (merged PR #663, issue #650) so `FETCH 1:* FULL` wouldn't stream every body. That stopgap emitted the extension fields under the `BODYSTRUCTURE` label rather than the RFC-exact non-extensible `BODY`-labelled structure. This PR replaces it with the real thing.

## Changes

- `types.ts` — `BodyStructureFetch` gains an `extensible: boolean`. `false` is the bare `BODY` form (labelled `BODY`, extension data dropped); `true` is full `BODYSTRUCTURE`.
- `util.ts` — `formatBodyStructure(mail, extensible = true)` drops the extension tail when non-extensible: md5/disposition/language/location on single (attachment) parts, and param-list/disposition/language/location on the multipart wrappers. Leaf text parts are already extension-free, so they're identical either way.
- `parsers/fetch-parsers.ts` — bare `BODY` → `{ type:'BODYSTRUCTURE', extensible:false }`; `BODYSTRUCTURE` → `{ ..., extensible:true }`; the FULL macro emits the non-extensible `BODY` directly, dropping the stopgap.
- `fetch-helpers.ts` — the `BODYSTRUCTURE` dispatch labels the response `BODY` vs `BODYSTRUCTURE` and picks the formatter mode by the flag.
- `BODY.PEEK[...]`, `BODY[...]`, `RFC822*` aliases unchanged. `BODY.PEEK` (bare, no section) left as-is — out of scope (this issue is specifically the bare `BODY`).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (17 pre-existing warnings, none in touched files)
- [x] `bun test src/server` — **1175 pass / 0 fail** (+ new unit tests: parser routing, non-extensible formatter, dispatch labelling, non-destructive `shouldMarkAsRead`)
- [x] **E2E — real FETCH pipeline drive.** Ran the literal client command strings through the actual `parseCommand → getRequestedFields → buildFetchResponse → writeFetchResponse + shouldMarkAsRead` chain (exactly what `_processFetchMessages` does), against a synthetic text+PDF-attachment mail. Observed wire responses:
  - `FETCH 1 BODY` → `* 1 FETCH (BODY ((TEXT PLAIN …) ("application" "pdf" ("NAME" …) NIL NIL BASE64 <size>) "mixed"))` — a **structure line** (attachment part ends at the size field; multipart tail is the bare `"mixed"`), **no** `BODY[]` content literal, `shouldMarkAsRead` → **false**.
  - `FETCH 1 BODYSTRUCTURE` → `BODYSTRUCTURE (… BASE64 <size> NIL ("ATTACHMENT" ("FILENAME" …)) NIL NIL) "mixed" NIL NIL NIL NIL)` — extension data present, `\Seen` untouched.
  - `FETCH 1 FULL` → emits the non-extensible `BODY (...)` alongside FLAGS/INTERNALDATE/RFC822.SIZE/ENVELOPE, **not** `BODY[]`; non-destructive.
  - `FETCH 1 BODY[]` (control) → still streams the content literal `BODY[] {N}…` and still sets `\Seen`.

Closes #666
