### PR TITLE
fix(imap): keep IDLE connections alive past the 5-minute socket timeout (#702 bug 3/3)

### DIFF
--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -86,7 +86,7 @@ interface TestSession {
   store: unknown;
   startIdle: (tag: string) => Promise<unknown>;
   isInIdleMode: () => boolean;
-  endIdle: () => void;
+  endIdle: (reason?: string) => void;
 }
 
 async function makeIdlingSession() {
@@ -174,5 +174,17 @@ describe("IMAP IDLE socket inactivity timeout (#702)", () => {
     socket.emit("data", Buffer.from("DONE\r\n"));
     await flush();
     expect(socket.timeouts.at(-1)).toBe(SOCKET_TIMEOUT_MS);
+  });
+
+  it("restores the short socket timeout when the idle-manager force-terminates", async () => {
+    // heartbeatTick force-terminates a stale IDLE session via
+    // session.endIdle("timeout") — the same reset path DONE uses. Drive that
+    // call directly to pin that the raised timeout is restored on it too.
+    const { socket, session } = await makeIdlingSession();
+    expect(socket.timeouts.at(-1)).toBe(IDLE_SOCKET_TIMEOUT_MS);
+    session.endIdle("timeout");
+    expect(session.isInIdleMode()).toBe(false);
+    expect(socket.timeouts.at(-1)).toBe(SOCKET_TIMEOUT_MS);
+    expect(socket.writes.join("")).toContain("a3 OK IDLE terminated (timeout)\r\n");
   });
 });

--- a/src/server/lib/imap/handler-idle.test.ts
+++ b/src/server/lib/imap/handler-idle.test.ts
@@ -18,7 +18,11 @@ import { EventEmitter } from "events";
 // Importing push first forces the graph to initialize in production order so the
 // singleton is constructed before we spy on it. (Same guard as idle-manager.test.ts.)
 import "../push";
-import { idleManager } from "./idle-manager";
+import {
+  idleManager,
+  IDLE_SOCKET_TIMEOUT_MS,
+  SOCKET_TIMEOUT_MS,
+} from "./idle-manager";
 
 // session.ts registers/unregisters IDLE sessions on the real `idleManager`
 // singleton. Spy on just those two methods (restored in afterAll) rather than
@@ -50,21 +54,25 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 15));
 function makeMockSocket() {
   const socket = new EventEmitter() as EventEmitter & {
     writes: string[];
+    timeouts: number[];
     writable: boolean;
     destroyed: boolean;
     write: (data: string) => boolean;
-    setTimeout: () => void;
+    setTimeout: (ms: number) => void;
     destroy: () => void;
     end: () => void;
   };
   socket.writes = [];
+  socket.timeouts = [];
   socket.writable = true;
   socket.destroyed = false;
   socket.write = (data: string) => {
     socket.writes.push(data);
     return true;
   };
-  socket.setTimeout = () => {};
+  socket.setTimeout = (ms: number) => {
+    socket.timeouts.push(ms);
+  };
   socket.destroy = () => {
     socket.destroyed = true;
   };
@@ -144,5 +152,27 @@ describe("IMAP IDLE DONE handling (#546)", () => {
     await flush();
     expect(session.isInIdleMode()).toBe(true);
     expect(socket.writes.join("")).not.toContain("a5 OK NOOP completed");
+  });
+});
+
+describe("IMAP IDLE socket inactivity timeout (#702)", () => {
+  beforeEach(() => {
+    mockAddIdleSession.mockClear();
+    mockRemoveIdleSession.mockClear();
+  });
+
+  it("raises the socket timeout past the idle-manager force-terminate on IDLE", async () => {
+    const { socket } = await makeIdlingSession();
+    // Last setTimeout call reflects the current policy: the extended IDLE
+    // window (> IDLE_TIMEOUT_MS so the raw socket never preempts the manager).
+    expect(socket.timeouts.at(-1)).toBe(IDLE_SOCKET_TIMEOUT_MS);
+    expect(IDLE_SOCKET_TIMEOUT_MS).toBeGreaterThan(SOCKET_TIMEOUT_MS);
+  });
+
+  it("restores the short socket timeout when IDLE ends via DONE", async () => {
+    const { socket } = await makeIdlingSession();
+    socket.emit("data", Buffer.from("DONE\r\n"));
+    await flush();
+    expect(socket.timeouts.at(-1)).toBe(SOCKET_TIMEOUT_MS);
   });
 });

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -6,6 +6,7 @@ import { Socket } from "net";
 import { ImapSession } from "./session";
 import { ImapRequest } from "./types";
 import { parseCommand } from "./parsers";
+import { SOCKET_TIMEOUT_MS } from "./idle-manager";
 import { logger } from "server";
 
 export class ImapRequestHandler {
@@ -204,7 +205,7 @@ export class ImapRequestHandler {
     });
 
     // Set socket timeout to prevent hanging connections
