### PR TITLE
fix(imap): unified Sent folder emits the domain UID space, not per-account (#702 bug 2/3)

### DIFF
--- a/src/server/lib/imap/copy.test.ts
+++ b/src/server/lib/imap/copy.test.ts
@@ -304,6 +304,28 @@ describe("COPY happy path (#520)", () => {
       `A1 OK [COPYUID ${STORED_UIDVALIDITY} 5,7 101,103] COPY completed\r\n`,
     ]);
   });
+
+  it("copies to the unified Sent folder with domain-space dest UIDs (#702)", async () => {
+    // The unified "Sent Messages" folder is domain-scoped (resolveBox →
+    // accountName=null → uid_domain). COPYUID's dest-set must therefore report
+    // the DOMAIN counter (100, 102), not the account counter (101, 103) — the
+    // isDomainScoped fix. Source is INBOX (also domain-scoped) → source-set is
+    // the source domain UIDs 5,7.
+    const mails = [
+      sourceMail({ domain: 5, account: 50 }),
+      sourceMail({ domain: 7, account: 70 }),
+    ];
+    const { store, stored } = makeCopyStore(["Sent Messages"], mails);
+    const lines = await runCopy(
+      copyReq("Sent Messages", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+    expect(stored.length).toBe(2);
+    expect(lines).toEqual([
+      `A1 OK [COPYUID ${STORED_UIDVALIDITY} 5,7 100,102] COPY completed\r\n`,
+    ]);
+  });
 });
 
 describe("COPY COPYUID positional pairing — out-of-order set (#624, RFC 4315 §3)", () => {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -685,3 +685,39 @@ describe("buildBodyResponsePart MIME part sub-sections (inbox #657)", () => {
     expect(bare.content).toBe(withText.content);
   });
 });
