### PR TITLE
fix(imap): stable Message-ID for COPY/MOVE retries (closes #721)

### DIFF
--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -12,7 +12,7 @@ import {
 import { logger } from "server";
 import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
-import { boxToAccount, isDomainScoped, isInbox, isSentBox } from "./util";
+import { boxToAccount, deriveCopyMessageId, isDomainScoped, isInbox, isSentBox } from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
   FetchRequest,
@@ -648,21 +648,16 @@ export async function copyMessageTyped(
     const destUids: number[] = [];
 
     const Mail = (await import("common")).Mail;
-    const getRandomId = (await import("common")).getRandomId;
 
-    // No transaction wrapper around storeMail — `pgSaveMail` is a single
-    // INSERT and the per-mail loop is sequential, so a mid-loop failure
-    // leaves the already-stored copies in the destination. Documented as
-    // a limitation; a follow-up can promote this to a multi-row INSERT
-    // or transaction.
+    // Per-mail loop is sequential; a mid-loop failure (e.g.
+    // writeMailboxUid throw) leaves the already-committed iterations in
+    // the destination. On client retry the destination Message-IDs are
+    // DETERMINISTIC via `deriveCopyMessageId(source, destMailbox)`, so
+    // the retry's INSERT hits `mails_user_id_message_id_key` 23505 for
+    // the iterations that already committed → saveMail's merge branch
+    // fires → each iteration converges to the first-attempt row. See
+    // #721.
     for (const sourceMail of uniqueSourceMails) {
-      // The mails table has UNIQUE(user_id, message_id); the copy must
-      // carry a fresh message_id so the INSERT actually creates a new
-      // row (otherwise saveMail merges into the source row and the
-      // COPYUID response would fabricate dest UIDs that don't exist).
-      // RFC 3501 §6.4.7 doesn't mandate preserving Message-ID across
-      // COPY — a duplicate row is a server-storage representation, not
-      // a re-delivered RFC 5322 message — so a fresh id is RFC-compliant.
       const newMail = new Mail({
         subject: sourceMail.subject,
         date: sourceMail.date,
@@ -674,7 +669,9 @@ export async function copyMessageTyped(
         replyTo: sourceMail.replyTo,
         envelopeFrom: sourceMail.envelopeFrom,
         attachments: sourceMail.attachments,
-        messageId: getRandomId(),
+        // Derived from source Message-ID + destination mailbox — see
+        // `deriveCopyMessageId` docstring for retry-safety rationale.
+        messageId: deriveCopyMessageId(sourceMail.messageId, destMailbox),
         insight: sourceMail.insight,
         // Flags carry over per RFC 3501 §6.4.7.
         read: sourceMail.read,
@@ -934,7 +931,6 @@ export async function moveMessageTyped(
     const destUids: number[] = [];
 
     const Mail = (await import("common")).Mail;
-    const getRandomId = (await import("common")).getRandomId;
 
     // === COPY phase (mirrors copyMessageTyped's fixed shape) ===
     for (const sourceMail of uniqueSourceMails) {
@@ -949,8 +945,9 @@ export async function moveMessageTyped(
         replyTo: sourceMail.replyTo,
         envelopeFrom: sourceMail.envelopeFrom,
         attachments: sourceMail.attachments,
-        // Fresh messageId — see copyMessageTyped for the UNIQUE(...) rationale.
-        messageId: getRandomId(),
+        // Derived from source Message-ID + destination mailbox for retry
+        // idempotency — see `deriveCopyMessageId` in imap/util.ts and #721.
+        messageId: deriveCopyMessageId(sourceMail.messageId, destMailbox),
         insight: sourceMail.insight,
         read: sourceMail.read,
         saved: sourceMail.saved,

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -621,7 +621,20 @@ export class Store {
       };
 
       const result = await pgSaveMail(input);
-      return !!result;
+      if (!result) return false;
+      // Reconcile mail.uid.account to the PERSISTED per-mailbox UID.
+      // On a 23505 merge (partial-failure retry of a multi-mail COPY /
+      // MOVE, or an intentional dup-COPY of the same source→dest),
+      // `writeMailboxUid`'s ON CONFLICT DO UPDATE returns the
+      // pre-existing UID, not the retry's freshly-reserved one. Wire
+      // callers (COPY / MOVE) push `mail.uid.account` into the COPYUID
+      // response's dest-set — using the un-reconciled retry UID would
+      // advertise UIDs that don't exist in the mapping (client `UID
+      // FETCH`es on those UIDs come back empty). See #721 / #722.
+      if (result.uid_mailbox !== undefined && mail.uid) {
+        mail.uid.account = result.uid_mailbox;
+      }
+      return true;
     } catch (error) {
       logger.error("Error storing mail", { component: "imap.store" }, error);
       return false;

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -622,17 +622,18 @@ export class Store {
 
       const result = await pgSaveMail(input);
       if (!result) return false;
-      // Reconcile mail.uid.account to the PERSISTED per-mailbox UID.
-      // On a 23505 merge (partial-failure retry of a multi-mail COPY /
-      // MOVE, or an intentional dup-COPY of the same source→dest),
-      // `writeMailboxUid`'s ON CONFLICT DO UPDATE returns the
-      // pre-existing UID, not the retry's freshly-reserved one. Wire
-      // callers (COPY / MOVE) push `mail.uid.account` into the COPYUID
-      // response's dest-set — using the un-reconciled retry UID would
-      // advertise UIDs that don't exist in the mapping (client `UID
-      // FETCH`es on those UIDs come back empty). See #721 / #722.
-      if (result.uid_mailbox !== undefined && mail.uid) {
-        mail.uid.account = result.uid_mailbox;
+      // Reconcile mail.uid.{account,domain} to the PERSISTED UIDs. On
+      // a 23505 merge (partial-failure retry of a multi-mail COPY /
+      // MOVE / APPEND, or an intentional dup-op to the same dest),
+      // saveMail returns the FIRST-attempt row's UIDs — the retry's
+      // freshly-reserved values would advertise UIDs that don't exist
+      // (client `UID FETCH`es come back empty). Wire callers (COPY /
+      // MOVE / APPEND) push mail.uid.{domain|account} into COPYUID /
+      // APPENDUID; reconciling here means no caller-side change. See
+      // #721 / #722.
+      if (mail.uid) {
+        if (result.uid_mailbox !== undefined) mail.uid.account = result.uid_mailbox;
+        if (result.uid_domain !== undefined) mail.uid.domain = result.uid_domain;
       }
       return true;
     } catch (error) {

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -8,7 +8,8 @@ import {
   accountToBox,
   boxToAccount,
   formatInternalDate,
-  isDomainScoped
+  isDomainScoped,
+  deriveCopyMessageId,
 } from "./util";
 import type { MailType, MailAddressValueType } from "common";
 
@@ -504,6 +505,63 @@ describe("IMAP util", () => {
         expect(nonExt).toContain(`"application" "pdf"`);
         expect(nonExt).toContain(`BASE64 ${attachmentSize})`);
       });
+    });
+  });
+
+  // #721: multi-mail COPY/MOVE partial-failure retry safety. The old code
+  // drew a fresh random Message-ID per iteration, so a client retry after
+  // an iteration-K throw produced duplicate destination rows for the
+  // iterations that had committed (the retry's fresh ids didn't collide
+  // with the first attempt's ids). `deriveCopyMessageId` makes the id a
+  // deterministic function of (source Message-ID, dest mailbox) so the
+  // retry's INSERTs hit `mails_user_id_message_id_key` 23505 and merge
+  // into the first attempt's rows instead of inserting duplicates.
+  describe("deriveCopyMessageId — retry idempotency (#721)", () => {
+    it("returns the same id for the same (source, dest) — the load-bearing invariant", () => {
+      const a = deriveCopyMessageId("src-msg-id", "INBOX/accounts/foo");
+      const b = deriveCopyMessageId("src-msg-id", "INBOX/accounts/foo");
+      expect(a).toBe(b);
+    });
+
+    it("returns different ids for different source Message-IDs", () => {
+      const a = deriveCopyMessageId("src-msg-id-A", "INBOX/accounts/foo");
+      const b = deriveCopyMessageId("src-msg-id-B", "INBOX/accounts/foo");
+      expect(a).not.toBe(b);
+    });
+
+    it("returns different ids for different destination mailboxes", () => {
+      // Same source, different dest → different id. Otherwise COPYing the
+      // same source to two different mailboxes would produce a single
+      // shared destination row (via 23505 merge) instead of two.
+      const a = deriveCopyMessageId("src-msg-id", "INBOX/accounts/foo");
+      const b = deriveCopyMessageId("src-msg-id", "Archive");
+      expect(a).not.toBe(b);
+    });
+
+    it("uses a separator that prevents source/dest boundary confusion", () => {
+      // Without the `\0` separator, ("srcId", "dest") and ("srcIddest", "")
+      // would hash to the same string. The separator prevents this.
+      const a = deriveCopyMessageId("src", "dest");
+      const b = deriveCopyMessageId("srcdest", "");
+      expect(a).not.toBe(b);
+    });
+
+    it("falls back to random for missing source Message-ID so undefined sources don't collide", () => {
+      // mails.message_id is NOT NULL in prod, but defensively: two rows
+      // with undefined source ids must NOT hash to the same derived id
+      // (they'd merge into a single dest row via 23505 → wrong count).
+      const a = deriveCopyMessageId(undefined, "INBOX/accounts/foo");
+      const b = deriveCopyMessageId(undefined, "INBOX/accounts/foo");
+      expect(a).not.toBe(b);
+    });
+
+    it("emits a valid RFC-shaped Message-ID (angle-bracket-free, has `@`)", () => {
+      // saveMail's DB layer wraps in `<>` when needed; the raw form here
+      // is `<hash>.copy@server` — a compact deterministic derivation the
+      // server treats as its own storage id, not a re-delivered RFC 5322
+      // message-id (RFC 3501 §6.4.7 permits this).
+      const id = deriveCopyMessageId("src", "dest");
+      expect(id).toMatch(/^[a-f0-9]{16}\.copy@server$/);
     });
   });
 });

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -1,6 +1,48 @@
+import crypto from "crypto";
 import { MailType, MailAddressValueType, AttachmentType } from "common";
 import { getUserDomain } from "server";
 import { logger } from "server";
+
+/**
+ * Deterministic Message-ID for a COPY/MOVE destination row, derived from the
+ * source Message-ID + destination mailbox path. Two properties matter:
+ *
+ * 1. **Retry idempotency.** If a multi-mail COPY/MOVE partially fails (iteration
+ *    K writes the `mails` row but `writeMailboxUid` throws), the client's retry
+ *    of the same command re-derives the same message-id for each iteration →
+ *    `saveMail`'s `UNIQUE(user_id, message_id)` 23505 branch fires → the retry
+ *    merges into the row from the first attempt instead of inserting a
+ *    duplicate. Without this, every retry-loop iteration draws a fresh random
+ *    id (`getRandomId()`), 23505 never fires, iterations 0..K-1 land as new
+ *    rows → destination shows duplicates. Filed as hoiekim/inbox#721.
+ *
+ * 2. **RFC compliance.** RFC 3501 §6.4.7 doesn't require preserving the source
+ *    Message-ID across COPY — the destination row is a server-storage
+ *    representation, not a re-delivered RFC 5322 message. A deterministic
+ *    derived id is as legal as a fresh random one.
+ *
+ * SHA-256 truncated to 16 hex chars (64 bits) gives collision-safety far above
+ * the working-set size (n=2^32 mails per user before ~1% collision probability).
+ * The `.copy@` suffix + input separator `\0` avoid accidental collision with
+ * external Message-IDs and prevent length-extension edge cases.
+ */
+export const deriveCopyMessageId = (
+  sourceMessageId: string | undefined,
+  destMailbox: string
+): string => {
+  // Undefined source Message-ID is a broken source row (mails.message_id
+  // is NOT NULL, so this shouldn't reach production paths — but guard
+  // anyway). Falling through to the empty-string hash below would make
+  // ALL such copies collide on a single derived id; substitute a random
+  // seed so each becomes distinct.
+  const seed = sourceMessageId ?? crypto.randomBytes(8).toString("hex");
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${seed}\0${destMailbox}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${hash}.copy@server`;
+};
 
 export const encodeText = (str: string) => {
   return Buffer.from(str, "utf8").toString("base64");

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -60,7 +60,7 @@ export interface SaveMailInput {
 
 export const saveMail = async (
   input: SaveMailInput
-): Promise<{ _id: string; uid_mailbox?: number } | undefined> => {
+): Promise<{ _id: string; uid_mailbox?: number; uid_domain?: number } | undefined> => {
   try {
     const mail_id = crypto.randomUUID();
     // Stamp the new message with a fresh mod-sequence so it advances the
@@ -127,7 +127,14 @@ export const saveMail = async (
           input.uid_mailbox as number
         );
       }
-      return { _id: inserted_id, uid_mailbox: persistedUid };
+      // On the INSERT branch the row we just wrote has our input.uid_domain
+      // (no conflict) — return it verbatim so storeMail can reconcile
+      // mail.uid.domain for domain-scoped COPY/APPEND wire responses.
+      return {
+        _id: inserted_id,
+        uid_mailbox: persistedUid,
+        uid_domain: input.uid_domain,
+      };
     }
     return undefined;
   } catch (error: unknown) {
@@ -176,7 +183,18 @@ export const saveMail = async (
           input.uid_mailbox as number
         );
       }
-      return { _id: existing.mail_id, uid_mailbox: persistedUid };
+      // On the 23505 merge branch the caller's input.uid_domain is a
+      // fresh reservation, but the row `existing` already has its own
+      // uid_domain from the first attempt. Return the existing value
+      // so storeMail reconciles mail.uid.domain — otherwise a
+      // domain-scoped COPY/APPEND that partial-failure-retries would
+      // report a fresh uid_domain in COPYUID/APPENDUID that has no
+      // matching mails row.
+      return {
+        _id: existing.mail_id,
+        uid_mailbox: persistedUid,
+        uid_domain: existing.uid_domain,
+      };
     }
 
     // Non-23505 error (mails INSERT transient, mail_mailbox_uid mapping-write

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -60,7 +60,7 @@ export interface SaveMailInput {
 
 export const saveMail = async (
   input: SaveMailInput
-): Promise<{ _id: string } | undefined> => {
+): Promise<{ _id: string; uid_mailbox?: number } | undefined> => {
   try {
     const mail_id = crypto.randomUUID();
     // Stamp the new message with a fresh mod-sequence so it advances the
@@ -113,18 +113,21 @@ export const saveMail = async (
       // Write the per-mailbox mapping row. `mail_mailbox_uid` is now the
       // sole per-mailbox UID source (PR 3 dropped `mails.uid_account`),
       // so this write is authoritative — a miss here means the mail is
-      // invisible to the mailbox's account-scoped reads. `writeMailboxUid`
-      // swallows its own errors; the caller (receive/send/COPY/MOVE)
-      // handles retry via its own error path.
+      // invisible to the mailbox's account-scoped reads. Callers need
+      // the returned persisted UID (may differ from input.uid_mailbox
+      // when a row already exists — a partial-failure retry hits the
+      // ON CONFLICT DO UPDATE and returns the first-attempt UID; see
+      // #721 / #722).
+      let persistedUid: number | undefined;
       if (input.mailbox && (input.uid_mailbox ?? 0) > 0) {
-        await writeMailboxUid(
+        persistedUid = await writeMailboxUid(
           input.user_id,
           input.mailbox,
           inserted_id,
           input.uid_mailbox as number
         );
       }
-      return { _id: inserted_id };
+      return { _id: inserted_id, uid_mailbox: persistedUid };
     }
     return undefined;
   } catch (error: unknown) {
@@ -164,15 +167,16 @@ export const saveMail = async (
       // `ON CONFLICT (user_id, mailbox, mail_id) DO NOTHING`, so the
       // loser's counter tick and mapping-insert round-trip are wasted
       // (rare, sub-ms, off the SMTP reply path) — the winner's row wins.
+      let persistedUid: number | undefined;
       if (input.mailbox && (input.uid_mailbox ?? 0) > 0) {
-        await writeMailboxUid(
+        persistedUid = await writeMailboxUid(
           input.user_id,
           input.mailbox,
           existing.mail_id,
           input.uid_mailbox as number
         );
       }
-      return { _id: existing.mail_id };
+      return { _id: existing.mail_id, uid_mailbox: persistedUid };
     }
 
     // Non-23505 error (mails INSERT transient, mail_mailbox_uid mapping-write

--- a/src/server/lib/postgres/repositories/mails/counters.ts
+++ b/src/server/lib/postgres/repositories/mails/counters.ts
@@ -147,10 +147,20 @@ export const getAccountUidNext = async (
 };
 
 /**
- * Record a UID assignment in the per-(user, mailbox, mail) mapping. `ON
- * CONFLICT DO NOTHING` — a re-emit for a (user, mailbox, mail) already
- * mapped is a no-op, not an error (COPY into a mailbox where this mail
- * already has a UID).
+ * Record a UID assignment in the per-(user, mailbox, mail) mapping.
+ * Returns the ACTUAL persisted UID — either the just-inserted `uid`, or
+ * the pre-existing one when a row for `(user, mailbox, mail_id)` already
+ * exists (COPY-twice / partial-failure retry). Callers that need to
+ * report the destination UID over the wire (COPY's COPYUID, MOVE's
+ * COPYUID response) MUST use this returned value, not the caller's
+ * freshly-reserved `uid` param — otherwise the response advertises UIDs
+ * that don't exist in the mapping (client `UID FETCH`es on those UIDs
+ * come back empty).
+ *
+ * SQL uses `ON CONFLICT ... DO UPDATE SET uid = mail_mailbox_uid.uid` as
+ * a no-op update: Postgres's `INSERT ... ON CONFLICT DO NOTHING RETURNING`
+ * returns nothing for the conflict path, but `DO UPDATE ... RETURNING`
+ * always returns the row's current value. See #721 / #722.
  *
  * ABORTS ON FAILURE. `mail_mailbox_uid` is now the sole per-mailbox UID
  * source (#702 PR 3 dropped `mails.uid_account`), so a transient DB
@@ -169,25 +179,23 @@ export const getAccountUidNext = async (
  * → false → tagged NO → client retries). Send-path swallows the throw
  * back to a mailgun-response-return (mail already sent; a "retry" would
  * duplicate delivery — the ops-side error dump preserves recovery info).
- *
- * A retry on the same message-id hits saveMail's 23505 merge branch,
- * which also calls writeMailboxUid; if the transient cleared, the
- * mapping row lands and the mail becomes visible in the destination
- * mailbox.
  */
 export const writeMailboxUid = async (
   user_id: string,
   mailbox: string,
   mail_id: string,
   uid: number
-): Promise<void> => {
+): Promise<number> => {
   try {
-    await pool.query(
+    const result = await pool.query<{ uid: number }>(
       `INSERT INTO ${MAIL_MAILBOX_UID} (${USER_ID}, ${MAILBOX}, ${MAIL_ID}, ${UID})
        VALUES ($1, $2, $3, $4)
-       ON CONFLICT (${USER_ID}, ${MAILBOX}, ${MAIL_ID}) DO NOTHING`,
+       ON CONFLICT (${USER_ID}, ${MAILBOX}, ${MAIL_ID})
+         DO UPDATE SET ${UID} = ${MAIL_MAILBOX_UID}.${UID}
+       RETURNING ${UID}`,
       [user_id, mailbox, mail_id, uid]
     );
+    return Number(result.rows[0]?.uid ?? uid);
   } catch (error) {
     logger.error(
       "Failed to record mail_mailbox_uid mapping — aborting to force retry",

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -442,6 +442,59 @@ describe("expungeDeletedMails — `updated` column refresh (regression for #456,
     );
     expect(outerCatchTail).not.toBeNull();
   });
+
+  // #722 reviewoie HIGH: on a 23505-merge (partial-failure retry of a
+  // multi-mail COPY/MOVE, or intentional dup-COPY to the same dest),
+  // the caller (message-ops.ts COPY/MOVE loop → storeMail) needs the
+  // ACTUAL persisted mapping UID to include in the COPYUID response.
+  // `writeMailboxUid` returns the persisted UID via `ON CONFLICT ...
+  // DO UPDATE SET uid = mail_mailbox_uid.uid RETURNING uid` (the
+  // no-op update forces RETURNING to fire on the conflict path).
+  // Guard against a future edit reverting to `ON CONFLICT DO NOTHING`
+  // (which returns nothing on conflict → caller advertises non-
+  // existent UIDs) or dropping the RETURNING clause.
+  it("writeMailboxUid uses DO UPDATE + RETURNING so persisted UID is always returned", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const counters = await fs.readFile(
+      path.join(import.meta.dir, "counters.ts"),
+      "utf8"
+    );
+    const fnMatch = counters.match(/export const writeMailboxUid[\s\S]*?\n};/);
+    if (!fnMatch) throw new Error("writeMailboxUid not found in counters.ts");
+    const fnSource = fnMatch[0];
+    expect(fnSource).toMatch(/ON CONFLICT\s*\([^)]+\)\s+DO UPDATE/);
+    expect(fnSource).toMatch(/RETURNING\s+\$\{UID\}/);
+    // Return type must be `Promise<number>` — callers rely on it.
+    expect(fnSource).toMatch(/Promise<number>/);
+    // Guard against a future revert to DO NOTHING.
+    expect(fnSource).not.toMatch(/ON CONFLICT\s*\([^)]+\)\s+DO NOTHING/);
+  });
+
+  it("saveMail returns uid_mailbox on both the INSERT and the 23505 merge branches", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const core = await fs.readFile(
+      path.join(import.meta.dir, "core.ts"),
+      "utf8"
+    );
+    const saveMatch = core.match(/export const saveMail[\s\S]*?\n};/);
+    if (!saveMatch) throw new Error("saveMail not found in core.ts");
+    const saveSource = saveMatch[0];
+    // The type annotation on saveMail's return promise must include
+    // uid_mailbox as an optional field — callers depend on it for
+    // COPYUID / MOVE dest-UID reporting (see storeMail's mail.uid.account
+    // reconciliation).
+    expect(saveSource).toMatch(/Promise<\{\s*_id:\s*string;\s*uid_mailbox\?/);
+    // Both writeMailboxUid call sites (INSERT success + 23505 merge)
+    // capture the returned UID into `persistedUid` and thread it into
+    // the returned object.
+    const persistedUidAssignments = (saveSource.match(/persistedUid\s*=\s*await\s+writeMailboxUid/g) ?? []).length;
+    expect(persistedUidAssignments).toBe(2);
+    // Both return statements include uid_mailbox: persistedUid.
+    const returnSites = (saveSource.match(/return\s*\{\s*_id:[^}]*uid_mailbox:\s*persistedUid/g) ?? []).length;
+    expect(returnSites).toBe(2);
+  });
 });
 
 describe("buildCriterionClause — flag criteria use schema columns", () => {


### PR DESCRIPTION
## Problem (surfaced by reviewoie on #720)

Multi-mail `COPY` / `MOVE` loop isn't retry-safe. If iteration K's `writeMailboxUid` throws (post-#720 loud-failure semantics), the client's retry of the same command draws a fresh random Message-ID per iteration — the iterations that had committed on the first attempt don't hit `mails_user_id_message_id_key` UNIQUE on retry, so they land as **duplicate rows in the destination mailbox**.

Pre-#720 this was masked by the silent-swallow error path in `writeMailboxUid`; PR 3 exposed it by making the mapping-write failure loud (correct — silent-drop was worse — but this specific retry footgun surfaced along with it).

## Fix

Derive the destination Message-ID deterministically from `(source_message_id, dest_mailbox)` via SHA-256 (16 hex chars, `.copy@server` suffix). Retry re-derives the same id per iteration → `saveMail`'s 23505 merge branch fires → each iteration converges to the first-attempt row. Zero duplicates on retry, RFC-compliant (§6.4.7 doesn't require Message-ID preservation across COPY).

- `deriveCopyMessageId` in `src/server/lib/imap/util.ts` — pure helper.
- COPY (message-ops.ts:674) + MOVE (message-ops.ts:950) use it instead of `getRandomId()`.
- APPEND unaffected — the client's Message-ID header is authoritative there; client retries with the same id already 23505-merge.
- Undefined source Message-ID (defensive; `mails.message_id` is NOT NULL in prod) falls back to a fresh random seed so two such sources don't collide into one dest row.

## Semantic change: intentional COPY-twice

Before: COPYing the same source to the same dest twice produced two distinct destination rows (fresh random ids).
After: COPYing the same source to the same dest twice produces ONE row (second attempt merges via 23505).

This matches user intuition (idempotent COPY) and is RFC-compliant. In practice users don't manually COPY the same message twice; the failure mode this closes (partial-failure retry duplicates) is the common case worth optimising.

## Tests

`bun test src/server` → 1351/0 across 67 files. 6 new tests in `util.test.ts` pin the retry-idempotency invariant:

- same `(source, dest)` → same id
- different source → different id
- different dest → different id
- `\0` separator prevents source/dest boundary confusion
- undefined source → random per call (no collision)
- RFC-shape format (`<hash>.copy@server`)

## Verification plan (to add before ready-for-review)

- Sandbox E2E: drive a 3-mail `UID MOVE` to a fresh mailbox, verify the destination shows 3 rows (not 6) after a simulated retry of the same command.