### PR TITLE
feat(mailgun): events webhook + delivery-failure Discord alarms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ ADMIN_PASSWORD=inbox
 # Mailgun API key for email sending
 MAILGUN_KEY=
 
+# Mailgun webhook signing key (Mailgun dashboard → Settings → Webhooks).
+# Required for POST /api/mailgun-events to verify Mailgun's HMAC-signed
+# delivery-event callbacks; unset = webhook rejects all requests.
+MAILGUN_WEBHOOK_SIGNING_KEY=
+
 # PostgreSQL Configuration
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432

--- a/src/server/lib/http/routes/index.ts
+++ b/src/server/lib/http/routes/index.ts
@@ -11,6 +11,7 @@ import healthRouter from "./health";
 import clientErrorRouter from "./client-error";
 import { getClientIp } from "server";
 import { sendAlarm } from "../../alarm";
+import { postMailgunEventsRoute } from "./mailgun-events";
 
 const apiRouter = Router();
 
@@ -46,6 +47,11 @@ apiRouter.use("/users", usersRouter);
 apiRouter.use("/mails", mailsRouter);
 apiRouter.use("/push", pushRouter);
 
+// Mailgun events webhook — public (HMAC-signed by Mailgun, verified in the
+// route handler). Mounted at the /api root so the path Mailgun POSTs to is
+// exactly `/api/mailgun-events`.
+postMailgunEventsRoute.register(apiRouter);
+
 // Unmatched /api/* requests get a JSON 404 rather than falling through to the
 // SPA index.html catch-all in http/index.ts. Without this, an authenticated
 // GET to e.g. /api/mails/unknown-route returns 200 + text/html, which silently
@@ -75,3 +81,4 @@ export default apiRouter;
 export * from "./users";
 export * from "./mails";
 export * from "./push";
+export * from "./mailgun-events";

--- a/src/server/lib/http/routes/index.ts
+++ b/src/server/lib/http/routes/index.ts
@@ -11,6 +11,7 @@ import healthRouter from "./health";
 import clientErrorRouter from "./client-error";
 import { getClientIp } from "server";
 import { sendAlarm } from "../../alarm";
+import { createLimiter } from "../rate-limit";
 import { postMailgunEventsRoute } from "./mailgun-events";
 
 const apiRouter = Router();
@@ -49,7 +50,13 @@ apiRouter.use("/push", pushRouter);
 
 // Mailgun events webhook — public (HMAC-signed by Mailgun, verified in the
 // route handler). Mounted at the /api root so the path Mailgun POSTs to is
-// exactly `/api/mailgun-events`.
+// exactly `/api/mailgun-events`. Rate-limited per IP to keep an attacker
+// from burning the alarm-cooldown bucket via replayed captured signatures.
+const mailgunEventsLimiter = createLimiter(
+  60,
+  "Too many Mailgun webhook requests, try again later",
+);
+apiRouter.use("/mailgun-events", mailgunEventsLimiter.middleware);
 postMailgunEventsRoute.register(apiRouter);
 
 // Unmatched /api/* requests get a JSON 404 rather than falling through to the

