### PR TITLE
fix(imap): pace pipelined command bursts instead of dropping them

### DIFF
--- a/src/common/throttler.test.ts
+++ b/src/common/throttler.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { Throttler } from "./throttler";
+
+describe("Throttler", () => {
+  it("reports 0 wait while under the limit", () => {
+    const throttler = new Throttler(3, 1000);
+    expect(throttler.msUntilFree()).toBe(0);
+    throttler.record();
+    throttler.record();
+    expect(throttler.msUntilFree()).toBe(0);
+  });
+
+  it("reports a positive wait once the window is full", () => {
+    const throttler = new Throttler(2, 1000);
+    throttler.record();
+    throttler.record();
+    const wait = throttler.msUntilFree();
+    expect(wait).toBeGreaterThan(0);
+    expect(wait).toBeLessThanOrEqual(1000);
+  });
+
+  it("does not record when peeking", () => {
+    const throttler = new Throttler(2, 1000);
+    // Peeking many times must never consume capacity.
+    for (let i = 0; i < 10; i++) {
+      expect(throttler.msUntilFree()).toBe(0);
+    }
+    throttler.record();
+    expect(throttler.msUntilFree()).toBe(0);
+  });
+
+  it("frees a slot after the window elapses", async () => {
+    const throttler = new Throttler(1, 30);
+    throttler.record();
+    expect(throttler.msUntilFree()).toBeGreaterThan(0);
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    expect(throttler.msUntilFree()).toBe(0);
+  });
+
+  it("wait time reflects the oldest blocking request", async () => {
+    const throttler = new Throttler(2, 100);
+    throttler.record();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    throttler.record();
+    // The first record is the blocking one; it expires ~70ms from now.
+    const wait = throttler.msUntilFree();
+    expect(wait).toBeGreaterThan(0);
+    expect(wait).toBeLessThanOrEqual(80);
+  });
+});

--- a/src/common/throttler.ts
+++ b/src/common/throttler.ts
@@ -8,10 +8,28 @@ export class Throttler {
     this.windowMs = windowMs;
   }
 
-  isThrottled(): boolean {
-    const now = Date.now();
+  private prune(now: number): void {
     this.requests = this.requests.filter((time) => now - time < this.windowMs);
+  }
+
+  /** Record one request against the window. */
+  record(): void {
+    const now = Date.now();
+    this.prune(now);
     this.requests.push(now);
-    return this.requests.length > this.maxRequests;
+  }
+
+  /**
+   * Milliseconds until a new request fits inside the window (0 = fits now).
+   * Does NOT record — callers that get 0 should call record() before
+   * proceeding. This split lets consumers apply backpressure (wait for a
+   * slot) rather than drop over-limit work.
+   */
+  msUntilFree(): number {
+    const now = Date.now();
+    this.prune(now);
+    if (this.requests.length < this.maxRequests) return 0;
+    const blocking = this.requests[this.requests.length - this.maxRequests];
+    return Math.max(1, blocking + this.windowMs - now);
   }
 }