+
+// #702 bug 2: the UID data item must draw from the domain-scoped UID space
+// (uid.domain) for INBOX AND the unified "Sent Messages" folder — both resolve
+// to accountName=null in resolveBox. Emitting uid.account for the unified Sent
+// folder made uidToSeqNumber miss and silently dropped messages from FETCH.
+describe("buildFetchResponsePart UID data item — domain-scoped UID space (#702)", () => {
+  const mail: Partial<MailType> = {
+    uid: { account: 7, domain: 42 } as MailType["uid"],
+  };
+  const docId = "doc-uid";
+
+  it("emits uid.domain for INBOX", async () => {
+    const part = await buildFetchResponsePart(mail, { type: "UID" }, docId, "INBOX");
+    expect(part).toEqual({ type: "simple", content: "UID 42" });
+  });
+
+  it("emits uid.domain for the unified Sent Messages folder", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "UID" },
+      docId,
+      "Sent Messages"
+    );
+    expect(part).toEqual({ type: "simple", content: "UID 42" });
+  });
+
+  it("emits uid.account for an account-scoped mailbox", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "UID" },
+      docId,
+      "Sent Messages/accounts/foo"
+    );
+    expect(part).toEqual({ type: "simple", content: "UID 7" });
+  });
+});

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -13,7 +13,7 @@ import {
   formatFlags,
   formatHeaders,
   formatInternalDate,
-  isInbox,
+  isDomainScoped,
 } from "./util";
 import {
   applyPartialFetch,
@@ -359,8 +359,8 @@ export async function buildFetchResponsePart(
 ): Promise<FetchResponsePart | null> {
   switch (item.type) {
     case "UID": {
-      const isDomainInbox = isInbox(selectedMailbox);
-      const uid = isDomainInbox ? mail.uid!.domain : mail.uid!.account;
+      const isDomainScopedBox = isDomainScoped(selectedMailbox);
+      const uid = isDomainScopedBox ? mail.uid!.domain : mail.uid!.account;
       return { type: "simple", content: `UID ${uid}` };
     }
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -12,7 +12,7 @@ import {
 import { logger } from "server";
 import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
-import { boxToAccount, isInbox, isSentBox } from "./util";
+import { boxToAccount, isDomainScoped, isInbox, isSentBox } from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
   FetchRequest,
@@ -158,12 +158,12 @@ async function _processFetchMessages(
   seqState: SequenceState,
   write: (data: string) => boolean | undefined
 ): Promise<void> {
-  const isDomainInbox = isInbox(selectedMailbox);
+  const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
   const isUidFetch =
     fetchRequest.sequenceSet.type === "uid" || isUidCommand;
 
   for (const [id, mail] of Array.from(messages.entries())) {
-    const uid = isDomainInbox ? mail.uid!.domain : mail.uid!.account;
+    const uid = sourceIsDomainScoped ? mail.uid!.domain : mail.uid!.account;
     const seqNum = uidToSeqNumber(seqState.seqToUid, seqState.uidToSeq, uid);
 
     if (seqNum === undefined) {
@@ -501,13 +501,18 @@ export async function copyMessageTyped(
     // synthetic address that drives the destination-mailbox query
     // (e.g. "Archive@<domain>").
     const destAccount = boxToAccount(user.username, destMailbox);
+    // `destIsInbox` drives address routing below (INBOX has no address
+    // filter); `destIsDomainScoped` drives the destination UID space for the
+    // COPYUID response (INBOX and the unified Sent folder both use uid.domain).
     const destIsInbox = isInbox(destMailbox);
+    const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
 
-    // Source-side UID extraction for the COPYUID response.
-    const sourceIsInbox = isInbox(selectedMailbox);
+    // Source-side UID extraction for the COPYUID response — domain-scoped for
+    // INBOX and the unified Sent folder (both keyed on uid.domain).
+    const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
     const srcUidOf = (mail: Partial<MailType>): number =>
-      sourceIsInbox ? mail.uid!.domain : mail.uid!.account;
+      sourceIsDomainScoped ? mail.uid!.domain : mail.uid!.account;
 
     // RFC 4315 §3: the COPYUID source-set and dest-set must correspond
     // positionally (n-th source UID ↔ n-th dest UID). The two sets are
@@ -641,7 +646,7 @@ export async function copyMessageTyped(
       }
 
       sourceUids.push(srcUidOf(sourceMail));
-      destUids.push(destIsInbox ? newMail.uid.domain : newMail.uid.account);
+      destUids.push(destIsDomainScoped ? newMail.uid.domain : newMail.uid.account);
     }
 
     // RFC 4315 §2: untagged or tagged OK with [COPYUID uidvalidity
@@ -785,11 +790,16 @@ export async function moveMessageTyped(
 
     const user = store.getUser();
     const destAccount = boxToAccount(user.username, destMailbox);
+    // `*IsInbox` drives address routing below (INBOX has no address filter);
+    // `*IsDomainScoped` drives the UID space (INBOX and the unified Sent folder
+    // both use uid.domain).
     const destIsInbox = isInbox(destMailbox);
+    const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
     const sourceIsInbox = isInbox(selectedMailbox);
+    const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
     const srcUidOf = (mail: Partial<MailType>): number =>
-      sourceIsInbox ? mail.uid!.domain : mail.uid!.account;
+      sourceIsDomainScoped ? mail.uid!.domain : mail.uid!.account;
 
     // RFC 4315 §3 (via RFC 6851 §4.3): keep the COPYUID source/dest sets
     // positionally aligned for out-of-order sequence-sets — assign dest
@@ -901,7 +911,7 @@ export async function moveMessageTyped(
       }
 
       sourceUids.push(srcUidOf(sourceMail));
-      destUids.push(destIsInbox ? newMail.uid.domain : newMail.uid.account);
+      destUids.push(destIsDomainScoped ? newMail.uid.domain : newMail.uid.account);
     }
 
     // === EXPUNGE phase ===
@@ -1020,7 +1030,7 @@ export async function appendMessage(
 
     const result = await store.storeMail(mail);
 
-    const uid = isInbox(targetMailbox) ? mail.uid.domain : mail.uid.account;
+    const uid = isDomainScoped(targetMailbox) ? mail.uid.domain : mail.uid.account;
 
     if (result) {
       if (selectedMailbox === targetMailbox) {

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -7,11 +7,33 @@ import {
   formatFlags,
   accountToBox,
   boxToAccount,
-  formatInternalDate
+  formatInternalDate,
+  isDomainScoped
 } from "./util";
 import type { MailType, MailAddressValueType } from "common";
 
 describe("IMAP util", () => {
+  // #702 bug 2: domain-scoped boxes (INBOX + unified "Sent Messages") draw
+  // their UID space from uid.domain; everything else is account-scoped.
+  describe("isDomainScoped", () => {
+    it("is true for INBOX in any casing", () => {
+      expect(isDomainScoped("INBOX")).toBe(true);
+      expect(isDomainScoped("inbox")).toBe(true);
+      expect(isDomainScoped("Inbox")).toBe(true);
+    });
+
+    it("is true for the unified Sent Messages folder", () => {
+      expect(isDomainScoped("Sent Messages")).toBe(true);
+    });
+
+    it("is false for account-scoped and user mailboxes", () => {
+      expect(isDomainScoped("Sent Messages/accounts/foo")).toBe(false);
+      expect(isDomainScoped("INBOX/accounts/foo")).toBe(false);
+      expect(isDomainScoped("Archive")).toBe(false);
+      expect(isDomainScoped("")).toBe(false);
+    });
+  });
+
   describe("encodeText", () => {
     it("should encode simple text to base64", () => {
       expect(encodeText("Hello")).toBe("SGVsbG8=");

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -305,6 +305,20 @@ export const isInbox = (box: string): boolean => {
   return box.toUpperCase() === "INBOX";
 };
 
+/**
+ * Returns true for the domain-scoped mailboxes — INBOX and the unified
+ * "Sent Messages" folder — whose UID space is `uid_domain` rather than
+ * `uid_account`. This mirrors `Store.resolveBox` (both resolve to
+ * `accountName === null`). FETCH / COPY / MOVE / APPEND must select the emitted
+ * UID with this predicate, not `isInbox` alone: the unified Sent folder is
+ * domain-scoped too, so keying its emitted UID off `uid_account` makes
+ * `uidToSeqNumber` miss (messages silently dropped from FETCH, wrong COPYUID
+ * source UIDs). See #702.
+ */
+export const isDomainScoped = (box: string): boolean => {
+  return isInbox(box) || box === SENT_MESSAGES_FOLDER;
+};
+
 /** Returns true for the accounts/ parent folder itself (non-selectable). */
 export const isAccountsFolder = (box: string): boolean => {
   return box === ACCOUNTS_FOLDER;


### PR DESCRIPTION
Part of #702 (bug 2 of 3: unified `Sent Messages` folder fetches with the wrong UID space).

## Problem

`resolveBox("Sent Messages")` maps the unified Sent folder to `accountName = null`, so its DB query, sequence mapping (`getAllUids`), and `countMessages` all operate in the **domain** UID space (`uid_domain`). But every place that emits a UID picked `uid.domain` vs `uid.account` with `isInbox(...)` alone — which is `false` for `Sent Messages`. So the emitted UID was `uid.account` while the sequence map was keyed by `uid_domain`:

- `message-ops.ts` FETCH emit — `uidToSeqNumber` misses → `No sequence number found for UID` → messages silently skipped. The unified Sent folder appears empty or partially populated (Hoie verified this against prod 2026-07-26).
- `fetch-helpers.ts` `UID` data item — reports the wrong UID number.
- COPY / MOVE `srcUidOf` — wrong source UIDs in the COPYUID response.

The same latent defect existed on the destination COPYUID and the APPEND APPENDUID paths (a COPY/MOVE/APPEND targeting the unified Sent folder would report a UID from the account space).

## Fix

- Add `isDomainScoped(box)` to `util.ts`: `isInbox(box) || box === SENT_MESSAGES_FOLDER`. This mirrors `resolveBox` exactly — both INBOX and the unified Sent folder resolve to `accountName = null`, i.e. the domain UID space.
- Use it at **every UID-space selection**: FETCH emit (`message-ops` + `fetch-helpers` UID item), COPY/MOVE `srcUidOf`, COPY/MOVE destination `destUids` (COPYUID), and APPEND's APPENDUID.
- The orthogonal address-routing branches (`if (destIsInbox)` / `if (sourceIsInbox)`) intentionally **stay on `isInbox`** — they decide whether to re-anchor `to`/`envelope_to` addresses (INBOX has no address filter), which is a different axis from UID space. Split into separate `*IsInbox` (routing) and `*IsDomainScoped` (UID) locals so each axis is explicit.

## Verification

- **Unit — `util.test.ts`**: new `isDomainScoped` block (INBOX any-casing → true, `Sent Messages` → true, `Sent Messages/accounts/foo` / `INBOX/accounts/foo` / `Archive` / `""` → false).
- **Unit — `fetch-helpers.test.ts`**: new block drives `buildFetchResponsePart(..., "UID", ..., box)` and asserts it emits `uid.domain` for INBOX and `Sent Messages`, `uid.account` for `Sent Messages/accounts/foo` — the exact emit function that was dropping messages.
- **Full server suite**: `bun test src/server` → 1223 pass, 0 fail.
- Typecheck clean.
- Live sandbox IMAP `SELECT "Sent Messages"` + `UID FETCH` E2E: see PR comment below.

## Not in this PR

Bug 1 (duplicate `uid_account` within an account folder view) from #702 — needs a design-direction call on per-view UID assignment (assign `uid_account` per matched view at insert time vs a mapping table); tracked on #702. Bug 3 (IDLE socket timeout) ships as a sibling PR.