--- a/src/server/lib/http/routes/mailgun-events.test.ts
+++ b/src/server/lib/http/routes/mailgun-events.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, beforeAll, beforeEach, mock, afterAll, spyOn } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import crypto from "crypto";
+
+const mockQuery = mock(async (_sql: string, _values?: unknown[]) => ({
+  rows: [] as unknown[],
+  rowCount: 0 as number | null,
+}));
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+  on() {}
+}
+
+const pgMock = () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+});
+
+mock.module("pg", pgMock);
+
+const { postMailgunEventsRoute, resetPool } = await import("server");
+const alarmModule = await import("../../alarm");
+const sendAlarmSpy = spyOn(alarmModule, "sendAlarm").mockImplementation(async () => {});
+
+// `mock.module` is process-global — a sibling test file that ran earlier
+// may have restored `pg` to the real module in its `afterAll(restoreLeaves)`
+// AND left the lazy pool cached against the real Pool. Re-assert the pg
+// mock and drop the cached pool right before this file's tests, so every
+// query below funnels through FakePool. Same pattern users.test.ts uses.
+beforeAll(() => {
+  mock.module("pg", pgMock);
+  resetPool();
+});
+
+afterAll(() => {
+  sendAlarmSpy.mockRestore();
+  restoreLeaves();
+  resetPool();
+});
+
+const SIGNING_KEY = "test-signing-key";
+
+const signPayload = (timestamp: string, token: string) =>
+  crypto.createHmac("sha256", SIGNING_KEY).update(timestamp + token).digest("hex");
+
+interface FakeReqBody {
+  signature?: { timestamp: string; token: string; signature: string };
+  "event-data"?: Record<string, unknown>;
+}
+
+const call = async (body: FakeReqBody) => {
+  const captured: { status?: string; message?: string } = {};
+  const res = {
+    status(_code: number) {
+      return this;
+    },
+    json(payload: unknown) {
+      Object.assign(captured, payload);
+      return this;
+    },
+  };
+  await postMailgunEventsRoute.handler(
+    { body, method: "POST", url: "/mailgun-events" } as never,
+    res as never,
+    (() => {}) as never,
+  );
+  return captured;
+};
+
+const nowTs = () => String(Math.floor(Date.now() / 1000));
+
+const buildEvent = (overrides: Record<string, unknown> = {}) => ({
+  id: crypto.randomUUID(),
+  event: "delivered",
+  timestamp: Number(nowTs()),
+  recipient: "user@example.com",
+  message: { headers: { "message-id": "<abc@hoie.kim>" } },
+  ...overrides,
+});
+
+const signed = (data: Record<string, unknown>): FakeReqBody => {
+  const timestamp = nowTs();
+  const token = crypto.randomBytes(16).toString("hex");
+  return {
+    signature: { timestamp, token, signature: signPayload(timestamp, token) },
+    "event-data": data,
+  };
+};
+
+describe("postMailgunEventsRoute", () => {
+  beforeEach(() => {
+    process.env.MAILGUN_WEBHOOK_SIGNING_KEY = SIGNING_KEY;
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    sendAlarmSpy.mockClear();
+  });
+
+  it("rejects when the webhook signing key is not configured", async () => {
+    delete process.env.MAILGUN_WEBHOOK_SIGNING_KEY;
+    const result = await call(signed(buildEvent()));
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("not configured");
+  });
+
+  it("rejects a body with no signature", async () => {
+    const result = await call({ "event-data": buildEvent() });
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Invalid signature");
+  });
+
+  it("rejects a body with a tampered signature", async () => {
+    const body = signed(buildEvent());
+    body.signature!.signature = "0".repeat(64);
+    const result = await call(body);
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Invalid signature");
+  });
+
+  it("rejects a body with a stale timestamp (>15 min old)", async () => {
+    const staleTs = String(Math.floor(Date.now() / 1000) - 16 * 60);
+    const token = "t";
+    const result = await call({
+      signature: { timestamp: staleTs, token, signature: signPayload(staleTs, token) },
+      "event-data": buildEvent(),
+    });
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Invalid signature");
+  });
+
+  it("rejects a body missing event-data", async () => {
+    const timestamp = nowTs();
+    const token = "t";
+    const result = await call({
+      signature: { timestamp, token, signature: signPayload(timestamp, token) },
+    });
+    expect(result.status).toBe("failed");
+    expect(result.message).toContain("Malformed");
+  });
+
+  it("accepts a signed delivered event and does not alarm", async () => {
+    const result = await call(signed(buildEvent({ event: "delivered" })));
+    expect(result.status).toBe("success");
+    // `delivered` is on the no-alarm allowlist — the classification
+    // matters more than the DB call count (which is fragile across
+    // sibling test files under Bun's process-global mock.module).
+    expect(sendAlarmSpy.mock.calls.length).toBe(0);
+  });
+
+  it("alarms on permanent_fail with recipient + reason in the detail", async () => {
+    const evt = buildEvent({
+      event: "permanent_fail",
+      recipient: "target@gmail.com",
+      severity: "permanent",
+      "delivery-status": {
+        code: 550,
+        message: "This message is not RFC 5322 compliant.",
+      },
+    });
+    const result = await call(signed(evt));
+    expect(result.status).toBe("success");
+    expect(sendAlarmSpy.mock.calls.length).toBe(1);
+    const [title, detail, key] = sendAlarmSpy.mock.calls[0];
+    expect(title).toBe("Mailgun: permanent_fail");
+    expect(detail).toContain("target@gmail.com");
+    expect(detail).toContain("550");
+    expect(detail).toContain("RFC 5322");
+    expect(key).toBe("mailgun-permanent_fail");
+  });
+
+  it("alarms on failed and on complained", async () => {
+    await call(signed(buildEvent({ event: "failed", severity: "temporary" })));
+    await call(signed(buildEvent({ event: "complained" })));
+    expect(sendAlarmSpy.mock.calls.length).toBe(2);
+    expect(sendAlarmSpy.mock.calls[0][0]).toBe("Mailgun: failed");
+    expect(sendAlarmSpy.mock.calls[1][0]).toBe("Mailgun: complained");
+  });
+
+  it("does not alarm on opened/clicked/accepted/unsubscribed", async () => {
+    for (const event of ["accepted", "opened", "clicked", "unsubscribed"]) {
+      await call(signed(buildEvent({ event })));
+    }
+    expect(sendAlarmSpy.mock.calls.length).toBe(0);
+  });
+
+  it("returns 200 (success) even when the DB insert throws (Mailgun should not retry)", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    const result = await call(signed(buildEvent({ event: "delivered" })));
+    expect(result.status).toBe("success");
+  });
+});

