### PR TITLE
feat(imap): ensureMailboxUids helper for read-path mailbox-UID lookup (#702 PR 2b-1)

### DIFF
--- a/src/server/lib/postgres/repositories/mails/counters.ts
+++ b/src/server/lib/postgres/repositories/mails/counters.ts
@@ -163,18 +163,27 @@ export const writeMailboxUid = async (
  * `mail_id` has a mapping row for `(user_id, mailbox, mail_id)` and
  * returns the full `mail_id → uid` map.
  *
- * The account-scoped read sites in `mails/imap.ts` join this mapping
- * instead of reading `mails.uid_account` directly. Rows written by
- * `saveMail` / `storeMail` (PR 2a) already have their mapping; mail
- * that predates that PR does not — this helper backfills those on
+ * Account-scoped IMAP reads join this mapping instead of reading
+ * `mails.uid_account` directly. Rows written by `saveMail` / `storeMail`
+ * (the write-side dual-write) already have their mapping; mail that
+ * predates the dual-write does not — this helper backfills those on
  * first access.
  *
- * Backfill shape: copy the mail's existing `uid_account` verbatim. The
- * UID was already reserved from `mail_uid_counters` at receive time, so
+ * Backfill copies the mail's existing `uid_account` verbatim. The UID
+ * was already reserved from `mail_uid_counters` at receive time, so
  * mirroring it preserves the per-account UID sequence without burning a
- * fresh counter tick. `ON CONFLICT DO NOTHING` makes a concurrent
- * ensureMailboxUids call idempotent — the loser reads the winner's row
- * on the second SELECT.
+ * fresh counter tick.
+ *
+ * `ON CONFLICT DO NOTHING` (with no explicit conflict target) is
+ * deliberate: `mail_mailbox_uid` has BOTH `PRIMARY KEY (user_id,
+ * mailbox, mail_id)` AND `UNIQUE (user_id, mailbox, uid)`. A
+ * target-scoped clause (`ON CONFLICT (user_id, mailbox, mail_id)`) only
+ * catches the PK collision; a duplicate-UID collision from legacy pre-
+ * atomic-reservation (#617) data would still throw and abort the whole
+ * INSERT batch, degrading `ensureMailboxUids` to zero backfill under
+ * try/catch. Bare `ON CONFLICT DO NOTHING` swallows both constraint
+ * violations, so good rows persist even when a poisoned pair sits
+ * inside the batch.
  *
  * Filters `uid_account > 0` so mails that were never assigned an
  * account UID (domain-only rows on a legacy path) don't emit a
@@ -192,7 +201,10 @@ export const ensureMailboxUids = async (
   // Backfill missing rows in one round-trip. INSERT … SELECT lets
   // Postgres do the "for each mail without a mapping, copy its
   // uid_account" work server-side; the anti-join (`WHERE NOT EXISTS`)
-  // narrows to the missing set.
+  // narrows to the missing set. Bare `ON CONFLICT DO NOTHING` (see
+  // docstring) swallows both the PK and the (user_id, mailbox, uid)
+  // UNIQUE — a target-scoped clause would leak the UNIQUE violation and
+  // abort the whole batch on pre-#617-fix legacy data.
   const backfillSql = `
     INSERT INTO ${MAIL_MAILBOX_UID} (${USER_ID}, ${MAILBOX}, ${MAIL_ID}, ${UID})
     SELECT m.user_id, $2, m.mail_id, m.uid_account
@@ -206,7 +218,7 @@ export const ensureMailboxUids = async (
           AND x.${MAILBOX} = $2
           AND x.${MAIL_ID} = m.mail_id
       )
-    ON CONFLICT (${USER_ID}, ${MAILBOX}, ${MAIL_ID}) DO NOTHING
+    ON CONFLICT DO NOTHING
   `;
   try {
     await pool.query(backfillSql, [user_id, mailbox, mail_ids]);
@@ -218,12 +230,12 @@ export const ensureMailboxUids = async (
     );
   }
 
-  // Read the complete set — includes rows PR 2a wrote at insert time,
-  // plus any rows the backfill above just created (or the concurrent
-  // caller's winner rows). Empty result for a given mail_id means it
-  // has no `uid_account` at all (never routed through an account UID
-  // space) — the caller filters those out via its own address
-  // predicate before they reach here.
+  // Read the complete set — rows the write-side dual-write laid down at
+  // insert time, plus any rows the backfill above just created (or a
+  // concurrent caller's winner rows). Empty result for a given mail_id
+  // means it has no `uid_account` at all (never routed through an
+  // account UID space) — the caller filters those out via its own
+  // address predicate before they reach here.
   try {
     const rows = await pool.query<{ mail_id: string; uid: number }>(
       `SELECT ${MAIL_ID} AS mail_id, ${UID} AS uid

--- a/src/server/lib/postgres/repositories/mails/counters.ts
+++ b/src/server/lib/postgres/repositories/mails/counters.ts
@@ -159,6 +159,92 @@ export const writeMailboxUid = async (
 };
 
 /**
+ * Read-path counterpart to `writeMailboxUid`: guarantees every requested
+ * `mail_id` has a mapping row for `(user_id, mailbox, mail_id)` and
+ * returns the full `mail_id → uid` map.
+ *
+ * The account-scoped read sites in `mails/imap.ts` join this mapping
+ * instead of reading `mails.uid_account` directly. Rows written by
+ * `saveMail` / `storeMail` (PR 2a) already have their mapping; mail
+ * that predates that PR does not — this helper backfills those on
+ * first access.
+ *
+ * Backfill shape: copy the mail's existing `uid_account` verbatim. The
+ * UID was already reserved from `mail_uid_counters` at receive time, so
+ * mirroring it preserves the per-account UID sequence without burning a
+ * fresh counter tick. `ON CONFLICT DO NOTHING` makes a concurrent
+ * ensureMailboxUids call idempotent — the loser reads the winner's row
+ * on the second SELECT.
+ *
+ * Filters `uid_account > 0` so mails that were never assigned an
+ * account UID (domain-only rows on a legacy path) don't emit a
+ * zero-UID mapping. Callers that only need domain UIDs skip this
+ * helper entirely.
+ */
+export const ensureMailboxUids = async (
+  user_id: string,
+  mailbox: string,
+  mail_ids: string[]
+): Promise<Map<string, number>> => {
+  const result = new Map<string, number>();
+  if (mail_ids.length === 0) return result;
+
+  // Backfill missing rows in one round-trip. INSERT … SELECT lets
+  // Postgres do the "for each mail without a mapping, copy its
+  // uid_account" work server-side; the anti-join (`WHERE NOT EXISTS`)
+  // narrows to the missing set.
+  const backfillSql = `
+    INSERT INTO ${MAIL_MAILBOX_UID} (${USER_ID}, ${MAILBOX}, ${MAIL_ID}, ${UID})
+    SELECT m.user_id, $2, m.mail_id, m.uid_account
+    FROM mails m
+    WHERE m.user_id = $1
+      AND m.mail_id = ANY($3::text[])
+      AND m.uid_account > 0
+      AND NOT EXISTS (
+        SELECT 1 FROM ${MAIL_MAILBOX_UID} x
+        WHERE x.${USER_ID} = m.user_id
+          AND x.${MAILBOX} = $2
+          AND x.${MAIL_ID} = m.mail_id
+      )
+    ON CONFLICT (${USER_ID}, ${MAILBOX}, ${MAIL_ID}) DO NOTHING
+  `;
+  try {
+    await pool.query(backfillSql, [user_id, mailbox, mail_ids]);
+  } catch (error) {
+    logger.warn(
+      "ensureMailboxUids backfill failed — proceeding with best-effort read",
+      { user_id, mailbox, mail_id_count: mail_ids.length },
+      error
+    );
+  }
+
+  // Read the complete set — includes rows PR 2a wrote at insert time,
+  // plus any rows the backfill above just created (or the concurrent
+  // caller's winner rows). Empty result for a given mail_id means it
+  // has no `uid_account` at all (never routed through an account UID
+  // space) — the caller filters those out via its own address
+  // predicate before they reach here.
+  try {
+    const rows = await pool.query<{ mail_id: string; uid: number }>(
+      `SELECT ${MAIL_ID} AS mail_id, ${UID} AS uid
+       FROM ${MAIL_MAILBOX_UID}
+       WHERE ${USER_ID} = $1 AND ${MAILBOX} = $2 AND ${MAIL_ID} = ANY($3::text[])`,
+      [user_id, mailbox, mail_ids]
+    );
+    for (const row of rows.rows) {
+      result.set(row.mail_id, Number(row.uid));
+    }
+  } catch (error) {
+    logger.error(
+      "ensureMailboxUids read failed",
+      { user_id, mailbox, mail_id_count: mail_ids.length },
+      error
+    );
+  }
+  return result;
+};
+
+/**
  * Per-user mod-sequence reservation query (CONDSTORE, RFC 7162 §3.1).
  *
  * Reuses the same atomic `mail_uid_counters` upsert as UID assignment — a single

--- a/src/server/lib/postgres/repositories/mails/ensure-mailbox-uids.test.ts
+++ b/src/server/lib/postgres/repositories/mails/ensure-mailbox-uids.test.ts
@@ -54,11 +54,20 @@ describe("ensureMailboxUids source shape (#702 PR 2b-1)", () => {
     expect(fnSource).toMatch(/uid_account\s*>\s*0/);
   });
 
-  it("uses ON CONFLICT DO NOTHING so concurrent callers are idempotent", () => {
-    // Two ensureMailboxUids invocations racing on the same missing tuple:
-    // one wins the INSERT, the other's INSERT is a no-op, both read the
-    // winner's row on the subsequent SELECT.
-    expect(fnSource).toMatch(/ON CONFLICT.*DO NOTHING/);
+  it("uses bare ON CONFLICT DO NOTHING (no target) to swallow BOTH constraint violations", () => {
+    // `mail_mailbox_uid` has PRIMARY KEY (user_id, mailbox, mail_id) AND
+    // UNIQUE (user_id, mailbox, uid). A target-scoped clause `ON
+    // CONFLICT (user_id, mailbox, mail_id)` only catches the PK; a
+    // duplicate-UID collision from legacy pre-#617-fix data (two mails
+    // sharing the same uid_account for a mailbox) would still throw and
+    // abort the WHOLE INSERT batch — every backfilled row lost, not just
+    // the offender. Bare `ON CONFLICT DO NOTHING` swallows both, so good
+    // rows persist even when a poisoned pair sits inside the batch.
+    // Concurrent callers (two ensureMailboxUids racing on the same
+    // missing tuple) still see idempotency from the PK path.
+    expect(fnSource).toMatch(/ON CONFLICT\s+DO NOTHING/);
+    // Guard against future edits reintroducing a target-scoped clause.
+    expect(fnSource).not.toMatch(/ON CONFLICT\s*\([^)]+\)\s*DO NOTHING/);
   });
 
   it("re-reads the complete mapping so PR 2a rows AND fresh backfill rows land in the return Map", () => {

--- a/src/server/lib/postgres/repositories/mails/ensure-mailbox-uids.test.ts
+++ b/src/server/lib/postgres/repositories/mails/ensure-mailbox-uids.test.ts
@@ -1,0 +1,84 @@
+/**
+ * `ensureMailboxUids` source-shape tests. The runtime shape (backfill
+ * from mails.uid_account, race safety via ON CONFLICT DO NOTHING,
+ * complete map return) is verified end-to-end by the PR 2b-2 sandbox
+ * E2E — this file guards the SQL shape against silent regression when
+ * future edits touch the counter/mapping paths.
+ *
+ * Pattern mirrors `imap.test.ts`'s existing source-scan style: read the
+ * function body as text and assert on the SQL fragments and control
+ * shape. That's stable against `mock.module` bleed (per
+ * feedback_bun_mock_module_global_hoisting) and doesn't need a live pg.
+ */
+import { describe, it, expect, beforeAll } from "bun:test";
+
+describe("ensureMailboxUids source shape (#702 PR 2b-1)", () => {
+  let fnSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const source = await fs.readFile(
+      path.join(import.meta.dir, "counters.ts"),
+      "utf8"
+    );
+    const match = source.match(/export const ensureMailboxUids[\s\S]*?\n};/);
+    if (!match) throw new Error("ensureMailboxUids not found in counters.ts");
+    fnSource = match[0];
+  });
+
+  it("early-returns an empty Map for zero input mail_ids", () => {
+    // No round-trip when the caller has nothing to look up.
+    expect(fnSource).toMatch(/mail_ids\.length === 0/);
+    expect(fnSource).toMatch(/return result/);
+  });
+
+  it("backfills missing rows in one round-trip via INSERT … SELECT anti-join", () => {
+    // Server-side backfill: for each requested mail_id lacking a mapping,
+    // mirror the mail's uid_account into mail_mailbox_uid. `NOT EXISTS`
+    // narrows to the missing set so the INSERT is a no-op for rows PR 2a
+    // already wrote.
+    expect(fnSource).toMatch(/INSERT INTO \$\{MAIL_MAILBOX_UID\}/);
+    expect(fnSource).toMatch(/SELECT m\.user_id, \$2, m\.mail_id, m\.uid_account/);
+    expect(fnSource).toMatch(/FROM mails m/);
+    expect(fnSource).toMatch(/WHERE m\.user_id = \$1/);
+    expect(fnSource).toMatch(/mail_id = ANY\(\$3::text\[\]\)/);
+    expect(fnSource).toMatch(/NOT EXISTS/);
+  });
+
+  it("filters uid_account > 0 so domain-only rows don't emit zero-UID mappings", () => {
+    // Mails that were never account-routed (legacy or domain-only paths)
+    // have uid_account = 0. Writing (mailbox, mail_id, 0) would occupy
+    // the UNIQUE (user_id, mailbox, uid) slot for UID 0 and shadow the
+    // legit first-account-mail UID for that mailbox. Skip them.
+    expect(fnSource).toMatch(/uid_account\s*>\s*0/);
+  });
+
+  it("uses ON CONFLICT DO NOTHING so concurrent callers are idempotent", () => {
+    // Two ensureMailboxUids invocations racing on the same missing tuple:
+    // one wins the INSERT, the other's INSERT is a no-op, both read the
+    // winner's row on the subsequent SELECT.
+    expect(fnSource).toMatch(/ON CONFLICT.*DO NOTHING/);
+  });
+
+  it("re-reads the complete mapping so PR 2a rows AND fresh backfill rows land in the return Map", () => {
+    // SELECT after the INSERT so rows PR 2a wrote at receive/send time
+    // are returned in the same call — the caller sees a full picture
+    // regardless of which write path populated the row.
+    expect(fnSource).toMatch(/SELECT/);
+    // Result populated from row iteration; keyed by mail_id, valued by uid.
+    expect(fnSource).toMatch(/result\.set\(row\.mail_id, Number\(row\.uid\)\)/);
+  });
+
+  it("errors on backfill or read do not throw — best-effort semantics", () => {
+    // The mapping is still non-authoritative in PR 2b-1. A missed
+    // backfill row falls back to a subsequent call (or PR 2b-2's read
+    // path degrading to mails.uid_account). Callers should not lose a
+    // request over a mapping-layer transient.
+    expect(fnSource).toMatch(/try \{/);
+    expect(fnSource).toMatch(/catch \(error\)/);
+    // Two try/catch blocks — one per pg round-trip.
+    const catches = (fnSource.match(/catch \(error\)/g) ?? []).length;
+    expect(catches).toBe(2);
+  });
+});


### PR DESCRIPTION
PR 2b-1 of the 3-PR arc migrating account-scoped IMAP reads off `mails.uid_account` onto `mail_mailbox_uid` (#702). Split from a larger PR 2b at your ask: helper here, 8-site read cutover in the follow-up (2b-2) where full edge-case sandbox E2E can focus.

## `ensureMailboxUids(user_id, mailbox, mail_ids)`

Read-side counterpart to #715's `writeMailboxUid` dual-write. Returns the complete `mail_id → uid` map for the requested set, backfilling any mail that predates the dual-write on the way.

**Backfill shape:** one round-trip via `INSERT … SELECT` anti-join. For each requested `mail_id` lacking a mapping, mirror the mail's existing `uid_account` verbatim into `mail_mailbox_uid`. Zero counter tick burn — the UID was already reserved from `mail_uid_counters` at receive time, so mirroring preserves the per-account sequence without introducing a UIDVALIDITY change.

```sql
INSERT INTO mail_mailbox_uid (user_id, mailbox, mail_id, uid)
SELECT m.user_id, $2, m.mail_id, m.uid_account
FROM mails m
WHERE m.user_id = $1
  AND m.mail_id = ANY($3::text[])
  AND m.uid_account > 0
  AND NOT EXISTS (SELECT 1 FROM mail_mailbox_uid x WHERE x.user_id = m.user_id AND x.mailbox = $2 AND x.mail_id = m.mail_id)
ON CONFLICT (user_id, mailbox, mail_id) DO NOTHING
```

Then a SELECT of the complete mapping for the requested set — rows PR 2a wrote at insert time AND rows the backfill just created (or a concurrent caller's winner rows).

**Race safety:** `ON CONFLICT DO NOTHING` makes concurrent callers idempotent. Two `ensureMailboxUids` invocations for the same missing tuple: one wins the INSERT, the other is a no-op; both read the winner's row on the final SELECT.

**uid_account > 0 filter:** mails that never routed through an account UID space (domain-only rows on a legacy path) don't emit zero-UID mappings that would occupy the `UNIQUE (user_id, mailbox, uid)` slot for UID 0 and shadow the mailbox's first legitimate row.

**Best-effort semantics:** both round-trips wrap in try/catch. While `mails.uid_account` is still authoritative (PR 2b-2 flips reads), a missed backfill falls back to a subsequent call — never loses a request.

## Why the helper lands without a caller

Deliberate — Hoie's explicit call to split so PR 2b-2's read cutover (8 sites in `mails/imap.ts` swap `MAX(uid_account)` etc. for a `mail_mailbox_uid` JOIN) gets a focused sandbox E2E sweep on its own. The helper is a public export ready for that PR to consume. Between this and 2b-2, the write-side keeps populating the mapping (PR 2a merged), so 2b-2's lazy backfill lands smaller.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/server/lib/postgres/repositories/mails` → 97/0 across 4 files
- [x] Source-shape tests in `ensure-mailbox-uids.test.ts` pin: zero-input short-circuit; INSERT … SELECT anti-join shape; `uid_account > 0` filter; `ON CONFLICT DO NOTHING`; final SELECT populates the Map; two try/catch round-trips
- [ ] CI green
- Runtime E2E lands with PR 2b-2 alongside the read cutover — this PR by itself has no observable behavior change (no read site calls the helper yet).

## What's next

- **PR 2b-2:** cut the 8 read sites in `mails/imap.ts` (`countMessages`, `getAllUids`, `getFirstUnseenUid`, `searchMailsByUid`, `expungeDeletedMails`, `expungeMailsByUid`, `setMailFlags`, `getMailsByRange`) from `mails.uid_account` to a `mail_mailbox_uid` JOIN — each site calls `ensureMailboxUids` on entry, then joins. Full edge-case E2E sweep: cold-cache first FETCH per folder, warm reload, 3× rapid reload, cross-mailbox MOVE, concurrent FETCH sessions racing on missing tuples.
- **PR 3:** drop `uid_account` column, bump `imap_uid_validity` per user so clients re-sync.