### PR TITLE
feat(imap): mail_mailbox_uid mapping table + writeMailboxUid helper (#702 bug 1 — PR 1/3)

### DIFF
--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -14,6 +14,7 @@ import {
   spamAllowlistTable,
   spamTrainingTable,
   mailUidCountersTable,
+  mailMailboxUidTable,
   mailgunEventsTable,
 } from "./models";
 
@@ -29,6 +30,8 @@ const tables: Table<unknown, Schema>[] = [
   spamAllowlistTable,
   spamTrainingTable,
   mailUidCountersTable,
+  // Depends on mails (FK to mails.mail_id ON DELETE CASCADE).
+  mailMailboxUidTable,
   mailgunEventsTable,
 ];
 

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -6,6 +6,12 @@ export const PUSH_SUBSCRIPTIONS = "push_subscriptions";
 export const SPAM_ALLOWLIST = "spam_allowlist";
 export const SPAM_TRAINING = "spam_training";
 export const MAIL_UID_COUNTERS = "mail_uid_counters";
+export const MAIL_MAILBOX_UID = "mail_mailbox_uid";
+
+// Columns on mail_mailbox_uid. `mailbox` holds the full IMAP path (INBOX,
+// Sent Messages, INBOX/accounts/<name>, and any future user-defined path).
+export const MAILBOX = "mailbox";
+export const UID = "uid";
 
 // Common column names
 export const UPDATED = "updated";

--- a/src/server/lib/postgres/models/index.ts
+++ b/src/server/lib/postgres/models/index.ts
@@ -8,4 +8,5 @@ export * from "./push_subscription";
 export * from "./spam_allowlist";
 export * from "./spam_training";
 export * from "./mail_uid_counter";
+export * from "./mail_mailbox_uid";
 export * from "./mailgun_event";

--- a/src/server/lib/postgres/models/mail_mailbox_uid.ts
+++ b/src/server/lib/postgres/models/mail_mailbox_uid.ts
@@ -1,0 +1,105 @@
+import {
+  USER_ID,
+  MAILBOX,
+  MAIL_ID,
+  UID,
+  MAIL_MAILBOX_UID,
+  MAILS,
+} from "./common";
+import { Model, createTable } from "./base";
+
+const isString = (v: unknown): v is string => typeof v === "string";
+const isNumber = (v: unknown): v is number => typeof v === "number";
+
+export interface MailMailboxUidJSON {
+  user_id: string;
+  mailbox: string;
+  mail_id: string;
+  uid: number;
+}
+
+// Per-(user, mailbox, mail) UID assignment for IMAP folder views.
+//
+// A single mail can appear in multiple mailbox views (to/cc/bcc/envelope_to
+// OR-containment across account inboxes; plus INBOX, Sent Messages, and any
+// future custom mailbox), so a single scalar `uid_account` on the mail row
+// assigned at receive time — scoped to `envelope_to` only — collided within
+// a single mailbox view when a mail surfaced in a folder that wasn't its
+// envelope_to account (issue #702 bug 1). Splitting the assignment out to
+// its own per-(user, mailbox, mail) row lets a mail carry a distinct UID
+// in every mailbox it appears in, and lets those UIDs be allocated lazily
+// on first FETCH of the folder instead of eagerly on receive.
+//
+// `mailbox` holds the full IMAP path — `INBOX`, `Sent Messages`,
+// `INBOX/accounts/<name>`, and any user-defined path in the future — so
+// extending to custom mailboxes needs no schema change.
+//
+// The counter (mail_uid_counters, kind + scope + sent) stays as the
+// authoritative UID source; this table records the per-mail assignment
+// consumed from it.
+const mailMailboxUidSchema = {
+  [USER_ID]: "UUID NOT NULL",
+  [MAILBOX]: "TEXT NOT NULL",
+  [MAIL_ID]: "UUID NOT NULL",
+  [UID]: "BIGINT NOT NULL",
+};
+
+type MailMailboxUidSchema = typeof mailMailboxUidSchema;
+
+export class MailMailboxUidModel extends Model<
+  MailMailboxUidJSON,
+  MailMailboxUidSchema
+> {
+  declare user_id: string;
+  declare mailbox: string;
+  declare mail_id: string;
+  declare uid: number;
+
+  static typeChecker = {
+    user_id: isString,
+    mailbox: isString,
+    mail_id: isString,
+    uid: isNumber,
+  };
+
+  constructor(data: unknown) {
+    super(data, MailMailboxUidModel.typeChecker);
+  }
+
+  toJSON(): MailMailboxUidJSON {
+    return {
+      user_id: this.user_id,
+      mailbox: this.mailbox,
+      mail_id: this.mail_id,
+      uid: this.uid,
+    };
+  }
+}
+
+export const mailMailboxUidTable = createTable({
+  name: MAIL_MAILBOX_UID,
+  // No surrogate id — the natural key is the composite PK below. `primaryKey`
+  // is required by the framework but only used by id-based helpers this
+  // table never calls; the real key is the PRIMARY KEY constraint.
+  primaryKey: USER_ID,
+  schema: mailMailboxUidSchema,
+  constraints: [
+    // Natural PK: one UID per (user, mailbox, mail).
+    `PRIMARY KEY (${USER_ID}, ${MAILBOX}, ${MAIL_ID})`,
+    // RFC 3501 §2.3.1.1 — UIDs strictly unique per mailbox. Doubles as the
+    // view-order index (SELECT … WHERE user, mailbox match ORDER BY uid ASC
+    // uses this prefix). Also load-bearing for the insert path's
+    // ON CONFLICT DO NOTHING — a losing racer that reserved a duplicate UID
+    // falls through and re-reads.
+    `UNIQUE (${USER_ID}, ${MAILBOX}, ${UID})`,
+    // Cascade delete when the mail row is expunged so the mapping doesn't
+    // leak. mails PK is `mail_id`; the (user_id, mail_id) pair is
+    // consistent by transitive relation through the mail row.
+    `FOREIGN KEY (${MAIL_ID}) REFERENCES ${MAILS}(${MAIL_ID}) ON DELETE CASCADE`,
+  ],
+  indexes: [],
+  ModelClass: MailMailboxUidModel,
+  supportsSoftDelete: false,
+});
+
+export const mailMailboxUidColumns = Object.keys(mailMailboxUidTable.schema);

--- a/src/server/lib/postgres/models/mail_mailbox_uid.ts
+++ b/src/server/lib/postgres/models/mail_mailbox_uid.ts
@@ -22,21 +22,16 @@ export interface MailMailboxUidJSON {
 //
 // A single mail can appear in multiple mailbox views (to/cc/bcc/envelope_to
 // OR-containment across account inboxes; plus INBOX, Sent Messages, and any
-// future custom mailbox), so a single scalar `uid_account` on the mail row
-// assigned at receive time — scoped to `envelope_to` only — collided within
-// a single mailbox view when a mail surfaced in a folder that wasn't its
-// envelope_to account (issue #702 bug 1). Splitting the assignment out to
-// its own per-(user, mailbox, mail) row lets a mail carry a distinct UID
-// in every mailbox it appears in, and lets those UIDs be allocated lazily
-// on first FETCH of the folder instead of eagerly on receive.
+// user-defined mailbox). Per-view UID assignment via this table lets a mail
+// carry a distinct UID in every mailbox it appears in, and lets those UIDs
+// be allocated lazily on first FETCH of the folder rather than eagerly on
+// receive.
 //
-// `mailbox` holds the full IMAP path — `INBOX`, `Sent Messages`,
-// `INBOX/accounts/<name>`, and any user-defined path in the future — so
-// extending to custom mailboxes needs no schema change.
+// `mailbox` holds the full IMAP path so extending to user-defined mailboxes
+// needs no schema change.
 //
-// The counter (mail_uid_counters, kind + scope + sent) stays as the
-// authoritative UID source; this table records the per-mail assignment
-// consumed from it.
+// UID reservation goes through `mail_uid_counters` (the authoritative
+// counter); this table records the per-mail assignment consumed from it.
 const mailMailboxUidSchema = {
   [USER_ID]: "UUID NOT NULL",
   [MAILBOX]: "TEXT NOT NULL",
@@ -92,12 +87,14 @@ export const mailMailboxUidTable = createTable({
     // ON CONFLICT DO NOTHING — a losing racer that reserved a duplicate UID
     // falls through and re-reads.
     `UNIQUE (${USER_ID}, ${MAILBOX}, ${UID})`,
-    // Cascade delete when the mail row is expunged so the mapping doesn't
-    // leak. mails PK is `mail_id`; the (user_id, mail_id) pair is
-    // consistent by transitive relation through the mail row.
+    // Cascade delete when the mail row is deleted so the mapping doesn't
+    // leak. Postgres does not auto-index the referencing column, so the
+    // `indexes` entry below stands the FK check up as a lookup instead of
+    // a seq scan; the same index also serves the "given a mail_id, list
+    // the mailbox views it's mapped in" reverse lookup (COPY/MOVE dest).
     `FOREIGN KEY (${MAIL_ID}) REFERENCES ${MAILS}(${MAIL_ID}) ON DELETE CASCADE`,
   ],
-  indexes: [],
+  indexes: [{ column: MAIL_ID }],
   ModelClass: MailMailboxUidModel,
   supportsSoftDelete: false,
 });

--- a/src/server/lib/postgres/repositories/mails/counters.ts
+++ b/src/server/lib/postgres/repositories/mails/counters.ts
@@ -13,6 +13,10 @@ import {
   UID_KIND,
   UID_SCOPE,
   LAST_UID,
+  MAIL_MAILBOX_UID,
+  MAILBOX,
+  MAIL_ID,
+  UID,
 } from "../../models";
 
 /**
@@ -121,6 +125,36 @@ export const getAccountUidNext = async (
   } catch (error) {
     logger.error("Error getting account UID next", {}, error);
     throw error;
+  }
+};
+
+/**
+ * Record a UID assignment in the per-(user, mailbox, mail) mapping. `ON
+ * CONFLICT DO NOTHING` — a re-emit for a (user, mailbox, mail) already
+ * mapped is a no-op, not an error (COPY into a mailbox where this mail
+ * already has a UID). Insert failure is logged rather than thrown while
+ * `mails.uid_account` is the authoritative UID source; when the mapping
+ * table becomes authoritative, this path needs to abort on failure.
+ */
+export const writeMailboxUid = async (
+  user_id: string,
+  mailbox: string,
+  mail_id: string,
+  uid: number
+): Promise<void> => {
+  try {
+    await pool.query(
+      `INSERT INTO ${MAIL_MAILBOX_UID} (${USER_ID}, ${MAILBOX}, ${MAIL_ID}, ${UID})
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (${USER_ID}, ${MAILBOX}, ${MAIL_ID}) DO NOTHING`,
+      [user_id, mailbox, mail_id, uid]
+    );
+  } catch (error) {
+    logger.warn(
+      "Failed to record mail_mailbox_uid mapping",
+      { user_id, mailbox, mail_id, uid },
+      error
+    );
   }
 };
 


### PR DESCRIPTION
Foundation PR of the 3-PR arc fixing #702 bug 1 (duplicate uid_account within an account folder view).

## The end state (all 3 PRs)

Per-mail UID assignment moves from a scalar `mails.uid_account` (assigned once at receive time, scoped to `envelope_to` only) to a per-(user, mailbox, mail) row in a new `mail_mailbox_uid` table, populated lazily on first FETCH of the folder. Mailbox path (`INBOX`, `Sent Messages`, `INBOX/accounts/<name>`, and any user-defined mailbox) is the natural key — no schema change needed to add custom mailboxes.

## This PR (foundation)

- Schema: `mail_mailbox_uid(user_id UUID, mailbox TEXT, mail_id UUID, uid BIGINT)`, PK `(user_id, mailbox, mail_id)`, UNIQUE `(user_id, mailbox, uid)` for RFC 3501 §2.3.1.1 uniqueness + view-order index, FK `mail_id → mails(mail_id) ON DELETE CASCADE`.
- Model + table registration in `initialize.ts` (positioned after `mailsTable` for the FK dependency).
- `writeMailboxUid(user_id, mailbox, mail_id, uid)` helper — one-tuple insert with `ON CONFLICT DO NOTHING`. Insert failure is logged, not thrown; the legacy `mails.uid_account` scalar is still authoritative in this PR, so a mapping-write hiccup can't corrupt reads.

No behavior change yet — no read path consults `mail_mailbox_uid`, no write path calls `writeMailboxUid`. That wiring is the next PR.

## PR 2 (read cutover)

- Wire `writeMailboxUid` into the 5 UID-assignment write sites: `receive.ts`, `send.ts`, and `imap/message-ops.ts` COPY/MOVE/APPEND. Each call resolves the mailbox path via `accountToBox`/`accountToSentBox`.
- Add `ensureMailboxUids(user, mailbox, mail_ids)` — atomic get-or-insert for view-time lazy assignment (missing tuples get UIDs reserved from `mail_uid_counters`, existing tuples returned as-is).
- Flip account-view reads (`getAllUids`, `getMailsByRange`, `countMessages`, `getFirstUnseenUid`, `searchMailsByUid`, `expungeDeletedMails`, `expungeMailsByUid`, `setMailFlags`) + `imap/store.ts` `mail.uid.account` synthesis to the mapping table.
- E2E: iOS-Mail-style pipelined burst of 25 STATUS calls against an account with duplicate `uid_account` rows in prod.

## PR 3 (cleanup)

- Drop the `uid_account` column via a one-shot migration.
- Remove the write-side legacy calls to `getAccountUidNext` + the `uid_account` field in `SaveMailInput`.
- Bump `users.imap_uid_validity` per user so clients re-sync folders on next connect — the UID space they saw is now stale.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun test src/server/lib/postgres/repositories/mail-uid-reservation.test.ts` — 7/7 pass (existing counter tests still work).
- [ ] Reviewoie pass — deferred to when the wiring lands in PR 2 (this PR is inert plumbing).
- [ ] Sandbox E2E — deferred to PR 2 for the same reason.

Draft while PR 2 lands on top; will move to ready when the arc completes.