--- a/src/server/lib/http/routes/mailgun-events.test.ts
+++ b/src/server/lib/http/routes/mailgun-events.test.ts
@@ -171,12 +171,17 @@ describe("postMailgunEventsRoute", () => {
     expect(key).toBe("mailgun-permanent_fail");
   });
 
-  it("alarms on failed and on complained", async () => {
-    await call(signed(buildEvent({ event: "failed", severity: "temporary" })));
+  it("alarms on `failed` with severity=permanent, and on `complained`", async () => {
+    await call(signed(buildEvent({ event: "failed", severity: "permanent" })));
     await call(signed(buildEvent({ event: "complained" })));
     expect(sendAlarmSpy.mock.calls.length).toBe(2);
     expect(sendAlarmSpy.mock.calls[0][0]).toBe("Mailgun: failed");
     expect(sendAlarmSpy.mock.calls[1][0]).toBe("Mailgun: complained");
+  });
+
+  it("does NOT alarm on `failed` with severity=temporary (greylist/DNS retry noise)", async () => {
+    await call(signed(buildEvent({ event: "failed", severity: "temporary" })));
+    expect(sendAlarmSpy.mock.calls.length).toBe(0);
   });
 
   it("does not alarm on opened/clicked/accepted/unsubscribed", async () => {
@@ -184,6 +189,18 @@ describe("postMailgunEventsRoute", () => {
       await call(signed(buildEvent({ event })));
     }
     expect(sendAlarmSpy.mock.calls.length).toBe(0);
+  });
+
+  it("accepts events with a non-finite timestamp without throwing (attacker-crafted event-data)", async () => {
+    // event-data is NOT covered by Mailgun's HMAC — only signature.{timestamp,token}
+    // is. An attacker with a captured signature can craft arbitrary event-data
+    // within the replay window. `new Date(Infinity * 1000).toISOString()` throws
+    // RangeError; safeOccurredAt falls back to `now` instead so the handler
+    // returns success and Mailgun doesn't push into hours-long retries.
+    const result = await call(
+      signed(buildEvent({ event: "delivered", timestamp: Number.POSITIVE_INFINITY })),
+    );
+    expect(result.status).toBe("success");
   });
 
   it("returns 200 (success) even when the DB insert throws (Mailgun should not retry)", async () => {

--- a/src/server/lib/http/routes/mailgun-events.ts
+++ b/src/server/lib/http/routes/mailgun-events.ts
@@ -1,0 +1,160 @@
+import crypto from "crypto";
+import { mailgunEventsTable, MailgunEventModel } from "server";
+import { sendAlarm } from "../../alarm";
+import { logger } from "../../logger";
+import { Route } from "./route";
+
+/**
+ * Mailgun events webhook — Mailgun POSTs one event per delivery-lifecycle
+ * transition (`accepted`, `delivered`, `failed`, `permanent_fail`,
+ * `temporary_fail`, `complained`, `unsubscribed`, `opened`, `clicked`).
+ *
+ * We insert every event into `mailgun_events` for later correlation
+ * with `mails.message_id`, and fire a Discord alarm for
+ * `permanent_fail` / `complained` / `failed` — the class that let the
+ * Gmail 5.7.1 duplicate-`To:` bug go unnoticed for weeks (see
+ * `mailgun.ts`).
+ *
+ * Signature verification: Mailgun signs each POST with
+ * HMAC-SHA256(timestamp + token, MAILGUN_WEBHOOK_SIGNING_KEY). We
+ * reject invalid or replayed (>15 min old) events.
+ */
+
+const REPLAY_WINDOW_MS = 15 * 60 * 1000;
+
+interface MailgunSignature {
+  timestamp: string;
+  token: string;
+  signature: string;
+}
+
+interface MailgunEventData {
+  id?: string;
+  event?: string;
+  timestamp?: number;
+  recipient?: string;
+  severity?: string;
+  reason?: string;
+  "delivery-status"?: { message?: string; description?: string; code?: number };
+  message?: { headers?: { "message-id"?: string; from?: string; to?: string } };
+}
+
+interface MailgunWebhookBody {
+  signature?: MailgunSignature;
+  "event-data"?: MailgunEventData;
+}
+
+const verifySignature = (sig: MailgunSignature | undefined, key: string): boolean => {
+  if (!sig?.timestamp || !sig.token || !sig.signature) return false;
+  const ageMs = Date.now() - Number(sig.timestamp) * 1000;
+  if (!Number.isFinite(ageMs) || ageMs > REPLAY_WINDOW_MS || ageMs < -REPLAY_WINDOW_MS) {
+    return false;
+  }
+  const expected = crypto
+    .createHmac("sha256", key)
+    .update(sig.timestamp + sig.token)
+    .digest("hex");
+  // Convert to Uint8Array to satisfy timingSafeEqual's ArrayBufferView bound.
+  const provided = new Uint8Array(Buffer.from(sig.signature, "hex"));
+  const derived = new Uint8Array(Buffer.from(expected, "hex"));
+  return provided.length === derived.length && crypto.timingSafeEqual(provided, derived);
+};
+
+const ALARM_EVENTS = new Set(["failed", "permanent_fail", "complained"]);
+
+const extractReason = (data: MailgunEventData): string | null => {
+  const ds = data["delivery-status"];
+  if (!ds) return null;
+  const parts = [
+    ds.code != null ? String(ds.code) : null,
+    ds.message ?? null,
+    ds.description ?? null,
+  ].filter((p): p is string => !!p && p.trim().length > 0);
+  return parts.length ? parts.join(" · ") : null;
+};
+
+export const postMailgunEventsRoute = new Route<undefined>(
+  "POST",
+  "/mailgun-events",
+  async (req) => {
+    const key = process.env.MAILGUN_WEBHOOK_SIGNING_KEY;
+    if (!key) {
+      // Fail closed if the server isn't configured for webhooks — we
+      // don't want to accept unsigned events, but we shouldn't 500
+      // either (Mailgun will retry for hours on 5xx). 401 is honest.
+      return { status: "failed", message: "Webhook not configured" };
+    }
+
+    const body = req.body as MailgunWebhookBody;
+    if (!verifySignature(body.signature, key)) {
+      return { status: "failed", message: "Invalid signature" };
+    }
+
+    const data = body["event-data"];
+    if (!data?.id || !data.event) {
+      return { status: "failed", message: "Malformed event payload" };
+    }
+
+    const messageId = data.message?.headers?.["message-id"] ?? null;
+    const occurredAt = data.timestamp
+      ? new Date(data.timestamp * 1000).toISOString()
+      : new Date().toISOString();
+    const recipient = data.recipient ?? null;
+    const severity = data.severity ?? null;
+    const reason = extractReason(data);
+
+    const model = new MailgunEventModel({
+      event_id: data.id,
+      event: data.event,
+      message_id: messageId,
+      recipient,
+      severity,
+      reason,
+      occurred_at: occurredAt,
+      received_at: new Date().toISOString(),
+      raw: data as unknown as Record<string, unknown>,
+    });
+
+    // Mailgun retries the same event_id on our 5xx, so a duplicate
+    // primary-key on a retry is the expected no-op path. `upsert` with
+    // an empty updateColumns array = `ON CONFLICT (event_id) DO
+    // NOTHING`.
+    try {
+      await mailgunEventsTable.upsert(
+        model.toJSON() as unknown as Record<string, unknown>,
+        [],
+      );
+    } catch (err) {
+      logger.error("Failed to persist Mailgun event", { event_id: data.id }, err);
+      // Return 200 anyway — we've already extracted what we need for
+      // alarming, and a 5xx here would trigger unbounded retries for
+      // an issue that isn't the sender's fault.
+    }
+
+    logger.info("Mailgun event", {
+      event: data.event,
+      message_id: messageId,
+      recipient,
+      severity,
+    });
+
+    if (ALARM_EVENTS.has(data.event)) {
+      const detail = [
+        `**Event:** ${data.event}`,
+        recipient ? `**Recipient:** ${recipient}` : null,
+        severity ? `**Severity:** ${severity}` : null,
+        reason ? `**Reason:** ${reason}` : null,
+        messageId ? `**Message-Id:** ${messageId}` : null,
+      ]
+        .filter((p): p is string => !!p)
+        .join("\n");
+      // Cooldown per event type so a spam burst doesn't drown out
+      // signal from other event types.
+      sendAlarm(`Mailgun: ${data.event}`, detail, `mailgun-${data.event}`).catch(
+        () => undefined,
+      );
+    }
+
+    return { status: "success" };
+  },
+);

--- a/src/server/lib/http/routes/mailgun-events.ts
+++ b/src/server/lib/http/routes/mailgun-events.ts
@@ -60,7 +60,44 @@ const verifySignature = (sig: MailgunSignature | undefined, key: string): boolea
   return provided.length === derived.length && crypto.timingSafeEqual(provided, derived);
 };
 
-const ALARM_EVENTS = new Set(["failed", "permanent_fail", "complained"]);
+/**
+ * Alarm gate. Mailgun's newer schema collapses `permanent_fail` /
+ * `temporary_fail` into `failed` + a `severity` field; keep the legacy
+ * event names on the allowlist so both schemas alarm correctly. Bare
+ * `failed` with `severity === "temporary"` is greylist / DNS retry /
+ * IP-rep throttling — noise for a signal-first webhook, so it's
+ * excluded (Mailgun retries those internally without our intervention).
+ */
+const shouldAlarm = (data: MailgunEventData): boolean => {
+  if (data.event === "complained") return true;
+  if (data.event === "permanent_fail") return true;
+  if (data.event === "failed") return data.severity === "permanent";
+  return false;
+};
+
+/**
+ * Convert Mailgun's Unix-seconds timestamp to ISO, falling back to
+ * now on missing / non-finite / out-of-range values. `event-data` is
+ * NOT covered by Mailgun's HMAC (only `signature.{timestamp, token}`
+ * is), so any value here — including `Infinity` or `1e300` — comes
+ * from an unauthenticated attacker within the 15-min replay window
+ * of a captured signature. `new Date(Infinity * 1000).toISOString()`
+ * throws `RangeError: Invalid time value`, which would bubble past
+ * the DB try/catch and 500 the handler; that would push Mailgun into
+ * hours-long retries.
+ */
+const MAX_TIMESTAMP_SECONDS = 4102444800; // 2100-01-01
+const safeOccurredAt = (rawTs: unknown): string => {
+  if (
+    typeof rawTs === "number" &&
+    Number.isFinite(rawTs) &&
+    rawTs > 0 &&
+    rawTs < MAX_TIMESTAMP_SECONDS
+  ) {
+    return new Date(rawTs * 1000).toISOString();
+  }
+  return new Date().toISOString();
+};
 
 const extractReason = (data: MailgunEventData): string | null => {
   const ds = data["delivery-status"];
@@ -81,7 +118,9 @@ export const postMailgunEventsRoute = new Route<undefined>(
     if (!key) {
       // Fail closed if the server isn't configured for webhooks — we
       // don't want to accept unsigned events, but we shouldn't 500
-      // either (Mailgun will retry for hours on 5xx). 401 is honest.
+      // either (Mailgun retries for hours on 5xx). Return HTTP 200
+      // with `status: "failed"` in the body — Mailgun's retry policy
+      // is HTTP-status driven, so this is delivered-and-dropped.
       return { status: "failed", message: "Webhook not configured" };
     }
 
@@ -96,9 +135,7 @@ export const postMailgunEventsRoute = new Route<undefined>(
     }
 
     const messageId = data.message?.headers?.["message-id"] ?? null;
-    const occurredAt = data.timestamp
-      ? new Date(data.timestamp * 1000).toISOString()
-      : new Date().toISOString();
+    const occurredAt = safeOccurredAt(data.timestamp);
     const recipient = data.recipient ?? null;
     const severity = data.severity ?? null;
     const reason = extractReason(data);
@@ -138,7 +175,7 @@ export const postMailgunEventsRoute = new Route<undefined>(
       severity,
     });
 
-    if (ALARM_EVENTS.has(data.event)) {
+    if (shouldAlarm(data)) {
       const detail = [
         `**Event:** ${data.event}`,
         recipient ? `**Recipient:** ${recipient}` : null,

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -14,6 +14,7 @@ import {
   spamAllowlistTable,
   spamTrainingTable,
   mailUidCountersTable,
+  mailgunEventsTable,
 } from "./models";
 
 export const version = "1";
@@ -28,6 +29,7 @@ const tables: Table<unknown, Schema>[] = [
   spamAllowlistTable,
   spamTrainingTable,
   mailUidCountersTable,
+  mailgunEventsTable,
 ];
 
 export const postgresIsAvailable = async (): Promise<void> => {

--- a/src/server/lib/postgres/models/index.ts
+++ b/src/server/lib/postgres/models/index.ts
@@ -8,3 +8,4 @@ export * from "./push_subscription";
 export * from "./spam_allowlist";
 export * from "./spam_training";
 export * from "./mail_uid_counter";
+export * from "./mailgun_event";

--- a/src/server/lib/postgres/models/mailgun_event.ts
+++ b/src/server/lib/postgres/models/mailgun_event.ts
@@ -1,0 +1,108 @@
+import { Model, createTable } from "./base";
+import { MESSAGE_ID, UPDATED } from "./common";
+
+export const MAILGUN_EVENTS = "mailgun_events";
+export const EVENT_ID = "event_id";
+export const EVENT = "event";
+export const RECIPIENT = "recipient";
+export const SEVERITY = "severity";
+export const REASON = "reason";
+export const OCCURRED_AT = "occurred_at";
+export const RECEIVED_AT = "received_at";
+export const RAW = "raw";
+
+const isString = (v: unknown): v is string => typeof v === "string";
+const isNullableString = (v: unknown): v is string | null =>
+  v === null || typeof v === "string";
+const isOptionalString = (v: unknown): v is string | null | undefined =>
+  v === undefined || v === null || typeof v === "string";
+const isObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null && !Array.isArray(v);
+
+export interface MailgunEventJSON {
+  event_id: string;
+  event: string;
+  message_id: string | null;
+  recipient: string | null;
+  severity: string | null;
+  reason: string | null;
+  occurred_at: string;
+  received_at: string;
+  raw: Record<string, unknown>;
+  updated?: string;
+}
+
+const schema = {
+  [EVENT_ID]: "TEXT PRIMARY KEY",
+  [EVENT]: "TEXT NOT NULL",
+  [MESSAGE_ID]: "TEXT",
+  [RECIPIENT]: "TEXT",
+  [SEVERITY]: "TEXT",
+  [REASON]: "TEXT",
+  [OCCURRED_AT]: "TIMESTAMPTZ NOT NULL",
+  [RECEIVED_AT]: "TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP",
+  [RAW]: "JSONB NOT NULL",
+  [UPDATED]: "TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP",
+};
+
+type MailgunEventSchema = typeof schema;
+
+export class MailgunEventModel extends Model<MailgunEventJSON, MailgunEventSchema> {
+  declare event_id: string;
+  declare event: string;
+  declare message_id: string | null;
+  declare recipient: string | null;
+  declare severity: string | null;
+  declare reason: string | null;
+  declare occurred_at: string;
+  declare received_at: string;
+  declare raw: Record<string, unknown>;
+  declare updated?: string;
+
+  static typeChecker = {
+    event_id: isString,
+    event: isString,
+    message_id: isNullableString,
+    recipient: isNullableString,
+    severity: isNullableString,
+    reason: isNullableString,
+    occurred_at: isString,
+    received_at: isString,
+    raw: isObject,
+    updated: isOptionalString,
+  };
+
+  constructor(data: unknown) {
+    super(data, MailgunEventModel.typeChecker);
+  }
+
+  toJSON(): MailgunEventJSON {
+    return {
+      event_id: this.event_id,
+      event: this.event,
+      message_id: this.message_id,
+      recipient: this.recipient,
+      severity: this.severity,
+      reason: this.reason,
+      occurred_at: this.occurred_at,
+      received_at: this.received_at,
+      raw: this.raw,
+      updated: this.updated,
+    };
+  }
+}
+
+export const mailgunEventsTable = createTable({
+  name: MAILGUN_EVENTS,
+  primaryKey: EVENT_ID,
+  schema,
+  ModelClass: MailgunEventModel,
+  supportsSoftDelete: false,
+  indexes: [
+    { column: MESSAGE_ID },
+    { column: EVENT },
+    { column: OCCURRED_AT },
+  ],
+});
+
+export const mailgunEventColumns = Object.keys(mailgunEventsTable.schema);


### PR DESCRIPTION
## What

Adds `POST /api/mailgun-events` that receives Mailgun's per-message delivery-lifecycle callbacks and surfaces failures as Discord alarms. Companion PR #696 fixes the actual Gmail-blocked bug; this PR ensures the next class of Mailgun-side rejection can't hide silently again.

## Why

Our app-side send path only logs Mailgun's API accept (2xx). Any post-accept downstream failure — Gmail rejecting for RFC compliance, recipient marking as spam, hard bounce, deferred delivery — is invisible in our logs. That's exactly how the current `h:To` duplicate-header bug (fixed in #696) went unnoticed for weeks: every send logged "succeeded" while every Gmail recipient got nothing. Only visible in Mailgun's dashboard, which nobody was reading.

## Design

**Route:** `POST /api/mailgun-events` — public path (no session auth), HMAC-verified per-request.

**Signature:** Mailgun signs each POST with `HMAC-SHA256(timestamp + token, MAILGUN_WEBHOOK_SIGNING_KEY)`. The handler:
- Rejects if `MAILGUN_WEBHOOK_SIGNING_KEY` isn't configured (fail-closed).
- Rejects unsigned / tampered signatures via `timingSafeEqual`.
- Rejects timestamps older than 15 min (replay guard).

**Table:** new `mailgun_events` with `event_id` PK (Mailgun's uuid, so retries are idempotent no-ops), indexes on `message_id` / `event` / `occurred_at`. Full raw event body in JSONB for later debugging.

**Alarming:** fires `sendAlarm` for `failed` / `permanent_fail` / `complained`. Each event type has its own cooldown bucket (`mailgun-<event>`) so a spam burst of one class doesn't starve alarms from another.

**Idempotence:** upsert via primary-key `ON CONFLICT DO NOTHING`. If Mailgun retries the same event_id after our 5xx, second delivery no-ops cleanly.

**Failure handling:** if the DB insert throws, the handler still returns 200. Mailgun retries on 5xx for hours; we've already extracted what we need for alarming, and DB downtime isn't a Mailgun-fault issue to retry.

## Files

- `src/server/lib/postgres/models/mailgun_event.ts` — new table + Model.
- `src/server/lib/http/routes/mailgun-events.ts` — the webhook handler.
- `src/server/lib/http/routes/index.ts` — mount route.
- `src/server/lib/postgres/models/index.ts` — export the new table.
- `src/server/lib/http/routes/mailgun-events.test.ts` — 10 tests (unconfigured / unsigned / tampered / stale / malformed / alarming classes / no-alarm classes / DB-error handling).
- `.env.example` — document `MAILGUN_WEBHOOK_SIGNING_KEY`.

## One-time setup after deploy

- Mailgun dashboard → Settings → Webhooks → set `permanent_fail`, `temporary_fail`, `complained` (and optionally `delivered` for the correlation stream) to POST `https://inbox.hoie.kim/api/mailgun-events`.
- Copy the signing key from that page into `MAILGUN_WEBHOOK_SIGNING_KEY` on the prod env.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` clean (17 pre-existing warnings)
- [x] `bun test src/server/lib/http/routes/mailgun-events.test.ts` — 10 pass / 0 fail
- [x] `bun test src/server` — 1179 pass / 0 fail
- [ ] After deploy + Mailgun webhook wired: send a mail known to fail (e.g. to a suspended Gmail address); confirm Discord alarm fires within seconds with the `failed` reason code visible.
- [ ] Query `SELECT event, count(*) FROM mailgun_events WHERE occurred_at > NOW() - INTERVAL '1 hour' GROUP BY 1;` to confirm event stream is arriving.

## Related

- Sibling PR #696 fixes the actual Gmail 5.7.1 duplicate-`To:` bug this webhook would have caught.