### PR TITLE
feat(imap): dual-write to mail_mailbox_uid on every account-UID write (#702 PR 2a)

### DIFF
--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -741,7 +741,14 @@ export async function copyMessageTyped(
       newMail.uid.domain = newDomainUid;
       newMail.uid.account = newAccountUid;
 
-      const ok = await store.storeMail(newMail);
+      // Dual-write toward #702 PR-2b: mirror the account UID into the
+      // `mail_mailbox_uid` map when the destination is account-scoped.
+      // Domain-scoped destinations (INBOX, unified Sent Messages) skip —
+      // the mapping only tracks account UID spaces.
+      const ok = await store.storeMail(
+        newMail,
+        destIsDomainScoped ? undefined : destMailbox,
+      );
       if (!ok) {
         write(`${tag} NO [SERVERBUG] COPY partially failed\r\n`);
         return;
@@ -1004,7 +1011,13 @@ export async function moveMessageTyped(
       newMail.uid.domain = newDomainUid;
       newMail.uid.account = newAccountUid;
 
-      const ok = await store.storeMail(newMail);
+      // Dual-write toward #702 PR-2b: mirror the account UID into the
+      // `mail_mailbox_uid` map when the destination is account-scoped.
+      // Domain-scoped destinations skip — see COPY for full rationale.
+      const ok = await store.storeMail(
+        newMail,
+        destIsDomainScoped ? undefined : destMailbox,
+      );
       if (!ok) {
         // Pre-deletion failure: copies already stored in the destination
         // linger; the source is untouched. Client can re-issue MOVE.
@@ -1130,7 +1143,12 @@ export async function appendMessage(
     mail.uid.domain = domainUid;
     mail.uid.account = accountUid;
 
-    const result = await store.storeMail(mail);
+    // Dual-write toward #702 PR-2b: mirror the account UID into the
+    // `mail_mailbox_uid` map when the APPEND target is account-scoped.
+    const result = await store.storeMail(
+      mail,
+      isDomainScoped(targetMailbox) ? undefined : targetMailbox,
+    );
 
     const uid = isDomainScoped(targetMailbox) ? mail.uid.domain : mail.uid.account;
 

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -561,9 +561,14 @@ export class Store {
   };
 
   /**
-   * Store a new mail message
+   * Store a new mail message. `mailbox` is the destination path
+   * (`COPY dest`, `MOVE dest`, `APPEND target`) — passed through to
+   * `pgSaveMail` for the account-scoped `mail_mailbox_uid` mapping.
+   * Caller passes `undefined` for domain-scoped destinations (INBOX,
+   * unified `Sent Messages`) so the mapping only records account-space
+   * UIDs. Undefined here + `pgSaveMail`'s guard skips the mapping write.
    */
-  storeMail = async (mail: Mail): Promise<boolean> => {
+  storeMail = async (mail: Mail, mailbox?: string): Promise<boolean> => {
     try {
       const input: SaveMailInput = {
         user_id: this.user.id,
@@ -594,6 +599,7 @@ export class Store {
         insight: mail.insight,
         uid_domain: mail.uid?.domain,
         uid_account: mail.uid?.account,
+        mailbox,
       };
 
       const result = await pgSaveMail(input);

--- a/src/server/lib/mails/receive.ts
+++ b/src/server/lib/mails/receive.ts
@@ -27,7 +27,7 @@ import {
   getAttachmentId,
 } from "./util";
 import { push } from "../push";
-import { accountToBox } from "../imap/util";
+import { accountToBox, accountToSentBox } from "../imap/util";
 import { checkSpam, SpamCheckResult, EmailContext } from "../spam";
 import { sendAlarm } from "../alarm";
 import { logger } from "../logger";
@@ -119,6 +119,26 @@ export const saveMail = async (
 ): Promise<{ _id: string } | undefined> => {
   if (!userId) return;
 
+  // Derive the destination account mailbox for the per-mailbox UID map
+  // (#702 PR-2b). This wrapper handles BOTH receive and send call sites:
+  //  - Received mail (mail.sent === false): envelope-to[0] is the
+  //    recipient account address; the mail lands in that account's
+  //    `INBOX/accounts/<local>` folder. Same address that scoped the
+  //    earlier `getAccountUidNext` reservation in `convertMail`.
+  //  - Sent mail (mail.sent === true): envelope-from[0] is the sender
+  //    account address; the mail lands in the sender's
+  //    `Sent Messages/accounts/<local>` folder. Same address that
+  //    scoped `getAccountUidNext(user, fromEmail, sent=true)` in
+  //    `sendMail`.
+  const scopeAddress = mail.sent
+    ? mail.envelopeFrom?.[0]?.address
+    : mail.envelopeTo?.[0]?.address;
+  const mailbox = scopeAddress
+    ? mail.sent
+      ? accountToSentBox(scopeAddress)
+      : accountToBox(scopeAddress)
+    : undefined;
+
   const input: SaveMailInput = {
     user_id: userId,
     message_id: mail.messageId,
@@ -146,6 +166,7 @@ export const saveMail = async (
     draft: mail.draft,
     uid_domain: mail.uid?.domain,
     uid_account: mail.uid?.account,
+    mailbox,
     spam_score: spamResult?.score ?? 0,
     spam_reasons: spamResult?.reasons ?? null,
     is_spam: spamResult?.isSpam ?? false,

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -3,7 +3,7 @@ import { logger } from "../../../logger";
 import { pool } from "../../client";
 import { ParamValue } from "../../database";
 import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO, DB_NOW } from "../../models";
-import { getNextModseq } from "./counters";
+import { getNextModseq, writeMailboxUid } from "./counters";
 
 export interface SaveMailInput {
   user_id: string;
@@ -38,6 +38,16 @@ export interface SaveMailInput {
   spam_score?: number;
   spam_reasons?: string[] | null;
   is_spam?: boolean;
+  /**
+   * Destination account-scoped mailbox path (e.g. `INBOX/accounts/claude`,
+   * `Sent Messages/accounts/claude`). When set alongside a non-zero
+   * `uid_account`, `saveMail` mirrors the (user, mailbox, mail_id, uid)
+   * tuple into `mail_mailbox_uid` — dual-write toward #702 PR-2b's read
+   * cutover. Domain-scoped destinations (INBOX, unified Sent Messages)
+   * are omitted deliberately: `uid_domain` is authoritative for those
+   * views and the mapping is only interested in per-account UID spaces.
+   */
+  mailbox?: string;
 }
 
 export const saveMail = async (
@@ -91,7 +101,24 @@ export const saveMail = async (
     };
 
     const row = await mailsTable.insert(data, [MAIL_ID]);
-    if (row) return { _id: row[MAIL_ID] as string };
+    if (row) {
+      const inserted_id = row[MAIL_ID] as string;
+      // Dual-write toward #702 PR-2b's read cutover: mirror the account
+      // UID into the per-mailbox mapping. Skipped when the destination
+      // is domain-scoped (no mailbox passed) or no account UID was
+      // reserved for this write. `writeMailboxUid` swallows its own
+      // errors — this row is still authoritative in `mails.uid_account`
+      // so a mapping-write miss doesn't lose the UID.
+      if (input.mailbox && (input.uid_account ?? 0) > 0) {
+        await writeMailboxUid(
+          input.user_id,
+          input.mailbox,
+          inserted_id,
+          input.uid_account as number
+        );
+      }
+      return { _id: inserted_id };
+    }
     return undefined;
   } catch (error: unknown) {
     // Unique constraint violation on (user_id, message_id):
@@ -119,6 +146,19 @@ export const saveMail = async (
         );
       }
 
+      // Same 23505 (duplicate message_id) → one mail delivered to two
+      // envelope-to addresses that both matched the user's accounts.
+      // Register the NEW envelope-to account's mailbox mapping against
+      // the existing mail_id so both account inboxes carry a UID for
+      // this message.
+      if (input.mailbox && (input.uid_account ?? 0) > 0) {
+        await writeMailboxUid(
+          input.user_id,
+          input.mailbox,
+          existing.mail_id,
+          input.uid_account as number
+        );
+      }
       return { _id: existing.mail_id };
     }
 

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -146,11 +146,17 @@ export const saveMail = async (
         );
       }
 
-      // Same 23505 (duplicate message_id) → one mail delivered to two
-      // envelope-to addresses that both matched the user's accounts.
-      // Register the NEW envelope-to account's mailbox mapping against
-      // the existing mail_id so both account inboxes carry a UID for
-      // this message.
+      // The 23505 branch fires for cross-delivery re-sends of the same
+      // Message-ID from distinct SMTP sessions — a mailgun retry landing
+      // on a different envelope, or a listserv fanning the same message
+      // to multiple recipients under separate connections. Each session
+      // has its own `input.mailbox`; the mapping row (existing_mail_id,
+      // new_mailbox, new_uid) surfaces the second delivery in the second
+      // account's UID space. Same-mailbox race between two concurrent
+      // saveIncomingMail calls hits `writeMailboxUid`'s
+      // `ON CONFLICT (user_id, mailbox, mail_id) DO NOTHING`, so the
+      // loser's counter tick and mapping-insert round-trip are wasted
+      // (rare, sub-ms, off the SMTP reply path) — the winner's row wins.
       if (input.mailbox && (input.uid_account ?? 0) > 0) {
         await writeMailboxUid(
           input.user_id,

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -338,6 +338,25 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456,
     expect(saveSource).toMatch(/\[ENVELOPE_TO\]:/);
     expect(saveSource).toMatch(/updated:\s*DB_NOW/);
   });
+
+  // #702 PR-2a — dual-write shape assertions. `saveMail` mirrors the
+  // reserved account UID into `mail_mailbox_uid` at insert time AND on
+  // the 23505 (duplicate message_id) merge path. Guards against the fix
+  // regressing when future edits reshape the insert/merge branches.
+  it("saveMail dual-writes to mail_mailbox_uid on the INSERT branch", () => {
+    const saveMatch = mailsSource.match(/export const saveMail[\s\S]*?\n};/);
+    if (!saveMatch) throw new Error("saveMail not found in mails/*.ts");
+    const saveSource = saveMatch[0];
+    // The call is gated: mailbox present AND uid_account > 0 (no
+    // account UID reserved → no mapping row).
+    expect(saveSource).toMatch(/writeMailboxUid\s*\(/);
+    expect(saveSource).toMatch(/input\.mailbox/);
+    expect(saveSource).toMatch(/uid_account/);
+    // Guards two call sites — INSERT success + 23505 conflict merge.
+    const writeMailboxUidCount =
+      (saveSource.match(/writeMailboxUid\s*\(/g) ?? []).length;
+    expect(writeMailboxUidCount).toBe(2);
+  });
 });
 
 describe("buildCriterionClause — flag criteria use schema columns", () => {


### PR DESCRIPTION
PR 2a of the 3-PR arc to migrate `uid_account` reads off `mails` onto the `mail_mailbox_uid` mapping (#702). Foundation from #707 landed the table + `writeMailboxUid` helper as inert plumbing; this PR wires the write half — every existing UID-assignment call site also records the (user, mailbox, mail_id, uid) tuple. Reads continue to use `mails.uid_account`.

## Wiring

**`SaveMailInput.mailbox?: string`** — destination path when account-scoped. `saveMail` in `mails/core.ts` calls `writeMailboxUid` after `mailsTable.insert` succeeds AND on the 23505 (duplicate message_id) merge branch. Both branches guard on `mailbox && uid_account > 0`.

**`receive.ts:saveMail`** (the wrapper that also handles `send.ts`'s `saveMail(sentMail)` call) derives the mailbox path from `mail.sent`:
- Received (`sent === false`): `envelope-to[0].address` → `accountToBox()` → `INBOX/accounts/<local>`
- Sent (`sent === true`): `envelope-from[0].address` → `accountToSentBox()` → `Sent Messages/accounts/<local>`

Same address that scoped the earlier `getAccountUidNext` reservation, so the mapping uses the same (user, account) UID space.

**`store.storeMail(mail, mailbox?)`** — optional `mailbox` param threaded through for COPY / MOVE / APPEND. Callers pass `destIsDomainScoped ? undefined : destMailbox` (COPY, MOVE) or `isDomainScoped(targetMailbox) ? undefined : targetMailbox` (APPEND) — domain-scoped destinations (INBOX, unified Sent Messages) skip the mapping since those views stay on `uid_domain`.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/server` → 1330/0 across 67 files (new source-shape guard on `saveMail`'s two `writeMailboxUid` sites — matches the existing #614 `updated: DB_NOW` guard pattern)
- [ ] CI green
- [ ] Sandbox: receive a mail → assert `mail_mailbox_uid` row exists for `(user_id, INBOX/accounts/<local>, mail_id, uid_account)`. Send a mail → assert row for `Sent Messages/accounts/<local>`. IMAP APPEND / COPY / MOVE to an account destination → assert rows. Domain-scoped destinations (INBOX, unified Sent Messages) skip mapping.
- Full runtime E2E (concurrent FETCH racing on missing tuple, cold-cache first FETCH, warm reload, cross-mailbox MOVE) lands in PR 2b alongside `ensureMailboxUids` + the read cutover.

## What's next

- **PR 2b**: `ensureMailboxUids(user, mailbox, mail_ids)` helper (find missing → reserve N counter slots → INSERT ON CONFLICT DO NOTHING) + cut the 8 read sites in `mails/imap.ts` from `mails.uid_account` to a `mail_mailbox_uid` join. Full edge-case E2E lives here.
- **PR 3**: Drop the `uid_account` column + bump `imap_uid_validity` per user so clients re-sync.