### PR TITLE
fix(imap): resolve bare `*` UID sentinel before it hits SQL (#678)

### DIFF
--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -519,12 +519,30 @@ describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
     ]);
   });
 
-  it("leaves non-SEQ criteria (flags, explicit UID) untouched", () => {
+  it("leaves flag criteria untouched; normalizes an explicit UID criterion's ranges", () => {
     const criteria: Parameters<typeof resolveSeqSearchKeys>[0] = [
       { type: "SEEN" },
       { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 42 }] } },
     ];
-    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual(criteria);
+    // The explicit `UID <set>` keyword already names UIDs, but still passes
+    // through resolveUidCriterionRanges to normalize `*` (#678) — a
+    // single-value range without a `*` comes out with end filled in.
+    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual([
+      { type: "SEEN" },
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 42, end: 42 }] } },
+    ]);
+  });
+
+  it("resolves a bare `*` in an explicit UID criterion to the highest UID (#678)", () => {
+    const criteria: Parameters<typeof resolveSeqSearchKeys>[0] = [
+      {
+        type: "UID",
+        sequenceSet: { type: "sequence", ranges: [{ start: Number.MAX_SAFE_INTEGER }] },
+      },
+    ];
+    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual([
+      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 11400, end: 11400 }] } },
+    ]);
   });
 
   it("resolves a SEQ set alongside a flag key (SEEN 1:3)", () => {
@@ -613,9 +631,19 @@ describe("searchTyped — multi-element bare set executes (#659)", () => {
     const { out, passed } = await run("t3", seqReq([{ start: 1 }, { start: 3 }]), true);
     expect(out).toContain("OK SEARCH completed");
     expect(out).not.toContain("NO Not supported");
-    // UID SEARCH: the set already names UIDs, so relabel untouched.
+    // UID SEARCH: the set already names UIDs, so relabel (with `*`
+    // normalized, though neither range here uses it — #678).
     expect(passed).toEqual([
-      { type: "UID", sequenceSet: { type: "sequence", ranges: [{ start: 1 }, { start: 3 }] } },
+      {
+        type: "UID",
+        sequenceSet: {
+          type: "sequence",
+          ranges: [
+            { start: 1, end: 1 },
+            { start: 3, end: 3 },
+          ],
+        },
+      },
     ]);
   });
 

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -556,6 +556,54 @@ describe("resolveSeqSearchKeys — bare sequence-set (#649)", () => {
     );
     expect(out.map((c) => c.type)).toEqual(["SEEN", "UID"]);
   });
+
+  // reviewoie finding on PR #708: store.simplifyCriterion recurses into
+  // NOT/OR operands, so a UID criterion nested under either must have its
+  // `*` sentinel resolved here too — otherwise `UID SEARCH NOT UID *` /
+  // `UID SEARCH OR UID 1000:* SEEN` still overflow the int4 uid column.
+  it("resolves a bare `*` nested under NOT (#678)", () => {
+    const criteria: Parameters<typeof resolveSeqSearchKeys>[0] = [
+      {
+        type: "NOT",
+        criterion: {
+          type: "UID",
+          sequenceSet: { type: "sequence", ranges: [{ start: Number.MAX_SAFE_INTEGER }] },
+        },
+      },
+    ];
+    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual([
+      {
+        type: "NOT",
+        criterion: {
+          type: "UID",
+          sequenceSet: { type: "sequence", ranges: [{ start: 11400, end: 11400 }] },
+        },
+      },
+    ]);
+  });
+
+  it("resolves a bare `*` nested under OR, on both sides (#678)", () => {
+    const criteria: Parameters<typeof resolveSeqSearchKeys>[0] = [
+      {
+        type: "OR",
+        left: {
+          type: "UID",
+          sequenceSet: { type: "sequence", ranges: [{ start: 1000, end: Number.MAX_SAFE_INTEGER }] },
+        },
+        right: { type: "SEEN" },
+      },
+    ];
+    expect(resolveSeqSearchKeys(criteria, false, seqState)).toEqual([
+      {
+        type: "OR",
+        left: {
+          type: "UID",
+          sequenceSet: { type: "sequence", ranges: [{ start: 1000, end: 11400 }] },
+        },
+        right: { type: "SEEN" },
+      },
+    ]);
+  });
 });
 
 // #659: a multi-element bare set (`SEARCH 1,3`) resolves to a multi-range UID

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -220,6 +220,60 @@ const resolveUidCriterionRanges = (
   return { type: "UID", sequenceSet: { type: "sequence", ranges: uidRanges } };
 };
 
