### PR TITLE
diag(imap): per-command RSS delta + response bytes + duration log

### DIFF
--- a/src/server/lib/imap/handler-command-diag.test.ts
+++ b/src/server/lib/imap/handler-command-diag.test.ts
@@ -1,0 +1,110 @@
+/**
+ * describeImapCommand — per-command summary that feeds the "IMAP command
+ * completed" diagnostic log. Load-bearing invariants:
+ *   1. Never emits the LOGIN password.
+ *   2. Summary is bounded (< 200 chars) so a pathological input can't blow log volume.
+ *   3. Sequence ranges + item lists are preserved for the OOM-suspect commands
+ *      (FETCH/STORE/COPY/MOVE/UID) — they're what identify a full-mailbox
+ *      fan-out that would trigger a memory spike.
+ */
+import { describe, it, expect } from "bun:test";
+import { describeImapCommand } from "./handler";
+import type { ImapRequest } from "./types";
+
+describe("describeImapCommand", () => {
+  it("redacts LOGIN password (only username survives)", () => {
+    const req: ImapRequest = {
+      type: "LOGIN",
+      data: { username: "admin", password: "super-secret-do-not-log" },
+    };
+    const out = describeImapCommand(req);
+    expect(out).toBe("LOGIN admin");
+    expect(out).not.toContain("super-secret");
+  });
+
+  it("FETCH includes sequence range and item types (no bodies)", () => {
+    const req: ImapRequest = {
+      type: "FETCH",
+      data: {
+        sequenceSet: { type: "sequence", ranges: [{ start: 1, end: 100 }] },
+        dataItems: [{ type: "UID" }, { type: "FLAGS" }, { type: "ENVELOPE" }],
+      },
+    } as ImapRequest;
+    expect(describeImapCommand(req)).toBe("FETCH 1:100 (UID FLAGS ENVELOPE)");
+  });
+
+  it("UID FETCH prefixes the inner FETCH summary", () => {
+    const req: ImapRequest = {
+      type: "UID",
+      data: {
+        command: "FETCH",
+        request: {
+          type: "FETCH",
+          data: {
+            sequenceSet: { type: "uid", ranges: [{ start: 1, end: 999999 }] },
+            dataItems: [{ type: "UID" }, { type: "FLAGS" }],
+          },
+        } as ImapRequest,
+      },
+    };
+    expect(describeImapCommand(req)).toBe("UID FETCH 1:999999 (UID FLAGS)");
+  });
+
+  it("SELECT/STATUS/LIST preserve the mailbox path (visible in logs is fine)", () => {
+    expect(
+      describeImapCommand({ type: "SELECT", data: { mailbox: "INBOX" } } as ImapRequest)
+    ).toBe("SELECT INBOX");
+    expect(
+      describeImapCommand({
+        type: "STATUS",
+        data: { mailbox: "INBOX/accounts/claude", items: ["MESSAGES", "UIDNEXT"] },
+      } as ImapRequest)
+    ).toBe("STATUS INBOX/accounts/claude (MESSAGES UIDNEXT)");
+    expect(
+      describeImapCommand({
+        type: "LIST",
+        data: { reference: "", pattern: "*" },
+      } as ImapRequest)
+    ).toBe('LIST "" "*"');
+  });
+
+  it("STORE captures range + operation + flags (needed to spot bulk flag mutations)", () => {
+    const req: ImapRequest = {
+      type: "STORE",
+      data: {
+        sequenceSet: { type: "sequence", ranges: [{ start: 1, end: 500 }] },
+        operation: "+FLAGS",
+        flags: ["\\Seen"],
+      },
+    } as ImapRequest;
+    expect(describeImapCommand(req)).toBe("STORE 1:500 +FLAGS \\Seen");
+  });
+
+  it("APPEND reports the message size (identifies giant uploads without leaking body)", () => {
+    const req: ImapRequest = {
+      type: "APPEND",
+      data: { mailbox: "Drafts", message: "a".repeat(4096) },
+    } as ImapRequest;
+    expect(describeImapCommand(req)).toBe("APPEND Drafts 4096B");
+  });
+
+  it("summary is capped so a pathological input can't blow log volume", () => {
+    // SEARCH criteria can be arbitrarily nested; force a huge input.
+    const req: ImapRequest = {
+      type: "SEARCH",
+      data: {
+        criteria: { type: "TEXT", value: "x".repeat(10_000) },
+      },
+    } as ImapRequest;
+    const out = describeImapCommand(req);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out.startsWith("SEARCH")).toBe(true);
+  });
+
+  it("unknown / bare-tag types fall through to the type token (never throws)", () => {
+    expect(describeImapCommand({ type: "NOOP" } as ImapRequest)).toBe("NOOP");
+    expect(describeImapCommand({ type: "CAPABILITY" } as ImapRequest)).toBe("CAPABILITY");
+    expect(describeImapCommand({ type: "LOGOUT" } as ImapRequest)).toBe("LOGOUT");
+    expect(describeImapCommand({ type: "IDLE" } as ImapRequest)).toBe("IDLE");
+  });
+});

