### PR TITLE
fix(imap): coalesce body serialization + chunked writes to cap FETCH RSS

### DIFF
--- a/src/server/lib/imap/body-buffer.test.ts
+++ b/src/server/lib/imap/body-buffer.test.ts
@@ -1,84 +1,132 @@
 /**
- * getSharedBodyBuffer coalescing invariants:
- *  1. Concurrent identical (cacheKey, build) calls share ONE Buffer
- *     instance — only the first `build()` runs.
+ * getSharedBodyResult coalescing + tri-state invariants:
+ *  1. Concurrent identical (cacheKey, build) calls share ONE result —
+ *     only the first `build()` runs.
  *  2. Different cacheKeys build independently — no cross-key contamination.
  *  3. After the promise settles, the cache entry drops (singleflight
  *     lifetime); a later caller with the same key re-builds. Intentional:
  *     the OOM comes from CONCURRENT duplicate serializations, not
  *     sequential ones.
- *  4. Returns a Buffer — the whole point vs a string cache is that
- *     `socket.write(buffer)` skips the UTF-8 conversion and V8 can GC the
- *     intermediate JS string.
+ *  4. Tri-state: `{ kind: "content", text }` → Buffer;
+ *     `{ kind: "nil" }` → `nil` result (caller emits `NIL` simple part);
+ *     `{ kind: "omit" }` → `omit` result (caller drops the part).
+ *     These three shapes preserve the pre-cache behavior of
+ *     `buildBodyResponsePart` on empty-body and nonexistent-part paths.
+ *  5. Content result is a Buffer — `socket.write(buffer)` skips the
+ *     UTF-8 conversion and V8 can GC the intermediate JS string.
  */
 import { describe, it, expect, beforeEach } from "bun:test";
-import { getSharedBodyBuffer, bodyBufferKey } from "./body-buffer";
+import { getSharedBodyResult, bodyBufferKey } from "./body-buffer";
 import { inflightReset, inflightSize } from "../postgres/repositories/mails/inflight";
 
 beforeEach(() => {
   inflightReset();
 });
 