-    socket.setTimeout(300000); // 5 minutes
+    socket.setTimeout(SOCKET_TIMEOUT_MS);
     socket.on("timeout", () => {
       logger.info("IMAP socket timeout", { component: "imap" });
       session.write("* BYE Timeout\r\n");

--- a/src/server/lib/imap/idle-manager.ts
+++ b/src/server/lib/imap/idle-manager.ts
@@ -19,6 +19,17 @@ interface IdleSession {
 export const IDLE_HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
 export const IDLE_TIMEOUT_MS = 25 * 60 * 1000;
 
+// Raw-socket inactivity timeouts (net.Socket.setTimeout). The default guards
+// against half-open/hung connections. During IMAP IDLE the client may
+// legitimately send nothing for the whole IDLE window (RFC 2177), so the socket
+// timeout is raised well past the idle-manager's own force-terminate
+// (IDLE_TIMEOUT_MS) — otherwise the raw socket tears the connection down
+// mid-IDLE. Prod saw constant `IMAP socket timeout` churn because the 5-minute
+// default equalled the keepalive interval and raced it. Reset to the default on
+// DONE / IDLE end. See #702.
+export const SOCKET_TIMEOUT_MS = 5 * 60 * 1000;
+export const IDLE_SOCKET_TIMEOUT_MS = 35 * 60 * 1000;
+
 export class IdleManager {
   private idleSessions: Map<string, IdleSession> = new Map();
   private heartbeatInterval: NodeJS.Timeout | null = null;

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -15,7 +15,11 @@ import {
   AppendRequest,
   StatusItem,
 } from "./types";
-import { idleManager } from "./idle-manager";
+import {
+  idleManager,
+  IDLE_SOCKET_TIMEOUT_MS,
+  SOCKET_TIMEOUT_MS,
+} from "./idle-manager";
 import { getCapabilities } from "./capabilities";
 import { ImapRequestHandler } from "./handler";
 
@@ -464,6 +468,11 @@ export class ImapSession {
     this.isIdling = true;
     this.idleTag = tag;
 
+    // A client in IDLE may send no traffic for the whole window; raise the
+    // raw-socket inactivity timeout past the idle-manager's force-terminate so
+    // the socket doesn't tear the connection down mid-IDLE. Reset on endIdle.
+    this.socket.setTimeout(IDLE_SOCKET_TIMEOUT_MS);
+
     const user = this.store.getUser();
     idleManager.addIdleSession(
       this.sessionId,
@@ -486,6 +495,8 @@ export class ImapSession {
     const tag = this.idleTag;
     this.idleTag = null;
     idleManager.removeIdleSession(this.sessionId);
+    // Back to normal command mode — restore the short inactivity timeout.
+    this.socket.setTimeout(SOCKET_TIMEOUT_MS);
     const suffix = reason ? ` (${reason})` : "";
     this.write(`${tag} OK IDLE terminated${suffix}\r\n`);
   };


### PR DESCRIPTION
Part of #702 (bug 3 of 3: 5-minute socket timeout destroys IDLE connections).

## Problem

`handler.ts` set a fixed 5-minute `socket.setTimeout(...)` and destroyed the socket on timeout. The server advertises IDLE (RFC 2177), whose contract lets a client sit idle for tens of minutes between refreshes — the idle-manager itself works on a 25-minute force-terminate cycle with a 5-minute keepalive. Any client in IDLE with no client→server traffic for 5 minutes had its connection destroyed. Prod logs showed constant `IMAP socket timeout` churn, and the 5-minute default *equalled* the keepalive interval, so the two raced.

## Fix

- Extract the two socket-lifetime constants into `idle-manager.ts`: `SOCKET_TIMEOUT_MS` (5 min, the pre-existing default) and `IDLE_SOCKET_TIMEOUT_MS` (35 min).
- `startIdle` raises the raw-socket inactivity timeout to 35 min — deliberately past the idle-manager's own 25-min force-terminate, so the manager (not the raw socket) governs IDLE lifetime.
- `endIdle` restores the 5-min default (covers both client `DONE` and the manager's force-terminate path, which routes through `endIdle`).
- Non-IDLE / pre-auth connections keep the short 5-min timeout unchanged.

## Verification

- **Unit** (`handler-idle.test.ts`): two new cases assert the socket timeout is raised to `IDLE_SOCKET_TIMEOUT_MS` on IDLE start and restored to `SOCKET_TIMEOUT_MS` on `DONE`. All 13 IDLE tests pass.
- **Full server suite**: `bun test src/server` → 1219 pass, 0 fail.
- **E2E against a real `net.Socket`** (not the mock): drove `handler.setSocket` → `startIdle` → `endIdle` over a live loopback socket pair and read back `socket.timeout` at each step:
  - after `setSocket`: 300000 (5 min)
  - after `startIdle`: 2100000 (35 min)
  - after `endIdle`: 300000 (5 min) restored

  Confirms the real Node socket honors every transition, not just the mock.
- Typecheck clean.

## Not in this PR

Bugs 1 (duplicate `uid_account`) and 2 (unified Sent wrong UID space) from #702 — bug 2 lands as a sibling PR; bug 1 needs a design-direction call and stays tracked on #702.