--- a/src/server/lib/imap/handler-throttle.test.ts
+++ b/src/server/lib/imap/handler-throttle.test.ts
@@ -1,15 +1,11 @@
 /**
- * Regression tests for command-burst handling (throttler backpressure).
+ * Command-burst pacing tests (throttler backpressure).
  *
- * The per-connection throttler used to DROP over-limit commands: it wrote an
- * untagged `* NO [TEMPORARY UNAVAILABLE]` and never executed the command, so
- * the client never received a tagged completion (RFC 3501 §7 violation).
- * Clients that pipeline aggressively during folder sync — iOS Mail sends
- * STATUS for every mailbox in one burst after LIST — hung waiting for tags
- * that never arrived and displayed every mailbox as empty.
- *
- * The fix paces over-limit bursts (waitForCommandSlot) instead of dropping
- * them: every pipelined command must eventually get its tagged response.
+ * RFC 3501 §7 requires a tagged completion for every command, and clients
+ * pipeline aggressively during folder sync — iOS Mail sends STATUS for every
+ * mailbox in one burst after LIST. Bursts beyond the per-second budget must
+ * therefore be paced into later windows with each command still answered,
+ * never refused or discarded.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -91,8 +87,31 @@ describe("IMAP handler command bursts", () => {
       expect(answered).toBe(true);
     }
 
-    // The drop-path response must be gone for good.
+    // No command may be refused with an untagged busy response.
     const dropped = socket.writes.filter((w) => w.includes("TEMPORARY UNAVAILABLE"));
     expect(dropped.length).toBe(0);
   }, 10000);
+
+  it("stops pacing when the socket is destroyed mid-wait", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+    const session = (
+      handler as unknown as {
+        session: { waitForCommandSlot: () => Promise<void> };
+      }
+    ).session;
+
+    // Exhaust the per-second budget so the next slot requires waiting out
+    // the window.
+    for (let i = 0; i < 100; i++) {
+      await session.waitForCommandSlot();
+    }
+
+    socket.destroyed = true;
+    const start = Date.now();
+    await session.waitForCommandSlot();
+    // Must bail immediately instead of waiting out the ~1s window.
+    expect(Date.now() - start).toBeLessThan(500);
+  });
 });

--- a/src/server/lib/imap/handler-throttle.test.ts
+++ b/src/server/lib/imap/handler-throttle.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression tests for command-burst handling (throttler backpressure).
+ *
+ * The per-connection throttler used to DROP over-limit commands: it wrote an
+ * untagged `* NO [TEMPORARY UNAVAILABLE]` and never executed the command, so
+ * the client never received a tagged completion (RFC 3501 §7 violation).
+ * Clients that pipeline aggressively during folder sync — iOS Mail sends
+ * STATUS for every mailbox in one burst after LIST — hung waiting for tags
+ * that never arrived and displayed every mailbox as empty.
+ *
+ * The fix paces over-limit bursts (waitForCommandSlot) instead of dropping
+ * them: every pipelined command must eventually get its tagged response.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { EventEmitter } from "events";
+// See handler-idle.test.ts: import push first so the idle-manager ↔ push ↔
+// server-barrel import cycle initializes in production order.
+import "../push";
+import { ImapRequestHandler } from "./handler";
+
+function makeMockSocket() {
+  const socket = new EventEmitter() as EventEmitter & {
+    writes: string[];
+    writable: boolean;
+    destroyed: boolean;
+    write: (data: string) => boolean;
+    setTimeout: () => void;
+    destroy: () => void;
+    end: () => void;
+  };
+  socket.writes = [];
+  socket.writable = true;
+  socket.destroyed = false;
+  socket.write = (data: string) => {
+    socket.writes.push(data);
+    return true;
+  };
+  socket.setTimeout = () => {};
+  socket.destroy = () => {
+    socket.destroyed = true;
+  };
+  socket.end = () => {};
+  return socket;
+}
+
+const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+  const start = Date.now();
+  while (!predicate() && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+};
+
+describe("IMAP handler command bursts", () => {
+  it("answers every command in a burst within the rate budget", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+
+    const burst = Array.from({ length: 30 }, (_, i) => `t${i + 1} NOOP\r\n`).join("");
+    socket.emit("data", Buffer.from(burst));
+
+    await waitFor(
+      () => socket.writes.filter((w) => w.includes("OK NOOP completed")).length >= 30,
+      1000
+    );
+
+    const okCount = socket.writes.filter((w) => w.includes("OK NOOP completed")).length;
+    expect(okCount).toBe(30);
+  });
+
+  it("paces (not drops) bursts beyond the per-second limit — every command gets a tagged completion", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+
+    // 150 pipelined commands exceeds the 100/sec budget; the overflow must be
+    // delayed into the next window, never discarded.
+    const total = 150;
+    const burst = Array.from({ length: total }, (_, i) => `t${i + 1} NOOP\r\n`).join("");
+    socket.emit("data", Buffer.from(burst));
+
+    await waitFor(
+      () =>
+        socket.writes.filter((w) => w.includes("OK NOOP completed")).length >= total,
+      4000
+    );
+
+    for (let i = 1; i <= total; i++) {
+      const answered = socket.writes.some((w) => w.startsWith(`t${i} OK`));
+      expect(answered).toBe(true);
+    }
+
+    // The drop-path response must be gone for good.
+    const dropped = socket.writes.filter((w) => w.includes("TEMPORARY UNAVAILABLE"));
+    expect(dropped.length).toBe(0);
+  }, 10000);
+});

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -121,13 +121,13 @@ export class ImapRequestHandler {
               mailbox: session.selectedMailbox
             });
 
-            // Check throttling before processing
-            if (session.isThrottled()) {
-              session.write(
-                "* NO [TEMPORARY UNAVAILABLE] Server is busy. Please try again later.\r\n"
-              );
-              continue;
-            }
+            // Pace pipelined bursts instead of dropping commands. Every
+            // command must eventually receive a tagged completion (RFC 3501
+            // §7) — the old path wrote an untagged NO and skipped the
+            // command, which left pipelining clients (iOS Mail sends STATUS
+            // for every mailbox in one burst after LIST) hanging on tags
+            // that never arrived, rendering mailboxes empty.
+            await session.waitForCommandSlot();
 
             // Detect APPEND command with a literal size indicator {N} or {N+}
             // e.g. "a001 APPEND INBOX (\Seen) {512}"

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -121,12 +121,11 @@ export class ImapRequestHandler {
               mailbox: session.selectedMailbox
             });
 
-            // Pace pipelined bursts instead of dropping commands. Every
-            // command must eventually receive a tagged completion (RFC 3501
-            // §7) — the old path wrote an untagged NO and skipped the
-            // command, which left pipelining clients (iOS Mail sends STATUS
-            // for every mailbox in one burst after LIST) hanging on tags
-            // that never arrived, rendering mailboxes empty.
+            // Pace pipelined bursts. RFC 3501 §7 requires a tagged
+            // completion for every command, so over-limit commands are
+            // delayed, never skipped — clients pipeline heavily during
+            // folder sync (iOS Mail sends STATUS for every mailbox in one
+            // burst after LIST).
             await session.waitForCommandSlot();
 
             // Detect APPEND command with a literal size indicator {N} or {N+}

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -53,9 +53,8 @@ export class ImapSession {
   private store: Store | null = null;
   // Mail clients pipeline aggressively during folder sync — iOS Mail sends
   // STATUS for every mailbox in one burst (hundreds of commands on accounts
-  // with many virtual folders). 100 commands/sec is far above any legitimate
-  // interactive rate but still bounds a runaway client; the handler paces
-  // over-limit bursts via waitForCommandSlot() instead of dropping them.
+  // with many virtual folders). 100 commands/sec stays far above any
+  // legitimate interactive rate while still bounding a runaway client.
   private throttler: Throttler = new Throttler(100, 1000);
   private authenticated: boolean = false;
   private isIdling: boolean = false;
@@ -108,18 +107,17 @@ export class ImapSession {
   };
 
   /**
-   * Backpressure for pipelined command bursts. Resolves when the connection
+   * Backpressure for pipelined command bursts: resolves once the connection
    * is within its command-rate budget, recording the command against the
-   * window. Never rejects and never skips — RFC 3501 §7 requires every
-   * command to end with a tagged completion, so over-limit commands are
-   * delayed, not dropped. (The previous implementation wrote an untagged
-   * `* NO` and discarded the command, which stalled clients that pipeline
-   * during folder sync — iOS Mail hung waiting for tagged responses that
-   * never came and displayed every mailbox as empty.)
+   * window. RFC 3501 §7 requires a tagged completion for every command, so
+   * over-limit commands are delayed, never dropped. Bails out early when the
+   * socket dies mid-wait — there is nobody left to answer, and pacing out
+   * the rest of a dead connection's queue would just burn timers.
    */
   waitForCommandSlot = async (): Promise<void> => {
     let wait = this.throttler.msUntilFree();
     while (wait > 0) {
+      if (this.socket.destroyed || !this.socket.writable) return;
       await new Promise((resolve) => setTimeout(resolve, wait));
       wait = this.throttler.msUntilFree();
     }

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -51,7 +51,12 @@ export class ImapSession {
   private selectedMailboxMessageCount: number = 0;
   public mailboxReadOnly: boolean = false;
   private store: Store | null = null;
-  private throttler: Throttler = new Throttler();
+  // Mail clients pipeline aggressively during folder sync — iOS Mail sends
+  // STATUS for every mailbox in one burst (hundreds of commands on accounts
+  // with many virtual folders). 100 commands/sec is far above any legitimate
+  // interactive rate but still bounds a runaway client; the handler paces
+  // over-limit bursts via waitForCommandSlot() instead of dropping them.
+  private throttler: Throttler = new Throttler(100, 1000);
   private authenticated: boolean = false;
   private isIdling: boolean = false;
   private idleTag: string | null = null;
@@ -102,9 +107,24 @@ export class ImapSession {
     }
   };
 
-  isThrottled(): boolean {
-    return this.throttler.isThrottled();
-  }
+  /**
+   * Backpressure for pipelined command bursts. Resolves when the connection
+   * is within its command-rate budget, recording the command against the
+   * window. Never rejects and never skips — RFC 3501 §7 requires every
+   * command to end with a tagged completion, so over-limit commands are
+   * delayed, not dropped. (The previous implementation wrote an untagged
+   * `* NO` and discarded the command, which stalled clients that pipeline
+   * during folder sync — iOS Mail hung waiting for tagged responses that
+   * never came and displayed every mailbox as empty.)
+   */
+  waitForCommandSlot = async (): Promise<void> => {
+    let wait = this.throttler.msUntilFree();
+    while (wait > 0) {
+      await new Promise((resolve) => setTimeout(resolve, wait));
+      wait = this.throttler.msUntilFree();
+    }
+    this.throttler.record();
+  };
 
   // ---------------------------------------------------------------------------
   // Simple commands


### PR DESCRIPTION
The per-connection throttler (10 commands/sec) discarded over-limit commands after writing an untagged `* NO [TEMPORARY UNAVAILABLE]` — the command never executed and never received a tagged completion, violating RFC 3501 §7. Clients that pipeline during folder sync hung waiting for tags that never arrived: iOS Mail sends STATUS for every mailbox in one burst after LIST (300+ folders on this deployment), so everything past the 10th command was silently swallowed and every mailbox rendered as empty.

Verified live against prod: a pipelined burst of 25 NOOPs got exactly 10 tagged OKs; commands 11-25 were dropped.

Fix: Throttler now separates a non-recording msUntilFree() peek from record(), and the handler awaits session.waitForCommandSlot() — delaying over-limit commands into the next window instead of dropping them. Budget raised to 100 commands/sec, far above legitimate interactive rates but still bounding a runaway client.