-describe("getSharedBodyBuffer", () => {
+describe("getSharedBodyResult", () => {
   it("coalesces two concurrent callers on the same key to one build + one Buffer", async () => {
     let builds = 0;
     // Both calls fire in the same synchronous tick — the second sees the
     // pending entry that the first inserted before returning (singleflight
     // sync-set-before-return semantic).
-    const p1 = getSharedBodyBuffer("k", () => {
+    const p1 = getSharedBodyResult("k", () => {
       builds += 1;
-      return "shared-body";
+      return { kind: "content", text: "shared-body" };
     });
-    const p2 = getSharedBodyBuffer("k", () => {
+    const p2 = getSharedBodyResult("k", () => {
       builds += 1;
-      return "would-lose-if-ran";
+      return { kind: "content", text: "would-lose-if-ran" };
     });
     // Both callers hold the SAME Promise reference — proof of coalescing at
     // the singleflight layer.
     expect(p1).toBe(p2);
     expect(inflightSize()).toBe(1);
-    const [b1, b2] = await Promise.all([p1, p2]);
-    expect(b1).toBe(b2);
-    expect(b1.toString("utf8")).toBe("shared-body");
-    // Only the first build ran. The second `build` callback was passed in
-    // but singleflight dropped it — that's the whole point.
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.kind).toBe("buffer");
+    if (r1.kind !== "buffer" || r2.kind !== "buffer") throw new Error();
+    // Same Buffer reference.
+    expect(r1.buffer).toBe(r2.buffer);
+    expect(r1.buffer.toString("utf8")).toBe("shared-body");
+    // Only the first build ran.
     expect(builds).toBe(1);
   });
 
   it("does NOT coalesce across different keys", async () => {
-    const b1 = await getSharedBodyBuffer("k1", () => "one");
-    const b2 = await getSharedBodyBuffer("k2", () => "two");
-    expect(b1.toString("utf8")).toBe("one");
-    expect(b2.toString("utf8")).toBe("two");
-    expect(b1).not.toBe(b2);
+    const r1 = await getSharedBodyResult("k1", () => ({ kind: "content", text: "one" }));
+    const r2 = await getSharedBodyResult("k2", () => ({ kind: "content", text: "two" }));
+    if (r1.kind !== "buffer" || r2.kind !== "buffer") throw new Error();
+    expect(r1.buffer.toString("utf8")).toBe("one");
+    expect(r2.buffer.toString("utf8")).toBe("two");
+    expect(r1.buffer).not.toBe(r2.buffer);
   });
 
-  it("returns a Buffer whose bytes match a UTF-8 encoding of build()'s output", async () => {
+  it("returns a Buffer whose bytes match a UTF-8 encoding of build()'s text", async () => {
     // Multi-byte codepoints — proves the encoding is UTF-8 and byteLength
     // is the octet count, not the JS-string length.
     const src = "hello — wörld";
-    const buf = await getSharedBodyBuffer("utf8", () => src);
-    expect(buf.byteLength).toBe(Buffer.byteLength(src, "utf8"));
-    expect(buf.toString("utf8")).toBe(src);
-    // JS-string length would be 13 but UTF-8 byteLength is 16 (—: 3 bytes,
-    // ö: 2 bytes). Guard the assertion from silently passing under
-    // ASCII-only inputs.
-    expect(buf.byteLength).not.toBe(src.length);
+    const r = await getSharedBodyResult("utf8", () => ({ kind: "content", text: src }));
+    if (r.kind !== "buffer") throw new Error();
+    expect(r.buffer.byteLength).toBe(Buffer.byteLength(src, "utf8"));
+    expect(r.buffer.toString("utf8")).toBe(src);
+    // Guard the assertion from silently passing under ASCII-only inputs.
+    expect(r.buffer.byteLength).not.toBe(src.length);
   });
 
   it("cache entry drops on settle so a later caller re-builds", async () => {
     let builds = 0;
-    const run = () => getSharedBodyBuffer("k", () => {
+    const run = () => getSharedBodyResult("k", () => {
       builds += 1;
-      return `run-${builds}`;
+      return { kind: "content", text: `run-${builds}` };
     });
     const first = await run();
-    expect(first.toString("utf8")).toBe("run-1");
+    if (first.kind !== "buffer") throw new Error();
+    expect(first.buffer.toString("utf8")).toBe("run-1");
     // singleflight semantics: entry cleared post-settle. Not a cache.
     expect(inflightSize()).toBe(0);
     const second = await run();
-    expect(second.toString("utf8")).toBe("run-2");
+    if (second.kind !== "buffer") throw new Error();
+    expect(second.buffer.toString("utf8")).toBe("run-2");
     expect(builds).toBe(2);
+  });
+
+  it("preserves `nil` sentinel across coalesced callers (empty-body path)", async () => {
+    // `BODY[TEXT]` on a mail with no text/html/attachments must emit
+    // `BODY[TEXT] NIL`, not a 2-byte CRLF literal. Regression: an earlier
+    // shape collapsed empty content into a zero-length Buffer and callers
+    // downstream couldn't distinguish it from a genuine "nil" sentinel.
+    let builds = 0;
+    const p1 = getSharedBodyResult("empty", () => {
+      builds += 1;
+      return { kind: "nil" };
+    });
+    const p2 = getSharedBodyResult("empty", () => {
+      builds += 1;
+      return { kind: "nil" };
+    });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.kind).toBe("nil");
+    expect(r2.kind).toBe("nil");
+    expect(builds).toBe(1);
+  });
+
+  it("preserves `omit` sentinel across coalesced callers (nonexistent-part path)", async () => {
+    // `BODY[99]` on a 2-part message must be DROPPED from the FETCH
+    // response, not emitted as `BODY[99] NIL`. Regression: same collapse
+    // as above but conflated with the empty-body case, so the null path
+    // that used to omit the part started emitting a NIL simple.
+    let builds = 0;
+    const p1 = getSharedBodyResult("gone", () => {
+      builds += 1;
+      return { kind: "omit" };
+    });
+    const p2 = getSharedBodyResult("gone", () => {
+      builds += 1;
+      return { kind: "omit" };
+    });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1.kind).toBe("omit");
+    expect(r2.kind).toBe("omit");
+    expect(builds).toBe(1);
   });
 });
 

--- a/src/server/lib/imap/body-buffer.test.ts
+++ b/src/server/lib/imap/body-buffer.test.ts
@@ -1,0 +1,106 @@
+/**
+ * getSharedBodyBuffer coalescing invariants:
+ *  1. Concurrent identical (cacheKey, build) calls share ONE Buffer
+ *     instance — only the first `build()` runs.
+ *  2. Different cacheKeys build independently — no cross-key contamination.
+ *  3. After the promise settles, the cache entry drops (singleflight
+ *     lifetime); a later caller with the same key re-builds. Intentional:
+ *     the OOM comes from CONCURRENT duplicate serializations, not
+ *     sequential ones.
+ *  4. Returns a Buffer — the whole point vs a string cache is that
+ *     `socket.write(buffer)` skips the UTF-8 conversion and V8 can GC the
+ *     intermediate JS string.
+ */
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getSharedBodyBuffer, bodyBufferKey } from "./body-buffer";
+import { inflightReset, inflightSize } from "../postgres/repositories/mails/inflight";
+
+beforeEach(() => {
+  inflightReset();
+});
+
+describe("getSharedBodyBuffer", () => {
+  it("coalesces two concurrent callers on the same key to one build + one Buffer", async () => {
+    let builds = 0;
+    // Both calls fire in the same synchronous tick — the second sees the
+    // pending entry that the first inserted before returning (singleflight
+    // sync-set-before-return semantic).
+    const p1 = getSharedBodyBuffer("k", () => {
+      builds += 1;
+      return "shared-body";
+    });
+    const p2 = getSharedBodyBuffer("k", () => {
+      builds += 1;
+      return "would-lose-if-ran";
+    });
+    // Both callers hold the SAME Promise reference — proof of coalescing at
+    // the singleflight layer.
+    expect(p1).toBe(p2);
+    expect(inflightSize()).toBe(1);
+    const [b1, b2] = await Promise.all([p1, p2]);
+    expect(b1).toBe(b2);
+    expect(b1.toString("utf8")).toBe("shared-body");
+    // Only the first build ran. The second `build` callback was passed in
+    // but singleflight dropped it — that's the whole point.
+    expect(builds).toBe(1);
+  });
+
+  it("does NOT coalesce across different keys", async () => {
+    const b1 = await getSharedBodyBuffer("k1", () => "one");
+    const b2 = await getSharedBodyBuffer("k2", () => "two");
+    expect(b1.toString("utf8")).toBe("one");
+    expect(b2.toString("utf8")).toBe("two");
+    expect(b1).not.toBe(b2);
+  });
+
+  it("returns a Buffer whose bytes match a UTF-8 encoding of build()'s output", async () => {
+    // Multi-byte codepoints — proves the encoding is UTF-8 and byteLength
+    // is the octet count, not the JS-string length.
+    const src = "hello — wörld";
+    const buf = await getSharedBodyBuffer("utf8", () => src);
+    expect(buf.byteLength).toBe(Buffer.byteLength(src, "utf8"));
+    expect(buf.toString("utf8")).toBe(src);
+    // JS-string length would be 13 but UTF-8 byteLength is 16 (—: 3 bytes,
+    // ö: 2 bytes). Guard the assertion from silently passing under
+    // ASCII-only inputs.
+    expect(buf.byteLength).not.toBe(src.length);
+  });
+
+  it("cache entry drops on settle so a later caller re-builds", async () => {
+    let builds = 0;
+    const run = () => getSharedBodyBuffer("k", () => {
+      builds += 1;
+      return `run-${builds}`;
+    });
+    const first = await run();
+    expect(first.toString("utf8")).toBe("run-1");
+    // singleflight semantics: entry cleared post-settle. Not a cache.
+    expect(inflightSize()).toBe(0);
+    const second = await run();
+    expect(second.toString("utf8")).toBe("run-2");
+    expect(builds).toBe(2);
+  });
+});
+
+describe("bodyBufferKey", () => {
+  it("composes mailId + sectionKey with a stable separator", () => {
+    expect(bodyBufferKey("mail-1", "BODY[]")).toBe("mail-1::BODY[]");
+    expect(bodyBufferKey("mail-1", "BODY[TEXT]")).toBe("mail-1::BODY[TEXT]");
+  });
+
+  it("gives distinct keys for the same mail across different sections", () => {
+    // Concurrent callers asking for DIFFERENT sections of the same mail
+    // must not share a buffer — one Buffer can't be both BODY[] and
+    // BODY[TEXT].
+    expect(bodyBufferKey("mail-1", "BODY[]")).not.toBe(
+      bodyBufferKey("mail-1", "BODY[TEXT]")
+    );
+  });
+
+  it("gives distinct keys for the same section across different mails", () => {
+    // Concurrent callers on different mails must not share either.
+    expect(bodyBufferKey("mail-1", "BODY[]")).not.toBe(
+      bodyBufferKey("mail-2", "BODY[]")
+    );
+  });
+});

--- a/src/server/lib/imap/body-buffer.ts
+++ b/src/server/lib/imap/body-buffer.ts
@@ -20,10 +20,28 @@ import { singleFlight } from "../postgres/repositories/mails/inflight";
  * copy — it enqueues a reference), so heap footprint stays at
  * O(distinct-in-flight-bodies) instead of O(callers).
  *
- * Why Buffer, not string:
- * - `Buffer.from(str, "utf8")` produces an allocation that lives outside
- *   V8's string heap, so the intermediate JS string built by
- *   `buildFullMessage` can be GC'd immediately after the encode.
+ * The tri-state result (buffer / nil / omit) preserves the three IMAP
+ * response shapes `buildBodyResponsePart` had to distinguish BEFORE this
+ * cache existed:
+ * - **buffer**: normal literal response `{N}\r\n<octets>`.
+ * - **nil**:   `<sectionKey> NIL` simple part (returned when the source
+ *              body exists but is empty — e.g. BODY[TEXT] on a mail with
+ *              no text/html/attachments).
+ * - **omit**:  the whole FETCH-response part is dropped (returned when
+ *              the section doesn't exist at all — e.g. BODY[99] on a
+ *              2-part message).
+ *
+ * Encoding those inside the closure (not outside) is REQUIRED: if the
+ * empty/omit check ran outside the singleflight, two concurrent callers
+ * would each independently call `getBodyContent` — which for the big
+ * cases means each redoes `buildFullMessage` (the multi-MB base64
+ * encode). That's the exact per-caller allocation this cache is here to
+ * eliminate.
+ *
+ * Why Buffer, not string, for the content case:
+ * - `Buffer.from(str, "utf8")` allocates outside V8's string heap, so
+ *   the intermediate JS string built by `buildFullMessage` can be GC'd
+ *   immediately after the encode.
  * - `socket.write(buffer)` skips the per-write UTF-8 conversion Node
  *   otherwise runs on string writes.
  *
@@ -31,11 +49,28 @@ import { singleFlight } from "../postgres/repositories/mails/inflight";
  * settle. That's the correct scope — the OOM comes from CONCURRENT
  * duplicate serializations; sequential callers can freely re-build.
  */
-export const getSharedBodyBuffer = (
+
+/** What the closure passed to `getSharedBodyResult` may return. */
+export type BodyBuildResult =
+  | { kind: "content"; text: string }
+  | { kind: "nil" }
+  | { kind: "omit" };
+
+/** What coalesced callers receive from `getSharedBodyResult`. */
+export type BodyCacheResult =
+  | { kind: "buffer"; buffer: Buffer }
+  | { kind: "nil" }
+  | { kind: "omit" };
+
+export const getSharedBodyResult = (
   cacheKey: string,
-  build: () => string
-): Promise<Buffer> =>
-  singleFlight(`body:${cacheKey}`, async () => Buffer.from(build(), "utf8"));
+  build: () => BodyBuildResult
+): Promise<BodyCacheResult> =>
+  singleFlight(`body:${cacheKey}`, async () => {
+    const r = build();
+    if (r.kind !== "content") return r;
+    return { kind: "buffer", buffer: Buffer.from(r.text, "utf8") };
+  });
 
 /**
  * Cache-key shape: `<mailId>::<sectionKey>`. `mailId` scopes to a single

--- a/src/server/lib/imap/body-buffer.ts
+++ b/src/server/lib/imap/body-buffer.ts
@@ -1,0 +1,47 @@
+import { singleFlight } from "../postgres/repositories/mails/inflight";
+
+/**
+ * Coalesce identical BODY-content serializations across concurrent FETCH
+ * handlers.
+ *
+ * `getMailsByRange` (postgres/repositories/mails/imap.ts) already single-
+ * flights the DB read — coalesced callers share one `PartialMailModel`
+ * instance and, transitively, one `mail.html` / `mail.text` string. But
+ * each handler was independently calling `buildFullMessage(mail)` and
+ * base64-encoding the shared body, producing N distinct multi-MB JS
+ * strings on top of the shared source. Under a client that pipelines
+ * duplicate `UID FETCH X (BODY)` (observed: iOS Mail hammering a slow
+ * response across a double-socket setup), those N strings pushed the
+ * container's RSS past the OOM cap.
+ *
+ * This cache coalesces the SERIALIZATION step too. Concurrent identical
+ * body-content builds share one `Buffer`; every coalesced caller
+ * `writeChunked`s the same Buffer reference (`socket.write(buffer)` doesn't
+ * copy — it enqueues a reference), so heap footprint stays at
+ * O(distinct-in-flight-bodies) instead of O(callers).
+ *
+ * Why Buffer, not string:
+ * - `Buffer.from(str, "utf8")` produces an allocation that lives outside
+ *   V8's string heap, so the intermediate JS string built by
+ *   `buildFullMessage` can be GC'd immediately after the encode.
+ * - `socket.write(buffer)` skips the per-write UTF-8 conversion Node
+ *   otherwise runs on string writes.
+ *
+ * Cache lifetime is the singleflight window: the entry deletes on
+ * settle. That's the correct scope — the OOM comes from CONCURRENT
+ * duplicate serializations; sequential callers can freely re-build.
+ */
+export const getSharedBodyBuffer = (
+  cacheKey: string,
+  build: () => string
+): Promise<Buffer> =>
+  singleFlight(`body:${cacheKey}`, async () => Buffer.from(build(), "utf8"));
+
+/**
+ * Cache-key shape: `<mailId>::<sectionKey>`. `mailId` scopes to a single
+ * mail; `sectionKey` distinguishes BODY[] vs BODY[TEXT] vs BODY[HEADER]
+ * etc. so two concurrent callers asking for DIFFERENT sections of the
+ * same mail don't erroneously share a buffer.
+ */
+export const bodyBufferKey = (mailId: string, sectionKey: string): string =>
+  `${mailId}::${sectionKey}`;

--- a/src/server/lib/imap/chunked-write.test.ts
+++ b/src/server/lib/imap/chunked-write.test.ts
@@ -1,0 +1,144 @@
+/**
+ * writeChunkedToSocket invariants:
+ *  1. Emits the payload in `CHUNK_BYTES`-sized zero-copy views that
+ *     reconstruct the original bytes when concatenated.
+ *  2. Backpressure: `socket.write` returning false pauses the loop until
+ *     'drain' fires. Without this, a retry-storm of multi-MB FETCH
+ *     responses lets the Node writable-side buffer grow unbounded,
+ *     defeating the RSS cap that motivated the fix.
+ *  3. Socket 'close' mid-drain wakes the awaiter — otherwise a socket
+ *     that dies between `write:false` and any potential `drain` hangs
+ *     the whole FETCH pipeline on that promise.
+ *  4. Destroyed / unwritable socket → returns 0 without writing.
+ *  5. Return value is the bytes actually written — bumped even on a
+ *     partial write (some chunks landed, later one threw). Callers use
+ *     this to keep the per-command diagnostic byte counter honest.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { EventEmitter } from "events";
+import {
+  writeChunkedToSocket,
+  CHUNK_BYTES,
+  ChunkedWriteSocket,
+} from "./chunked-write";
+
+const makeFakeSocket = (behavior: {
+  writeFn: (chunk: Uint8Array) => boolean;
+  destroyed?: boolean;
+  writable?: boolean;
+}): ChunkedWriteSocket => {
+  const ee = new EventEmitter();
+  return Object.assign(ee, {
+    destroyed: behavior.destroyed ?? false,
+    writable: behavior.writable ?? true,
+    write: behavior.writeFn,
+  }) as ChunkedWriteSocket;
+};
+
+describe("writeChunkedToSocket", () => {
+  it("emits the payload as CHUNK_BYTES-sized chunks that concatenate back to it", async () => {
+    const chunks: Buffer[] = [];
+    const socket = makeFakeSocket({
+      writeFn: (c) => {
+        // Buffer.from copies so a later slice reuse can't mutate history.
+        chunks.push(Buffer.from(c));
+        return true;
+      },
+    });
+    // 3.5 chunks worth — the tail chunk is intentionally short.
+    const payload = Buffer.alloc(3 * CHUNK_BYTES + 17, 0x41);
+    const written = await writeChunkedToSocket(socket, payload, () => {});
+    expect(written).toBe(payload.byteLength);
+    expect(chunks.length).toBe(4);
+    expect(chunks[0].byteLength).toBe(CHUNK_BYTES);
+    expect(chunks[1].byteLength).toBe(CHUNK_BYTES);
+    expect(chunks[2].byteLength).toBe(CHUNK_BYTES);
+    expect(chunks[3].byteLength).toBe(17); // tail
+    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+  });
+
+  it("awaits 'drain' before continuing when socket.write returns false", async () => {
+    let writeCount = 0;
+    const socket = makeFakeSocket({
+      writeFn: () => {
+        writeCount += 1;
+        // Only the first write reports backpressure — 2nd must wait for
+        // a 'drain' event before firing.
+        return writeCount !== 1;
+      },
+    });
+    const payload = Buffer.alloc(2 * CHUNK_BYTES, 0x42);
+    const done = writeChunkedToSocket(socket, payload, () => {});
+    // Let the promise reach the drain-await; two microtask flushes cover
+    // it comfortably.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeCount).toBe(1); // 2nd write is parked on drain
+    socket.emit("drain");
+    const written = await done;
+    expect(writeCount).toBe(2);
+    expect(written).toBe(payload.byteLength);
+  });
+
+  it("resolves when the socket 'close's mid-drain (does not hang)", async () => {
+    // Permanent backpressure: every write returns false. Without the
+    // 'close' fallback the awaiter would sit forever.
+    const socket = makeFakeSocket({ writeFn: () => false });
+    const payload = Buffer.alloc(CHUNK_BYTES, 0x43);
+    const done = writeChunkedToSocket(socket, payload, () => {});
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("close");
+    // If this test hangs, the close-fallback is broken.
+    const written = await done;
+    // Byte counter bumped for the queued chunk even though the socket
+    // died before drain — write() DID succeed (returned false), the OS
+    // has the bytes.
+    expect(written).toBe(CHUNK_BYTES);
+  });
+
+  it("returns 0 without writing when the socket is destroyed", async () => {
+    const write = mock(() => true);
+    const socket = makeFakeSocket({ writeFn: write, destroyed: true });
+    const written = await writeChunkedToSocket(
+      socket,
+      Buffer.alloc(CHUNK_BYTES),
+      () => {}
+    );
+    expect(written).toBe(0);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 without writing when the socket is unwritable", async () => {
+    const write = mock(() => true);
+    const socket = makeFakeSocket({ writeFn: write, writable: false });
+    const written = await writeChunkedToSocket(
+      socket,
+      Buffer.alloc(CHUNK_BYTES),
+      () => {}
+    );
+    expect(written).toBe(0);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("calls onError and returns the running written count when write throws mid-payload", async () => {
+    let writes = 0;
+    const errors: unknown[] = [];
+    const socket = makeFakeSocket({
+      writeFn: () => {
+        writes += 1;
+        if (writes === 3) throw new Error("EPIPE");
+        return true;
+      },
+    });
+    const payload = Buffer.alloc(4 * CHUNK_BYTES, 0x44);
+    const written = await writeChunkedToSocket(socket, payload, (e) =>
+      errors.push(e)
+    );
+    // Two chunks landed before the third threw.
+    expect(written).toBe(2 * CHUNK_BYTES);
+    expect(writes).toBe(3);
+    expect(errors.length).toBe(1);
+    expect((errors[0] as Error).message).toBe("EPIPE");
+  });
+});

--- a/src/server/lib/imap/chunked-write.test.ts
+++ b/src/server/lib/imap/chunked-write.test.ts
@@ -6,9 +6,11 @@
  *     'drain' fires. Without this, a retry-storm of multi-MB FETCH
  *     responses lets the Node writable-side buffer grow unbounded,
  *     defeating the RSS cap that motivated the fix.
- *  3. Socket 'close' mid-drain wakes the awaiter — otherwise a socket
- *     that dies between `write:false` and any potential `drain` hangs
- *     the whole FETCH pipeline on that promise.
+ *  3. Socket 'close' mid-drain wakes the awaiter AND stops the loop —
+ *     otherwise a socket that dies between `write:false` and any potential
+ *     `drain` hangs the whole FETCH pipeline: on a multi-chunk payload the
+ *     next `socket.write` to the dead socket returns false (no sync throw),
+ *     re-awaiting a drain/close that never fires.
  *  4. Destroyed / unwritable socket → returns 0 without writing.
  *  5. Return value is the bytes actually written — bumped even on a
  *     partial write (some chunks landed, later one threw). Callers use
@@ -95,6 +97,31 @@ describe("writeChunkedToSocket", () => {
     // died before drain — write() DID succeed (returned false), the OS
     // has the bytes.
     expect(written).toBe(CHUNK_BYTES);
+  });
+
+  it("stops the loop when a multi-chunk payload's socket 'close's mid-drain (does not hang)", async () => {
+    // Multi-chunk payload with permanent backpressure. 'close' fires
+    // during chunk 0's drain-await and marks the socket destroyed. The
+    // loop must NOT proceed to chunk 1 — writing to the dead socket would
+    // return false again and re-await a drain/close that never comes.
+    let writes = 0;
+    const socket = makeFakeSocket({
+      writeFn: () => {
+        writes += 1;
+        return false;
+      },
+    });
+    const payload = Buffer.alloc(2 * CHUNK_BYTES, 0x45);
+    const done = writeChunkedToSocket(socket, payload, () => {});
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writes).toBe(1); // parked on chunk 0's drain
+    (socket as { destroyed: boolean }).destroyed = true;
+    socket.emit("close");
+    // If this test hangs, the loop kept writing to a dead socket.
+    const written = await done;
+    expect(writes).toBe(1); // chunk 1 never attempted
+    expect(written).toBe(CHUNK_BYTES); // only chunk 0 landed
   });
 
   it("returns 0 without writing when the socket is destroyed", async () => {

--- a/src/server/lib/imap/chunked-write.ts
+++ b/src/server/lib/imap/chunked-write.ts
@@ -1,0 +1,77 @@
+import { EventEmitter } from "events";
+
+/**
+ * Socket-agnostic backpressure-aware chunked writer.
+ *
+ * Extracted from `ImapSession` so the write loop can be unit-tested
+ * against a fake socket without pulling the full session (and its
+ * transitive `server` barrel dependency) into leaf test files. The
+ * session's `writeChunked` method is a thin wrapper — see `session.ts`.
+ *
+ * The loop:
+ * - Slices `payload` into `CHUNK_BYTES`-sized zero-copy views.
+ * - For each slice: `socket.write(slice)`; if that returns false (Node
+ *   reports its writable-side high-water mark reached), await `drain`
+ *   before writing the next chunk. That's the whole point: without this
+ *   await, a retry-storm of multi-MB responses lets the outbound queue
+ *   grow unbounded, defeating the RSS cap that motivated this fix.
+ * - `close` mid-drain also wakes the awaiter — otherwise a socket that
+ *   dies between `write:false` and any potential `drain` would hang the
+ *   whole FETCH pipeline on that promise.
+ *
+ * `onError` receives any exception thrown by `socket.write` so callers
+ * can log with their own component tag; it's invoked once per failed
+ * write and the function returns early (partial write, no throw).
+ */
+export interface ChunkedWriteSocket extends EventEmitter {
+  destroyed: boolean;
+  writable: boolean;
+  write(chunk: Uint8Array): boolean;
+}
+
+export const CHUNK_BYTES = 64 * 1024; // matches typical TCP high-water mark
+
+export const writeChunkedToSocket = async (
+  socket: ChunkedWriteSocket,
+  payload: Buffer,
+  onError: (err: unknown) => void
+): Promise<number> => {
+  if (socket.destroyed || !socket.writable) return 0;
+
+  let written = 0;
+  for (let offset = 0; offset < payload.byteLength; offset += CHUNK_BYTES) {
+    const end = Math.min(offset + CHUNK_BYTES, payload.byteLength);
+    // Zero-copy view; cast because Node's `socket.write` types constrain
+    // the backing ArrayBuffer more tightly than `Buffer.subarray`'s
+    // return.
+    const slice = payload.subarray(offset, end) as unknown as Uint8Array;
+
+    let ok: boolean;
+    try {
+      ok = socket.write(slice);
+    } catch (error) {
+      onError(error);
+      return written;
+    }
+    written += slice.byteLength;
+
+    if (!ok) {
+      // Resolve on 'drain' (normal) or 'close' (socket died — no drain
+      // is coming and we mustn't hang the awaiting FETCH). Both cleanup
+      // paths remove the other listener so nothing leaks.
+      await new Promise<void>((resolve) => {
+        const onDrain = () => {
+          socket.off("close", onClose);
+          resolve();
+        };
+        const onClose = () => {
+          socket.off("drain", onDrain);
+          resolve();
+        };
+        socket.once("drain", onDrain);
+        socket.once("close", onClose);
+      });
+    }
+  }
+  return written;
+};

--- a/src/server/lib/imap/chunked-write.ts
+++ b/src/server/lib/imap/chunked-write.ts
@@ -71,6 +71,11 @@ export const writeChunkedToSocket = async (
         socket.once("drain", onDrain);
         socket.once("close", onClose);
       });
+      // If the wake came from 'close', the socket is dead: a further
+      // write returns false (Node emits ERR_STREAM_DESTROYED async, no
+      // sync throw for the try/catch), so continuing the loop would
+      // re-await a drain/close that never fires and wedge the FETCH.
+      if (socket.destroyed || !socket.writable) return written;
     }
   }
   return written;

--- a/src/server/lib/imap/condstore.test.ts
+++ b/src/server/lib/imap/condstore.test.ts
@@ -477,6 +477,9 @@ const runFetch = async (
       lines.push(data);
       return true;
     },
+    async (payload: Buffer) => {
+      lines.push(payload.toString("utf8"));
+    },
     condstoreEnabled
   );
   return { captured, out: lines.join("") };

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -27,10 +27,19 @@ import {
   buildFetchResponsePart,
   buildBodyResponsePart,
   convertSequenceSet,
+  FetchResponsePart,
 } from "./fetch-helpers";
 import { formatEnvelope } from "./util";
 import { BodyFetch, SequenceSet } from "./types";
 import type { MailType } from "common";
+
+// Wire content is `string | Buffer` — large non-partial body payloads flow
+// through the shared body-buffer cache and land as Buffer. Every test in
+// this file reasons about them as UTF-8 text, so coerce at the boundary.
+const contentAsString = (
+  part: Extract<FetchResponsePart, { type: "literal" }>
+): string =>
+  Buffer.isBuffer(part.content) ? part.content.toString("utf8") : part.content;
 
 describe("getRequestedFields", () => {
   describe("FLAGS", () => {
@@ -186,7 +195,7 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
     expect(rfc).not.toBeNull();
     expect(rfc!.type).toBe("literal");
     if (rfc!.type === "literal" && body!.type === "literal") {
-      expect(rfc!.content).toBe(body!.content);
+      expect(contentAsString(rfc)).toBe(contentAsString(body));
       expect(rfc!.length).toBe(body!.length);
       expect(rfc!.header).toBe("RFC822");
       expect(body!.header).toBe("BODY[]");
@@ -203,7 +212,11 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
     );
     expect(rfc!.type).toBe("literal");
     if (rfc!.type === "literal" && body!.type === "literal") {
-      expect(rfc!.content).toBe(body!.content);
+      // Compare octets, not identity — the two paths now flow through a
+      // shared body-buffer cache keyed on section-label (RFC822.HEADER vs
+      // BODY[HEADER]), so they produce distinct Buffer instances that
+      // encode identical bytes.
+      expect(contentAsString(rfc)).toBe(contentAsString(body));
       expect(rfc!.header).toBe("RFC822.HEADER");
     }
   });
@@ -218,7 +231,7 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
     );
     expect(rfc!.type).toBe("literal");
     if (rfc!.type === "literal" && body!.type === "literal") {
-      expect(rfc!.content).toBe(body!.content);
+      expect(contentAsString(rfc)).toBe(contentAsString(body));
       expect(rfc!.header).toBe("RFC822.TEXT");
     }
   });
