### PR TITLE
fix(imap): SEARCH fails closed on unexpressible criteria instead of matching all

### DIFF
--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -168,6 +168,32 @@ describe("simplifyCriterion — NOT/OR operand normalisation (regression for #55
   });
 });
 
+describe("simplifyCriterion — unexpressible criteria are preserved, not dropped (#672)", () => {
+  // Dropping a criterion here (returning null) removes it from the WHERE clause,
+  // which matches every message (fail-open). Instead these are preserved so
+  // buildCriterionClause can fail them CLOSED. KEYWORD/UNKEYWORD normalise to a
+  // bare { type } (the flag value is irrelevant — no custom keywords are stored).
+
+  it("preserves KEYWORD as a bare { type }", () => {
+    expect(simplifyCriterion({ type: "KEYWORD", flag: "Foo" } as never)).toEqual({
+      type: "KEYWORD",
+    });
+  });
+
+  it("preserves UNKEYWORD as a bare { type }", () => {
+    expect(simplifyCriterion({ type: "UNKEYWORD", flag: "Foo" } as never)).toEqual({
+      type: "UNKEYWORD",
+    });
+  });
+
+  it("preserves an unknown criterion type instead of dropping it to null", () => {
+    // Pre-fix this returned null and the criterion vanished from the query.
+    expect(simplifyCriterion({ type: "SOMETHING-UNSUPPORTED" } as never)).toEqual({
+      type: "SOMETHING-UNSUPPORTED",
+    });
+  });
+});
+
 describe("Store.getFirstUnseenUid", () => {
   beforeEach(() => {
     mockGetFirstUnseenUid.mockClear();

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -48,7 +48,9 @@ type SimplifiedCriterion = { type: string; value?: unknown };
  * searchMailsByUid consumes. NOT/OR recurse so their operands are normalised too —
  * otherwise the SQL builder would read the wrong field off the raw parser shape
  * (e.g. `.date`/`.field` instead of `.value`) and silently mis-handle the nested
- * criterion. Returns null when the criterion imposes no constraint. A UID set
+ * criterion. An unexpressible leaf is preserved as a bare `{ type }` (never
+ * dropped) so buildCriterionClause maps it to a match-none fragment — the SEARCH
+ * fails closed, never matching every message (#672). A UID set
  * normalises to one `UID_SET` entry carrying all its ranges, so the SQL builder
  * ORs the ranges among themselves (a message is in the set if it falls in ANY
  * range) — nested UID keys under NOT/OR resolve the same way. See #551, #659.
@@ -111,7 +113,12 @@ export const simplifyCriterion = (
       return { type, value: sizeCriterion.size };
     }
 
-    // Logical NOT: negate a single (normalised) criterion
+    // Logical NOT: negate a single (normalised) criterion. `inner` is never
+    // null in practice — no leaf returns null post-#672 (unexpressible leaves
+    // fail closed via the default case), so the null-guard here is defensively
+    // unreachable. If a null-returning leaf is ever reintroduced, route it
+    // through buildCriterionClause's match-none algebra rather than dropping
+    // the node — a dropped NOT fails OPEN (matches everything).
     case "NOT": {
       const notCriterion = criterion as { type: string; criterion: SearchCriterion };
       const inner = simplifyCriterion(notCriterion.criterion);
@@ -128,8 +135,11 @@ export const simplifyCriterion = (
       const left = simplifyCriterion(orCriterion.left);
       const right = simplifyCriterion(orCriterion.right);
       if (left && right) return { type: "OR", value: { left, right } };
-      // An OR with an unconstrained/unsupported side matches everything; drop it
-      // rather than over-narrow to the one expressible side.
+      // Defensively unreachable: neither side is null because no leaf returns
+      // null post-#672. Were a side ever null, dropping the OR fails OPEN
+      // (matches everything) — the opposite of the fail-closed direction the
+      // rest of the search path now takes. A reintroduced null-leaf should
+      // preserve the OR node and let buildCriterionClause reduce it instead.
       return null;
     }
 

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -133,6 +133,15 @@ export const simplifyCriterion = (
       return null;
     }
 
+    // Custom keyword flags. The server stores only the system flag set
+    // (\Seen \Flagged \Deleted \Draft \Answered) and no custom keywords, so
+    // KEYWORD can never match and UNKEYWORD always matches — the flag value is
+    // irrelevant. Preserve the type (no value) and let buildCriterionClause map
+    // KEYWORD to match-none and UNKEYWORD to match-all.
+    case "KEYWORD":
+    case "UNKEYWORD":
+      return { type };
+
     // UID set: carry every range in one entry so the SQL builder ORs them —
     // set membership means a message matches if it falls in ANY range (#659).
     case "UID": {
@@ -140,9 +149,14 @@ export const simplifyCriterion = (
       return { type: "UID_SET", value: uidCriterion.sequenceSet.ranges };
     }
 
+    // Unsupported criterion: preserve the type (no value) rather than dropping
+    // it here. Dropping would leave it out of the WHERE clause entirely, which
+    // matches EVERY message (fail-open) — the dangerous direction for a filter.
+    // buildCriterionClause maps any type it can't express to a match-none
+    // fragment, so the criterion fails closed instead. (#672)
     default:
       logger.warn("Unsupported search criterion", { component: "imap.store", type });
-      return null;
+      return { type };
   }
 };
 

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -650,3 +650,114 @@ describe("buildCriterionClause — BODY/TEXT search the message body (#552)", ()
     expect(frag).toContain("text ILIKE");
   });
 });
+
+describe("buildCriterionClause — unexpressible criteria fail closed (#672)", () => {
+  // Before this fix, any criterion the SQL backend couldn't express returned
+  // null ("no constraint") and was dropped from the WHERE clause, so it matched
+  // EVERY message (fail-open) — RFC 3501 §6.4.4 requires the exact match set,
+  // and fail-open is the dangerous direction (a filter that should match none
+  // returns all, and a client may bulk-move/flag/delete the whole mailbox).
+  // The fix returns a MATCH_NONE sentinel ("FALSE") so the criterion fails
+  // closed instead. KEYWORD/UNKEYWORD are exact evaluations (the server stores
+  // no custom keywords); LARGER/SMALLER/arbitrary-HEADER are fail-closed until
+  // backing data exists.
+  const build = async (
+    criterion: { type: string; value?: unknown },
+    values: unknown[] = [],
+  ) => {
+    const { buildCriterionClause } = await import(".");
+    return buildCriterionClause(criterion, "uid_account", values as never);
+  };
+
+  it("MATCH_NONE is a truthy SQL fragment so searchMailsByUid keeps it in the AND", async () => {
+    const { MATCH_NONE } = await import(".");
+    // searchMailsByUid does `if (frag) conditions.push(frag)`. The sentinel must
+    // stay truthy — an empty string would be dropped and re-open the fail-open hole.
+    expect(MATCH_NONE).toBe("FALSE");
+    expect(Boolean(MATCH_NONE)).toBe(true);
+  });
+
+  it("KEYWORD can never match (no custom keywords stored) → match-none", async () => {
+    const values: unknown[] = [];
+    expect(await build({ type: "KEYWORD", value: "Foo" }, values)).toBe("FALSE");
+    expect(values).toHaveLength(0); // no bound param
+  });
+
+  it("UNKEYWORD always matches (no message has the keyword) → match-all (null)", async () => {
+    expect(await build({ type: "UNKEYWORD", value: "Foo" })).toBeNull();
+  });
+
+  it("LARGER / SMALLER fail closed (RFC822.SIZE not persisted) → match-none", async () => {
+    const lv: unknown[] = [];
+    expect(await build({ type: "LARGER", value: 999999999 }, lv)).toBe("FALSE");
+    expect(lv).toHaveLength(0);
+    const sv: unknown[] = [];
+    expect(await build({ type: "SMALLER", value: 1 }, sv)).toBe("FALSE");
+    expect(sv).toHaveLength(0);
+  });
+
+  it("HEADER on an unsupported field fails closed → match-none", async () => {
+    const values: unknown[] = [];
+    expect(
+      await build({ type: "HEADER", value: { field: "X-Mailer", text: "z" } }, values),
+    ).toBe("FALSE");
+    expect(values).toHaveLength(0);
+  });
+
+  it("HEADER on a supported field still filters (control — not swept into fail-closed)", async () => {
+    const values: unknown[] = [];
+    expect(
+      await build({ type: "HEADER", value: { field: "Subject", text: "hi" } }, values),
+    ).toBe("subject ILIKE $1");
+    expect(values).toEqual(["%hi%"]);
+  });
+
+  it("an unknown criterion type fails closed → match-none", async () => {
+    expect(await build({ type: "SOMETHING-UNSUPPORTED" })).toBe("FALSE");
+  });
+
+  it("`SEEN AND KEYWORD` — the KEYWORD fragment is FALSE so the AND matches nothing", async () => {
+    // searchMailsByUid ANDs sibling fragments. SEEN → real column, KEYWORD → FALSE.
+    expect(await build({ type: "SEEN" })).toBe("read = TRUE");
+    expect(await build({ type: "KEYWORD", value: "Foo" })).toBe("FALSE");
+    // Joined: "read = TRUE AND FALSE" → empty set (was "read = TRUE" alone before).
+  });
+
+  it("`OR SEEN KEYWORD` reduces to the constrained side (X OR none = X)", async () => {
+    expect(
+      await build({
+        type: "OR",
+        value: { left: { type: "SEEN" }, right: { type: "KEYWORD", value: "Foo" } },
+      }),
+    ).toBe("read = TRUE");
+  });
+
+  it("`OR KEYWORD KEYWORD` (both match-none) stays match-none", async () => {
+    expect(
+      await build({
+        type: "OR",
+        value: {
+          left: { type: "KEYWORD", value: "A" },
+          right: { type: "KEYWORD", value: "B" },
+        },
+      }),
+    ).toBe("FALSE");
+  });
+
+  it("`OR SEEN ALL` still matches everything (match-all side wins — control)", async () => {
+    expect(
+      await build({
+        type: "OR",
+        value: { left: { type: "SEEN" }, right: { type: "ALL" } },
+      }),
+    ).toBeNull();
+  });
+
+  it("`NOT KEYWORD` = match-all (every message lacks the keyword)", async () => {
+    expect(await build({ type: "NOT", value: { type: "KEYWORD", value: "Foo" } })).toBeNull();
+  });
+
+  it("`NOT ALL` = match-none (double-checks NOT of match-all)", async () => {
+    expect(await build({ type: "NOT", value: { type: "ALL" } })).toBe("FALSE");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -761,3 +761,95 @@ describe("buildCriterionClause — unexpressible criteria fail closed (#672)", (
     expect(await build({ type: "NOT", value: { type: "ALL" } })).toBe("FALSE");
   });
 });
+
+describe("buildCriterionClause — combinators don't orphan bound params (#672)", () => {
+  // Recursion pushes params onto the shared `values` as a side effect. When a
+  // reduction discards a side that already pushed a param (e.g. an OR that
+  // reduces to match-all because the OTHER side is ALL/UNKEYWORD), the discarded
+  // param must be rolled back — otherwise values.length exceeds the max `$N`
+  // referenced and Postgres rejects the Bind ("supplies N parameters, but
+  // prepared statement requires M"), so searchMailsByUid throws and returns [].
+  const build = async (
+    criterion: { type: string; value?: unknown },
+    values: unknown[],
+  ) => {
+    const { buildCriterionClause } = await import(".");
+    return buildCriterionClause(criterion, "uid_account", values as never);
+  };
+
+  it("`OR SUBJECT x ALL` → match-all, and rolls back SUBJECT's param", async () => {
+    const values: unknown[] = ["user-1", false]; // base user_id/sent seed
+    const frag = await build(
+      { type: "OR", value: { left: { type: "SUBJECT", value: "x" }, right: { type: "ALL" } } },
+      values,
+    );
+    expect(frag).toBeNull(); // X OR match-all = match-all
+    expect(values).toEqual(["user-1", false]); // %x% rolled back — no orphan
+  });
+
+  it("`OR SUBJECT x UNKEYWORD Foo` → match-all, param rolled back (was a hard throw)", async () => {
+    const values: unknown[] = ["user-1", false];
+    const frag = await build(
+      {
+        type: "OR",
+        value: { left: { type: "SUBJECT", value: "x" }, right: { type: "UNKEYWORD" } },
+      },
+      values,
+    );
+    expect(frag).toBeNull();
+    expect(values).toEqual(["user-1", false]);
+  });
+
+  it("`OR ALL SUBJECT x` (null on the left) also rolls back", async () => {
+    const values: unknown[] = ["user-1", false];
+    const frag = await build(
+      { type: "OR", value: { left: { type: "ALL" }, right: { type: "SUBJECT", value: "x" } } },
+      values,
+    );
+    expect(frag).toBeNull();
+    expect(values).toEqual(["user-1", false]);
+  });
+
+  it("`NOT (OR SUBJECT x ALL)` → match-none, nested param rolled back", async () => {
+    const values: unknown[] = ["user-1", false];
+    const frag = await build(
+      {
+        type: "NOT",
+        value: {
+          type: "OR",
+          value: { left: { type: "SUBJECT", value: "x" }, right: { type: "ALL" } },
+        },
+      },
+      values,
+    );
+    // inner OR = match-all (null) → NOT match-all = match-none.
+    expect(frag).toBe("FALSE");
+    expect(values).toEqual(["user-1", false]);
+  });
+
+  it("a real OR with two param-pushing sides keeps BOTH params, contiguously numbered", async () => {
+    const values: unknown[] = ["user-1", false];
+    const frag = await build(
+      {
+        type: "OR",
+        value: { left: { type: "SUBJECT", value: "x" }, right: { type: "FROM", value: "y" } },
+      },
+      values,
+    );
+    expect(frag).toBe("(subject ILIKE $3 OR from_text ILIKE $4)");
+    expect(values).toEqual(["user-1", false, "%x%", "%y%"]);
+  });
+
+  it("`X OR none` keeps X's param aligned (match-none side pushed nothing)", async () => {
+    const values: unknown[] = ["user-1", false];
+    const frag = await build(
+      {
+        type: "OR",
+        value: { left: { type: "SUBJECT", value: "x" }, right: { type: "KEYWORD" } },
+      },
+      values,
+    );
+    expect(frag).toBe("subject ILIKE $3"); // KEYWORD = match-none → reduces to X
+    expect(values).toEqual(["user-1", false, "%x%"]);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -407,15 +407,28 @@ export const buildCriterionClause = (
   const type = criterion.type.toUpperCase();
   switch (type) {
     // Logical operators — recurse into operands carried on `value`.
+    // Recursion pushes bound params onto the shared `values` as a side effect,
+    // so whenever a reduction DISCARDS a recursed fragment (rather than emitting
+    // it), it must roll `values` back to the pre-recursion length — otherwise the
+    // discarded side's params are orphaned (present in `values`, referenced by no
+    // `$N`), desyncing the count and making Postgres reject the whole Bind.
     case "NOT": {
+      const savedLen = values.length;
       const inner = buildCriterionClause(
         criterion.value as { type: string; value?: unknown },
         uidField,
         values
       );
       // NOT match-all → match-none; NOT match-none → match-all; else negate.
-      if (inner === null) return MATCH_NONE;
-      if (inner === MATCH_NONE) return null;
+      // Both non-negating outcomes discard `inner`, so drop any params it pushed.
+      if (inner === null) {
+        values.length = savedLen;
+        return MATCH_NONE;
+      }
+      if (inner === MATCH_NONE) {
+        values.length = savedLen;
+        return null;
+      }
       return `NOT (${inner})`;
     }
     case "OR": {
@@ -423,13 +436,22 @@ export const buildCriterionClause = (
         left: { type: string; value?: unknown };
         right: { type: string; value?: unknown };
       };
+      const savedLen = values.length;
       const l = buildCriterionClause(left, uidField, values);
       const r = buildCriterionClause(right, uidField, values);
-      // An OR with a match-all (null) side matches everything → match-all.
-      if (l === null || r === null) return null;
-      // Both sides match nothing → match-none. Otherwise OR-with-match-none
-      // reduces to the other side (`X OR none` = `X`).
-      if (l === MATCH_NONE && r === MATCH_NONE) return MATCH_NONE;
+      // An OR with a match-all (null) side matches everything → match-all. Both
+      // fragments are discarded, so roll `values` back to before this OR.
+      if (l === null || r === null) {
+        values.length = savedLen;
+        return null;
+      }
+      // Both sides match nothing → match-none (neither pushed a param). Otherwise
+      // OR-with-match-none reduces to the other side (`X OR none` = `X`); the
+      // match-none side pushed nothing, so the kept side's params stay aligned.
+      if (l === MATCH_NONE && r === MATCH_NONE) {
+        values.length = savedLen;
+        return MATCH_NONE;
+      }
       if (l === MATCH_NONE) return r;
       if (r === MATCH_NONE) return l;
       return `(${l} OR ${r})`;

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -380,11 +380,24 @@ const toUpdatedMailFlags = (row: Record<string, unknown>): UpdatedMailFlags => (
 });
 
 /**
+ * SQL fragment for a criterion the backend cannot express as a real predicate,
+ * but which the RFC 3501 §6.4.4 semantics say matches NO message (e.g. KEYWORD
+ * when no custom keywords are stored). Emitting a literal `FALSE` fails the
+ * search CLOSED — the safe direction — instead of dropping the criterion, which
+ * would leave it out of the WHERE clause and match every message (fail-open).
+ */
+export const MATCH_NONE = "FALSE";
+
+/**
  * Builds the SQL boolean fragment for a single IMAP SEARCH criterion, pushing any
  * bound parameters onto `values` (1-indexed `$N` placeholders track `values.length`).
- * Returns `null` for criteria that impose no constraint (ALL, unsupported keys), so
- * the caller simply skips them. NOT/OR recurse so negation and disjunction compose
- * instead of falling through and matching every message.
+ * Three-valued: returns a constraint string, `null` for criteria that impose no
+ * constraint (match-all: ALL, UNKEYWORD, unsupported combinator operands), or the
+ * `MATCH_NONE` sentinel for criteria that can match nothing (KEYWORD, and any key
+ * the backend can't express — failing closed per #672). NOT/OR recurse so negation
+ * and disjunction compose the three values correctly instead of falling through and
+ * matching every message. The caller drops `null` fragments and keeps `MATCH_NONE`
+ * (a valid SQL boolean) so the enclosing AND collapses to the empty set.
  */
 export const buildCriterionClause = (
   criterion: { type: string; value?: unknown },
@@ -400,7 +413,10 @@ export const buildCriterionClause = (
         uidField,
         values
       );
-      return inner ? `NOT (${inner})` : null;
+      // NOT match-all → match-none; NOT match-none → match-all; else negate.
+      if (inner === null) return MATCH_NONE;
+      if (inner === MATCH_NONE) return null;
+      return `NOT (${inner})`;
     }
     case "OR": {
       const { left, right } = criterion.value as {
@@ -409,10 +425,14 @@ export const buildCriterionClause = (
       };
       const l = buildCriterionClause(left, uidField, values);
       const r = buildCriterionClause(right, uidField, values);
-      if (l && r) return `(${l} OR ${r})`;
-      // One side imposes no constraint: an OR with an unconstrained side matches
-      // everything, so drop the whole disjunction rather than over-narrow it.
-      return null;
+      // An OR with a match-all (null) side matches everything → match-all.
+      if (l === null || r === null) return null;
+      // Both sides match nothing → match-none. Otherwise OR-with-match-none
+      // reduces to the other side (`X OR none` = `X`).
+      if (l === MATCH_NONE && r === MATCH_NONE) return MATCH_NONE;
+      if (l === MATCH_NONE) return r;
+      if (r === MATCH_NONE) return l;
+      return `(${l} OR ${r})`;
     }
 
     // ALL: match everything — no additional condition needed
@@ -487,10 +507,22 @@ export const buildCriterionClause = (
       else if (fieldLower === "to") column = "to_text";
       else if (fieldLower === "message-id") column = "message_id";
       // Unsupported header field — skip to avoid incorrect results
-      if (column === null) return null;
+      // Only subject/from/to/message-id are stored as searchable columns.
+      // An arbitrary header field can't be evaluated → fail closed (match-none)
+      // rather than dropping the criterion and matching every message (#672).
+      if (column === null) return MATCH_NONE;
       values.push(`%${text}%`);
       return `${column} ILIKE $${values.length}`;
     }
+
+    // Custom keyword flags. The server stores only the system flag set and no
+    // custom keywords, so KEYWORD <x> can never match (match-none) and
+    // UNKEYWORD <x> always matches (match-all). Both are exact evaluations, not
+    // fail-closed guesses (#672).
+    case "KEYWORD":
+      return MATCH_NONE;
+    case "UNKEYWORD":
+      return null;
 
     // Date criteria (using internal date — date column)
     case "BEFORE":
@@ -521,10 +553,14 @@ export const buildCriterionClause = (
       values.push(criterion.value as Date);
       return `date >= $${values.length}`;
 
-    // Size criteria: not tracked per-row; skip to avoid incorrect results
+    // Size criteria: RFC822.SIZE is not persisted per-row, so the octet count
+    // can't be evaluated. Fail closed (match-none) rather than dropping the
+    // criterion — a dropped LARGER/SMALLER matches every message (fail-open),
+    // the dangerous direction. Exact evaluation needs an rfc822_size column
+    // (follow-up #665); until then match-none is the safe interim (#672).
     case "LARGER":
     case "SMALLER":
-      return null;
+      return MATCH_NONE;
 
     // A UID sequence-set: its ranges are alternatives, so OR them among
     // themselves (a message matches if it falls in ANY range) while the whole
@@ -544,9 +580,10 @@ export const buildCriterionClause = (
       return parts.length === 1 ? parts[0] : `(${parts.join(" OR ")})`;
     }
 
-    // Unsupported criterion — impose no constraint (caller skips it).
+    // Unsupported criterion — can't be evaluated, so fail closed (match-none)
+    // rather than imposing no constraint and matching every message (#672).
     default:
-      return null;
+      return MATCH_NONE;
   }
 };
 


### PR DESCRIPTION
Closes #672

## Problem

IMAP `SEARCH` silently **dropped** any criterion the SQL backend couldn't express, then ran the query with the rest. A dropped criterion imposes no `WHERE` clause, so it matches **every** message — a fail-open superset instead of the exact set RFC 3501 §6.4.4 requires. Fail-open is the dangerous direction: a filter that should match **nothing** returns the **whole mailbox**, and a real client (Apple Mail / Thunderbird bulk actions) may move/flag/delete on the whole set.

Four criteria hit this, one root class (two-valued pipeline: a criterion normalises to a constraint **or** `null` = "no constraint" = match-all; there was no way to say "match none"):

- `KEYWORD` / `UNKEYWORD` — fell through `simplifyCriterion`'s `default` → dropped.
- `LARGER` / `SMALLER` — `buildCriterionClause` returned `null` ("not tracked per-row; skip") — but skipping *produces* the false positives, it doesn't avoid them.
- `HEADER` with a field other than subject/from/to/message-id — returned `null`.

The `null`-means-match-all convention also poisoned the combinators: `OR none X` dropped the whole disjunction, and `NOT none` / `NOT all` returned the wrong side.

## Fix

Make the pipeline **three-valued**: constraint / match-all (`null`) / **match-none** (a `MATCH_NONE = "FALSE"` SQL sentinel). The enclosing `AND` in `searchMailsByUid` keeps the truthy `FALSE` fragment, so the whole clause collapses to the empty set.

- `simplifyCriterion` (store.ts) now **preserves** unexpressible criteria (incl. the `default`) instead of dropping them, so the SQL builder can fail them closed.
- `buildCriterionClause` (mails/imap.ts):
  - **KEYWORD → match-none, UNKEYWORD → match-all** — *exact* evaluations: the server stores only the system flag set (`\Seen \Flagged \Deleted \Draft \Answered`) and no custom keywords, so a custom keyword can never be set.
  - **LARGER / SMALLER / arbitrary-HEADER / unknown keys → fail closed** (match-none). Exact size evaluation needs an `rfc822_size` column (follow-up #665); until then match-none is the safe interim.
  - **NOT / OR** rewritten for the three-valued algebra: `NOT all = none`, `NOT none = all`, `OR` with a match-all side = match-all, `X OR none = X`, `none OR none = none`.

## Tests

- `buildCriterionClause` — new block: KEYWORD→`FALSE`, UNKEYWORD→`null`, LARGER/SMALLER→`FALSE`, unsupported-HEADER→`FALSE`, supported-HEADER control still filters, unknown-type→`FALSE`, plus the `MATCH_NONE` truthiness pin and the OR/NOT combinator cases.
- `simplifyCriterion` — new block: KEYWORD/UNKEYWORD/unknown-type preserved (not dropped to `null`).
- Full server suite green: **1303 pass / 0 fail**. typecheck + lint clean (0 errors).

## E2E (live IMAP DB path, admin INBOX)

Drove the real `searchMailsByUid` against the live local `inbox` DB (admin INBOX, the same 11324-message mailbox the issue reproduced against). Before the fix each buggy criterion returned all 11324; after:

| SEARCH | before | after | expected |
|---|---|---|---|
| `KEYWORD Foo` | 11324 | **0** | empty |
| `SMALLER 1` | 11324 | **0** | empty |
| `LARGER 999999999` | 11324 | **0** | empty |
| `HEADER X-Mailer nonexistent` | 11324 | **0** | empty |
| `SEEN KEYWORD Foo` | 11322 (==SEEN) | **0** | empty |
| `NOT ALL` | 11324 | **0** | empty |
| `UNKEYWORD Foo` | — | 11324 | match-all |
| `NOT KEYWORD Foo` | — | 11324 | match-all |
| `OR SEEN KEYWORD Foo` | — | 11322 | ==SEEN (X OR none = X) |

Controls prove the query isn't just broken-to-empty: `ALL`=11324, `SEEN`=11322, `HEADER Subject "zzzz-nomatch"`=0 (a real filter that genuinely matches none).

Browser sandbox can't reach the IMAP SEARCH path (protocol-level, not a UI surface); verification is the live-DB drive above plus the unit coverage.

## Combinator param-safety (self-review follow-up)

`buildCriterionClause` pushes bound params onto a shared array during recursion. Preserving KEYWORD/UNKEYWORD routed more `OR`/`NOT` shapes into the builder, exposing a latent hazard: when an `OR` reduces to match-all because the *other* side is `ALL`/`UNKEYWORD`, the constraint side had already pushed a param — orphaning it, desyncing `$N`, and making Postgres reject the Bind (so `SEARCH OR SUBJECT hello UNKEYWORD Foo`, which must match all, threw and returned empty). Fixed by snapshotting `values.length` before recursing and rolling it back on every discard branch; regression tests assert no orphaned param. Verified live: both `OR SUBJECT hello UNKEYWORD Foo` and `OR SUBJECT hello ALL` now return the full mailbox (were a hard throw); a real two-sided OR still returns its subset. Full server suite **1309 pass / 0 fail**.
