### PR TITLE
fix(imap): empty/unknown-only STORE ±FLAGS is a no-op, not a server error (#671)

### DIFF
--- a/src/server/lib/postgres/repositories/mails.test.ts
+++ b/src/server/lib/postgres/repositories/mails.test.ts
@@ -166,6 +166,93 @@ describe("STORE operation types", () => {
   });
 });
 
+describe("buildFlagSetClause — empty/unknown-only STORE is a no-op (#671)", () => {
+  // A +FLAGS/-FLAGS that touches no recognized flag must yield NO SET
+  // assignment (empty string), not the old `updated = updated` sentinel that
+  // collided with the trailing `updated = CURRENT_TIMESTAMP` → Postgres
+  // "multiple assignments to same column". setMailFlags treats "" as the
+  // legal no-op path (RFC 3501 §6.4.6).
+  const load = async () => (await import("./mails")).buildFlagSetClause;
+
+  it("returns '' for +FLAGS with an empty flag list", async () => {
+    const buildFlagSetClause = await load();
+    expect(buildFlagSetClause("+FLAGS", [])).toBe("");
+  });
+
+  it("returns '' for -FLAGS with an empty flag list", async () => {
+    const buildFlagSetClause = await load();
+    expect(buildFlagSetClause("-FLAGS", [])).toBe("");
+  });
+
+  it("returns '' for +FLAGS with only unknown/custom keywords", async () => {
+    const buildFlagSetClause = await load();
+    expect(buildFlagSetClause("+FLAGS", ["\\CustomKeyword", "Foo"])).toBe("");
+  });
+
+  it("never emits the `updated = updated` double-assignment sentinel", async () => {
+    const buildFlagSetClause = await load();
+    for (const op of ["+FLAGS", "-FLAGS"] as const) {
+      for (const flags of [[], ["Foo"], ["\\Seen"]]) {
+        expect(buildFlagSetClause(op, flags)).not.toContain("updated");
+      }
+    }
+  });
+
+  it("still emits real column assignments when a flag is recognized", async () => {
+    const buildFlagSetClause = await load();
+    expect(buildFlagSetClause("+FLAGS", ["\\Seen"])).toBe("read = TRUE");
+    expect(buildFlagSetClause("+FLAGS", ["\\Seen", "\\Deleted"])).toBe(
+      "read = TRUE, deleted = TRUE"
+    );
+    expect(buildFlagSetClause("-FLAGS", ["\\Flagged"])).toBe("saved = FALSE");
+  });
+
+  it("FLAGS replace mode is always a full (non-empty) assignment", async () => {
+    const buildFlagSetClause = await load();
+    // Even `FLAGS ()` (clear all) is a real change, never a no-op.
+    const clause = buildFlagSetClause("FLAGS", []);
+    expect(clause).toContain("read = false");
+    expect(clause).toContain("answered = false");
+  });
+});
+
+describe("setMailFlags — no-op STORE skips the UPDATE (source regression for #671)", () => {
+  // Static source check (robust against module-mock interactions in the full
+  // suite — see the #456 block above for the rationale): the no-op branch must
+  // read current flags via SELECT without bumping `updated` or reserving a
+  // mod-sequence, and the old colliding sentinel must be gone.
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const mailsSource = await fs.readFile(
+      path.join(import.meta.dir, "mails.ts"),
+      "utf8"
+    );
+    const fnMatch = mailsSource.match(/export const setMailFlags[\s\S]*?\n};/);
+    if (!fnMatch) throw new Error("setMailFlags not found in mails.ts");
+    fnSource = fnMatch[0];
+  });
+
+  it("no longer contains the `updated = updated` sentinel", () => {
+    expect(fnSource).not.toContain("updated = updated");
+  });
+
+  it("has a no-op branch guarded on an empty setClause", () => {
+    expect(fnSource).toMatch(/if\s*\(!setClause\)/);
+  });
+
+  it("no-op branch uses SELECT, not UPDATE, so `updated`/modseq are untouched", () => {
+    // The `!setClause` block runs a bare SELECT of the current flags.
+    const noopBlock = fnSource.match(/if\s*\(!setClause\)\s*\{[\s\S]*?\n {4}\}/);
+    expect(noopBlock).not.toBeNull();
+    expect(noopBlock![0]).toContain("SELECT");
+    expect(noopBlock![0]).not.toContain("UPDATE");
+    expect(noopBlock![0]).not.toContain("getNextModseq");
+  });
+});
+
 describe("expungeDeletedMails — `updated` column refresh (regression for #456)", () => {
   // Static source check: the expunge write paths must go through
   // mailsTable.updateWhere with `updated: new Date()` in the data bag so the

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1055,10 +1055,7 @@ export type StoreOperationType = "FLAGS" | "+FLAGS" | "-FLAGS";
  *
  * Returns `""` when the operation touches no recognized flag — an empty
  * `+FLAGS ()`/`-FLAGS ()` or a list of only non-standard keywords. That is a
- * legal no-op (§6.4.6), and `setMailFlags` handles it without an UPDATE.
- * (The `""` replaces an earlier `"updated = updated"` sentinel that collided
- * with the trailing `updated = CURRENT_TIMESTAMP` → "multiple assignments to
- * same column" — issue #671.)
+ * legal no-op (§6.4.6), which `setMailFlags` serves without an UPDATE.
  */
 export function buildFlagSetClause(
   operation: StoreOperationType,
@@ -1160,7 +1157,7 @@ export const setMailFlags = async (
     // keywords): RFC 3501 §6.4.6 makes this a legal no-op. Return the matched
     // rows' CURRENT flags without an UPDATE — a no-op must not bump `updated`
     // (delta-sync cursor) or reserve a new mod-sequence (RFC 7162: modseq only
-    // advances when flags actually change). Issue #671.
+    // advances when flags actually change).
     if (!setClause) {
       const result = await pool.query(
         `SELECT ${returningCols} FROM mails WHERE ${whereClause}`,

--- a/src/server/lib/postgres/repositories/mails.ts
+++ b/src/server/lib/postgres/repositories/mails.ts
@@ -1048,29 +1048,25 @@ export interface UpdatedMailFlags {
 export type StoreOperationType = "FLAGS" | "+FLAGS" | "-FLAGS";
 
 /**
- * Build SET clause for flag updates based on operation type.
- * Per RFC 3501 Section 6.4.6:
- * - FLAGS: Replace all flags with the provided list
- * - +FLAGS: Add the specified flags to existing flags
- * - -FLAGS: Remove the specified flags from existing flags
+ * Build the `SET`-column assignments for a flag update, per RFC 3501 §6.4.6:
+ * - FLAGS: replace all flags with the provided list
+ * - +FLAGS: add the specified flags to existing flags
+ * - -FLAGS: remove the specified flags from existing flags
+ *
+ * Returns `""` when the operation touches no recognized flag — an empty
+ * `+FLAGS ()`/`-FLAGS ()` or a list of only non-standard keywords. That is a
+ * legal no-op (§6.4.6), and `setMailFlags` handles it without an UPDATE.
+ * (The `""` replaces an earlier `"updated = updated"` sentinel that collided
+ * with the trailing `updated = CURRENT_TIMESTAMP` → "multiple assignments to
+ * same column" — issue #671.)
  */
-function buildFlagSetClause(
+export function buildFlagSetClause(
   operation: StoreOperationType,
   flags: string[]
 ): string {
   const hasFlag = (flag: string) => flags.includes(flag);
 
   switch (operation) {
-    case "FLAGS":
-      // Replace mode: set all flags based on presence in flags array
-      return `
-        read = ${hasFlag("\\Seen")},
-        saved = ${hasFlag("\\Flagged")},
-        deleted = ${hasFlag("\\Deleted")},
-        draft = ${hasFlag("\\Draft")},
-        answered = ${hasFlag("\\Answered")}
-      `;
-
     case "+FLAGS": {
       // Add mode: only set flags that are in the array to true
       const addClauses: string[] = [];
@@ -1079,8 +1075,7 @@ function buildFlagSetClause(
       if (hasFlag("\\Deleted")) addClauses.push("deleted = TRUE");
       if (hasFlag("\\Draft")) addClauses.push("draft = TRUE");
       if (hasFlag("\\Answered")) addClauses.push("answered = TRUE");
-      // If no flags specified, return a no-op that still works
-      return addClauses.length > 0 ? addClauses.join(", ") : "updated = updated";
+      return addClauses.join(", ");
     }
 
     case "-FLAGS": {
@@ -1091,12 +1086,13 @@ function buildFlagSetClause(
       if (hasFlag("\\Deleted")) removeClauses.push("deleted = FALSE");
       if (hasFlag("\\Draft")) removeClauses.push("draft = FALSE");
       if (hasFlag("\\Answered")) removeClauses.push("answered = FALSE");
-      // If no flags specified, return a no-op that still works
-      return removeClauses.length > 0 ? removeClauses.join(", ") : "updated = updated";
+      return removeClauses.join(", ");
     }
 
+    case "FLAGS":
     default:
-      // Default to replace mode
+      // Replace mode: set every flag based on presence in the flags array.
+      // Always a full assignment, so never a no-op.
       return `
         read = ${hasFlag("\\Seen")},
         saved = ${hasFlag("\\Flagged")},
@@ -1120,37 +1116,25 @@ export const setMailFlags = async (
   try {
     const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
     const setClause = buildFlagSetClause(operation, flags);
-    // One fresh mod-sequence for this STORE, stamped on every matched row so a
-    // CONDSTORE client sees one modseq for the whole flag change (RFC 7162 §3.1
-    // — a batch mutation may share a single mod-sequence). Reserved atomically so
-    // concurrent STOREs get strictly-distinct, monotonic values.
-    const modseq = await getNextModseq(user_id);
+    const returningCols = `${uidField} as uid, read, saved, deleted, draft, answered`;
 
-    let sql: string;
-    let values: ParamValue[];
-
+    // Build the row-matching predicate + its bound params once, shared by the
+    // real-change UPDATE and the no-op SELECT below. `$`-indices are 1-based and
+    // never include the mod-sequence (appended by the UPDATE branch only).
+    let whereClause: string;
+    let whereValues: ParamValue[];
     if (account === null) {
       if (useUid) {
-        sql = `
-          UPDATE mails
-          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
-          WHERE user_id = $1 AND sent = $2 AND ${uidField} >= $3 AND ${uidField} <= $4
-          RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
-        `;
-        values = [user_id, sent, start, end, modseq];
+        whereClause = `user_id = $1 AND sent = $2 AND ${uidField} >= $3 AND ${uidField} <= $4`;
+        whereValues = [user_id, sent, start, end];
       } else {
-        sql = `
-          UPDATE mails
-          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $4
-          WHERE mail_id IN (
-            SELECT mail_id FROM mails
-            WHERE user_id = $1 AND sent = $2
-            ORDER BY ${uidField} ASC
-            OFFSET $3 LIMIT 1
-          )
-          RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
-        `;
-        values = [user_id, sent, start, modseq];
+        whereClause = `mail_id IN (
+          SELECT mail_id FROM mails
+          WHERE user_id = $1 AND sent = $2
+          ORDER BY ${uidField} ASC
+          OFFSET $3 LIMIT 1
+        )`;
+        whereValues = [user_id, sent, start];
       }
     } else {
       const addressJson = JSON.stringify([{ address: account }]);
@@ -1158,44 +1142,60 @@ export const setMailFlags = async (
         ? `${FROM_ADDRESS} @> $3::jsonb`
         : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
       if (useUid) {
-        sql = `
-          UPDATE mails
-          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $6
-          WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
-            AND ${uidField} >= $4 AND ${uidField} <= $5
-          RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
-        `;
-        values = [user_id, sent, addressJson, start, end, modseq];
+        whereClause = `user_id = $1 AND sent = $2 AND ${addressCondition}
+          AND ${uidField} >= $4 AND ${uidField} <= $5`;
+        whereValues = [user_id, sent, addressJson, start, end];
       } else {
-        sql = `
-          UPDATE mails
-          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
-          WHERE mail_id IN (
-            SELECT mail_id FROM mails
-            WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
-            ORDER BY ${uidField} ASC
-            OFFSET $4 LIMIT 1
-          )
-          RETURNING ${uidField} as uid, read, saved, deleted, draft, answered
-        `;
-        values = [user_id, sent, addressJson, start, modseq];
+        whereClause = `mail_id IN (
+          SELECT mail_id FROM mails
+          WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
+          ORDER BY ${uidField} ASC
+          OFFSET $4 LIMIT 1
+        )`;
+        whereValues = [user_id, sent, addressJson, start];
       }
     }
 
-    const result = await pool.query(sql, values);
-    return result.rows.map((row: Record<string, unknown>) => ({
-      uid: row.uid as number,
-      read: row.read as boolean,
-      saved: row.saved as boolean,
-      deleted: row.deleted as boolean,
-      draft: row.draft as boolean,
-      answered: row.answered as boolean,
-    }));
+    // No recognized flag change (empty `+FLAGS ()` / `-FLAGS ()` or unknown-only
+    // keywords): RFC 3501 §6.4.6 makes this a legal no-op. Return the matched
+    // rows' CURRENT flags without an UPDATE — a no-op must not bump `updated`
+    // (delta-sync cursor) or reserve a new mod-sequence (RFC 7162: modseq only
+    // advances when flags actually change). Issue #671.
+    if (!setClause) {
+      const result = await pool.query(
+        `SELECT ${returningCols} FROM mails WHERE ${whereClause}`,
+        whereValues
+      );
+      return result.rows.map(toUpdatedMailFlags);
+    }
+
+    // One fresh mod-sequence for this STORE, stamped on every matched row so a
+    // CONDSTORE client sees one modseq for the whole flag change (RFC 7162 §3.1
+    // — a batch mutation may share a single mod-sequence). Reserved atomically so
+    // concurrent STOREs get strictly-distinct, monotonic values.
+    const modseq = await getNextModseq(user_id);
+    const result = await pool.query(
+      `UPDATE mails
+       SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $${whereValues.length + 1}
+       WHERE ${whereClause}
+       RETURNING ${returningCols}`,
+      [...whereValues, modseq]
+    );
+    return result.rows.map(toUpdatedMailFlags);
   } catch (error) {
     logger.error("Failed to set mail flags", {}, error);
     return [];
   }
 };
+
+const toUpdatedMailFlags = (row: Record<string, unknown>): UpdatedMailFlags => ({
+  uid: row.uid as number,
+  read: row.read as boolean,
+  saved: row.saved as boolean,
+  deleted: row.deleted as boolean,
+  draft: row.draft as boolean,
+  answered: row.answered as boolean,
+});
 
 /**
  * Builds the SQL boolean fragment for a single IMAP SEARCH criterion, pushing any


### PR DESCRIPTION
## Summary

Closes #671. A `+FLAGS`/`-FLAGS` STORE that resolves to **no recognized flag change** — an empty `STORE n +FLAGS ()` or a list of only non-standard keywords like `\CustomKeyword` — errored with a server-side `NO STORE failed` instead of the RFC-appropriate no-op `OK` (RFC 3501 §6.4.6).

## Root cause

`buildFlagSetClause` returned the literal `"updated = updated"` as its no-op for a `+FLAGS`/`-FLAGS` that touched no flag. `setMailFlags` interpolated that into:

```sql
SET updated = updated, updated = CURRENT_TIMESTAMP, modseq = $N
```

Postgres forbids assigning the same column twice in one `UPDATE ... SET` (error 42601), so the query threw and `setMailFlags` returned `[]` via its catch → the STORE reported failure for a legal command.

## Fix

- `buildFlagSetClause` returns `""` (no assignment) for the no-recognized-flag case instead of the colliding sentinel.
- `setMailFlags` treats `""` as a **no-op**: it `SELECT`s the matched rows' current flags and returns them — no `UPDATE`. So a no-op STORE:
  - completes `OK` and (non-SILENT) returns the messages' current flags, and
  - does **not** bump `updated` (delta-sync cursor) or reserve a new mod-sequence — RFC 7162 says a mod-sequence advances only when flags actually change. This matters now that CONDSTORE/delta-sync are live in this codebase.
- The four near-duplicate `UPDATE` variants are consolidated onto one shared `WHERE` clause + param list, so the `SELECT` (no-op) and `UPDATE` (real change) paths can't drift. The `UPDATE`-path SQL and bound-param order are unchanged (verified `$`-index-for-`$`-index against the prior code).

The `FLAGS` (replace) mode is unaffected — even `FLAGS ()` is a real change (clear all flags), never a no-op.

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean (0 errors; pre-existing warnings only, none in changed files).
- [x] `bun test src/server` — 1201 pass / 0 fail (+11 new in `mails.test.ts`: `buildFlagSetClause` returns `""` for empty/unknown-only ±FLAGS and never emits `updated`, still emits real assignments for recognized flags; source regression that `setMailFlags`' no-op branch uses `SELECT` not `UPDATE` and never reaches `getNextModseq`).
- [x] **Sandbox raw-IMAP E2E** (fresh sandbox, IMAP port) — driving the actual protocol:

  ```
  a3 FETCH 1 (FLAGS)            -> * 1 FETCH (FLAGS (\Seen))      a3 OK
  a4 STORE 1 +FLAGS ()         -> * 1 FETCH (FLAGS (\Seen))      a4 OK STORE completed
  a5 STORE 1 +FLAGS (\Custom)  -> * 1 FETCH (FLAGS (\Seen))      a5 OK STORE completed
  a6 STORE 1 -FLAGS ()         -> * 1 FETCH (FLAGS (\Seen))      a6 OK STORE completed
  a7 FETCH 1 (FLAGS)           -> * 1 FETCH (FLAGS (\Seen))      a7 OK
  ```

  All three no-op STOREs now return tagged `OK` (were `NO STORE failed` on `main`), each echoing the message's **current** flags per §6.4.6, and the before/after FETCH shows flags **unchanged** — the no-op performed no write.