### PR TITLE
perf(db): cap pg queries with statement_timeout + query_timeout

### DIFF
--- a/src/server/lib/postgres/client.test.ts
+++ b/src/server/lib/postgres/client.test.ts
@@ -96,3 +96,21 @@ describe("lazy pool Proxy", () => {
     expect(ctorCalls.mock.calls.length).toBe(before + 1);
   });
 });
+
+describe("pool config", () => {
+  test("passes both a server-side (statement_timeout) and client-side (query_timeout) cap", () => {
+    resetPool();
+    // Force construction so FakePool captures the config we handed to `new Pool()`.
+    void pool.ending;
+    const cfg = (pool as unknown as { config: Record<string, unknown> }).config;
+    // Both caps are required. statement_timeout aborts on the server via
+    // Postgres 57014; query_timeout is node-postgres' backstop for when the
+    // TCP connection is silently wedged and the server never delivers the
+    // abort. A single cap leaves one of those failure modes uncovered —
+    // load-bearing because the #710 single-flight coalesce turns one hung
+    // query into blocked callers waiting on the shared promise, so an
+    // unbounded query pins the map entry for the whole failure window.
+    expect(cfg.statement_timeout).toBe(30_000);
+    expect(cfg.query_timeout).toBe(30_000);
+  });
+});

--- a/src/server/lib/postgres/client.ts
+++ b/src/server/lib/postgres/client.ts
@@ -24,6 +24,13 @@ const config: PoolConfig = {
   max: 20,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 2000,
+  // Server-side cap: Postgres aborts the query with 57014 after 30s. Guards
+  // against runaway queries pinning a pool client (and, since #710, blocking
+  // every coalesced caller waiting on that client's inflight promise).
+  statement_timeout: 30_000,
+  // Client-side backstop: fires if statement_timeout can't — e.g. the TCP
+  // connection is silently wedged and the server never delivers the abort.
+  query_timeout: 30_000,
   types: {
     getTypeParser(id, format) {
       if (id === types.builtins.NUMERIC) return parseFloat;


### PR DESCRIPTION
## Summary
Closes #711 (follow-up from #710 reviewoie).

Adds two 30 s query caps to the pg pool config:
- `statement_timeout` — Postgres-side, aborts the query with 57014 on the server.
- `query_timeout` — node-postgres-side, backstop for when the TCP connection is silently wedged and the server never delivers the abort.

The pool previously had only `connectionTimeoutMillis: 2000` (client-acquisition timeout). A runaway query would pin its pool client until TCP keepalive gave up.

## Why now
Pre-existing gap, but the failure mode is amplified by #710's single-flight coalescing:
- Without coalescing: one hung query blocks one caller until the connection dies.
- With coalescing: one hung `getMailsByRange` blocks EVERY coalesced caller waiting on the shared promise, AND pins the inflight-map entry until the underlying pg client fails. Coalescing turns "one blocked caller" into "all callers on that key blocked".

## Value pick
30 s covers the slowest known query paths:
- Unbounded IMAP SEARCH (`src/server/lib/postgres/repositories/mails/imap.ts:582` — per RFC 3501 6.4.4 no LIMIT allowed).
- Startup schema-migration ALTER TABLE / column adds (`migration.ts`, runs against dev-sized tables).

Cron / bulk paths that legitimately need more time can override per-call via `SET LOCAL statement_timeout` on a dedicated client or scoped BEGIN block.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/server/lib/postgres/client.test.ts` -> 7/7 (new: `pool config > passes both a server-side (statement_timeout) and client-side (query_timeout) cap` — asserts both fields land in the config handed to `new Pool()`)
- [x] `bun test src/server` -> 1288/0 across 65 files
- [ ] CI green