@@ -375,7 +388,7 @@ describe("buildBodyResponsePart header terminators (inbox #645)", () => {
     if (part!.type !== "literal") throw new Error("expected literal part");
     // The advertised {N} literal must equal the emitted octets.
     expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
-    return part!.content;
+    return contentAsString(part!);
   };
 
   it("BODY[HEADER] ends in exactly one delimiting blank line", async () => {
@@ -623,7 +636,12 @@ describe("buildBodyResponsePart MIME part sub-sections (inbox #657)", () => {
     if (part!.type !== "literal") throw new Error("expected literal part");
     // The advertised {N} literal must equal the emitted octets.
     expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
-    return part!;
+    // Give tests a stringy `content` alongside the raw part — they all treat
+    // it as UTF-8 text.
+    return {
+      ...part,
+      content: contentAsString(part),
+    };
   };
 
   it("BODY[1.MIME] returns part 1 MIME header block, keyed BODY[1.MIME]", async () => {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -739,3 +739,75 @@ describe("buildFetchResponsePart UID data item — domain-scoped UID space (#702
     expect(part).toEqual({ type: "simple", content: "UID 7" });
   });
 });
+
+// #713 regression: the cached FULL/TEXT/MIME_PART path must preserve the
+// three response shapes the string path returned for empty and
+// nonexistent-part inputs. An earlier draft collapsed both into a
+// zero-length Buffer, which the caller rendered as either a 2-byte CRLF
+// literal (empty body) or a spurious `NIL` simple part (nonexistent part).
+describe("buildBodyResponsePart cached-path shape preservation (#713)", () => {
+  it("BODY[TEXT] on a mail with no text/html/attachments emits `BODY[TEXT] NIL`", async () => {
+    // No text, no html, no attachments — the source content is `""`. Old
+    // string path returned `{ type: "simple", content: "BODY[TEXT] NIL" }`;
+    // a broken cached path emitted a 2-byte `\r\n` literal.
+    const mail: Partial<MailType> = {
+      messageId: "<empty@local>",
+      text: "",
+      html: "",
+      attachments: [],
+    };
+    const part = await buildBodyResponsePart(
+      mail,
+      { type: "BODY", peek: false, section: { type: "TEXT" } },
+      "doc-empty-text",
+      "INBOX"
+    );
+    expect(part).toEqual({ type: "simple", content: "BODY[TEXT] NIL" });
+  });
+
+  it("BODY[99] on a message that has no such part is DROPPED (returns null)", async () => {
+    // Nonexistent MIME part → `getBodyPart` returns `null` →
+    // `getBodyContent` returns `null` → the whole response part is omitted
+    // from the FETCH tuple. A broken cached path would emit a spurious
+    // `BODY[99] NIL` simple where nothing used to be there.
+    const mail: Partial<MailType> = {
+      messageId: "<nopart@local>",
+      text: "some text",
+      html: "<p>some html</p>",
+      attachments: [],
+    };
+    const part = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "MIME_PART", partNumber: "99" },
+      },
+      "doc-nopart",
+      "INBOX"
+    );
+    expect(part).toBeNull();
+  });
+
+  it("BODY[2] on a text-only mail (no part 2) is DROPPED, not emitted as NIL", async () => {
+    // Text-only mail → only part 1 exists. Asking for part 2 must drop the
+    // response part entirely.
+    const mail: Partial<MailType> = {
+      messageId: "<textonly@local>",
+      text: "only text here",
+      html: "",
+      attachments: [],
+    };
+    const part = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "MIME_PART", partNumber: "2" },
+      },
+      "doc-textonly-part2",
+      "INBOX"
+    );
+    expect(part).toBeNull();
+  });
+});

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -740,16 +740,15 @@ describe("buildFetchResponsePart UID data item — domain-scoped UID space (#702
   });
 });
 