+// Resolve one criterion, recursing into NOT/OR operands — store.ts's
+// simplifyCriterion recurses the same way, so a UID/SEQ set nested under
+// NOT/OR (e.g. `UID SEARCH NOT UID *`, `UID SEARCH OR UID 1000:* SEEN`) must
+// be resolved here too, or its `*` sentinel reaches buildCriterionClause
+// unresolved and overflows the int4 uid column exactly like the top-level
+// case (#678).
+const resolveOneSearchKey = (
+  criterion: SearchCriterion,
+  isUidCommand: boolean,
+  seqState: SequenceState
+): SearchCriterion => {
+  if (criterion.type === "NOT") {
+    const notCriterion = criterion as { type: "NOT"; criterion: SearchCriterion };
+    return {
+      type: "NOT",
+      criterion: resolveOneSearchKey(notCriterion.criterion, isUidCommand, seqState),
+    };
+  }
+  if (criterion.type === "OR") {
+    const orCriterion = criterion as {
+      type: "OR";
+      left: SearchCriterion;
+      right: SearchCriterion;
+    };
+    return {
+      type: "OR",
+      left: resolveOneSearchKey(orCriterion.left, isUidCommand, seqState),
+      right: resolveOneSearchKey(orCriterion.right, isUidCommand, seqState),
+    };
+  }
+  // Explicit `UID <set>` keyword — already UID-axis, but `*` still needs
+  // resolving before it reaches the SQL layer and overflows a Postgres
+  // `integer` bind parameter (#678).
+  if (criterion.type === "UID") {
+    return resolveUidCriterionRanges(criterion as UidCriterion, seqState);
+  }
+  if (criterion.type !== "SEQ") return criterion;
+  if (isUidCommand) {
+    return resolveUidCriterionRanges(
+      { type: "UID", sequenceSet: criterion.sequenceSet } as UidCriterion,
+      seqState
+    );
+  }
+  const uidRanges = convertSequenceSet(criterion.sequenceSet)
+    .map(({ start, end }) => resolveSeqRangeToUids(seqState.seqToUid, start, end))
+    .filter((r): r is { uidStart: number; uidEnd: number } => r !== undefined)
+    .map(({ uidStart, uidEnd }) => ({ start: uidStart, end: uidEnd }));
+  // A set whose sequence numbers all lie past the end of the mailbox matches
+  // no messages. It must return the empty set — not vanish from the AND and
+  // match everything — so pin it to an impossible UID range (UIDs are ≥ 1).
+  if (uidRanges.length === 0) uidRanges.push({ start: -1, end: -1 });
+  return { type: "UID", sequenceSet: { type: "sequence", ranges: uidRanges } };
+};
+
 // A bare message sequence-set is a top-level SEARCH key (RFC 3501 §6.4.4),
 // parsed as a SEQ criterion. In a plain SEARCH it names message sequence
 // numbers, so resolve it against the mailbox's seq→uid map before querying; in
