### PR TITLE
fix(mailgun): drop h:To custom header — Gmail 5.7.1 blocks duplicate To

### DIFF
--- a/src/server/lib/mails/mailgun.test.ts
+++ b/src/server/lib/mails/mailgun.test.ts
@@ -87,20 +87,15 @@ describe("sendMailgunMail", () => {
     expect(toList).toContain("b@yahoo.com");
   });
 
-  it("should always include the original h:To header", async () => {
-    const toValue = "a@gmail.com, b@yahoo.com";
-    const mail = new MailDataToSend({ ...baseMail, to: toValue });
+  // Mailgun renders a `To:` header from the `to:` parameter on its own.
+  // Passing `h:To` as well appends a SECOND `To:` header to the RFC 5322
+  // message, which Gmail rejects with `5.7.1 … multiple To headers`. Keep
+  // the envelope-only shape.
+  it("should not set the h:To custom header (would duplicate the To: header)", async () => {
+    const mail = new MailDataToSend({ ...baseMail, to: "a@gmail.com, b@yahoo.com" });
     await sendMailgunMail("admin", mail);
     const msgData = mockMessagesCreate.mock.calls[0][1];
-    expect(msgData["h:To"]).toBe(toValue);
-  });
-
-  it("should include the original To header for all recipients", async () => {
-    const toValue = "external@gmail.com, internal@mydomain";
-    const mail = new MailDataToSend({ ...baseMail, to: toValue });
-    await sendMailgunMail("admin", mail);
-    const msgData = mockMessagesCreate.mock.calls[0][1];
-    expect(msgData["h:To"]).toBe(toValue);
+    expect(msgData["h:To"]).toBeUndefined();
   });
 
   it("should format from address with senderFullName when provided", async () => {

--- a/src/server/lib/mails/mailgun.ts
+++ b/src/server/lib/mails/mailgun.ts
@@ -69,7 +69,6 @@ export const sendMailgunMail = async (
     html,
     text,
     attachment: getAttachments(files),
-    "h:To": to,
     "h:In-Reply-To": inReplyTo
   };
 


### PR DESCRIPTION
## Summary

Every message our `POST /api/mails/send` path sent to Gmail was silently bounced downstream of Mailgun's API accept, with:

```
5.7.1 This message is not RFC 5322 compliant. There are multiple To
headers. To reduce the amount of spam sent to Gmail, this message
has been blocked.
```

Root cause is a single line in `src/server/lib/mails/mailgun.ts`:

```ts
const mailgunMessage: MailgunMessageData = {
  from,
  to: envelopTo,        // Mailgun renders "To: envelopTo[0], envelopTo[1], ..." from this
  ...
  "h:To": to,           // ← ALSO renders "To: <original csv string>"  →  TWO To headers  →  BLOCK
  "h:In-Reply-To": inReplyTo
};
```

Mailgun's `messages.create()` inserts a `To:` header into the RFC 5322 message from its `to:` parameter. Passing `h:To` appends a SECOND `To:` header. Gmail's RFC-5322-strict inbound edge (rolled out through 2024–25 as part of their bulk-sender enforcement — see the [Gmail help page](https://support.google.com/mail/?p=RfcMessageNonCompliant)) blocks the message.

Mailgun's own log shows the bounce reason clearly. Our app logs show `Email sending request succeeded` because the API returned 2xx before Gmail rejected — no exception, no MailSendingError, no user-facing signal.

## What changed

- `mailgun.ts`: dropped the `"h:To": to` line. Recipients now see the envelope-`to:` list as the `To:` header, one and only one.
- `mailgun.test.ts`: flipped the two tests that asserted `h:To` was set to one test asserting `h:To` is UNDEFINED — regression guard.

The `h:To` was intended to display the ORIGINAL comma-separated To list (including addresses that were filtered out of the envelope for being self-`@EMAIL_DOMAIN`). Nice-to-have UX; catastrophic RFC violation. Any recipient whose address happened to end in `@EMAIL_DOMAIN` won't appear in the To: header now, but they weren't going to receive the mail anyway (they were filtered out by the `envelopTo` step). The header is now the honest render.

## Follow-up (separate PR)

`POST /api/mailgun-events` webhook + Discord alarming, so a Gmail rejection surfaces as an alarm within seconds instead of us investigating from Mailgun's dashboard 3 days later. Design already agreed with Hoie in the Mailgun-deliverability thread.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (17 pre-existing warnings, no new)
- [x] `bun test src/server/lib/mails/mailgun.test.ts` — 13 pass / 0 fail
- [x] `bun test src/server` — 1168 pass / 0 fail
- [ ] Sandbox E2E: send from the inbox UI to a Gmail address; open the delivered message and confirm exactly one `To:` header in "Show original."