### PR TITLE
fix(imap): single-flight coalesce getMailsByRange to cap OOM under client retry storm

### DIFF
--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -16,6 +16,7 @@ import {
   EXPUNGED,
 } from "../../models";
 import { getNextModseq } from "./counters";
+import { singleFlight } from "./inflight";
 
 export const countMessages = async (
   user_id: string,
@@ -74,6 +75,40 @@ export const getMailsByRange = async (
   end: number,
   useUid: boolean,
   fields: string[] = ["*"]
+): Promise<Map<string, PartialMailModel>> => {
+  // Single-flight: a client-side retry storm on the same UID (observed as
+  // 208.82.98.54 issuing `UID FETCH 12365 BODY` 7x in ~10 s per socket,
+  // both sockets racing) previously ran N concurrent SQL loads of the same
+  // ~2 MB body, multiplying RSS per message by concurrent-inflight-count
+  // until the container OOM-killed at 256 MiB. The second caller now
+  // awaits the first's promise and every caller shares the same result
+  // Map — memory becomes O(distinct-in-flight-queries) not O(callers).
+  // Key includes the fields list (sorted, so different callers' array
+  // order collapses to the same key) so mismatched shapes don't
+  // erroneously share results.
+  const sortedFields = [...fields].sort();
+  const inflightKey = JSON.stringify([
+    user_id,
+    account,
+    sent,
+    start,
+    end,
+    useUid,
+    sortedFields,
+  ]);
+  return singleFlight(inflightKey, () => getMailsByRangeUncoalesced(
+    user_id, account, sent, start, end, useUid, fields
+  ));
+};
+
+const getMailsByRangeUncoalesced = async (
+  user_id: string,
+  account: string | null,
+  sent: boolean,
+  start: number,
+  end: number,
+  useUid: boolean,
+  fields: string[]
 ): Promise<Map<string, PartialMailModel>> => {
   try {
     const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -67,6 +67,27 @@ export const countMessages = async (
   }
 };
 
+/**
+ * IMAP-facing range read over the `mails` table.
+ *
+ * **Return-value sharing.** Coalesced callers (see below) receive the SAME
+ * `Map` reference AND the same `PartialMailModel` instances. Do not mutate
+ * either — treat the return as read-only. Load-bearing for the memory
+ * property below.
+ *
+ * **Single-flight coalescing.** Concurrent identical calls (same key: user
+ * + account + sent + range + field-set) share one in-flight promise. A
+ * misbehaving IMAP client that pipelines duplicate `UID FETCH <UID> BODY`
+ * requests would otherwise trigger N concurrent SQL loads of the same
+ * multi-MB body, multiplying container RSS by concurrent-inflight-count
+ * (the OOM path). Memory footprint is now
+ * `O(distinct-in-flight-queries)` instead of `O(callers)`.
+ *
+ * Key sorts the field list so different argument-order variants collapse
+ * to the same key — strict-subset field lists intentionally do NOT
+ * coalesce (different SELECT projections → different rows to construct
+ * `PartialMailModel` from).
+ */
 export const getMailsByRange = async (
   user_id: string,
   account: string | null,
@@ -76,16 +97,6 @@ export const getMailsByRange = async (
   useUid: boolean,
   fields: string[] = ["*"]
 ): Promise<Map<string, PartialMailModel>> => {
-  // Single-flight: a client-side retry storm on the same UID (observed as
-  // 208.82.98.54 issuing `UID FETCH 12365 BODY` 7x in ~10 s per socket,
-  // both sockets racing) previously ran N concurrent SQL loads of the same
-  // ~2 MB body, multiplying RSS per message by concurrent-inflight-count
-  // until the container OOM-killed at 256 MiB. The second caller now
-  // awaits the first's promise and every caller shares the same result
-  // Map — memory becomes O(distinct-in-flight-queries) not O(callers).
-  // Key includes the fields list (sorted, so different callers' array
-  // order collapses to the same key) so mismatched shapes don't
-  // erroneously share results.
   const sortedFields = [...fields].sort();
   const inflightKey = JSON.stringify([
     user_id,

--- a/src/server/lib/postgres/repositories/mails/inflight.test.ts
+++ b/src/server/lib/postgres/repositories/mails/inflight.test.ts
@@ -1,0 +1,124 @@
+/**
+ * singleFlight coalescing invariants:
+ *   1. Two callers with the same key + overlap window get the SAME promise
+ *      (one work function invocation).
+ *   2. Different keys → separate promises (no coalescing).
+ *   3. Entry is deleted on both success AND failure — a failed load must
+ *      not stick around and short-circuit future callers with the same
+ *      error.
+ *   4. Post-settle callers start fresh (no cache behavior).
+ */
+import { describe, it, expect, beforeEach } from "bun:test";
+import { singleFlight, inflightSize, inflightReset } from "./inflight";
+
+beforeEach(() => {
+  inflightReset();
+});
+
+describe("singleFlight", () => {
+  it("coalesces two callers with the same key into one work invocation", async () => {
+    let invocations = 0;
+    const gate = withGate<string>();
+    const work = async () => {
+      invocations += 1;
+      return gate.promise;
+    };
+
+    const p1 = singleFlight("k", work);
+    const p2 = singleFlight("k", work);
+    // Both callers should hold the same promise reference — proof of coalescing.
+    expect(p1).toBe(p2);
+    expect(invocations).toBe(1);
+    expect(inflightSize()).toBe(1);
+
+    gate.resolve("body");
+    expect(await p1).toBe("body");
+    expect(await p2).toBe("body");
+    expect(invocations).toBe(1);
+  });
+
+  it("does NOT coalesce across different keys", async () => {
+    let invocations = 0;
+    const gates = { a: withGate<string>(), b: withGate<string>() };
+    const work = (label: "a" | "b") => async () => {
+      invocations += 1;
+      return gates[label].promise;
+    };
+
+    const pa = singleFlight("a", work("a"));
+    const pb = singleFlight("b", work("b"));
+    expect(pa).not.toBe(pb);
+    expect(invocations).toBe(2);
+    expect(inflightSize()).toBe(2);
+
+    gates.a.resolve("A");
+    gates.b.resolve("B");
+    expect(await pa).toBe("A");
+    expect(await pb).toBe("B");
+  });
+
+  it("deletes the entry on SUCCESS so subsequent callers start fresh", async () => {
+    let invocations = 0;
+    const run = () => singleFlight("k", async () => {
+      invocations += 1;
+      return invocations;
+    });
+
+    expect(await run()).toBe(1);
+    // A later caller after settle must NOT ride the completed promise —
+    // singleFlight is not a cache; the entry must be gone.
+    expect(inflightSize()).toBe(0);
+    expect(await run()).toBe(2);
+  });
+
+  it("deletes the entry on FAILURE so a failed load doesn't stick", async () => {
+    let invocations = 0;
+    const run = () => singleFlight("k", async () => {
+      invocations += 1;
+      throw new Error(`boom ${invocations}`);
+    });
+
+    // Attach handler synchronously so Bun's unhandled-rejection tracker
+    // doesn't fire between throw and the caller's await.
+    const first = run().catch((e: Error) => e.message);
+    expect(await first).toBe("boom 1");
+    // Second call must re-run work, not re-throw the cached error forever.
+    expect(inflightSize()).toBe(0);
+    const second = run().catch((e: Error) => e.message);
+    expect(await second).toBe("boom 2");
+  });
+
+  it("callers waiting on a failing in-flight all see the SAME rejection", async () => {
+    let invocations = 0;
+    const gate = withGate<never>();
+    const work = async () => {
+      invocations += 1;
+      return gate.promise;
+    };
+
+    const p1 = singleFlight("k", work);
+    const p2 = singleFlight("k", work);
+    expect(invocations).toBe(1);
+    // Attach rejection handlers synchronously before rejecting, or Bun's
+    // unhandled-rejection tracker fires between reject and the `await`.
+    const settled1 = p1.catch((e: Error) => e.message);
+    const settled2 = p2.catch((e: Error) => e.message);
+
+    gate.reject(new Error("shared"));
+    expect(await settled1).toBe("shared");
+    expect(await settled2).toBe("shared");
+    // And post-settle the entry is gone.
+    expect(inflightSize()).toBe(0);
+  });
+});
+
+/** Manual deferred so tests can control resolution order. */
+function withGate<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}

--- a/src/server/lib/postgres/repositories/mails/inflight.ts
+++ b/src/server/lib/postgres/repositories/mails/inflight.ts
@@ -1,0 +1,45 @@
+/**
+ * Single-flight coalescing for identical, currently-running work.
+ *
+ * A `Map<string, Promise<T>>` keyed by a caller-supplied string. If a call
+ * arrives while an identical one is in flight, the second caller awaits the
+ * same promise instead of starting a duplicate load — memory footprint
+ * becomes O(distinct-in-flight-shapes) instead of O(concurrent-callers).
+ *
+ * This is not a cache. The entry is deleted the instant the promise
+ * settles (success or failure), so subsequent callers get a fresh load. The
+ * only overlap window is "callers that arrived while the first was still
+ * awaiting" — which is exactly the client-retry-storm shape that
+ * multiplied per-message RSS on the OOM path.
+ */
+const inflight = new Map<string, Promise<unknown>>();
+
+// NOT `async` — the whole point is that two callers with the same key get
+// the SAME Promise reference so the underlying work runs once. An `async`
+// wrapper would return a fresh promise per call that awaits the cached one,
+// defeating the coalescing at the identity level even if only running work
+// once at the mechanics level.
+export function singleFlight<T>(
+  key: string,
+  work: () => Promise<T>,
+): Promise<T> {
+  const pending = inflight.get(key);
+  if (pending) return pending as Promise<T>;
+  // Kick off `work` synchronously so a caller that arrives on the same
+  // microtask sees the entry. `.finally` deletes on both success and throw
+  // — a failed load must not stick around and short-circuit every later
+  // caller with the same error.
+  const promise = work().finally(() => inflight.delete(key));
+  inflight.set(key, promise);
+  return promise;
+}
+
+/** Test-only: peek at the number of in-flight entries. */
+export function inflightSize(): number {
+  return inflight.size;
+}
+
+/** Test-only: clear all in-flight state. Never called by production code. */
+export function inflightReset(): void {
+  inflight.clear();
+}


### PR DESCRIPTION
Direct fix for the confirmed OOM root cause tonight — 4x `hoie-inbox-1` crashes traced (via #709's per-command RSS log, now live in prod) to a mail client at `208.82.98.54` issuing `UID FETCH 12365 BODY` + `UID FETCH 12381 BODY` in an escalating retry storm across two sockets. Each concurrent in-flight fetch held tens of MB in RSS; the 256 MiB container cap was hit within ~10 s and the process OOM-killed 4 times in the same evening.

## Fix

Single-flight coalescing at the repository layer. `getMailsByRange` callers with the same `(user_id, account, sent, start, end, useUid, sorted-fields)` key share a **single in-flight Promise**; the second caller awaits the first's result Map instead of triggering a duplicate SQL load into memory.

```ts
export function singleFlight<T>(key: string, work: () => Promise<T>): Promise<T> {
  const pending = inflight.get(key);
  if (pending) return pending as Promise<T>;
  const promise = work().finally(() => inflight.delete(key));
  inflight.set(key, promise);
  return promise;
}
```

**Not a cache.** The entry is deleted on both success AND failure (`.finally(() => inflight.delete(key))`) — the next request after settle does a fresh load. `singleFlight` is intentionally NOT `async` so the two callers get the SAME Promise reference; an async wrapper would return a fresh promise per call that awaits the cached one, defeating identity-level coalescing.

**Not Redis.** Wrong tool: the problem is duplicate work IN FLIGHT in the SAME process, not repeat reads across processes/time. Redis adds a durable dependency + failure mode without addressing the concurrent-memory-multiplication root cause. Discussed with Hoie before implementing.

## Memory footprint

Before: `O(concurrent-callers-per-message-body)` — the observed 7× retry storm on a 2.75 MB body → ~19 MB per message in flight.
After: `O(distinct-in-flight-queries)` — a 7× retry on the same UID → ~2.75 MB, once.

## Test plan

- [x] `bunx tsc --noEmit` clean.
- [x] `bun test src/server/lib/postgres/repositories/mails/inflight.test.ts` — 5/5. Covers: identity (same key → same promise reference), no-coalescing across keys, entry-deleted-on-success, entry-deleted-on-failure (a failed load must not stick around and short-circuit every later caller), shared rejection.
- [x] `bun test src/server` — 1244/0.
- [ ] Sandbox behavior parity — deferred; this is a repository-layer change with unit-level identity + settle behavior covered, and reproducing the "retry storm from a real mail client at 208.82.98.54" is not something a sandbox can simulate. The observable prod signal will be the `IMAP command completed` log lines from #709: duplicate `UID FETCH X BODY` on the same session should now show `rssDeltaMB` near-zero on the second caller onward instead of proportional to body size.
- [ ] Reviewoie — spawning next.

Closes the acute prod OOM. Follow-up idea worth noting but not this PR: rate-limit / reject duplicate UID FETCH from the same client within a short window (defense in depth against pathological clients).