@@ -232,30 +286,9 @@ export function resolveSeqSearchKeys(
   isUidCommand: boolean,
   seqState: SequenceState
 ): SearchCriterion[] {
-  return criteria.map((criterion) => {
-    // Explicit `UID <set>` keyword — already UID-axis, but `*` still needs
-    // resolving before it reaches the SQL layer and overflows a Postgres
-    // `integer` bind parameter (#678).
-    if (criterion.type === "UID") {
-      return resolveUidCriterionRanges(criterion as UidCriterion, seqState);
-    }
-    if (criterion.type !== "SEQ") return criterion;
-    if (isUidCommand) {
-      return resolveUidCriterionRanges(
-        { type: "UID", sequenceSet: criterion.sequenceSet } as UidCriterion,
-        seqState
-      );
-    }
-    const uidRanges = convertSequenceSet(criterion.sequenceSet)
-      .map(({ start, end }) => resolveSeqRangeToUids(seqState.seqToUid, start, end))
-      .filter((r): r is { uidStart: number; uidEnd: number } => r !== undefined)
-      .map(({ uidStart, uidEnd }) => ({ start: uidStart, end: uidEnd }));
-    // A set whose sequence numbers all lie past the end of the mailbox matches
-    // no messages. It must return the empty set — not vanish from the AND and
-    // match everything — so pin it to an impossible UID range (UIDs are ≥ 1).
-    if (uidRanges.length === 0) uidRanges.push({ start: -1, end: -1 });
-    return { type: "UID", sequenceSet: { type: "sequence", ranges: uidRanges } };
-  });
+  return criteria.map((criterion) =>
+    resolveOneSearchKey(criterion, isUidCommand, seqState)
+  );
 }
 
 export async function searchTyped(

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -22,6 +22,7 @@ import {
   CopyRequest,
   MoveRequest,
   AppendRequest,
+  UidCriterion,
 } from "./types";
 import {
   buildFetchResponse,
@@ -31,6 +32,7 @@ import {
 } from "./fetch-helpers";
 import {
   resolveSeqRangeToUids,
+  resolveUidRangeSentinel,
   uidToSeqNumber,
   countSequenceSetMessages,
   buildSequenceMapping,
@@ -131,6 +133,10 @@ async function _fetchMessages(
         }
         uidStart = resolved.uidStart;
         uidEnd = resolved.uidEnd;
+      } else {
+        const resolved = resolveUidRangeSentinel(seqState.seqToUid, start, end);
+        uidStart = resolved.uidStart;
+        uidEnd = resolved.uidEnd;
       }
 
       const messages = await store.getMessages(
@@ -198,10 +204,27 @@ async function _processFetchMessages(
 // SEARCH
 // ---------------------------------------------------------------------------
 
+// Resolve a UID-axis sequence set's ranges to concrete UIDs, mapping the
+// `*` sentinel (Number.MAX_SAFE_INTEGER) to the mailbox's actual highest
+// UID. Shared by the bare-set and explicit-`UID <set>`-keyword cases below.
+const resolveUidCriterionRanges = (
+  criterion: UidCriterion,
+  seqState: SequenceState
+): SearchCriterion => {
+  const uidRanges = convertSequenceSet(criterion.sequenceSet).map(
+    ({ start, end }) => {
+      const resolved = resolveUidRangeSentinel(seqState.seqToUid, start, end);
+      return { start: resolved.uidStart, end: resolved.uidEnd };
+    }
+  );
+  return { type: "UID", sequenceSet: { type: "sequence", ranges: uidRanges } };
+};
+
 // A bare message sequence-set is a top-level SEARCH key (RFC 3501 §6.4.4),
 // parsed as a SEQ criterion. In a plain SEARCH it names message sequence
 // numbers, so resolve it against the mailbox's seq→uid map before querying; in
-// a UID SEARCH the same set already names UIDs, so relabel it as UID untouched.
+// a UID SEARCH the same set already names UIDs, so relabel it as UID and
+// resolve its `*` sentinel the same way an explicit `UID <set>` keyword does.
 // (`store.search` only understands UID/flag/text/date criteria — it has no
 // access to seqState — so the resolution has to happen here.)
 export function resolveSeqSearchKeys(
@@ -210,9 +233,18 @@ export function resolveSeqSearchKeys(
   seqState: SequenceState
 ): SearchCriterion[] {
   return criteria.map((criterion) => {
+    // Explicit `UID <set>` keyword — already UID-axis, but `*` still needs
+    // resolving before it reaches the SQL layer and overflows a Postgres
+    // `integer` bind parameter (#678).
+    if (criterion.type === "UID") {
+      return resolveUidCriterionRanges(criterion as UidCriterion, seqState);
+    }
     if (criterion.type !== "SEQ") return criterion;
     if (isUidCommand) {
-      return { type: "UID", sequenceSet: criterion.sequenceSet };
+      return resolveUidCriterionRanges(
+        { type: "UID", sequenceSet: criterion.sequenceSet } as UidCriterion,
+        seqState
+      );
     }
     const uidRanges = convertSequenceSet(criterion.sequenceSet)
       .map(({ start, end }) => resolveSeqRangeToUids(seqState.seqToUid, start, end))
@@ -316,6 +348,10 @@ export async function storeFlagsTyped(
           });
           continue;
         }
+        uidStart = resolved.uidStart;
+        uidEnd = resolved.uidEnd;
+      } else {
+        const resolved = resolveUidRangeSentinel(seqState.seqToUid, start, end);
         uidStart = resolved.uidStart;
         uidEnd = resolved.uidEnd;
       }
@@ -434,7 +470,7 @@ export async function copyMessageTyped(
     const uidRanges: Array<{ uidStart: number; uidEnd: number }> = [];
     for (const { start, end } of ranges) {
       if (isUidCopy) {
-        uidRanges.push({ uidStart: start, uidEnd: end });
+        uidRanges.push(resolveUidRangeSentinel(seqState.seqToUid, start, end));
       } else {
         const resolved = resolveSeqRangeToUids(seqState.seqToUid, start, end);
         if (!resolved) continue;
@@ -739,7 +775,7 @@ export async function moveMessageTyped(
     const uidRanges: Array<{ uidStart: number; uidEnd: number }> = [];
     for (const { start, end } of ranges) {
       if (isUidMove) {
-        uidRanges.push({ uidStart: start, uidEnd: end });
+        uidRanges.push(resolveUidRangeSentinel(seqState.seqToUid, start, end));
       } else {
         const resolved = resolveSeqRangeToUids(seqState.seqToUid, start, end);
         if (!resolved) continue;

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   seqToUidNumber,
   uidToSeqNumber,
   resolveSeqRangeToUids,
+  resolveUidRangeSentinel,
   countSequenceSetMessages,
   type SequenceState,
 } from "./sequence-resolver";
@@ -153,6 +154,54 @@ describe("resolveSeqRangeToUids (inbox #588)", () => {
     // `6:*` on a 5-message mailbox: the start (6) is a real number past the
     // end, so it matches nothing — only `*` itself is treated as the last msg.
     expect(resolveSeqRangeToUids(uids, 6, Number.MAX_SAFE_INTEGER)).toBeUndefined();
+  });
+});
+
+describe("resolveUidRangeSentinel (inbox #678)", () => {
+  const uids = [10, 20, 30, 40, 50];
+
+  it("passes concrete UIDs through unchanged", () => {
+    expect(resolveUidRangeSentinel(uids, 20, 40)).toEqual({ uidStart: 20, uidEnd: 40 });
+  });
+
+  it("resolves a bare `*` (start and end are `*`) to the highest UID", () => {
+    expect(
+      resolveUidRangeSentinel(uids, Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    ).toEqual({ uidStart: 50, uidEnd: 50 });
+  });
+
+  it("resolves an open-ended `n:*` upper bound to the highest UID", () => {
+    expect(resolveUidRangeSentinel(uids, 30, Number.MAX_SAFE_INTEGER)).toEqual({
+      uidStart: 30,
+      uidEnd: 50,
+    });
+  });
+
+  // The regression this closes: `*` used to reach the SQL layer as the raw
+  // Number.MAX_SAFE_INTEGER sentinel and overflow a Postgres `integer` bind
+  // parameter (crashed hoie-inbox-1 via a `UID SEARCH *` retry loop, OOM'd
+  // after ~9 min of the resulting tight failure loop).
+  it("never leaves MAX_SAFE_INTEGER in the resolved pair", () => {
+    const { uidStart, uidEnd } = resolveUidRangeSentinel(
+      uids,
+      Number.MAX_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER
+    );
+    expect(uidStart).toBeLessThan(2147483647); // Postgres `integer` max (int4)
+    expect(uidEnd).toBeLessThan(2147483647);
+  });
+
+  it("resolves `*` to -1 on an empty mailbox (no highest UID to resolve to)", () => {
+    expect(
+      resolveUidRangeSentinel([], Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER)
+    ).toEqual({ uidStart: -1, uidEnd: -1 });
+  });
+
+  it("a concrete out-of-range UID still passes through (matches nothing downstream)", () => {
+    expect(resolveUidRangeSentinel(uids, 999999, 999999)).toEqual({
+      uidStart: 999999,
+      uidEnd: 999999,
+    });
   });
 });
 

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -101,6 +101,27 @@ export function uidToSeqNumber(
 }
 
 /**
+ * Resolve the '*' UID sentinel (MAX_SAFE_INTEGER) in a UID-axis range to the
+ * mailbox's actual highest UID (RFC 3501 §9: '*' = highest UID in the
+ * mailbox). Concrete UIDs pass through unchanged. Unlike the sequence-number
+ * axis, an out-of-range concrete UID is not an error case — it simply
+ * matches no messages — so this always returns a resolved pair rather than
+ * undefined. On an empty mailbox the sentinel resolves to -1 (below any real
+ * UID, which are ≥ 1) instead of leaving MAX_SAFE_INTEGER to overflow a
+ * Postgres `integer` bind parameter (#678).
+ */
+export function resolveUidRangeSentinel(
+  seqToUid: number[],
+  start: number,
+  end: number
+): { uidStart: number; uidEnd: number } {
+  const maxUid = seqToUid.length > 0 ? seqToUid[seqToUid.length - 1] : -1;
+  const resolve = (value: number) =>
+    value === Number.MAX_SAFE_INTEGER ? maxUid : value;
+  return { uidStart: resolve(start), uidEnd: resolve(end) };
+}
+
+/**
  * Count messages covered by a sequence set (clamped to actual mailbox size).
  * Used for FETCH limit checks.
  */


### PR DESCRIPTION
## Summary

`UID SEARCH *` / `UID FETCH *` / `UID STORE *` / `UID COPY *` / `UID MOVE *` parse `*` to `Number.MAX_SAFE_INTEGER` per RFC 3501 §9, but the UID-axis paths never resolved that sentinel to the mailbox's actual highest UID — only the sequence-number axis was fixed, by 660/677. SEARCH passed the raw sentinel straight into a Postgres `integer` bind parameter and threw `value "9007199254740991" is out of range for type integer` on every attempt; FETCH/STORE/COPY/MOVE silently matched nothing instead of erroring (getMailsByRange clamps its upper bound, so those paths didn't crash, just returned wrong results).

Closes #678.

## Incident context

This is also the root cause I identified for a Shepherd OOM alarm on `hoie-inbox-1` today (2026-07-27/28): container logs (persisted across the restart) show a ~9-minute tight failure loop immediately before the OOM kill — `searchMailsByUid` threw the integer-overflow error 70x and `getMailsByRange` hit connection timeouts 20x/4x, consistent with a mail client repeat-polling a failing `UID SEARCH *`. The container auto-restarted and is healthy; this PR is the fix for the recurring failure, not an emergency mitigation.

## Fix

Added `resolveUidRangeSentinel` (`sequence-resolver.ts`), mapping the `*` sentinel to the session's known max UID (`seqState.seqToUid`), and applied it at the 5 call sites that previously passed UID-axis ranges through unresolved:
- `resolveSeqSearchKeys` (bare UID-SEARCH set + explicit `UID <set>` keyword)
- `_fetchMessages` (FETCH)
- `storeFlagsTyped` (STORE)
- `copyMessageTyped` (COPY)
- `moveMessageTyped` (MOVE)

On an empty mailbox the sentinel resolves to `-1` (below any real UID) instead of leaving `MAX_SAFE_INTEGER` to overflow the bind parameter.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/server` — 1237 pass, 0 fail (added regression coverage in `sequence-resolver.test.ts` for `resolveUidRangeSentinel`, and updated/added `resolveSeqSearchKeys` cases in `message-ops.test.ts` for the bare-`*`-in-explicit-UID-criterion path)
- [x] `bun run lint` — 0 errors (pre-existing unrelated warnings only)
- [x] Live IMAP verification against the dev server (raw socket client, admin INBOX, 11324 messages):
  - `UID SEARCH *` → `* SEARCH 11397` (previously would throw the integer-overflow error and return empty)
  - `UID FETCH * (UID FLAGS)` → `* 11324 FETCH (UID 11397 FLAGS ())` (previously matched nothing)
  - `UID SEARCH 11390:*` → correct open-ended range `11390..11397`
  - `UID STORE * +FLAGS (\Seen)` / reverted with `-FLAGS (\Seen)` → correctly targeted UID 11397, flag state restored to original after the test
  - Server log clean throughout — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)