### PR TITLE
feat(imap): cut account-scoped reads over to mail_mailbox_uid (#702 PR 2b-2)

### DIFF
--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -27,6 +27,7 @@ import {
   accountToBox,
   accountToSentBox,
   boxToAccount,
+  isDomainScoped,
   isInbox,
   isSentBox,
   isAccountsFolder,
@@ -197,6 +198,21 @@ export class Store {
   }
 
   /**
+   * Variant of `resolveBox` for the eight #702 mapping-aware read/write sites
+   * (countMessages/getMailsByRange/setMailFlags/getAllUids/getFirstUnseenUid/
+   * searchMailsByUid/expungeDeletedMails/expungeMailsByUid). `mailboxArg` is
+   * the raw box path — the same string the write side stores in
+   * `mail_mailbox_uid.mailbox` — for account-scoped, sent-account-scoped, AND
+   * user-created mailboxes (`Archive`, etc.). `null` for the two domain-scoped
+   * views (`INBOX`, unified `Sent Messages`), which stay on `mails.uid_domain`.
+   */
+  private resolveMappedBox(box: string): { mailboxArg: string | null; isSent: boolean } {
+    const isSent = isSentBox(box);
+    const mailboxArg = isDomainScoped(box) ? null : box;
+    return { mailboxArg, isSent };
+  }
+
+  /**
    * Build the listable mailbox set; propagate backend errors. `listMailboxes`
    * (below) wraps this in a fallback so the LIST command stays resilient,
    * but the existence gate (`mailboxExists`) needs to distinguish "the user
@@ -310,8 +326,8 @@ export class Store {
     box: string
   ): Promise<{ total: number; unread: number; maxUid: number } | null> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
-      return await countMessages(this.user.id, accountName, isSent);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
+      return await countMessages(this.user.id, mailboxArg, isSent);
     } catch (error) {
       logger.error("Error counting messages", { component: "imap.store", box }, error);
       return null;
@@ -324,8 +340,8 @@ export class Store {
    */
   getAllUids = async (box: string): Promise<number[]> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
-      return await pgGetAllUids(this.user.id, accountName, isSent);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
+      return await pgGetAllUids(this.user.id, mailboxArg, isSent);
     } catch (error) {
       logger.error("Error getting all UIDs", { component: "imap.store", box }, error);
       return [];
@@ -338,8 +354,8 @@ export class Store {
    */
   getFirstUnseenUid = async (box: string): Promise<number | null> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
-      return await pgGetFirstUnseenUid(this.user.id, accountName, isSent);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
+      return await pgGetFirstUnseenUid(this.user.id, mailboxArg, isSent);
     } catch (error) {
       logger.error("Error getting first unseen UID", { component: "imap.store", box }, error);
       return null;
@@ -371,10 +387,10 @@ export class Store {
     useUid: boolean = false
   ): Promise<Map<string, Partial<Mail>>> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
       const mailModels = await getMailsByRange(
         this.user.id,
-        accountName,
+        mailboxArg,
         isSent,
         start,
         end,
@@ -486,10 +502,10 @@ export class Store {
     operation: StoreOperationType = "FLAGS"
   ): Promise<UpdatedMailFlags[]> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
       return await setMailFlags(
         this.user.id,
-        accountName,
+        mailboxArg,
         isSent,
         start,
         end,
@@ -509,8 +525,8 @@ export class Store {
    */
   expunge = async (box: string): Promise<number[]> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
-      return await expungeDeletedMails(this.user.id, accountName, isSent);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
+      return await expungeDeletedMails(this.user.id, mailboxArg, isSent);
     } catch (error) {
       logger.error("Error expunging messages", { component: "imap.store", box }, error);
       throw error;
@@ -527,8 +543,8 @@ export class Store {
    */
   expungeUids = async (box: string, uids: number[]): Promise<number[]> => {
     if (uids.length === 0) return [];
-    const { accountName, isSent } = this.resolveBox(box);
-    return await expungeMailsByUid(this.user.id, accountName, isSent, uids);
+    const { mailboxArg, isSent } = this.resolveMappedBox(box);
+    return await expungeMailsByUid(this.user.id, mailboxArg, isSent, uids);
   };
 
   search = async (
@@ -536,7 +552,7 @@ export class Store {
     criteria: SearchCriterion[]
   ): Promise<number[]> => {
     try {
-      const { accountName, isSent } = this.resolveBox(box);
+      const { mailboxArg, isSent } = this.resolveMappedBox(box);
 
       // Convert criteria to a simpler flat format for searchMailsByUid. Every
       // criterion — UID sets (one UID_SET entry per set), flags, text, dates,
@@ -550,7 +566,7 @@ export class Store {
 
       return await searchMailsByUid(
         this.user.id,
-        accountName,
+        mailboxArg,
         isSent,
         simplifiedCriteria
       );

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -246,12 +246,17 @@ describe("setMailFlags — no-op STORE skips the UPDATE (source regression for #
     expect(fnSource).toMatch(/if\s*\(!setClause\)/);
   });
 
-  it("no-op branch uses SELECT, not UPDATE, so `updated`/modseq are untouched", () => {
-    // The `!setClause` block runs a bare SELECT of the current flags.
+  it("no-op branch runs the SELECT variant and never touches the UPDATE variant", () => {
+    // The `!setClause` block calls `selectSql`; the UPDATE variant lives
+    // in `updateSql` and is only reachable after the branch. #702 PR 2b-2
+    // split the two SQL strings apart (needed distinct query shapes for
+    // the account-scoped JOIN vs domain-scoped table access), so the
+    // no-op invariant is now "the no-op block references selectSql, not
+    // updateSql".
     const noopBlock = fnSource.match(/if\s*\(!setClause\)\s*\{[\s\S]*?\n {4}\}/);
     expect(noopBlock).not.toBeNull();
-    expect(noopBlock![0]).toContain("SELECT");
-    expect(noopBlock![0]).not.toContain("UPDATE");
+    expect(noopBlock![0]).toContain("selectSql");
+    expect(noopBlock![0]).not.toContain("updateSql");
     expect(noopBlock![0]).not.toContain("getNextModseq");
   });
 });

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -261,6 +261,65 @@ describe("setMailFlags — no-op STORE skips the UPDATE (source regression for #
   });
 });
 
+describe("account-scoped reads use the raw mailbox path (#702 PR 2b-2)", () => {
+  // The read cutover joins mail_mailbox_uid on `x.mailbox = $N` where `$N` is
+  // the mailbox path the caller passed in — the SAME string the write side
+  // stored via writeMailboxUid. An earlier revision derived the JOIN target
+  // as `INBOX/accounts/${localPart}` from a synthetic account address, which
+  // broke user-created mailboxes: `Archive` stores its rows with
+  // mail_mailbox_uid.mailbox = "Archive", but the derivation produced
+  // `INBOX/accounts/Archive` → JOIN returned 0 rows → mail invisible.
+  //
+  // Static source check to guard against future re-derivation. The reader
+  // must (a) accept a `mailbox` parameter (nullable for domain-scoped views),
+  // (b) bind that parameter directly onto `x.mailbox = $N`, and
+  // (c) NOT redefine the mailboxPathForAccount helper that used to derive it.
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(path.join(import.meta.dir, "imap.ts"), "utf8");
+  });
+
+  it("no longer defines the derived-path helper", () => {
+    expect(mailsSource).not.toContain("mailboxPathForAccount");
+  });
+
+  const fns = [
+    "countMessages",
+    "getMailsByRange",
+    "setMailFlags",
+    "searchMailsByUid",
+    "getAllUids",
+    "getFirstUnseenUid",
+    "expungeDeletedMails",
+    "expungeMailsByUid",
+  ];
+
+  it.each(fns)("%s takes `mailbox` (not `account`) as the mapping key", (fn) => {
+    // Extract the function's signature via the export line. Every refactored
+    // reader must name its per-mailbox arg `mailbox` so future edits can't
+    // rename it back to `account` (a legacy shape that implied a synthetic
+    // address input, which is the pattern that caused the user-created bug).
+    const sigMatch = mailsSource.match(
+      new RegExp(`export const ${fn}\\s*=\\s*async\\s*\\(([\\s\\S]*?)\\)`)
+    );
+    expect(sigMatch, `signature not found for ${fn}`).not.toBeNull();
+    expect(sigMatch![1]).toMatch(/\bmailbox\s*:\s*string\s*\|\s*null/);
+    expect(sigMatch![1]).not.toMatch(/\baccount\s*:\s*string\s*\|\s*null/);
+  });
+
+  it("every account-scoped JOIN binds `x.mailbox = $N` with N in scope", () => {
+    // Coarse but effective: each per-mailbox branch must contain the
+    // parameterised mailbox filter — never a derived literal.
+    const branches = mailsSource.match(/x\.\$\{MAILBOX\}\s*=\s*\$\d+/g) ?? [];
+    // 8 refactored sites; getMailsByRange has 2 (useUid + seq) and setMailFlags
+    // has 3 (useUid selectSql + updateSql + seq target subquery). Bound: ≥8.
+    expect(branches.length).toBeGreaterThanOrEqual(8);
+  });
+});
+
 describe("expungeDeletedMails — `updated` column refresh (regression for #456, #614)", () => {
   // Static source check: the expunge write paths must go through
   // mailsTable.updateWhere with `updated: DB_NOW` in the data bag so the

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -20,34 +20,25 @@ import { getNextModseq } from "./counters";
 import { singleFlight } from "./inflight";
 
 /**
- * Derive the `mail_mailbox_uid.mailbox` path for an account-scoped view.
- * Local helper (not imported from `imap/util.ts`) to avoid a
- * repositories → imap layer inversion — the repositories layer depends
- * on nothing above it, and the two path shapes here are the exact
- * inverse of `accountToBox` / `accountToSentBox`. Callers pass a full
- * address like `claoie@hoie.kim`; the mapping table stores the local
- * part under the folder root, matching how the write-side dual-write
- * (saveMail / storeMail) records the row.
+ * Callers pass `mailbox` as the raw IMAP box path (e.g. `INBOX/accounts/amazon`,
+ * `Sent Messages/accounts/claoie`, or a user-created box like `Archive`) — the
+ * exact string the write side stores in `mail_mailbox_uid.mailbox`. `null` is
+ * reserved for domain-scoped views (`INBOX`, unified `Sent Messages`), which
+ * stay on `mails.uid_domain` and don't participate in the per-mailbox mapping.
  */
-const mailboxPathForAccount = (account: string, sent: boolean): string => {
-  const localPart = account.split("@")[0];
-  return sent
-    ? `Sent Messages/accounts/${localPart}`
-    : `INBOX/accounts/${localPart}`;
-};
 
 export const countMessages = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean
 ): Promise<{ total: number; unread: number; maxUid: number }> => {
   try {
     let sql: string;
     let values: ParamValue[];
 
-    if (account === null) {
+    if (mailbox === null) {
       // Domain-wide count (INBOX / unified Sent Messages) — still keyed on
-      // uid_domain, unchanged by #702's per-account mapping migration.
+      // uid_domain, unchanged by #702's per-mailbox mapping migration.
       sql = `
         SELECT
           COUNT(*) as total,
@@ -58,11 +49,14 @@ export const countMessages = async (
       `;
       values = [user_id, sent];
     } else {
-      // Account-scoped view — the `mail_mailbox_uid` mapping is now the
+      // Per-mailbox view — the `mail_mailbox_uid` mapping is the
       // authoritative membership + UID source. INNER JOIN encodes both:
       // a row exists iff the mail is in this mailbox, and its `uid`
-      // column is the per-account UID the client sees.
-      const mailbox = mailboxPathForAccount(account, sent);
+      // column is the per-mailbox UID the client sees. Legacy mails
+      // that predate the write-side dual-write (pre-#615) and never got
+      // backfilled — e.g. the 140 rows the one-shot script skipped over
+      // duplicate-UID collisions from a #617-era race — have no mapping
+      // row and are intentionally invisible to reads.
       sql = `
         SELECT
           COUNT(*) as total,
@@ -113,7 +107,7 @@ export const countMessages = async (
  */
 export const getMailsByRange = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean,
   start: number,
   end: number,
@@ -123,7 +117,7 @@ export const getMailsByRange = async (
   const sortedFields = [...fields].sort();
   const inflightKey = JSON.stringify([
     user_id,
-    account,
+    mailbox,
     sent,
     start,
     end,
@@ -131,13 +125,13 @@ export const getMailsByRange = async (
     sortedFields,
   ]);
   return singleFlight(inflightKey, () => getMailsByRangeUncoalesced(
-    user_id, account, sent, start, end, useUid, fields
+    user_id, mailbox, sent, start, end, useUid, fields
   ));
 };
 
 const getMailsByRangeUncoalesced = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean,
   start: number,
   end: number,
@@ -171,9 +165,9 @@ const getMailsByRangeUncoalesced = async (
       safeFields.unshift("mail_id");
     }
 
-    if (account === null) {
+    if (mailbox === null) {
       // Domain-wide query (INBOX / unified Sent Messages) — still on
-      // uid_domain, unchanged by the per-account mapping migration.
+      // uid_domain, unchanged by the per-mailbox mapping migration.
       const fieldList = safeFields.length > 0 ? safeFields.join(", ") : "*";
       if (useUid) {
         sql = `
@@ -193,11 +187,10 @@ const getMailsByRangeUncoalesced = async (
         values = [user_id, sent, start - 1, end - start + 1];
       }
     } else {
-      // Account-scoped query — JOIN `mail_mailbox_uid` to fetch per-
-      // account UID and enforce mailbox membership. Fields on `mails`
+      // Per-mailbox query — JOIN `mail_mailbox_uid` to fetch the
+      // mailbox-specific UID and enforce membership. Fields on `mails`
       // are prefixed with `m.` so the SELECT is unambiguous across the
       // join.
-      const mailbox = mailboxPathForAccount(account, sent);
       const qualifiedFields = safeFields
         .map((f) => `m.${f}`)
         .join(", ");
@@ -318,7 +311,7 @@ export function buildFlagSetClause(
 
 export const setMailFlags = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean,
   start: number,
   end: number,
@@ -330,13 +323,13 @@ export const setMailFlags = async (
     const setClause = buildFlagSetClause(operation, flags);
 
     // Two flavors of query — domain-scoped stays on `mails.uid_domain`,
-    // account-scoped joins `mail_mailbox_uid`. RETURNING clauses select
+    // per-mailbox joins `mail_mailbox_uid`. RETURNING clauses select
     // the appropriate UID and the shared flag/modseq columns.
     let selectSql: string;
     let updateSql: string;
     let baseValues: ParamValue[];
 
-    if (account === null) {
+    if (mailbox === null) {
       const returningCols = `${UID_DOMAIN} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
       if (useUid) {
         const whereClause = `user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4`;
@@ -361,9 +354,8 @@ export const setMailFlags = async (
         baseValues = [user_id, sent, start];
       }
     } else {
-      const mailbox = mailboxPathForAccount(account, sent);
-      // Account-scoped: JOIN `mail_mailbox_uid` for both membership and
-      // UID. RETURNING `x.uid` (the per-account UID the client sees),
+      // Per-mailbox: JOIN `mail_mailbox_uid` for both membership and
+      // UID. RETURNING `x.uid` (the mailbox-specific UID the client sees),
       // NOT `m.uid_account` — the column is scheduled for removal in
       // PR 3 and the JOIN is now the source of truth.
       const returningCols = `x.${UID} as uid, m.read, m.saved, m.deleted, m.draft, m.answered, m.${MODSEQ} as modseq`;
@@ -670,16 +662,16 @@ export const buildCriterionClause = (
 
 export const searchMailsByUid = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean,
   criteria: { type: string; value?: unknown }[]
 ): Promise<number[]> => {
   try {
     // Column reference for the criterion clauses. Domain-scoped view
-    // uses the plain column on `mails`; account-scoped uses the
+    // uses the plain column on `mails`; per-mailbox uses the
     // JOIN-aliased mapping. `buildCriterionClause` emits fragments like
     // `${uidField} >= $N`, so the alias needs to be qualified.
-    const uidField = account === null ? UID_DOMAIN : `x.${UID}`;
+    const uidField = mailbox === null ? UID_DOMAIN : `x.${UID}`;
 
     // Always exclude expunged messages from search
     const conditions: string[] = ["m.user_id = $1", "m.sent = $2", "m.expunged = FALSE"];
@@ -687,10 +679,9 @@ export const searchMailsByUid = async (
 
     // Base table + optional mailbox join
     let fromClause: string;
-    if (account === null) {
+    if (mailbox === null) {
       fromClause = "mails m";
     } else {
-      const mailbox = mailboxPathForAccount(account, sent);
       // JOIN mapping — the mailbox condition IS the membership predicate.
       conditions.push(`x.${USER_ID} = m.${USER_ID}`);
       conditions.push(`x.${MAILBOX} = $3`);
@@ -733,14 +724,14 @@ export const searchMailsByUid = async (
  */
 export const getAllUids = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean
 ): Promise<number[]> => {
   try {
     let sql: string;
     let values: ParamValue[];
 
-    if (account === null) {
+    if (mailbox === null) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
@@ -748,7 +739,6 @@ export const getAllUids = async (
       `;
       values = [user_id, sent];
     } else {
-      const mailbox = mailboxPathForAccount(account, sent);
       sql = `
         SELECT x.${UID} as uid FROM mails m
         JOIN ${MAIL_MAILBOX_UID} x
@@ -777,14 +767,14 @@ export const getAllUids = async (
  */
 export const getFirstUnseenUid = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean
 ): Promise<number | null> => {
   try {
     let sql: string;
     let values: ParamValue[];
 
-    if (account === null) {
+    if (mailbox === null) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE
@@ -793,7 +783,6 @@ export const getFirstUnseenUid = async (
       `;
       values = [user_id, sent];
     } else {
-      const mailbox = mailboxPathForAccount(account, sent);
       sql = `
         SELECT x.${UID} as uid FROM mails m
         JOIN ${MAIL_MAILBOX_UID} x
@@ -823,11 +812,11 @@ export const getFirstUnseenUid = async (
  */
 export const expungeDeletedMails = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean
 ): Promise<number[]> => {
   try {
-    if (account === null) {
+    if (mailbox === null) {
       // Domain-wide expunge — still on uid_domain, unchanged.
       const rows = await mailsTable.updateWhere(
         { [USER_ID]: user_id, [SENT]: sent, [DELETED]: true, [EXPUNGED]: false },
@@ -839,12 +828,11 @@ export const expungeDeletedMails = async (
       return rows.map((row: Record<string, unknown>) => row.uid as number);
     }
 
-    // Account-scoped expunge: JOIN `mail_mailbox_uid` to resolve the
+    // Per-mailbox expunge: JOIN `mail_mailbox_uid` to resolve the
     // mail_ids that belong to this mailbox, then framework updateWhere
     // with an IN filter so the data-bag pattern bumps `updated`. The
     // RETURNING side reads x.uid from a second SELECT that fetches the
-    // per-account UIDs for the just-expunged rows.
-    const mailbox = mailboxPathForAccount(account, sent);
+    // per-mailbox UIDs for the just-expunged rows.
     const selectSql = `
       SELECT m.${MAIL_ID} as mail_id, x.${UID} as uid FROM mails m
       JOIN ${MAIL_MAILBOX_UID} x
@@ -886,22 +874,22 @@ export const expungeDeletedMails = async (
 };
 
 /**
- * Soft-delete a specific set of UIDs in one mailbox (account / sent /
- * domain), regardless of their `\Deleted` flag. The MOVE command needs
- * this — RFC 6851 §3.3 forbids the COPY+STORE(\Deleted)+EXPUNGE pattern
- * the prior implementation used (it caused mailbox-wide collateral
+ * Soft-delete a specific set of UIDs in one mailbox (per-mailbox /
+ * sent-unified / domain), regardless of their `\Deleted` flag. The MOVE
+ * command needs this — RFC 6851 §3.3 forbids the COPY+STORE(\Deleted)+EXPUNGE
+ * pattern the prior implementation used (it caused mailbox-wide collateral
  * EXPUNGE of pre-existing \Deleted-flagged mails). Returns the UIDs
  * actually flipped, in case any were already expunged concurrently.
  */
 export const expungeMailsByUid = async (
   user_id: string,
-  account: string | null,
+  mailbox: string | null,
   sent: boolean,
   uids: number[]
 ): Promise<number[]> => {
   if (uids.length === 0) return [];
   try {
-    if (account === null) {
+    if (mailbox === null) {
       // Domain-wide: simple equality on user_id+sent + IN(uids).
       const rows = await mailsTable.updateWhere(
         {
@@ -918,11 +906,10 @@ export const expungeMailsByUid = async (
       return rows.map((row: Record<string, unknown>) => row.uid as number);
     }
 
-    // Account-scoped: JOIN `mail_mailbox_uid` to filter by (mailbox, uid IN),
+    // Per-mailbox: JOIN `mail_mailbox_uid` to filter by (mailbox, uid IN),
     // resolve the mail_ids, then updateWhere by mail_id IN so the data-bag
     // pattern bumps `updated`. Snapshot uid_by_mail_id so RETURNING can
-    // map the UPDATE's mail_id output back to the per-account UIDs.
-    const mailbox = mailboxPathForAccount(account, sent);
+    // map the UPDATE's mail_id output back to the per-mailbox UIDs.
     const uidPlaceholders = uids.map((_, i) => `$${i + 4}`).join(",");
     const selectSql = `
       SELECT m.${MAIL_ID} as mail_id, x.${UID} as uid FROM mails m

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -7,17 +7,34 @@ import {
   MAIL_ID,
   USER_ID,
   UID_DOMAIN,
-  UID_ACCOUNT,
   MODSEQ,
-  TO_ADDRESS,
-  FROM_ADDRESS,
   SENT,
   DELETED,
   EXPUNGED,
   DB_NOW,
+  MAIL_MAILBOX_UID,
+  MAILBOX,
+  UID,
 } from "../../models";
 import { getNextModseq } from "./counters";
 import { singleFlight } from "./inflight";
+
+/**
+ * Derive the `mail_mailbox_uid.mailbox` path for an account-scoped view.
+ * Local helper (not imported from `imap/util.ts`) to avoid a
+ * repositories → imap layer inversion — the repositories layer depends
+ * on nothing above it, and the two path shapes here are the exact
+ * inverse of `accountToBox` / `accountToSentBox`. Callers pass a full
+ * address like `claoie@hoie.kim`; the mapping table stores the local
+ * part under the folder root, matching how the write-side dual-write
+ * (saveMail / storeMail) records the row.
+ */
+const mailboxPathForAccount = (account: string, sent: boolean): string => {
+  const localPart = account.split("@")[0];
+  return sent
+    ? `Sent Messages/accounts/${localPart}`
+    : `INBOX/accounts/${localPart}`;
+};
 
 export const countMessages = async (
   user_id: string,
@@ -27,33 +44,38 @@ export const countMessages = async (
   try {
     let sql: string;
     let values: ParamValue[];
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
 
     if (account === null) {
-      // Domain-wide count (exclude expunged messages)
-      sql = `
-        SELECT 
-          COUNT(*) as total,
-          SUM(CASE WHEN read = FALSE THEN 1 ELSE 0 END) as unread,
-          COALESCE(MAX(${uidField}), 0) as max_uid
-        FROM mails 
-        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
-      `;
-      values = [user_id, sent];
-    } else {
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $3::jsonb`
-        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      // Domain-wide count (INBOX / unified Sent Messages) — still keyed on
+      // uid_domain, unchanged by #702's per-account mapping migration.
       sql = `
         SELECT
           COUNT(*) as total,
           SUM(CASE WHEN read = FALSE THEN 1 ELSE 0 END) as unread,
-          COALESCE(MAX(${uidField}), 0) as max_uid
+          COALESCE(MAX(${UID_DOMAIN}), 0) as max_uid
         FROM mails
-        WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND expunged = FALSE
+        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
       `;
-      values = [user_id, sent, addressJson];
+      values = [user_id, sent];
+    } else {
+      // Account-scoped view — the `mail_mailbox_uid` mapping is now the
+      // authoritative membership + UID source. INNER JOIN encodes both:
+      // a row exists iff the mail is in this mailbox, and its `uid`
+      // column is the per-account UID the client sees.
+      const mailbox = mailboxPathForAccount(account, sent);
+      sql = `
+        SELECT
+          COUNT(*) as total,
+          SUM(CASE WHEN m.read = FALSE THEN 1 ELSE 0 END) as unread,
+          COALESCE(MAX(x.${UID}), 0) as max_uid
+        FROM mails m
+        JOIN ${MAIL_MAILBOX_UID} x
+          ON x.${USER_ID} = m.${USER_ID}
+          AND x.${MAILBOX} = $3
+          AND x.${MAIL_ID} = m.${MAIL_ID}
+        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE
+      `;
+      values = [user_id, sent, mailbox];
     }
 
     const result = await pool.query(sql, values);
@@ -123,8 +145,6 @@ const getMailsByRangeUncoalesced = async (
   fields: string[]
 ): Promise<Map<string, PartialMailModel>> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
-
     let sql: string;
     let values: ParamValue[];
 
@@ -150,49 +170,63 @@ const getMailsByRangeUncoalesced = async (
     if (!safeFields.includes("mail_id")) {
       safeFields.unshift("mail_id");
     }
-    const fieldList = safeFields.length > 0 ? safeFields.join(", ") : "*";
 
     if (account === null) {
-      // Domain-wide query (exclude expunged messages)
+      // Domain-wide query (INBOX / unified Sent Messages) — still on
+      // uid_domain, unchanged by the per-account mapping migration.
+      const fieldList = safeFields.length > 0 ? safeFields.join(", ") : "*";
       if (useUid) {
         sql = `
-          SELECT ${fieldList} FROM mails 
-          WHERE user_id = $1 AND sent = $2 AND ${uidField} >= $3 AND ${uidField} <= $4
+          SELECT ${fieldList} FROM mails
+          WHERE user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4
             AND expunged = FALSE
-          ORDER BY ${uidField} ASC
+          ORDER BY ${UID_DOMAIN} ASC
         `;
         values = [user_id, sent, start, Math.min(end, 999999999)];
       } else {
         sql = `
-          SELECT ${fieldList} FROM mails 
+          SELECT ${fieldList} FROM mails
           WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
-          ORDER BY ${uidField} ASC
+          ORDER BY ${UID_DOMAIN} ASC
           OFFSET $3 LIMIT $4
         `;
         values = [user_id, sent, start - 1, end - start + 1];
       }
     } else {
-      // Account-specific query (exclude expunged messages)
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $3::jsonb`
-        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      // Account-scoped query — JOIN `mail_mailbox_uid` to fetch per-
+      // account UID and enforce mailbox membership. Fields on `mails`
+      // are prefixed with `m.` so the SELECT is unambiguous across the
+      // join.
+      const mailbox = mailboxPathForAccount(account, sent);
+      const qualifiedFields = safeFields
+        .map((f) => `m.${f}`)
+        .join(", ");
+      const fieldList = qualifiedFields.length > 0 ? qualifiedFields : "m.*";
       if (useUid) {
         sql = `
-          SELECT ${fieldList} FROM mails
-          WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
-            AND ${uidField} >= $4 AND ${uidField} <= $5 AND expunged = FALSE
-          ORDER BY ${uidField} ASC
+          SELECT ${fieldList} FROM mails m
+          JOIN ${MAIL_MAILBOX_UID} x
+            ON x.${USER_ID} = m.${USER_ID}
+            AND x.${MAILBOX} = $3
+            AND x.${MAIL_ID} = m.${MAIL_ID}
+          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2
+            AND x.${UID} >= $4 AND x.${UID} <= $5
+            AND m.${EXPUNGED} = FALSE
+          ORDER BY x.${UID} ASC
         `;
-        values = [user_id, sent, addressJson, start, Math.min(end, 999999999)];
+        values = [user_id, sent, mailbox, start, Math.min(end, 999999999)];
       } else {
         sql = `
-          SELECT ${fieldList} FROM mails 
-          WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND expunged = FALSE
-          ORDER BY ${uidField} ASC
+          SELECT ${fieldList} FROM mails m
+          JOIN ${MAIL_MAILBOX_UID} x
+            ON x.${USER_ID} = m.${USER_ID}
+            AND x.${MAILBOX} = $3
+            AND x.${MAIL_ID} = m.${MAIL_ID}
+          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE
+          ORDER BY x.${UID} ASC
           OFFSET $4 LIMIT $5
         `;
-        values = [user_id, sent, addressJson, start - 1, end - start + 1];
+        values = [user_id, sent, mailbox, start - 1, end - start + 1];
       }
     }
 
@@ -293,45 +327,79 @@ export const setMailFlags = async (
   operation: StoreOperationType = "FLAGS"
 ): Promise<UpdatedMailFlags[]> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
     const setClause = buildFlagSetClause(operation, flags);
-    const returningCols = `${uidField} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
 
-    // Build the row-matching predicate + its bound params once, shared by the
-    // real-change UPDATE and the no-op SELECT below. `$`-indices are 1-based and
-    // never include the mod-sequence (appended by the UPDATE branch only).
-    let whereClause: string;
-    let whereValues: ParamValue[];
+    // Two flavors of query — domain-scoped stays on `mails.uid_domain`,
+    // account-scoped joins `mail_mailbox_uid`. RETURNING clauses select
+    // the appropriate UID and the shared flag/modseq columns.
+    let selectSql: string;
+    let updateSql: string;
+    let baseValues: ParamValue[];
+
     if (account === null) {
+      const returningCols = `${UID_DOMAIN} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
       if (useUid) {
-        whereClause = `user_id = $1 AND sent = $2 AND ${uidField} >= $3 AND ${uidField} <= $4`;
-        whereValues = [user_id, sent, start, end];
+        const whereClause = `user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4`;
+        selectSql = `SELECT ${returningCols} FROM mails WHERE ${whereClause}`;
+        updateSql = `UPDATE mails
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
+          WHERE ${whereClause}
+          RETURNING ${returningCols}`;
+        baseValues = [user_id, sent, start, end];
       } else {
-        whereClause = `mail_id IN (
+        const whereClause = `mail_id IN (
           SELECT mail_id FROM mails
           WHERE user_id = $1 AND sent = $2
-          ORDER BY ${uidField} ASC
+          ORDER BY ${UID_DOMAIN} ASC
           OFFSET $3 LIMIT 1
         )`;
-        whereValues = [user_id, sent, start];
+        selectSql = `SELECT ${returningCols} FROM mails WHERE ${whereClause}`;
+        updateSql = `UPDATE mails
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $4
+          WHERE ${whereClause}
+          RETURNING ${returningCols}`;
+        baseValues = [user_id, sent, start];
       }
     } else {
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $3::jsonb`
-        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      const mailbox = mailboxPathForAccount(account, sent);
+      // Account-scoped: JOIN `mail_mailbox_uid` for both membership and
+      // UID. RETURNING `x.uid` (the per-account UID the client sees),
+      // NOT `m.uid_account` — the column is scheduled for removal in
+      // PR 3 and the JOIN is now the source of truth.
+      const returningCols = `x.${UID} as uid, m.read, m.saved, m.deleted, m.draft, m.answered, m.${MODSEQ} as modseq`;
       if (useUid) {
-        whereClause = `user_id = $1 AND sent = $2 AND ${addressCondition}
-          AND ${uidField} >= $4 AND ${uidField} <= $5`;
-        whereValues = [user_id, sent, addressJson, start, end];
+        const whereClause = `m.${USER_ID} = $1 AND m.${SENT} = $2
+          AND x.${USER_ID} = m.${USER_ID} AND x.${MAILBOX} = $3 AND x.${MAIL_ID} = m.${MAIL_ID}
+          AND x.${UID} >= $4 AND x.${UID} <= $5`;
+        selectSql = `SELECT ${returningCols} FROM mails m, ${MAIL_MAILBOX_UID} x WHERE ${whereClause}`;
+        // UPDATE ... FROM syntax joins the mapping to the target mails
+        // rows. Postgres semantics: rows matching the join get updated
+        // once. RETURNING refers to columns from either side.
+        updateSql = `UPDATE mails m
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $6
+          FROM ${MAIL_MAILBOX_UID} x
+          WHERE ${whereClause}
+          RETURNING ${returningCols}`;
+        baseValues = [user_id, sent, mailbox, start, end];
       } else {
-        whereClause = `mail_id IN (
-          SELECT mail_id FROM mails
-          WHERE user_id = $1 AND sent = $2 AND ${addressCondition}
-          ORDER BY ${uidField} ASC
+        // Sequence-number path: match a single row at the OFFSETth
+        // position in the mailbox's UID-ordered list.
+        const targetSubquery = `(
+          SELECT y.${MAIL_ID} FROM ${MAIL_MAILBOX_UID} y
+          WHERE y.${USER_ID} = $1 AND y.${MAILBOX} = $3
+          ORDER BY y.${UID} ASC
           OFFSET $4 LIMIT 1
         )`;
-        whereValues = [user_id, sent, addressJson, start];
+        const whereClause = `m.${USER_ID} = $1 AND m.${SENT} = $2
+          AND x.${USER_ID} = m.${USER_ID} AND x.${MAILBOX} = $3 AND x.${MAIL_ID} = m.${MAIL_ID}
+          AND m.${MAIL_ID} IN ${targetSubquery}`;
+        selectSql = `SELECT ${returningCols} FROM mails m, ${MAIL_MAILBOX_UID} x WHERE ${whereClause}`;
+        updateSql = `UPDATE mails m
+          SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
+          FROM ${MAIL_MAILBOX_UID} x
+          WHERE ${whereClause}
+          RETURNING ${returningCols}`;
+        baseValues = [user_id, sent, mailbox, start];
       }
     }
 
@@ -341,10 +409,7 @@ export const setMailFlags = async (
     // (delta-sync cursor) or reserve a new mod-sequence (RFC 7162: modseq only
     // advances when flags actually change).
     if (!setClause) {
-      const result = await pool.query(
-        `SELECT ${returningCols} FROM mails WHERE ${whereClause}`,
-        whereValues
-      );
+      const result = await pool.query(selectSql, baseValues);
       return result.rows.map(toUpdatedMailFlags);
     }
 
@@ -353,13 +418,7 @@ export const setMailFlags = async (
     // — a batch mutation may share a single mod-sequence). Reserved atomically so
     // concurrent STOREs get strictly-distinct, monotonic values.
     const modseq = await getNextModseq(user_id);
-    const result = await pool.query(
-      `UPDATE mails
-       SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $${whereValues.length + 1}
-       WHERE ${whereClause}
-       RETURNING ${returningCols}`,
-      [...whereValues, modseq]
-    );
+    const result = await pool.query(updateSql, [...baseValues, modseq]);
     return result.rows.map(toUpdatedMailFlags);
   } catch (error) {
     logger.error("Failed to set mail flags", {}, error);
@@ -616,24 +675,34 @@ export const searchMailsByUid = async (
   criteria: { type: string; value?: unknown }[]
 ): Promise<number[]> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
+    // Column reference for the criterion clauses. Domain-scoped view
+    // uses the plain column on `mails`; account-scoped uses the
+    // JOIN-aliased mapping. `buildCriterionClause` emits fragments like
+    // `${uidField} >= $N`, so the alias needs to be qualified.
+    const uidField = account === null ? UID_DOMAIN : `x.${UID}`;
 
     // Always exclude expunged messages from search
-    const conditions: string[] = ["user_id = $1", "sent = $2", "expunged = FALSE"];
+    const conditions: string[] = ["m.user_id = $1", "m.sent = $2", "m.expunged = FALSE"];
     const values: ParamValue[] = [user_id, sent];
-    let paramIdx = 3;
 
-    if (account !== null) {
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $${paramIdx}::jsonb`
-        : `(${TO_ADDRESS} @> $${paramIdx}::jsonb OR cc_address @> $${paramIdx}::jsonb OR bcc_address @> $${paramIdx}::jsonb OR envelope_to @> $${paramIdx}::jsonb)`;
-      conditions.push(addressCondition);
-      values.push(addressJson);
-      paramIdx++;
+    // Base table + optional mailbox join
+    let fromClause: string;
+    if (account === null) {
+      fromClause = "mails m";
+    } else {
+      const mailbox = mailboxPathForAccount(account, sent);
+      // JOIN mapping — the mailbox condition IS the membership predicate.
+      conditions.push(`x.${USER_ID} = m.${USER_ID}`);
+      conditions.push(`x.${MAILBOX} = $3`);
+      conditions.push(`x.${MAIL_ID} = m.${MAIL_ID}`);
+      values.push(mailbox);
+      fromClause = `mails m, ${MAIL_MAILBOX_UID} x`;
     }
 
     for (const criterion of criteria) {
+      // Criterion clauses reference columns on `mails` unqualified
+      // (`answered = TRUE`, `to_address @> …`) — those still work under
+      // the `m` alias since column names are unambiguous with the join.
       const frag = buildCriterionClause(criterion, uidField, values);
       if (frag) conditions.push(frag);
     }
@@ -643,7 +712,7 @@ export const searchMailsByUid = async (
     // newest messages on mailboxes larger than the cap. Consistent with
     // the unbounded getAllUids / getMailsByRange enumeration paths.
     const sql = `
-      SELECT ${uidField} as uid FROM mails
+      SELECT ${uidField} as uid FROM ${fromClause}
       WHERE ${conditions.join(" AND ")}
       ORDER BY ${uidField} ASC
     `;
@@ -668,31 +737,28 @@ export const getAllUids = async (
   sent: boolean
 ): Promise<number[]> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
-
     let sql: string;
     let values: ParamValue[];
 
     if (account === null) {
-      // Domain-wide query (exclude expunged messages)
       sql = `
-        SELECT ${uidField} as uid FROM mails 
+        SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
-        ORDER BY ${uidField} ASC
+        ORDER BY ${UID_DOMAIN} ASC
       `;
       values = [user_id, sent];
     } else {
-      // Account-specific query (exclude expunged messages)
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $3::jsonb`
-        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      const mailbox = mailboxPathForAccount(account, sent);
       sql = `
-        SELECT ${uidField} as uid FROM mails
-        WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND expunged = FALSE
-        ORDER BY ${uidField} ASC
+        SELECT x.${UID} as uid FROM mails m
+        JOIN ${MAIL_MAILBOX_UID} x
+          ON x.${USER_ID} = m.${USER_ID}
+          AND x.${MAILBOX} = $3
+          AND x.${MAIL_ID} = m.${MAIL_ID}
+        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE
+        ORDER BY x.${UID} ASC
       `;
-      values = [user_id, sent, addressJson];
+      values = [user_id, sent, mailbox];
     }
 
     const result = await pool.query(sql, values);
@@ -715,33 +781,30 @@ export const getFirstUnseenUid = async (
   sent: boolean
 ): Promise<number | null> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
-
     let sql: string;
     let values: ParamValue[];
 
     if (account === null) {
-      // Domain-wide query (exclude expunged messages)
       sql = `
-        SELECT ${uidField} as uid FROM mails
+        SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE
-        ORDER BY ${uidField} ASC
+        ORDER BY ${UID_DOMAIN} ASC
         LIMIT 1
       `;
       values = [user_id, sent];
     } else {
-      // Account-specific query (exclude expunged messages)
-      const addressJson = JSON.stringify([{ address: account }]);
-      const addressCondition = sent
-        ? `${FROM_ADDRESS} @> $3::jsonb`
-        : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+      const mailbox = mailboxPathForAccount(account, sent);
       sql = `
-        SELECT ${uidField} as uid FROM mails
-        WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND expunged = FALSE AND read = FALSE
-        ORDER BY ${uidField} ASC
+        SELECT x.${UID} as uid FROM mails m
+        JOIN ${MAIL_MAILBOX_UID} x
+          ON x.${USER_ID} = m.${USER_ID}
+          AND x.${MAILBOX} = $3
+          AND x.${MAIL_ID} = m.${MAIL_ID}
+        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE AND m.read = FALSE
+        ORDER BY x.${UID} ASC
         LIMIT 1
       `;
-      values = [user_id, sent, addressJson];
+      values = [user_id, sent, mailbox];
     }
 
     const result = await pool.query(sql, values);
@@ -764,46 +827,58 @@ export const expungeDeletedMails = async (
   sent: boolean
 ): Promise<number[]> => {
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
-
     if (account === null) {
-      // Domain-wide expunge: simple equality filters → use the framework's
-      // updateWhere so `updated` is bumped via the standard data-bag pattern.
+      // Domain-wide expunge — still on uid_domain, unchanged.
       const rows = await mailsTable.updateWhere(
         { [USER_ID]: user_id, [SENT]: sent, [DELETED]: true, [EXPUNGED]: false },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
         { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
-        [`${uidField} as uid`]
+        [`${UID_DOMAIN} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
     }
 
-    // Account-specific expunge: the address filter uses jsonb `@>` containment
-    // (with an OR across to/cc/bcc on the recv side), which WhereFilters cannot
-    // express. Two-step: raw SELECT to resolve mail_ids, then framework
-    // updateWhere with an IN filter so the data-bag pattern bumps `updated`.
-    const addressJson = JSON.stringify([{ address: account }]);
-    const addressCondition = sent
-      ? `${FROM_ADDRESS} @> $3::jsonb`
-      : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+    // Account-scoped expunge: JOIN `mail_mailbox_uid` to resolve the
+    // mail_ids that belong to this mailbox, then framework updateWhere
+    // with an IN filter so the data-bag pattern bumps `updated`. The
+    // RETURNING side reads x.uid from a second SELECT that fetches the
+    // per-account UIDs for the just-expunged rows.
+    const mailbox = mailboxPathForAccount(account, sent);
     const selectSql = `
-      SELECT ${MAIL_ID} as mail_id FROM mails
-      WHERE user_id = $1 AND sent = $2 AND ${addressCondition} AND deleted = TRUE AND expunged = FALSE
+      SELECT m.${MAIL_ID} as mail_id, x.${UID} as uid FROM mails m
+      JOIN ${MAIL_MAILBOX_UID} x
+        ON x.${USER_ID} = m.${USER_ID}
+        AND x.${MAILBOX} = $3
+        AND x.${MAIL_ID} = m.${MAIL_ID}
+      WHERE m.${USER_ID} = $1 AND m.${SENT} = $2
+        AND m.${DELETED} = TRUE AND m.${EXPUNGED} = FALSE
     `;
-    const selectValues: ParamValue[] = [user_id, sent, addressJson];
-    const selectResult = await pool.query(selectSql, selectValues);
-    const mailIds = selectResult.rows.map((row: Record<string, unknown>) => row.mail_id as string);
-    if (mailIds.length === 0) return [];
+    const selectResult = await pool.query(selectSql, [user_id, sent, mailbox]);
+    if (selectResult.rows.length === 0) return [];
+    const mailIds = selectResult.rows.map(
+      (row: Record<string, unknown>) => row.mail_id as string
+    );
+    const uidsByMailId = new Map<string, number>(
+      selectResult.rows.map((row: Record<string, unknown>) => [
+        row.mail_id as string,
+        row.uid as number,
+      ])
+    );
 
     const rows = await mailsTable.updateWhere(
       { [MAIL_ID]: { op: "IN", value: mailIds } },
       // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
       // resyncing CONDSTORE/QRESYNC client detects the removal.
       { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
-      [`${uidField} as uid`]
+      [MAIL_ID]
     );
-    return rows.map((row: Record<string, unknown>) => row.uid as number);
+    // Map the UPDATE's returned mail_ids back to their per-account UIDs
+    // via the SELECT snapshot. This is the wire signal for EXPUNGE
+    // responses.
+    return rows
+      .map((row: Record<string, unknown>) => uidsByMailId.get(row[MAIL_ID] as string))
+      .filter((u): u is number => u !== undefined);
   } catch (error) {
     logger.error("Failed to expunge deleted mails", {}, error);
     return [];
@@ -826,8 +901,6 @@ export const expungeMailsByUid = async (
 ): Promise<number[]> => {
   if (uids.length === 0) return [];
   try {
-    const uidField = account === null ? UID_DOMAIN : UID_ACCOUNT;
-
     if (account === null) {
       // Domain-wide: simple equality on user_id+sent + IN(uids).
       const rows = await mailsTable.updateWhere(
@@ -835,34 +908,41 @@ export const expungeMailsByUid = async (
           [USER_ID]: user_id,
           [SENT]: sent,
           [EXPUNGED]: false,
-          [uidField]: { op: "IN", value: uids },
+          [UID_DOMAIN]: { op: "IN", value: uids },
         },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
         { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
-        [`${uidField} as uid`]
+        [`${UID_DOMAIN} as uid`]
       );
       return rows.map((row: Record<string, unknown>) => row.uid as number);
     }
 
-    // Account-specific: mirror `expungeDeletedMails`'s two-step pattern.
-    // SELECT mail_ids via the address-OR predicate + UID IN, then UPDATE
-    // by mail_id IN so the data-bag pattern bumps `updated`.
-    const addressJson = JSON.stringify([{ address: account }]);
-    const addressCondition = sent
-      ? `${FROM_ADDRESS} @> $3::jsonb`
-      : `(${TO_ADDRESS} @> $3::jsonb OR cc_address @> $3::jsonb OR bcc_address @> $3::jsonb OR envelope_to @> $3::jsonb)`;
+    // Account-scoped: JOIN `mail_mailbox_uid` to filter by (mailbox, uid IN),
+    // resolve the mail_ids, then updateWhere by mail_id IN so the data-bag
+    // pattern bumps `updated`. Snapshot uid_by_mail_id so RETURNING can
+    // map the UPDATE's mail_id output back to the per-account UIDs.
+    const mailbox = mailboxPathForAccount(account, sent);
     const uidPlaceholders = uids.map((_, i) => `$${i + 4}`).join(",");
     const selectSql = `
-      SELECT ${MAIL_ID} as mail_id FROM mails
-      WHERE user_id = $1
-        AND sent = $2
-        AND ${addressCondition}
-        AND ${uidField} IN (${uidPlaceholders})
-        AND expunged = FALSE
+      SELECT m.${MAIL_ID} as mail_id, x.${UID} as uid FROM mails m
+      JOIN ${MAIL_MAILBOX_UID} x
+        ON x.${USER_ID} = m.${USER_ID}
+        AND x.${MAILBOX} = $3
+        AND x.${MAIL_ID} = m.${MAIL_ID}
+      WHERE m.${USER_ID} = $1
+        AND m.${SENT} = $2
+        AND x.${UID} IN (${uidPlaceholders})
+        AND m.${EXPUNGED} = FALSE
     `;
-    const selectValues: ParamValue[] = [user_id, sent, addressJson, ...uids];
+    const selectValues: ParamValue[] = [user_id, sent, mailbox, ...uids];
     const selectResult = await pool.query(selectSql, selectValues);
+    const uidsByMailId = new Map<string, number>(
+      selectResult.rows.map((row: Record<string, unknown>) => [
+        row.mail_id as string,
+        row.uid as number,
+      ])
+    );
     const mailIds = selectResult.rows.map(
       (row: Record<string, unknown>) => row.mail_id as string
     );
@@ -873,9 +953,11 @@ export const expungeMailsByUid = async (
       // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
       // resyncing CONDSTORE/QRESYNC client detects the removal.
       { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
-      [`${uidField} as uid`]
+      [MAIL_ID]
     );
-    return rows.map((row: Record<string, unknown>) => row.uid as number);
+    return rows
+      .map((row: Record<string, unknown>) => uidsByMailId.get(row[MAIL_ID] as string))
+      .filter((u): u is number => u !== undefined);
   } catch (error) {
     logger.error("Failed to expunge mails by UID", { uids }, error);
     throw error;


### PR DESCRIPTION
Third and final PR of the #702 migration off `mails.uid_account` onto the `mail_mailbox_uid` mapping table.

**PR 2a (#715, merged)** — dual-write: `writeMailboxUid` fires from every receive/COPY/MOVE/APPEND site.
**PR 2b-1 (#717, merged)** — `ensureMailboxUids` helper: per-read best-effort backfill from `mails.uid_account`, bare `ON CONFLICT DO NOTHING`.
**PR 2b-2 (this)** — read cutover: the 8 account-scoped read sites in `src/server/lib/postgres/repositories/mails/imap.ts` now JOIN `mail_mailbox_uid` instead of filtering on `mails.uid_account`.
**PR 3 (next)** — drop the `uid_account` column + bump `imap_uid_validity` per user.

## Sites migrated
`countMessages`, `getMailsByRange`, `setMailFlags`, `getAllUids`, `getFirstUnseenUid`, `searchMailsByUid`, `expungeDeletedMails`, `expungeMailsByUid`. Domain-scoped branches (INBOX, unified Sent) stay on `uid_domain` — the mapping table is per-mailbox and INBOX/unified-Sent have no mailbox row.

## Backfill posture
Hoie ran the one-shot backfill script on prod — 12,874 rows inserted. 140 legacy mail_ids couldn't be backfilled due to legacy pre-#617-fix duplicate-UID collisions inside a single mailbox; those mails become invisible to IMAP under the new read path (they were only visible via the old `uid_account` fallback anyway, with duplicate-UID clients likely eating one of the pair). Shipping as-is per Hoie's call.

## E2E — 24/24 pass on sandbox (prod clone)
Drove the running IMAP server on port 31998:

- **LIST** — account + Sent-account mailboxes visible ✅
- **SELECT account mailbox** — EXISTS = 1010, `[UNSEEN 1006]` code populated ✅
- **STATUS** — MESSAGES = 1010, UNSEEN = 5 ✅
- **UID SEARCH ALL** — 1010 UIDs ✅
- **UID SEARCH UNSEEN** — 5 ✅
- **UID FETCH range** — 10 rows ✅
- **UID STORE +FLAGS \\Seen** — flag applied, echoed FETCH ✅
- **STATUS UNSEEN after STORE** — 4 (down by 1) ✅
- **UID STORE -FLAGS \\Seen** — unread restored ✅
- **Sent-account SELECT/UID SEARCH** — EXISTS = 83, SEARCH = 83 ✅
- **INBOX (domain-scoped) SELECT/UID SEARCH** — EXISTS = 12380, SEARCH = 12380 — regression guard for the `uid_domain` branch ✅
- **STORE +\\Deleted + EXPUNGE** — STATUS down by 2, expunged UIDs gone from SEARCH ✅
- **UID MOVE to INBOX** — STATUS on source down by 1 (exercises `expungeMailsByUid`) ✅

## Test coverage
`bun test src/server/lib/postgres/repositories/mails/ src/server/lib/imap/` → 757/0 across 31 files.

Closes 3 of the 3 planned PRs in the migration arc (2a/2b-1/2b-2). PR 3 tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)