-// #713 regression: the cached FULL/TEXT/MIME_PART path must preserve the
-// three response shapes the string path returned for empty and
-// nonexistent-part inputs. An earlier draft collapsed both into a
-// zero-length Buffer, which the caller rendered as either a 2-byte CRLF
-// literal (empty body) or a spurious `NIL` simple part (nonexistent part).
-describe("buildBodyResponsePart cached-path shape preservation (#713)", () => {
+// The cached FULL/TEXT/MIME_PART path must preserve three distinct
+// response shapes: an empty body renders `BODY[TEXT] NIL` (not a 2-byte
+// CRLF literal), and a nonexistent part drops the response part entirely
+// (not a spurious `NIL` simple). A zero-length Buffer cannot distinguish
+// them, so the cache carries a tri-state result instead.
+describe("buildBodyResponsePart cached-path shape preservation", () => {
   it("BODY[TEXT] on a mail with no text/html/attachments emits `BODY[TEXT] NIL`", async () => {
-    // No text, no html, no attachments — the source content is `""`. Old
-    // string path returned `{ type: "simple", content: "BODY[TEXT] NIL" }`;
-    // a broken cached path emitted a 2-byte `\r\n` literal.
+    // No text, no html, no attachments — the source content is `""`, which
+    // RFC 3501 renders as `BODY[TEXT] NIL`, not a 2-byte `\r\n` literal.
     const mail: Partial<MailType> = {
       messageId: "<empty@local>",
       text: "",
@@ -768,8 +767,7 @@ describe("buildBodyResponsePart cached-path shape preservation (#713)", () => {
   it("BODY[99] on a message that has no such part is DROPPED (returns null)", async () => {
     // Nonexistent MIME part → `getBodyPart` returns `null` →
     // `getBodyContent` returns `null` → the whole response part is omitted
-    // from the FETCH tuple. A broken cached path would emit a spurious
-    // `BODY[99] NIL` simple where nothing used to be there.
+    // from the FETCH tuple (not emitted as a spurious `BODY[99] NIL`).
     const mail: Partial<MailType> = {
       messageId: "<nopart@local>",
       text: "some text",

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -27,14 +27,20 @@ import {
   BodySection,
   FetchDataItem,
 } from "./types";
+import { bodyBufferKey, getSharedBodyBuffer } from "./body-buffer";
 
 // ---------------------------------------------------------------------------
 // FetchResponsePart types (local to the fetch subsystem)
 // ---------------------------------------------------------------------------
 
+// `content` is a string for small parts (headers, simple attributes) and a
+// Buffer for large body payloads that flow through the shared body-buffer
+// cache — one Buffer reference is shared across every coalesced FETCH
+// handler for the same (mail, section), so heap footprint stays flat under
+// duplicate-FETCH storms. See `body-buffer.ts`.
 export type FetchResponsePart =
   | { type: "simple"; content: string }
-  | { type: "literal"; content: string; header: string; length: number };
+  | { type: "literal"; content: string | Buffer; header: string; length: number };
 
 // ---------------------------------------------------------------------------
 // Body content extraction
@@ -305,14 +311,45 @@ export async function buildBodyResponsePart(
   void selectedMailbox; // reserved for future per-mailbox logic
   const { section, partial } = bodyFetch;
 
+  // RFC822 / RFC822.HEADER / RFC822.TEXT reuse the BODY[...] builders but must
+  // label the response part with the item the client requested.
+  const sectionKey = keyOverride ?? getBodySectionKey(section);
+
+  // Fast path for large body sections (FULL / TEXT / bare MIME_PART): route
+  // the serialization through the shared body-buffer cache so N concurrent
+  // FETCH handlers for the same (docId, sectionKey) share one Buffer
+  // instead of each independently rebuilding a multi-MB string. Skips
+  // partial fetches (`<start.length>`) because their key would need the
+  // slice bounds and concurrent slices of the same body are uncommon
+  // enough that the coalescing benefit doesn't offset the added logic.
+  if (!partial && !isHeaderLikeSection(section)) {
+    const buffer = await getSharedBodyBuffer(
+      bodyBufferKey(docId, sectionKey),
+      // The trailing `\r\n` MUST be included in the cached value — it's part
+      // of the wire content and its byteLength is what the `{length}`
+      // literal advertises to the client. Appending it per-caller would
+      // negate the whole point of coalescing.
+      () => {
+        const raw = getBodyContent(mail, section, docId);
+        return raw === null ? "" : raw + "\r\n";
+      }
+    );
+    if (buffer.byteLength === 0) {
+      return { type: "simple", content: `${sectionKey} NIL` };
+    }
+    return {
+      type: "literal",
+      content: buffer,
+      header: sectionKey,
+      length: buffer.byteLength,
+    };
+  }
+
   const content = getBodyContent(mail, section, docId);
   if (content === null) {
     return null;
   }
 
-  // RFC822 / RFC822.HEADER / RFC822.TEXT reuse the BODY[...] builders but must
-  // label the response part with the item the client requested.
-  const sectionKey = keyOverride ?? getBodySectionKey(section);
   let header = sectionKey;
   let finalContent = content;
   let length = Buffer.byteLength(finalContent, "utf8");
@@ -338,15 +375,9 @@ export async function buildBodyResponsePart(
     // CRLF. (The non-partial branch below appends one and recounts `length`;
     // doing that here would emit 2 octets more than the `{length}` literal
     // advertises, desyncing clients that read exactly `length` octets.)
-  } else if (!isHeaderLikeSection(section)) {
-    // Body sections (FULL / TEXT / bare MIME_PART) get a trailing CRLF here.
-    // Header sections already carry their own delimiting blank line from
-    // `getBodyContent` (HEADER: `\r\n\r\n`; HEADER_FIELDS: last-field `\r\n` +
-    // blank line; MIME_PART `.HEADER`/`.MIME`: `\r\n\r\n`), so appending another
-    // `\r\n` would emit a spurious second blank line.
-    finalContent += "\r\n";
-    length = Buffer.byteLength(finalContent, "utf8");
   }
+  // (Non-partial, non-header-like branch is handled by the cached fast
+  // path above and returns before reaching here.)
 
   return { type: "literal", content: finalContent, header, length };
 }
@@ -481,11 +512,22 @@ export async function buildFetchResponse(
   return parts;
 }
 
-export function writeFetchResponse(
+/**
+ * Async writer for large payloads with socket-level backpressure. Called
+ * for `literal` parts whose `content` is a `Buffer` (i.e. flowed through
+ * the shared body-buffer cache). Chunks the write so V8 doesn't hold the
+ * whole payload in an outbound queue simultaneously, and awaits `drain`
+ * when `socket.write` reports back-pressure. `writeChunked` returning
+ * without an error means the payload is drained to the OS.
+ */
+export type WriteChunked = (payload: Buffer) => Promise<void>;
+
+export async function writeFetchResponse(
   write: (data: string) => boolean | undefined,
+  writeChunked: WriteChunked,
   seqNum: number,
   parts: FetchResponsePart[]
-) {
+): Promise<void> {
   write(`* ${seqNum} FETCH (`);
 
   for (let i = 0; i < parts.length; i++) {
@@ -493,7 +535,14 @@ export function writeFetchResponse(
 
     const part = parts[i];
     if (part.type === "literal") {
-      write(`${part.header} {${part.length}}\r\n${part.content}`);
+      write(`${part.header} {${part.length}}\r\n`);
+      // Buffer content flows through the chunked writer with drain
+      // awareness; string content stays on the fast synchronous path.
+      if (Buffer.isBuffer(part.content)) {
+        await writeChunked(part.content);
+      } else {
+        write(part.content);
+      }
     } else {
       write(part.content);
     }

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -27,7 +27,7 @@ import {
   BodySection,
   FetchDataItem,
 } from "./types";
-import { bodyBufferKey, getSharedBodyBuffer } from "./body-buffer";
+import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
 
 // ---------------------------------------------------------------------------
 // FetchResponsePart types (local to the fetch subsystem)
@@ -322,26 +322,37 @@ export async function buildBodyResponsePart(
   // partial fetches (`<start.length>`) because their key would need the
   // slice bounds and concurrent slices of the same body are uncommon
   // enough that the coalescing benefit doesn't offset the added logic.
+  //
+  // Preserving the three response shapes the string path returns is
+  // load-bearing (see `body-buffer.ts` docs):
+  //  - `getBodyContent` → null: the whole part is dropped from the FETCH
+  //    response (e.g. `BODY[99]` on a 2-part message).
+  //  - `getBodyContent` → "":   emit `<sectionKey> NIL` (e.g.
+  //    `BODY[TEXT]` on a mail with no text/html/attachments).
+  //  - non-empty: emit a `{N}\r\n<octets>` literal, with the trailing
+  //    `\r\n` INCLUDED in the cached value (so the {N} literal length
+  //    matches the emitted octets — building the CRLF per caller after
+  //    the cache would defeat the coalescing entirely for the wire
+  //    check).
   if (!partial && !isHeaderLikeSection(section)) {
-    const buffer = await getSharedBodyBuffer(
+    const cached = await getSharedBodyResult(
       bodyBufferKey(docId, sectionKey),
-      // The trailing `\r\n` MUST be included in the cached value — it's part
-      // of the wire content and its byteLength is what the `{length}`
-      // literal advertises to the client. Appending it per-caller would
-      // negate the whole point of coalescing.
       () => {
         const raw = getBodyContent(mail, section, docId);
-        return raw === null ? "" : raw + "\r\n";
+        if (raw === null) return { kind: "omit" };
+        if (raw === "") return { kind: "nil" };
+        return { kind: "content", text: raw + "\r\n" };
       }
     );
-    if (buffer.byteLength === 0) {
+    if (cached.kind === "omit") return null;
+    if (cached.kind === "nil") {
       return { type: "simple", content: `${sectionKey} NIL` };
     }
     return {
       type: "literal",
-      content: buffer,
+      content: cached.buffer,
       header: sectionKey,
-      length: buffer.byteLength,
+      length: cached.buffer.byteLength,
     };
   }
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -29,6 +29,7 @@ import {
   writeFetchResponse,
   getRequestedFields,
   convertSequenceSet,
+  WriteChunked,
 } from "./fetch-helpers";
 import {
   resolveSeqRangeToUids,
@@ -51,6 +52,7 @@ export async function fetchMessagesTyped(
   selectedMailbox: string,
   seqState: SequenceState,
   write: (data: string) => boolean | undefined,
+  writeChunked: WriteChunked,
   condstoreEnabled: boolean = false
 ): Promise<void> {
   const isFlagsOnly = fetchRequest.dataItems.every(
@@ -96,6 +98,7 @@ export async function fetchMessagesTyped(
       selectedMailbox,
       seqState,
       write,
+      writeChunked,
       condstoreEnabled
     );
     write(`${tag} OK FETCH completed\r\n`);
@@ -176,6 +179,7 @@ async function _processFetchMessages(
   selectedMailbox: string,
   seqState: SequenceState,
   write: (data: string) => boolean | undefined,
+  writeChunked: WriteChunked,
   condstoreEnabled: boolean
 ): Promise<void> {
   const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
@@ -204,7 +208,7 @@ async function _processFetchMessages(
         selectedMailbox,
         condstoreEnabled
       );
-      writeFetchResponse(write, seqNum, response);
+      await writeFetchResponse(write, writeChunked, seqNum, response);
 
       if (shouldMarkAsRead(fetchRequest.dataItems)) {
         await markRead(store.getUser().id, id);

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -135,7 +135,7 @@ export class ImapSession {
    * multi-MB body in one shot, and awaits `drain` between chunks whenever
    * `socket.write` reports its high-water mark reached. This is the write
    * path FETCH BODY responses take once the payload is a shared Buffer
-   * from `getSharedBodyBuffer` — resolves after every chunk is queued and
+   * from `getSharedBodyResult` — resolves after every chunk is queued and
    * the socket is under its high-water mark again.
    *
    * The `payload` parameter is a Buffer specifically so V8 can GC the

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -22,6 +22,7 @@ import {
 } from "./idle-manager";
 import { getCapabilities } from "./capabilities";
 import { ImapRequestHandler } from "./handler";
+import { writeChunkedToSocket } from "./chunked-write";
 
 // Extracted module helpers
 import { handleAuthenticate, handleLogin } from "./auth";
@@ -126,6 +127,36 @@ export class ImapSession {
       logger.error("Error writing to socket", { component: "imap" }, error);
       return false;
     }
+  };
+
+  /**
+   * Write a large Buffer with socket-level backpressure. Chunks the payload
+   * so the kernel/OS outbound queue doesn't have to buffer the entire
+   * multi-MB body in one shot, and awaits `drain` between chunks whenever
+   * `socket.write` reports its high-water mark reached. This is the write
+   * path FETCH BODY responses take once the payload is a shared Buffer
+   * from `getSharedBodyBuffer` — resolves after every chunk is queued and
+   * the socket is under its high-water mark again.
+   *
+   * The `payload` parameter is a Buffer specifically so V8 can GC the
+   * intermediate JS string that `buildFullMessage` produced, and so
+   * `socket.write` doesn't run a per-write UTF-8 conversion.
+   */
+  writeChunked = async (payload: Buffer): Promise<void> => {
+    if (this.socket.destroyed || !this.socket.writable) {
+      logger.warn("Attempted to writeChunked to destroyed/unwritable socket", {
+        component: "imap",
+      });
+      return;
+    }
+    const written = await writeChunkedToSocket(this.socket, payload, (error) =>
+      logger.error(
+        "Error in writeChunked socket.write",
+        { component: "imap" },
+        error
+      )
+    );
+    this.bytesWritten += written;
   };
 
   /**
@@ -344,6 +375,7 @@ export class ImapSession {
       this.selectedMailbox,
       this.seqState,
       this.write,
+      this.writeChunked,
       this.condstoreEnabled
     );
   };


### PR DESCRIPTION
Follow-up to #710 for the OOM you hit at 22:03 PST (2026-07-27) — ~8 min after #710 went live.

## Why #710 wasn't enough

#710 single-flighted the DB read: N concurrent \`UID FETCH X (BODY)\` for the same UID share one PartialMailModel. But each handler was still independently calling \`buildFullMessage(mail)\` and base64-encoding the shared body, producing N distinct multi-MB JS strings on top of the shared source. Under an iOS Mail double-socket retry storm (208.82.98.54, 15+ concurrent FETCHes on UID 12365 in ~10s), that pushed RSS to 253 MB — a hair under the 256 MiB cap. Any small spike killed it.

Log evidence #710 was live and coalescing correctly at the SQL layer:
- Sibling tags A124/A125 both \`UID FETCH 12365 (UID BODY)\` completed at 5:03:44 with durationMs 2876/2877 (~identical) — that's the shape of two callers awaiting the same shared promise.
- Response bytes per handler were consistent (~2.25MB) — DB fetch was shared.

But peak RSS still climbed to 253 MB because the per-handler wire-response allocation was still O(N-callers).

## What this PR changes

**1. Body-buffer cache (\`body-buffer.ts\`)** — coalesces the SERIALIZATION step through the same singleflight primitive #710 used. Concurrent identical \`(docId, sectionKey)\` builds share one Buffer; every coalesced caller writes the same Buffer reference. Value is a Buffer (not string) so V8 can GC the intermediate encode-source string and \`socket.write(buffer)\` skips the per-write UTF-8 conversion. Heap becomes O(distinct-in-flight-bodies) instead of O(callers).

**2. Chunked backpressure-aware write (\`chunked-write.ts\` + \`session.writeChunked\`)** — writes large Buffer payloads in 64 KiB slices, awaiting \`drain\` when Node reports its writable-side high-water mark reached. Without this, a retry-storm of multi-MB responses lets the outbound queue grow unbounded. Falls back to \`close\` mid-drain so a socket that dies between \`write:false\` and any potential \`drain\` doesn't hang the FETCH pipeline.

\`fetch-helpers.ts\`:
- \`FetchResponsePart.literal.content\` widened to \`string | Buffer\`.
- \`buildBodyResponsePart\` routes non-partial non-header body sections through the shared cache. Partials keep the string path (their key would need slice bounds and concurrent identical partials are rare enough that the coalescing benefit doesn't offset the extra logic).
- \`writeFetchResponse\` becomes async and takes a \`WriteChunked\` callback; Buffer parts flow through it, string parts stay on the fast synchronous path.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] New \`body-buffer.test.ts\` — coalescing (same-key → same Promise/Buffer, one build), no cross-key sharing, entry drops on settle, UTF-8 byteLength invariant, key composition
- [x] New \`chunked-write.test.ts\` — chunk boundaries, drain-awaited backpressure, close-mid-drain wake, destroyed/unwritable early-out, write-throws mid-payload accounting
- [x] Existing MIME/RFC822/HEADER assertions in \`fetch-helpers.test.ts\` all pass — Buffer content coerced back to string at the assertion boundary
- [x] \`bun test src/server\` → 1300/0 across 67 files
- [ ] CI green
- [ ] Prod: post-deploy, watch \`/logs/hoie-inbox-1\` for peak \`rssAfterMB\` under the next iOS-Mail storm. Expect a step change: multiple concurrent identical FETCHes should show one Buffer build (`getSharedBodyBuffer` singleflight `inflightSize()` at 1 during the storm) rather than N.

Related: #710 (DB coalescing) closes the earlier layer of the same OOM.