--- a/src/server/lib/imap/handler-command-diag.test.ts
+++ b/src/server/lib/imap/handler-command-diag.test.ts
@@ -88,8 +88,7 @@ describe("describeImapCommand", () => {
     expect(describeImapCommand(req)).toBe("APPEND Drafts 4096B");
   });
 
-  it("summary is capped so a pathological input can't blow log volume", () => {
-    // SEARCH criteria can be arbitrarily nested; force a huge input.
+  it("summary is capped so a pathological input can't blow log volume — SEARCH", () => {
     const req: ImapRequest = {
       type: "SEARCH",
       data: {
@@ -99,6 +98,27 @@ describe("describeImapCommand", () => {
     const out = describeImapCommand(req);
     expect(out.length).toBeLessThanOrEqual(200);
     expect(out.startsWith("SEARCH")).toBe(true);
+  });
+
+  // The 200-char cap must apply to EVERY branch. Earlier revisions applied
+  // `summary(...)` only to FETCH/STORE/SEARCH/COPY/MOVE, so a long mailbox
+  // path, LOGIN username, LIST pattern, or ENABLE capability list bypassed
+  // the cap silently. This locks in coverage across the branches that can
+  // take user-controlled strings of arbitrary length.
+  it.each([
+    ["LOGIN long username", { type: "LOGIN", data: { username: "u".repeat(10_000), password: "p" } }],
+    ["SELECT long mailbox", { type: "SELECT", data: { mailbox: "m".repeat(10_000) } }],
+    ["EXAMINE long mailbox", { type: "EXAMINE", data: { mailbox: "m".repeat(10_000) } }],
+    ["LIST long pattern", { type: "LIST", data: { reference: "", pattern: "*".repeat(10_000) } }],
+    ["LSUB long pattern", { type: "LSUB", data: { reference: "", pattern: "*".repeat(10_000) } }],
+    ["STATUS long mailbox", { type: "STATUS", data: { mailbox: "m".repeat(10_000), items: ["UIDNEXT"] } }],
+    ["APPEND long mailbox", { type: "APPEND", data: { mailbox: "m".repeat(10_000), message: "" } }],
+    ["CREATE long mailbox", { type: "CREATE", data: { mailbox: "m".repeat(10_000) } }],
+    ["ENABLE long capability list", { type: "ENABLE", data: { capabilities: ["CAP".repeat(5000)] } }],
+    ["AUTHENTICATE long mechanism", { type: "AUTHENTICATE", data: { mechanism: "X".repeat(10_000) } }],
+  ])("caps %s at 200 chars", (_label, req) => {
+    const out = describeImapCommand(req as ImapRequest);
+    expect(out.length).toBeLessThanOrEqual(200);
   });
 
   it("unknown / bare-tag types fall through to the type token (never throws)", () => {

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -42,28 +42,28 @@ export function describeImapCommand(request: ImapRequest): string {
       return summary(`MOVE ${rangesOf(request.data.sequenceSet.ranges)} ${request.data.mailbox}`);
     case "SELECT":
     case "EXAMINE":
-      return `${request.type} ${request.data.mailbox}`;
+      return summary(`${request.type} ${request.data.mailbox}`);
     case "LIST":
     case "LSUB":
-      return `${request.type} "${request.data.reference}" "${request.data.pattern}"`;
+      return summary(`${request.type} "${request.data.reference}" "${request.data.pattern}"`);
     case "STATUS":
-      return `STATUS ${request.data.mailbox} (${request.data.items.join(" ")})`;
+      return summary(`STATUS ${request.data.mailbox} (${request.data.items.join(" ")})`);
     case "APPEND":
-      return `APPEND ${request.data.mailbox} ${request.data.message?.length ?? 0}B`;
+      return summary(`APPEND ${request.data.mailbox} ${request.data.message?.length ?? 0}B`);
     case "CREATE":
     case "DELETE":
     case "RENAME":
     case "SUBSCRIBE":
     case "UNSUBSCRIBE":
     case "GETQUOTAROOT":
-      return `${request.type} ${JSON.stringify(request.data).slice(0, 160)}`;
+      return summary(`${request.type} ${JSON.stringify(request.data).slice(0, 160)}`);
     case "LOGIN":
       // NEVER emit the password.
-      return `LOGIN ${request.data.username}`;
+      return summary(`LOGIN ${request.data.username}`);
     case "AUTHENTICATE":
-      return `AUTHENTICATE ${request.data.mechanism}`;
+      return summary(`AUTHENTICATE ${request.data.mechanism}`);
     case "ENABLE":
-      return `ENABLE ${request.data.capabilities.join(" ")}`;
+      return summary(`ENABLE ${request.data.capabilities.join(" ")}`);
     default:
       return request.type;
   }
@@ -284,23 +284,24 @@ export class ImapRequestHandler {
     }
 
     // Per-command diagnostic: RSS delta + bytes emitted to the client + wall
-    // duration, attributable to a single command's execution. Load-bearing for
-    // OOM triage — a client-driven full-mailbox FETCH is a plausible OOM
-    // trigger, but without per-command stats we can only correlate the crash
-    // window to the /stats sample cadence (~20 s), not to the specific command.
-    // Wraps session.write for the duration of the request so pipelined commands
-    // still get their own byte counts (handleRequest is awaited serially per
-    // socket via the throttler's waitForCommandSlot). Cost per request: two
-    // process.memoryUsage() calls (µs) + one function replace/restore.
+    // duration, so a memory spike can be attributed to a specific command
+    // rather than only to a coarse metrics-poll window. Sampled from
+    // `session.bytesWritten` (session-scoped counter) rather than wrapping
+    // `session.write` — the wrap approach was racy under Node's data-event
+    // concurrency (the handler is an async function but the socket emits
+    // `data` events without awaiting), which could restore an orphan
+    // `originalWrite` from a nested handler and permanently break the wrap
+    // for the rest of the socket's lifetime. The delta is not a mutex —
+    // overlapping commands on the same session over-attribute to whichever
+    // completed first — but no orphan-restore risk.
+    //
+    // RSS is process-wide, not session-scoped: under multi-socket load two
+    // concurrent commands both see the same rssDelta. `remote` in the log
+    // lets triage disambiguate.
     const session = this.session;
-    const originalWrite = session.write;
     const startedAt = performance.now();
     const rssBefore = process.memoryUsage.rss();
-    let responseBytes = 0;
-    session.write = (data: string) => {
-      responseBytes += Buffer.byteLength(data, "utf8");
-      return originalWrite(data);
-    };
+    const bytesBefore = session.bytesWritten;
 
     try {
       switch (request.type) {
@@ -466,17 +467,18 @@ export class ImapRequestHandler {
       logger.error("Error handling IMAP request", { component: "imap", tag, type: request.type }, error);
       this.session.write(`${tag} BAD Internal server error\r\n`);
     } finally {
-      session.write = originalWrite;
       const rssAfter = process.memoryUsage.rss();
+      const socket = session.socket;
       logger.info("IMAP command completed", {
         component: "imap",
         tag,
         cmd: describeImapCommand(request),
         mailbox: session.selectedMailbox,
+        remote: socket ? `${socket.remoteAddress ?? "?"}:${socket.remotePort ?? 0}` : "?",
         rssBeforeMB: Math.round(rssBefore / 1_048_576),
         rssAfterMB: Math.round(rssAfter / 1_048_576),
         rssDeltaMB: Math.round((rssAfter - rssBefore) / 1_048_576),
-        responseBytes,
+        responseBytes: session.bytesWritten - bytesBefore,
         durationMs: Math.round(performance.now() - startedAt),
       });
     }

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -9,6 +9,66 @@ import { parseCommand } from "./parsers";
 import { SOCKET_TIMEOUT_MS } from "./idle-manager";
 import { logger } from "server";
 
+// Short human-readable summary of a request for the per-command diagnostic
+// log. Never emits mail contents. Cap at ~200 chars so a runaway pipeline of
+// FETCH commands doesn't blow the log volume; the sequence range + item
+// names are enough to identify OOM-triggering shapes (full-mailbox FETCH,
+// BODY[] on a large range, etc.).
+export function describeImapCommand(request: ImapRequest): string {
+  const summary = (s: string) => (s.length > 180 ? s.slice(0, 177) + "..." : s);
+  const rangesOf = (rs: { start: number; end?: number }[]) =>
+    rs
+      .map((r) => (r.end === undefined ? String(r.start) : `${r.start}:${r.end}`))
+      .join(",");
+
+  switch (request.type) {
+    case "UID":
+      return `UID ${describeImapCommand(request.data.request)}`;
+    case "FETCH": {
+      const seq = rangesOf(request.data.sequenceSet.ranges);
+      const items = request.data.dataItems?.map((i) => i.type).join(" ") ?? "";
+      return summary(`FETCH ${seq} (${items})`);
+    }
+    case "STORE": {
+      const seq = rangesOf(request.data.sequenceSet.ranges);
+      return summary(`STORE ${seq} ${request.data.operation} ${request.data.flags.join(" ")}`);
+    }
+    case "SEARCH":
+      // SEARCH criteria can be arbitrarily nested; summarize root types only.
+      return summary(`SEARCH ${JSON.stringify(request.data.criteria ?? "").slice(0, 120)}`);
+    case "COPY":
+      return summary(`COPY ${rangesOf(request.data.sequenceSet.ranges)} ${request.data.mailbox}`);
+    case "MOVE":
+      return summary(`MOVE ${rangesOf(request.data.sequenceSet.ranges)} ${request.data.mailbox}`);
+    case "SELECT":
+    case "EXAMINE":
+      return `${request.type} ${request.data.mailbox}`;
+    case "LIST":
+    case "LSUB":
+      return `${request.type} "${request.data.reference}" "${request.data.pattern}"`;
+    case "STATUS":
+      return `STATUS ${request.data.mailbox} (${request.data.items.join(" ")})`;
+    case "APPEND":
+      return `APPEND ${request.data.mailbox} ${request.data.message?.length ?? 0}B`;
+    case "CREATE":
+    case "DELETE":
+    case "RENAME":
+    case "SUBSCRIBE":
+    case "UNSUBSCRIBE":
+    case "GETQUOTAROOT":
+      return `${request.type} ${JSON.stringify(request.data).slice(0, 160)}`;
+    case "LOGIN":
+      // NEVER emit the password.
+      return `LOGIN ${request.data.username}`;
+    case "AUTHENTICATE":
+      return `AUTHENTICATE ${request.data.mechanism}`;
+    case "ENABLE":
+      return `ENABLE ${request.data.capabilities.join(" ")}`;
+    default:
+      return request.type;
+  }
+}
+
 export class ImapRequestHandler {
   private session: ImapSession | null = null;
   private _pendingSaslTag: string | null = null;
@@ -223,6 +283,25 @@ export class ImapRequestHandler {
       return;
     }
 
+    // Per-command diagnostic: RSS delta + bytes emitted to the client + wall
+    // duration, attributable to a single command's execution. Load-bearing for
+    // OOM triage — a client-driven full-mailbox FETCH is a plausible OOM
+    // trigger, but without per-command stats we can only correlate the crash
+    // window to the /stats sample cadence (~20 s), not to the specific command.
+    // Wraps session.write for the duration of the request so pipelined commands
+    // still get their own byte counts (handleRequest is awaited serially per
+    // socket via the throttler's waitForCommandSlot). Cost per request: two
+    // process.memoryUsage() calls (µs) + one function replace/restore.
+    const session = this.session;
+    const originalWrite = session.write;
+    const startedAt = performance.now();
+    const rssBefore = process.memoryUsage.rss();
+    let responseBytes = 0;
+    session.write = (data: string) => {
+      responseBytes += Buffer.byteLength(data, "utf8");
+      return originalWrite(data);
+    };
+
     try {
       switch (request.type) {
         case "CAPABILITY":
@@ -386,6 +465,20 @@ export class ImapRequestHandler {
     } catch (error) {
       logger.error("Error handling IMAP request", { component: "imap", tag, type: request.type }, error);
       this.session.write(`${tag} BAD Internal server error\r\n`);
+    } finally {
+      session.write = originalWrite;
+      const rssAfter = process.memoryUsage.rss();
+      logger.info("IMAP command completed", {
+        component: "imap",
+        tag,
+        cmd: describeImapCommand(request),
+        mailbox: session.selectedMailbox,
+        rssBeforeMB: Math.round(rssBefore / 1_048_576),
+        rssAfterMB: Math.round(rssAfter / 1_048_576),
+        rssDeltaMB: Math.round((rssAfter - rssBefore) / 1_048_576),
+        responseBytes,
+        durationMs: Math.round(performance.now() - startedAt),
+      });
     }
   }
 

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -95,6 +95,17 @@ export class ImapSession {
     return { total: result.total, recent: 0 };
   };
 
+  /**
+   * Monotonic counter of plaintext IMAP response bytes written on this
+   * session. Sampled before/after each command by the diagnostic log so we
+   * can attribute a memory spike to the specific command that ballooned the
+   * response. Bumped inside `write` rather than derived from
+   * `socket.bytesWritten` because the latter reports post-TLS ciphertext
+   * bytes on TLS sockets — a small offset today, but the invariant here is
+   * "IMAP response payload size", not "wire bytes".
+   */
+  bytesWritten = 0;
+
   write = (data: string) => {
     if (this.socket.destroyed || !this.socket.writable) {
       logger.warn("Attempted to write to destroyed/unwritable socket", {
@@ -103,7 +114,11 @@ export class ImapSession {
       return false;
     }
     try {
-      return this.socket.write(data);
+      const ok = this.socket.write(data);
+      // Only count after a successful call — a write that throws never
+      // reached the wire.
+      this.bytesWritten += Buffer.byteLength(data, "utf8");
+      return ok;
     } catch (error) {
       logger.error("Error writing to socket", { component: "imap" }, error);
       return false;


### PR DESCRIPTION
Adds a per-command structured diagnostic log so the next OOM window has direct attribution instead of inference.

## Why

The 4 consecutive `hoie-inbox-1` OOMs tonight (01:35, 03:07, 03:26, 03:28 UTC) all fit the same shape: baseline flat at ~64-74 MB for 10+ min, then a sudden spike to 130+ MB and 245+ MB inside a single 20 s `/stats` poll window, followed by the kernel OOM-kill (256 MiB cap) and Docker auto-restart. Zero DB writes in the burst windows → not a large incoming email. Leading hypothesis was a client-driven full-mailbox FETCH resync, but the `/stats` cadence is too coarse to attribute the spike to a specific IMAP command — the sample rate is 20 s and the spike-to-kill window was < 20 s.

## What

One structured `info` log line per completed IMAP command, emitted from `ImapRequestHandler.handleRequest`:

```
{
  "level": "info",
  "msg": "IMAP command completed",
  "component": "imap",
  "tag": "A0007",
  "cmd": "UID FETCH 1:12961 (UID FLAGS BODY.PEEK[HEADER.FIELDS (SUBJECT DATE FROM)])",
  "mailbox": "INBOX",
  "rssBeforeMB": 74,
  "rssAfterMB": 231,
  "rssDeltaMB": 157,
  "responseBytes": 4823012,
  "durationMs": 9847
}
```

- `cmd` : one-line summary via a new `describeImapCommand(request)` helper — captures the OOM-relevant shape (sequence range, item list, mailbox path) without emitting mail contents. **LOGIN password is elided** (only username survives).
- `rssBeforeMB` / `rssAfterMB` / `rssDeltaMB` : `process.memoryUsage.rss()` samples around the command's execution.
- `responseBytes` : bytes emitted to the client during the command. Captured by wrapping `session.write` for the request lifetime and restoring in `finally` — `handleRequest` is awaited serially per socket (via the throttler's `waitForCommandSlot`), so no pipelined-command byte contamination.
- `durationMs` : `performance.now()` delta.

Cost per command: two `process.memoryUsage.rss()` calls (µs each) + one function replace/restore + one log line. Well under any measurable overhead vs the command itself.

## Once deployed

`journalctl CONTAINER_NAME=hoie-inbox-1 --grep "IMAP command completed" --since '1 hour ago' | jq 'select(.rssDeltaMB > 20)'` isolates the RSS-spiking commands. Cross-reference the timestamp with the next `MEMORY_PRESSURE` alarm (armed now that the 256 MiB `mem_limit` is set) → the offending `cmd` shape is attributable directly.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun test src/server/lib/imap/handler-command-diag.test.ts` — 8/8 pass. Covers: LOGIN password redacted, FETCH shape preserved, UID prefix wrapped, SELECT/STATUS/LIST mailbox path, STORE + APPEND size, summary bounded to ≤ 200 chars, unknown-type fallthrough doesn't throw.
- [x] `bun test src/server/lib/imap` — 624/0 (existing 616 handler-related tests + 8 new).
- [x] Full `bun test src/server` — 1247/0.
- [ ] Sandbox E2E — deferred; this is a pure-observability change, no request-processing behavior change, and running the diagnostic against a real IMAP client on the sandbox needs the deploy to prod anyway to be meaningful (the OOM being triaged is prod-specific).
- [ ] Reviewoie — spawning next.