### PR TITLE
feat(imap): CONDSTORE phase 3 — FETCH CHANGEDSINCE modifier

### DIFF
--- a/src/server/lib/imap/condstore.test.ts
+++ b/src/server/lib/imap/condstore.test.ts
@@ -436,15 +436,23 @@ describe("CONDSTORE — STORE flag echo carries MODSEQ", () => {
 // FETCH — the modseq column is only pulled from the store when needed
 // ---------------------------------------------------------------------------
 
-const recordingFetchStore = (captured: { fields: string[] }): Store =>
+interface FetchCapture {
+  fields: string[];
+  changedSince?: number;
+}
+
+const recordingFetchStore = (captured: FetchCapture): Store =>
   ({
     getMessages: async (
       _box: string,
       _start: number,
       _end: number,
-      fields: string[]
+      fields: string[],
+      _useUid: boolean,
+      changedSince?: number
     ) => {
       captured.fields = fields;
+      captured.changedSince = changedSince;
       const m = new Map<string, Partial<MailType>>();
       m.set("doc1", {
         uid: { domain: 8, account: 8 },
@@ -462,13 +470,14 @@ const recordingFetchStore = (captured: { fields: string[] }): Store =>
 
 const runFetch = async (
   dataItems: FetchDataItem[],
-  condstoreEnabled: boolean
+  condstoreEnabled: boolean,
+  changedSince?: number
 ) => {
-  const captured = { fields: [] as string[] };
+  const captured: FetchCapture = { fields: [] };
   const lines: string[] = [];
   await fetchMessagesTyped(
     "A1",
-    { sequenceSet: { type: "uid", ranges: [{ start: 8 }] }, dataItems },
+    { sequenceSet: { type: "uid", ranges: [{ start: 8 }] }, dataItems, changedSince },
     true,
     recordingFetchStore(captured),
     "INBOX",
@@ -504,5 +513,121 @@ describe("CONDSTORE — FETCH pulls the modseq column only when needed", () => {
     const { captured, out } = await runFetch([{ type: "FLAGS" }], false);
     expect(captured.fields).not.toContain("modseq");
     expect(out).not.toContain("MODSEQ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3 (#609) — FETCH CHANGEDSINCE: parsing, filter threading, implicit MODSEQ
+// ---------------------------------------------------------------------------
+
+const fetchDataOf = (line: string) => {
+  const result = parseCommand(line);
+  expect(result.success).toBe(true);
+  const request = result.value!.request;
+  // A plain FETCH is `{ type: "FETCH", data }`; a UID FETCH wraps it as
+  // `{ type: "UID", data: { command: "FETCH", request: { type: "FETCH", data } } }`.
+  if (request.type === "FETCH") return request.data;
+  if (request.type === "UID" && request.data.request.type === "FETCH") {
+    return request.data.request.data;
+  }
+  throw new Error("not a FETCH command");
+};
+
+describe("CONDSTORE phase 3 — FETCH CHANGEDSINCE parsing", () => {
+  it("parses a trailing (CHANGEDSINCE n) modifier off a plain FETCH", () => {
+    const data = fetchDataOf("A1 FETCH 1:* (FLAGS) (CHANGEDSINCE 12345)");
+    expect(data.changedSince).toBe(12345);
+    expect(data.dataItems.map((i) => i.type)).toEqual(["FLAGS"]);
+  });
+
+  it("parses (CHANGEDSINCE n) off a UID FETCH", () => {
+    const data = fetchDataOf("A1 UID FETCH 1:* (FLAGS UID) (CHANGEDSINCE 7)");
+    expect(data.changedSince).toBe(7);
+  });
+
+  it("parses CHANGEDSINCE 0 as a real value (not falsy-dropped)", () => {
+    const data = fetchDataOf("A1 FETCH 1 (FLAGS) (CHANGEDSINCE 0)");
+    expect(data.changedSince).toBe(0);
+  });
+
+  it("leaves changedSince undefined when no modifier group is present", () => {
+    const data = fetchDataOf("A1 FETCH 1 (FLAGS)");
+    expect(data.changedSince).toBeUndefined();
+  });
+
+  it("rejects an unknown FETCH modifier with a parse failure (BAD)", () => {
+    const result = parseCommand("A1 FETCH 1 (FLAGS) (BOGUS 1)");
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects CHANGEDSINCE with no mod-sequence value", () => {
+    const result = parseCommand("A1 FETCH 1 (FLAGS) (CHANGEDSINCE)");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("CONDSTORE phase 3 — CHANGEDSINCE threading + implicit MODSEQ", () => {
+  it("threads changedSince through to store.getMessages", async () => {
+    const { captured } = await runFetch([{ type: "FLAGS" }], false, 100);
+    expect(captured.changedSince).toBe(100);
+  });
+
+  it("pulls the modseq column for a CHANGEDSINCE fetch even without ENABLE", async () => {
+    const { captured } = await runFetch([{ type: "FLAGS" }], false, 100);
+    expect(captured.fields).toContain("modseq");
+  });
+
+  it("emits `MODSEQ (n)` implicitly for a CHANGEDSINCE fetch even without ENABLE", async () => {
+    // RFC 4551 §3.3.1: CHANGEDSINCE implies the MODSEQ data item.
+    const { out } = await runFetch([{ type: "FLAGS" }], false, 100);
+    expect(out).toContain("MODSEQ (5)");
+  });
+
+  it("does not thread changedSince when the modifier is absent", async () => {
+    const { captured } = await runFetch([{ type: "FLAGS" }], false);
+    expect(captured.changedSince).toBeUndefined();
+  });
+});
+
+describe("CONDSTORE phase 3 — FETCH CHANGEDSINCE persistently enables CONDSTORE", () => {
+  // RFC 4551 §3.3.1: a CHANGEDSINCE fetch automatically enables CONDSTORE for
+  // the session, so a later plain FETCH also carries MODSEQ.
+  const buildSession = async () => {
+    const { session, writes } = makeSession();
+    // Reach past auth/select: the guards only check these three fields.
+    (session as unknown as { authenticated: boolean }).authenticated = true;
+    (session as unknown as { store: Store }).store = recordingFetchStore({
+      fields: [],
+    });
+    (session as unknown as { selectedMailbox: string }).selectedMailbox = "INBOX";
+    (session as unknown as { seqState: SequenceState }).seqState =
+      seqStateFor([8]);
+    return { session, writes };
+  };
+
+  it("a CHANGEDSINCE fetch flips the session condstore flag", async () => {
+    const { session, writes } = await buildSession();
+    await session.fetchMessagesTyped(
+      "A1",
+      {
+        sequenceSet: { type: "uid", ranges: [{ start: 8 }] },
+        dataItems: [{ type: "FLAGS" }],
+        changedSince: 3,
+      },
+      true
+    );
+    // This response carries MODSEQ...
+    expect(writes.join("")).toContain("MODSEQ (5)");
+    // ...and a subsequent plain fetch (no CHANGEDSINCE) now carries it too.
+    const before = writes.length;
+    await session.fetchMessagesTyped(
+      "A2",
+      {
+        sequenceSet: { type: "uid", ranges: [{ start: 8 }] },
+        dataItems: [{ type: "FLAGS" }],
+      },
+      true
+    );
+    expect(writes.slice(before).join("")).toContain("MODSEQ (5)");
   });
 });

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -83,6 +83,14 @@ export async function fetchMessagesTyped(
     return;
   }
 
+  // RFC 4551 §3.3.1: a CHANGEDSINCE fetch implies the MODSEQ data item, so the
+  // response carries `MODSEQ (n)` even if the client never ENABLEd CONDSTORE.
+  // The session separately flips its persistent condstore flag so subsequent
+  // plain fetches also carry MODSEQ; this local flag keeps THIS response
+  // correct in isolation.
+  const emitCondstore =
+    condstoreEnabled || fetchRequest.changedSince !== undefined;
+
   try {
     const messages = await _fetchMessages(
       fetchRequest,
@@ -90,7 +98,7 @@ export async function fetchMessagesTyped(
       store,
       selectedMailbox,
       seqState,
-      condstoreEnabled
+      emitCondstore
     );
     await _processFetchMessages(
       messages,
@@ -102,7 +110,7 @@ export async function fetchMessagesTyped(
       write,
       writeChunked,
       writeStream,
-      condstoreEnabled
+      emitCondstore
     );
     write(`${tag} OK FETCH completed\r\n`);
   } catch (error) {
@@ -163,7 +171,8 @@ async function _fetchMessages(
         uidStart,
         uidEnd,
         Array.from(requestedFields),
-        true
+        true,
+        fetchRequest.changedSince
       );
       messages.forEach((mail, id) => {
         result.set(id, mail);

--- a/src/server/lib/imap/parsers/fetch-parsers.ts
+++ b/src/server/lib/imap/parsers/fetch-parsers.ts
@@ -3,7 +3,7 @@
  */
 
 import { ParseContext, ParseResult, ImapRequest, FetchDataItem, BodyFetch, BodyStructureFetch, BodySection, PartialRange } from '../types';
-import { parseSequenceSet, skipWhitespace, peek, parseAtom } from './primitive-parsers';
+import { parseSequenceSet, skipWhitespace, peek, parseAtom, parseNumber } from './primitive-parsers';
 
 /**
  * Parse FETCH command
@@ -21,17 +21,67 @@ export const parseFetch = (context: ParseContext): ParseResult<ImapRequest> => {
     return { success: false, error: 'Invalid data items in FETCH', consumed: 0 };
   }
 
+  // RFC 4551 §3.3.1: an optional trailing `(CHANGEDSINCE <modseq>)` FETCH
+  // modifier group follows the data-item spec. Absent → normal FETCH.
+  const modifiers = parseFetchModifiers(context);
+  if (!modifiers.success) {
+    return { success: false, error: modifiers.error, consumed: 0 };
+  }
+
   return {
     success: true,
     value: {
       type: 'FETCH',
       data: {
         sequenceSet: sequenceSet.value!,
-        dataItems: dataItems.value!
+        dataItems: dataItems.value!,
+        changedSince: modifiers.value!.changedSince
       }
     },
     consumed: context.position
   };
+};
+
+/**
+ * Parse the optional trailing FETCH modifier group (RFC 4551 §3.3.1):
+ *   fetch-mod       = "(" fetch-mod-param *(SP fetch-mod-param) ")"
+ *   fetch-mod-param = "CHANGEDSINCE" SP mod-sequence-value
+ * CONDSTORE defines only CHANGEDSINCE; an unknown modifier is a client error
+ * (BAD). No modifier group at all is the normal case (returns undefined).
+ */
+const parseFetchModifiers = (
+  context: ParseContext
+): ParseResult<{ changedSince?: number }> => {
+  skipWhitespace(context);
+  if (peek(context) !== '(') {
+    return { success: true, value: {}, consumed: context.position };
+  }
+  context.position++; // consume '('
+
+  let changedSince: number | undefined;
+  while (context.position < context.length) {
+    skipWhitespace(context);
+    if (peek(context) === ')') {
+      context.position++; // consume ')'
+      return { success: true, value: { changedSince }, consumed: context.position };
+    }
+
+    const name = parseAtom(context);
+    if (!name.success) {
+      return { success: false, error: 'Invalid FETCH modifier', consumed: 0 };
+    }
+    if (name.value!.toUpperCase() !== 'CHANGEDSINCE') {
+      return { success: false, error: `Unknown FETCH modifier: ${name.value}`, consumed: 0 };
+    }
+    skipWhitespace(context);
+    const modseq = parseNumber(context);
+    if (!modseq.success) {
+      return { success: false, error: 'CHANGEDSINCE requires a mod-sequence value', consumed: 0 };
+    }
+    changedSince = modseq.value!;
+  }
+
+  return { success: false, error: 'Unterminated FETCH modifier group', consumed: 0 };
 };
 
 /**

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -397,6 +397,12 @@ export class ImapSession {
     if (!this.selectedMailbox) {
       return this.write(`${tag} BAD No mailbox selected\r\n`);
     }
+    // RFC 4551 §3.3.1: the CHANGEDSINCE modifier implicitly enables CONDSTORE
+    // for the session — subsequent FETCH/STORE responses carry MODSEQ, and
+    // this response emits it too.
+    if (fetchRequest.changedSince !== undefined) {
+      this.condstoreEnabled = true;
+    }
     return fetchMessagesOp(
       tag,
       fetchRequest,

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -400,7 +400,8 @@ export class Store {
     start: number,
     end: number,
     fields: string[],
-    useUid: boolean = false
+    useUid: boolean = false,
+    changedSince?: number
   ): Promise<Map<string, StoreFetchedMail>> => {
     try {
       const { mailboxArg, isSent } = this.resolveMappedBox(box);
@@ -411,7 +412,8 @@ export class Store {
         start,
         end,
         useUid,
-        fields.flatMap((f) => this.mapFieldName(f))
+        fields.flatMap((f) => this.mapFieldName(f)),
+        changedSince
       );
 
       const mails = new Map<string, StoreFetchedMail>();

--- a/src/server/lib/imap/types.ts
+++ b/src/server/lib/imap/types.ts
@@ -110,6 +110,10 @@ export interface SequenceRange {
 export interface FetchRequest {
   sequenceSet: SequenceSet;
   dataItems: FetchDataItem[];
+  // RFC 4551 §3.3.1 CHANGEDSINCE modifier: `FETCH … (CHANGEDSINCE <modseq>)`.
+  // When set, the server returns only messages whose mod-sequence is greater
+  // than this value, and implicitly enables CONDSTORE + emits MODSEQ.
+  changedSince?: number;
 }
 
 export type FetchDataItem =

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -358,6 +358,45 @@ describe("getMailsByRange — text_octets / html_octets synthetic projection", (
   });
 });
 
+describe("getMailsByRange — CHANGEDSINCE modseq filter (CONDSTORE phase 3, #609)", () => {
+  // Source-text scan (robust against module-mock interactions in the full
+  // suite): the CHANGEDSINCE modifier must add a `modseq > $N` predicate to the
+  // range query in both the domain-wide and per-mailbox branches, so the filter
+  // runs in SQL (O(rows-changed)) rather than as a JS post-filter over the
+  // whole window.
+  let mailsSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    mailsSource = await fs.readFile(path.join(import.meta.dir, "imap.ts"), "utf8");
+  });
+
+  it("takes an optional changedSince parameter", () => {
+    const sigMatch = mailsSource.match(
+      /export const getMailsByRange\s*=\s*async\s*\(([\s\S]*?)\)/
+    );
+    expect(sigMatch).not.toBeNull();
+    expect(sigMatch![1]).toMatch(/changedSince\s*\??\s*:\s*number/);
+  });
+
+  it("adds a `modseq > $N` predicate for the domain-wide branch", () => {
+    // `${MODSEQ} > $5` — the param after the domain branch's fixed 4 args.
+    expect(mailsSource).toMatch(/\$\{MODSEQ\}\s*>\s*\$5/);
+  });
+
+  it("adds a qualified `m.modseq > $N` predicate for the per-mailbox branch", () => {
+    // `m.${MODSEQ} > $6` — the param after the per-mailbox branch's fixed 5 args.
+    expect(mailsSource).toMatch(/m\.\$\{MODSEQ\}\s*>\s*\$6/);
+  });
+
+  it("only appends the predicate when changedSince is provided", () => {
+    // The clause is gated on `changedSince !== undefined` so existing callers
+    // (no modifier) issue the identical pre-#609 query.
+    expect(mailsSource).toMatch(/changedSince !== undefined/);
+  });
+});
+
 describe("expungeDeletedMails — `updated` column refresh (regression for #456, #614)", () => {
   // Static source check: the expunge write paths must go through
   // mailsTable.updateWhere with `updated: DB_NOW` in the data bag so the

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -173,7 +173,8 @@ export const getMailsByRange = async (
   start: number,
   end: number,
   useUid: boolean,
-  fields: string[] = ["*"]
+  fields: string[] = ["*"],
+  changedSince?: number
 ): Promise<Map<string, PartialMailModel>> => {
   const sortedFields = [...fields].sort();
   const inflightKey = JSON.stringify([
@@ -184,9 +185,10 @@ export const getMailsByRange = async (
     end,
     useUid,
     sortedFields,
+    changedSince ?? null,
   ]);
   return singleFlight(inflightKey, () => getMailsByRangeUncoalesced(
-    user_id, mailbox, sent, start, end, useUid, fields
+    user_id, mailbox, sent, start, end, useUid, fields, changedSince
   ));
 };
 
@@ -197,7 +199,8 @@ const getMailsByRangeUncoalesced = async (
   start: number,
   end: number,
   useUid: boolean,
-  fields: string[]
+  fields: string[],
+  changedSince?: number
 ): Promise<Map<string, PartialMailModel>> => {
   try {
     let sql: string;
@@ -246,6 +249,17 @@ const getMailsByRangeUncoalesced = async (
       return parts.length ? ", " + parts.join(", ") : "";
     };
 
+    // RFC 4551 CHANGEDSINCE: filter to messages whose mod-sequence exceeds the
+    // requested value in the same range query (O(rows-changed), not a JS
+    // post-filter over the whole window). `modseq` is BIGINT NOT NULL DEFAULT 1
+    // so every row has a value — `CHANGEDSINCE 0` returns all, `CHANGEDSINCE 1`
+    // drops the never-modified baseline. The predicate references the param
+    // appended after each branch's fixed argument list ($5 domain, $6 per-box).
+    const modseqDomainClause =
+      changedSince !== undefined ? ` AND ${MODSEQ} > $5` : "";
+    const modseqMailboxClause =
+      changedSince !== undefined ? ` AND m.${MODSEQ} > $6` : "";
+
     if (mailbox === null) {
       // Domain-wide query (INBOX / unified Sent Messages) — still on
       // uid_domain, unchanged by the per-mailbox mapping migration.
@@ -258,18 +272,20 @@ const getMailsByRangeUncoalesced = async (
         sql = `
           SELECT ${fieldList} FROM mails
           WHERE user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4
-            AND expunged = FALSE
+            AND expunged = FALSE${modseqDomainClause}
           ORDER BY ${UID_DOMAIN} ASC
         `;
         values = [user_id, sent, start, Math.min(end, 999999999)];
+        if (changedSince !== undefined) values.push(changedSince);
       } else {
         sql = `
           SELECT ${fieldList} FROM mails
-          WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
+          WHERE user_id = $1 AND sent = $2 AND expunged = FALSE${modseqDomainClause}
           ORDER BY ${UID_DOMAIN} ASC
           OFFSET $3 LIMIT $4
         `;
         values = [user_id, sent, start - 1, end - start + 1];
+        if (changedSince !== undefined) values.push(changedSince);
       }
     } else {
       // Per-mailbox query — JOIN `mail_mailbox_uid` to fetch the
@@ -297,10 +313,11 @@ const getMailsByRangeUncoalesced = async (
             AND x.${MAIL_ID} = m.${MAIL_ID}
           WHERE m.${USER_ID} = $1 AND m.${SENT} = $2
             AND x.${UID} >= $4 AND x.${UID} <= $5
-            AND m.${EXPUNGED} = FALSE
+            AND m.${EXPUNGED} = FALSE${modseqMailboxClause}
           ORDER BY x.${UID} ASC
         `;
         values = [user_id, sent, mailbox, start, Math.min(end, 999999999)];
+        if (changedSince !== undefined) values.push(changedSince);
       } else {
         sql = `
           SELECT ${fieldList} FROM mails m
@@ -308,11 +325,12 @@ const getMailsByRangeUncoalesced = async (
             ON x.${USER_ID} = m.${USER_ID}
             AND x.${MAILBOX} = $3
             AND x.${MAIL_ID} = m.${MAIL_ID}
-          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE
+          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE${modseqMailboxClause}
           ORDER BY x.${UID} ASC
           OFFSET $4 LIMIT $5
         `;
         values = [user_id, sent, mailbox, start - 1, end - start + 1];
+        if (changedSince !== undefined) values.push(changedSince);
       }
     }
 


### PR DESCRIPTION
## What

Phase 3 of 4 of the CONDSTORE (RFC 4551) arc — the split from #454(b). Adds the **CHANGEDSINCE FETCH modifier**: the point at which mod-sequence becomes *usable* for incremental sync rather than merely visible.

Clients issue `FETCH x:y (FLAGS) (CHANGEDSINCE N)` and the server returns only messages whose mod-sequence is greater than N — order-of-magnitude bandwidth/latency savings on incremental sync of large mailboxes (Apple Mail, Thunderbird, and iOS Mail all use this on reconnect).

Depends on phase 1 (#607, modseq column) and phase 2 (#608, CAPABILITY + ENABLE + MODSEQ item), both merged.

## How

- **Parser** (`parsers/fetch-parsers.ts`) — parse the optional trailing `(CHANGEDSINCE <modseq>)` modifier group off the FETCH command tail into `FetchRequest.changedSince`. An unknown modifier or a missing mod-sequence value is a client error (parse failure → BAD).
- **Filter** (`repositories/mails/imap.ts`) — threaded through `store.getMessages` → `getMailsByRange` as a SQL `WHERE modseq > $N` predicate in the same range query. Applied to both the domain-wide (INBOX/unified Sent) and per-mailbox branches. This is `O(rows-changed)`, not a JS post-filter over the whole window (scalability rule).
- **Implicit MODSEQ + CONDSTORE enable** (RFC 4551 §3.3.1) — a CHANGEDSINCE fetch implies the MODSEQ data item, so the response carries `MODSEQ (n)` even without a prior `ENABLE CONDSTORE`; the session's persistent condstore flag also flips so subsequent plain fetches carry MODSEQ too.

`modseq` is `BIGINT NOT NULL DEFAULT 1` (phase-1 backfill stamped every existing row), so `CHANGEDSINCE 0` returns everything and `CHANGEDSINCE 1` drops the never-modified baseline — RFC-correct with no NULL-row surprises.

## Test plan

**Automated (green):**
- Full server suite: `bun test src/server` — 1368 pass / 0 fail.
- `bun run typecheck` clean, `bun run lint` 0 errors.
- New unit coverage in `condstore.test.ts`:
  - Parser: `(CHANGEDSINCE n)` off plain + UID FETCH; `CHANGEDSINCE 0` kept (not falsy-dropped); absent → undefined; unknown modifier → BAD; `CHANGEDSINCE` with no value → BAD.
  - Threading: `changedSince` reaches `store.getMessages`; modseq column pulled; `MODSEQ (n)` emitted implicitly without ENABLE.
  - Persistence: a CHANGEDSINCE fetch flips the session flag so a later plain fetch also carries MODSEQ.
- New source-scan coverage in `repositories/mails/imap.test.ts`: `modseq > $N` predicate present in both branches; gated on `changedSince !== undefined`.

**IMAP-session E2E (sandbox, plain IMAP port):** raw IMAP client, LOGIN admin → SELECT INBOX (EXISTS 12384, HIGHESTMODSEQ 107) → drove the filter end-to-end:
1. `FETCH 1:30 (FLAGS) (CHANGEDSINCE 0)` → all 30 lines returned, **every** line carries `MODSEQ (n)` implicitly (no `ENABLE CONDSTORE` was ever issued this session).
2. `FETCH 1:30 (FLAGS) (CHANGEDSINCE 107)` (= HIGHESTMODSEQ) → **0** lines (nothing exceeds the max).
3. `STORE 1 +FLAGS (\Flagged)` bumps seq 1's modseq 107 → 111, then `FETCH 1:30 (FLAGS) (CHANGEDSINCE 107)` returns **exactly seq 1** (`MODSEQ (111)`) — proves the `modseq > $N` predicate selects only the changed row, not the whole window.
4. `FETCH 1 (FLAGS) (BOGUS 1)` → tagged **BAD** (unknown modifier rejected).
5. `UID FETCH 1:* (FLAGS) (CHANGEDSINCE 107)` → OK, the one changed message returned carrying both `UID` and `MODSEQ`.

All five assertions passed (`E2E VERDICT: PASS`).

Closes #609.

