### PR TITLE
perf(mails): GIN indexes on jsonb address columns for per-account reads

### DIFF
--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -58,10 +58,18 @@ export function buildCreateTable(
 export function buildCreateIndex(
   tableName: string,
   column: string,
-  indexName?: string
+  indexName?: string,
+  using?: string,
+  opclass?: string
 ): string {
-  const name = indexName || `idx_${tableName}_${column}`;
-  return `CREATE INDEX IF NOT EXISTS ${name} ON ${tableName}(${column})`;
+  // Non-btree indexes take a method suffix so they can't collide with the
+  // btree name for the same column — `CREATE INDEX IF NOT EXISTS` would
+  // silently no-op the second one, reverting the optimization with no error.
+  const suffix = using ? `_${using}` : "";
+  const name = indexName || `idx_${tableName}_${column}${suffix}`;
+  const target = opclass ? `${column} ${opclass}` : column;
+  const method = using ? ` USING ${using}` : "";
+  return `CREATE INDEX IF NOT EXISTS ${name} ON ${tableName}${method} (${target})`;
 }
 
 export function prepareParamValue(value: ParamValue): ParamValue {

--- a/src/server/lib/postgres/initialize.test.ts
+++ b/src/server/lib/postgres/initialize.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeAll } from "bun:test";
+import { mailsTable } from "./models/mail";
+import { buildCreateIndex } from "./database";
 
 // getMailHeaders and getMailHeadersDelta filter rows with a jsonb `@>`
 // containment OR across the address columns (buildHeaderAddressCondition in
@@ -6,22 +8,17 @@ import { describe, it, expect, beforeAll } from "bun:test";
 // (jsonb_path_ops) index or the planner seq-scans the whole mailbox on every
 // account open and delta poll — O(mailbox) instead of O(matches) (#679).
 //
-// These invariants only manifest against a live Postgres planner, so — per the
-// repo's established SQL-shape-guard style (see http.test.ts) — this asserts on
-// the source: every address column the containment filter touches must have a
-// matching GIN index declared in initialize.ts. Adding a 6th address column to
-// the OR-union without an index, or dropping an index, fails this test.
+// The index set is declared on the model, so that half asserts on the real
+// definition. The filter side only manifests against a live planner, so — per
+// the repo's established SQL-shape-guard style (see http.test.ts) — it is read
+// off the source. Adding a 6th address column to the OR-union without an index,
+// or dropping an index, fails this test.
 describe("initialize — GIN index coverage for the address containment filter", () => {
-  let initializeSource: string;
   let conditionSource: string;
 
   beforeAll(async () => {
     const fs = await import("fs/promises");
     const path = await import("path");
-    initializeSource = await fs.readFile(
-      path.join(import.meta.dir, "initialize.ts"),
-      "utf8"
-    );
     conditionSource = await fs.readFile(
       path.join(import.meta.dir, "repositories/mails/http.ts"),
       "utf8"
@@ -41,17 +38,11 @@ describe("initialize — GIN index coverage for the address containment filter",
     return [...fn.matchAll(/(\w+)\s+@>/g)].map((m) => m[1]).sort();
   };
 
-  // Columns given a jsonb_path_ops GIN index in initialize.ts. They are emitted
-  // by a `for (const column of [...]) { ... gin (${column} jsonb_path_ops) }`
-  // loop, so match the loop (asserting it still emits a jsonb_path_ops GIN
-  // index) and read the column array it iterates.
-  const ginIndexedColumns = () => {
-    const loop = initializeSource.match(
-      /for \(const column of \[([\s\S]*?)\]\)\s*\{[\s\S]*?gin \(\$\{column\} jsonb_path_ops\)/
-    );
-    if (!loop) throw new Error("address GIN index loop not found in initialize.ts");
-    return [...loop[1].matchAll(/"(\w+)"/g)].map((m) => m[1]).sort();
-  };
+  const ginIndexedColumns = () =>
+    mailsTable.indexes
+      .filter((i) => i.using === "gin" && i.opclass === "jsonb_path_ops")
+      .map((i) => i.column)
+      .sort();
 
   it("every address column the containment filter touches has a GIN index", () => {
     const filtered = new Set(filteredAddressColumns());
@@ -77,5 +68,33 @@ describe("initialize — GIN index coverage for the address containment filter",
       "from_address",
       "to_address",
     ]);
+  });
+
+  it("emits a jsonb_path_ops GIN index, not a btree, for each address column", () => {
+    for (const column of ginIndexedColumns()) {
+      expect(buildCreateIndex("mails", column, undefined, "gin", "jsonb_path_ops")).toBe(
+        `CREATE INDEX IF NOT EXISTS idx_mails_${column}_gin ` +
+          `ON mails USING gin (${column} jsonb_path_ops)`
+      );
+    }
+  });
+
+  // A GIN index must not take the name buildCreateIndex would generate for a
+  // btree on the same column: the model loop creates btrees first, so a name
+  // collision would make `CREATE INDEX IF NOT EXISTS` silently no-op the GIN
+  // index and revert the optimization with no error and no failing test.
+  const indexNameOf = (sql: string) => {
+    const match = sql.match(/CREATE INDEX IF NOT EXISTS (\w+) /);
+    if (!match) throw new Error(`no index name in: ${sql}`);
+    return match[1];
+  };
+
+  it("names GIN indexes distinctly from the btree on the same column", () => {
+    for (const column of ginIndexedColumns()) {
+      const gin = indexNameOf(
+        buildCreateIndex("mails", column, undefined, "gin", "jsonb_path_ops")
+      );
+      expect(gin).not.toBe(indexNameOf(buildCreateIndex("mails", column)));
+    }
   });
 });

--- a/src/server/lib/postgres/initialize.test.ts
+++ b/src/server/lib/postgres/initialize.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from "bun:test";
+
+// The per-account header/delta/UID reads filter rows with a jsonb `@>`
+// containment OR across the address columns (buildHeaderAddressCondition in
+// repositories/mails/http.ts). Each of those columns needs a GIN
+// (jsonb_path_ops) index or the planner seq-scans the whole mailbox on every
+// account open and delta poll — O(mailbox) instead of O(matches) (#679).
+//
+// These invariants only manifest against a live Postgres planner, so — per the
+// repo's established SQL-shape-guard style (see http.test.ts) — this asserts on
+// the source: every address column the containment filter touches must have a
+// matching GIN index declared in initialize.ts. Adding a 6th address column to
+// the OR-union without an index, or dropping an index, fails this test.
+describe("initialize — GIN index coverage for the address containment filter", () => {
+  let initializeSource: string;
+  let conditionSource: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    initializeSource = await fs.readFile(
+      path.join(import.meta.dir, "initialize.ts"),
+      "utf8"
+    );
+    conditionSource = await fs.readFile(
+      path.join(import.meta.dir, "repositories/mails/http.ts"),
+      "utf8"
+    );
+  });
+
+  // Columns filtered with `@>` inside buildHeaderAddressCondition. The two
+  // template tokens resolve to their models/common.ts constant values.
+  const filteredAddressColumns = () => {
+    const fnMatch = conditionSource.match(
+      /export const buildHeaderAddressCondition[\s\S]*?\n};/
+    );
+    if (!fnMatch) throw new Error("buildHeaderAddressCondition not found");
+    const fn = fnMatch[0]
+      .replaceAll("${FROM_ADDRESS}", "from_address")
+      .replaceAll("${TO_ADDRESS}", "to_address");
+    return [...fn.matchAll(/(\w+)\s+@>/g)].map((m) => m[1]).sort();
+  };
+
+  // Columns given a jsonb_path_ops GIN index in initialize.ts. They are emitted
+  // by a `for (const column of [...]) { ... gin (${column} jsonb_path_ops) }`
+  // loop, so match the loop (asserting it still emits a jsonb_path_ops GIN
+  // index) and read the column array it iterates.
+  const ginIndexedColumns = () => {
+    const loop = initializeSource.match(
+      /for \(const column of \[([\s\S]*?)\]\)\s*\{[\s\S]*?gin \(\$\{column\} jsonb_path_ops\)/
+    );
+    if (!loop) throw new Error("address GIN index loop not found in initialize.ts");
+    return [...loop[1].matchAll(/"(\w+)"/g)].map((m) => m[1]).sort();
+  };
+
+  it("every address column the containment filter touches has a GIN index", () => {
+    const filtered = new Set(filteredAddressColumns());
+    const indexed = new Set(ginIndexedColumns());
+    expect(filtered.size).toBeGreaterThan(0);
+    for (const column of filtered) {
+      expect(indexed.has(column)).toBe(true);
+    }
+  });
+
+  it("indexes exactly the five filtered address columns (no stray, none missing)", () => {
+    expect(ginIndexedColumns()).toEqual([
+      "bcc_address",
+      "cc_address",
+      "envelope_to",
+      "from_address",
+      "to_address",
+    ]);
+    expect(filteredAddressColumns()).toEqual([
+      "bcc_address",
+      "cc_address",
+      "envelope_to",
+      "from_address",
+      "to_address",
+    ]);
+  });
+});

--- a/src/server/lib/postgres/initialize.test.ts
+++ b/src/server/lib/postgres/initialize.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll } from "bun:test";
 
-// The per-account header/delta/UID reads filter rows with a jsonb `@>`
+// getMailHeaders and getMailHeadersDelta filter rows with a jsonb `@>`
 // containment OR across the address columns (buildHeaderAddressCondition in
 // repositories/mails/http.ts). Each of those columns needs a GIN
 // (jsonb_path_ops) index or the planner seq-scans the whole mailbox on every

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -86,7 +86,13 @@ export const initializePostgres = async (): Promise<void> => {
     // Create indexes after migrations ensure all columns exist
     for (const table of tables) {
       for (const idx of table.indexes) {
-        const createIndexSql = buildCreateIndex(table.name, idx.column);
+        const createIndexSql = buildCreateIndex(
+          table.name,
+          idx.column,
+          undefined,
+          idx.using,
+          idx.opclass
+        );
         await pool.query(createIndexSql);
       }
     }
@@ -96,26 +102,6 @@ export const initializePostgres = async (): Promise<void> => {
       CREATE INDEX IF NOT EXISTS idx_mails_search 
       ON mails USING GIN(search_vector)
     `);
-
-    // GIN indexes for the per-account address containment (@>) filter shared by
-    // getMailHeaders and getMailHeadersDelta (buildHeaderAddressCondition in
-    // repositories/mails/http.ts). Without these the planner seq-scans the user's
-    // whole mailbox on every account open and every delta poll — O(mailbox) instead
-    // of O(matches). jsonb_path_ops is the smallest opclass that supports @>.
-    // Kept raw here (not in the model's `indexes` block) because buildCreateIndex only
-    // emits single-column btree; this mirrors the idx_mails_search GIN index above.
-    for (const column of [
-      "to_address",
-      "cc_address",
-      "bcc_address",
-      "envelope_to",
-      "from_address",
-    ]) {
-      await pool.query(`
-        CREATE INDEX IF NOT EXISTS idx_mails_${column}
-        ON mails USING gin (${column} jsonb_path_ops)
-      `);
-    }
 
     // Trigger function + the INSERT / column-scoped UPDATE trigger pair, then
     // the reindex — all three derived from `searchVectorExpression` so the

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -98,10 +98,10 @@ export const initializePostgres = async (): Promise<void> => {
     `);
 
     // GIN indexes for the per-account address containment (@>) filter shared by
-    // getMailHeaders / getMailHeadersDelta / getAllUids (buildHeaderAddressCondition
-    // in repositories/mails/http.ts + imap.ts). Without these the planner seq-scans
-    // the user's whole mailbox on every account open and every delta poll — O(mailbox)
-    // instead of O(matches). jsonb_path_ops is the smallest opclass that supports @>.
+    // getMailHeaders and getMailHeadersDelta (buildHeaderAddressCondition in
+    // repositories/mails/http.ts). Without these the planner seq-scans the user's
+    // whole mailbox on every account open and every delta poll — O(mailbox) instead
+    // of O(matches). jsonb_path_ops is the smallest opclass that supports @>.
     // Kept raw here (not in the model's `indexes` block) because buildCreateIndex only
     // emits single-column btree; this mirrors the idx_mails_search GIN index above.
     for (const column of [

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -97,6 +97,26 @@ export const initializePostgres = async (): Promise<void> => {
       ON mails USING GIN(search_vector)
     `);
 
+    // GIN indexes for the per-account address containment (@>) filter shared by
+    // getMailHeaders / getMailHeadersDelta / getAllUids (buildHeaderAddressCondition
+    // in repositories/mails/http.ts + imap.ts). Without these the planner seq-scans
+    // the user's whole mailbox on every account open and every delta poll — O(mailbox)
+    // instead of O(matches). jsonb_path_ops is the smallest opclass that supports @>.
+    // Kept raw here (not in the model's `indexes` block) because buildCreateIndex only
+    // emits single-column btree; this mirrors the idx_mails_search GIN index above.
+    for (const column of [
+      "to_address",
+      "cc_address",
+      "bcc_address",
+      "envelope_to",
+      "from_address",
+    ]) {
+      await pool.query(`
+        CREATE INDEX IF NOT EXISTS idx_mails_${column}
+        ON mails USING gin (${column} jsonb_path_ops)
+      `);
+    }
+
     // Trigger function + the INSERT / column-scoped UPDATE trigger pair, then
     // the reindex — all three derived from `searchVectorExpression` so the
     // trigger and the direct write can't drift apart. See search-vector.ts.

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -38,6 +38,10 @@ export type Constraints = string[];
 
 export interface IndexDefinition {
   column: string;
+  /** Index method. Omit for the btree default. */
+  using?: "gin" | "gist";
+  /** Operator class, e.g. `jsonb_path_ops` for a `@>` containment filter. */
+  opclass?: string;
 }
 
 export type PropertyChecker<T> = {

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -413,6 +413,14 @@ export const mailsTable = createTable<MailJSON, MailSchema, MailModel>({
     { column: MODSEQ },
     { column: IS_SPAM },
     { column: EXPUNGED },
+    // Address containment (@>) filters for the per-account reads —
+    // buildHeaderAddressCondition in repositories/mails/http.ts. jsonb_path_ops
+    // is the smallest opclass that supports @>.
+    { column: TO_ADDRESS, using: "gin", opclass: "jsonb_path_ops" },
+    { column: CC_ADDRESS, using: "gin", opclass: "jsonb_path_ops" },
+    { column: BCC_ADDRESS, using: "gin", opclass: "jsonb_path_ops" },
+    { column: ENVELOPE_TO, using: "gin", opclass: "jsonb_path_ops" },
+    { column: FROM_ADDRESS, using: "gin", opclass: "jsonb_path_ops" },
   ],
   ModelClass: MailModel,
   supportsSoftDelete: false,


### PR DESCRIPTION
## What

Add five GIN (`jsonb_path_ops`) indexes on the `mails` address columns
(`to_address`, `cc_address`, `bcc_address`, `envelope_to`, `from_address`),
declared on the model (`mailsTable.indexes`) and emitted by `buildCreateIndex`.

Closes #679.

## Why

The per-account header list (`getMailHeaders`) and the delta-sync poll
(`getMailHeadersDelta`, run on every `?since=` IDB-cache refresh) filter rows
with the same jsonb `@>` containment OR across the address columns
(`buildHeaderAddressCondition`, `repositories/mails/http.ts`). (`getAllUids` and
the IMAP SEARCH path filter on `user_id/sent/expunged` and `*_text ILIKE`
respectively — no address `@>` — so they are intentionally not beneficiaries.) None of those columns had a supporting index, so
Postgres **sequentially scanned the user's entire mailbox** on every account
open and every delta poll, discarding the non-matching rows — O(mailbox-size) on
the hottest read path, degrading linearly as a mailbox grows. This is exactly
the "works for large mailboxes / many users out of the box" scalability goal
(rule 13 / Sweep 7).

`jsonb_path_ops` is the smallest opclass that supports `@>`. No query-code
change is needed — the planner picks up the existing conditions automatically
via a `BitmapOr`.

## Scope

Additive at the query layer: the five address indexes plus the builder change
that lets them be declared. No query, model, or behavior change; result sets are
byte-identical (only the access path changes). The `getAccountStats` aggregate
is a different, larger problem (it must touch every row to count) and is
deliberately left out per the issue's scope note.

The indexes are declared on `mailsTable.indexes` alongside every other index.
`IndexDefinition` takes an optional `using` / `opclass`, and `buildCreateIndex`
emits `USING gin (col jsonb_path_ops)` for them — so `mail.ts` stays the single
source of truth for the table's indexes rather than half of them living in raw
DDL in `initialize.ts`. Non-btree indexes take a method suffix in the generated
name (`idx_mails_to_address_gin`), because sharing the btree name would let
`CREATE INDEX IF NOT EXISTS` silently no-op the GIN index if the same column
were ever also declared btree.

## Measured benefit is tied to the current call shape

The win is measured at the request shape production actually issues: `Pagination`
defaults to `size=10000` and no caller sets `pagination`, so the list query runs
effectively unlimited and the planner takes the `BitmapOr` path over the GIN
indexes. At a small `LIMIT` the planner instead prefers a backward scan on
`idx_mails_date` and these indexes stop being selected. So if `?size=` is ever
plumbed through `get-headers.ts`, the benefit needs re-measuring at that page
size rather than assumed to carry over.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `eslint` (changed files) — clean
- [x] `bun test src/server` — **1440 pass / 0 fail**
- [x] **New unit guard** (`initialize.test.ts`): asserts every address column the
  `@>` containment filter touches has a matching `jsonb_path_ops` GIN index
  declared on `mailsTable.indexes`, and that the indexed set is exactly the five
  filtered columns (fires if a 6th OR-column is added without an index, or an
  index is dropped).
- [x] **DDL + EXPLAIN ANALYZE E2E** (real local `inbox` DB, 11,851 mails, indexes
  created in a **rolled-back** txn — nothing persisted):
  - Baseline plan for the received-branch `getMailHeaders` query (~740 matches):
    **`Seq Scan on mails`, Rows Removed by Filter: 11,109, ~33 ms.**
  - With the 5 GIN indexes: **`Bitmap Heap Scan` → `BitmapOr` across
    `idx_mails_to_address_gin` / `idx_mails_cc_address_gin` /
    `idx_mails_bcc_address_gin` / `idx_mails_envelope_to_gin`, ~1.3 ms** — same
    742 rows returned. Shape flips from
    O(mailbox) to O(matches) (the important invariant; the ~24× here widens with
    mailbox size).
  - Created index defs confirmed: `USING gin (<col> jsonb_path_ops)` for all five.
- [x] **Boot code-path E2E**: ran the real `initializePostgres()` against the local
  DB — the model-declared entries created all five indexes at boot with the
  correct `jsonb_path_ops` defs (then dropped, DB left as-found).
- [ ] No UI-visible change to eye-check: this is a query-plan optimization with
  byte-identical result sets, so the verification is the plan flip above (per the
  CLAUDE.md carve-out for paths with no rendered surface).




## Note for anyone tempted to finish the refactor

`idx_mails_search` is deliberately still raw DDL in `initialize.ts`. Declaring it
on the model would rename it to `idx_mails_search_vector_gin`, and because
`CREATE INDEX IF NOT EXISTS` matches on **name** only, every already-deployed
database would keep the old `idx_mails_search` alongside the new one — two
identical tsvector GIN indexes, forever. Moving it needs an explicit rename
migration, not a declaration change.
