### PR TITLE
perf(imap): global concurrency budget for large-body FETCH (closes #726)

### DIFF
--- a/src/server/lib/imap/body-budget.test.ts
+++ b/src/server/lib/imap/body-budget.test.ts
@@ -6,7 +6,8 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import {
   withBodyBudget,
   bodyBudgetCapacity,
-  getLastBodyBudgetWaitMs,
+  runInBodyBudgetContext,
+  getBodyBudgetWaitMs,
   _resetBodyBudget,
 } from "./body-budget";
 
@@ -78,29 +79,53 @@ describe("body-budget semaphore (#726)", () => {
     await extra;
   });
 
-  it("records the acquire wait latency for the most recent acquire", async () => {
+  it("attributes wait time to the request-scoped ledger, not a global cell", async () => {
+    // The load-bearing invariant. Two concurrent request scopes run
+    // side by side; each scope's wait-ledger MUST reflect ONLY its own
+    // queue latency, not the other scope's. The pre-AsyncLocalStorage
+    // shape wrote to a module-scoped variable that both scopes would
+    // race on and overwrite.
     const holding = Array.from({ length: CAP }, () => defer<void>());
-    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+    const holdingRuns = holding.map((g) =>
+      runInBodyBudgetContext(() => withBodyBudget(() => g.promise))
+    );
 
-    // A queued caller can measure its own wait time — the value is
-    // overwritten on the next acquire, so capture it inside the
-    // waited callback.
-    const waitedCaptured = defer<number>();
-    const queued = withBodyBudget(async () => {
-      waitedCaptured.resolve(getLastBodyBudgetWaitMs());
-      return "queued-done";
+    // Queue scope A first — it'll acquire the first slot freed by a
+    // filler. Its fn holds the slot briefly so scope B (queued next)
+    // must wait through that hold.
+    const aWait = defer<number>();
+    const bWait = defer<number>();
+    const scopeA = runInBodyBudgetContext(async () => {
+      await withBodyBudget(async () => {
+        aWait.resolve(getBodyBudgetWaitMs());
+        await new Promise((r) => setTimeout(r, 40));
+      });
     });
+    // Yield so A's acquire hits the queue before B's.
+    await nextTick();
+    const scopeB = runInBodyBudgetContext(async () => {
+      await withBodyBudget(async () => {
+        bWait.resolve(getBodyBudgetWaitMs());
+      });
+    });
+    await nextTick();
 
-    // Small delay so the queued caller has non-zero wait time.
-    await new Promise((r) => setTimeout(r, 25));
+    // Release only ONE filler → wakes A (queued first). All other
+    // fillers stay held throughout, so when A's fn completes and A
+    // releases, B is the ONLY caller that can acquire (no other slots
+    // free) → B's wait spans A's ~40 ms fn hold. A's own wait was
+    // short (one microtask after filler[0] released). Distinct scopes
+    // → distinct ledgers.
     holding[0].resolve();
-    const waited = await waitedCaptured.promise;
-    expect(waited).toBeGreaterThan(0);
 
-    // Drain.
+    const [a, b] = await Promise.all([aWait.promise, bWait.promise]);
+    expect(b).toBeGreaterThan(a + 20);
+
+    // Drain remaining fillers so their runs don't hang the suite.
     holding.slice(1).forEach((g) => g.resolve());
+    await scopeA;
+    await scopeB;
     await Promise.all(holdingRuns);
-    await queued;
   });
 
   it("releases on throw so subsequent callers still run", async () => {
@@ -122,9 +147,15 @@ describe("body-budget semaphore (#726)", () => {
     expect(ranAfter).toBe(true);
   });
 
-  it("acquire wait is 0 when the caller acquires without queuing", async () => {
+  it("wait ledger stays at 0 when the caller acquires without queuing", async () => {
     _resetBodyBudget();
-    await withBodyBudget(async () => {});
-    expect(getLastBodyBudgetWaitMs()).toBe(0);
+    await runInBodyBudgetContext(async () => {
+      await withBodyBudget(async () => {});
+      expect(getBodyBudgetWaitMs()).toBe(0);
+    });
+  });
+
+  it("getBodyBudgetWaitMs outside a context returns 0 (no throw)", () => {
+    expect(getBodyBudgetWaitMs()).toBe(0);
   });
 });

--- a/src/server/lib/imap/body-budget.test.ts
+++ b/src/server/lib/imap/body-budget.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Body-budget semaphore invariants (#726).
+ */
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import {
+  withBodyBudget,
+  bodyBudgetCapacity,
+  getLastBodyBudgetWaitMs,
+  _resetBodyBudget,
+} from "./body-budget";
+
+const CAP = bodyBudgetCapacity();
+
+const defer = <T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+} => {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+const nextTick = () => new Promise<void>((r) => setImmediate(r));
+
+describe("body-budget semaphore (#726)", () => {
+  beforeEach(() => {
+    _resetBodyBudget();
+  });
+
+  it("runs up to CAP callers concurrently", async () => {
+    // Kick off CAP callers that never resolve on their own — they hold
+    // their slot until we resolve them. They should all be RUNNING (not
+    // queued) after a tick.
+    const gates = Array.from({ length: CAP }, () => defer<string>());
+    const running: string[] = [];
+    const wrapped = gates.map((g, i) =>
+      withBodyBudget(async () => {
+        running.push(`start-${i}`);
+        return await g.promise;
+      })
+    );
+
+    await nextTick();
+    // All CAP starts should have fired.
+    expect(running).toHaveLength(CAP);
+
+    // Release everyone.
+    gates.forEach((g, i) => g.resolve(`done-${i}`));
+    const results = await Promise.all(wrapped);
+    expect(results).toEqual(gates.map((_, i) => `done-${i}`));
+  });
+
+  it("queues an extra caller until a slot frees", async () => {
+    const holding = Array.from({ length: CAP }, () => defer<void>());
+    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+
+    let extraStarted = false;
+    const extra = withBodyBudget(async () => {
+      extraStarted = true;
+      return "extra-done";
+    });
+
+    await nextTick();
+    expect(extraStarted).toBe(false);
+
+    // Free one slot — the extra caller should now run.
+    holding[0].resolve();
+    await holding[0].promise;
+    await nextTick();
+    expect(extraStarted).toBe(true);
+
+    // Drain the rest so the returned promises don't hang the suite.
+    holding.slice(1).forEach((g) => g.resolve());
+    await Promise.all(holdingRuns);
+    await extra;
+  });
+
+  it("records the acquire wait latency for the most recent acquire", async () => {
+    const holding = Array.from({ length: CAP }, () => defer<void>());
+    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+
+    // A queued caller can measure its own wait time — the value is
+    // overwritten on the next acquire, so capture it inside the
+    // waited callback.
+    const waitedCaptured = defer<number>();
+    const queued = withBodyBudget(async () => {
+      waitedCaptured.resolve(getLastBodyBudgetWaitMs());
+      return "queued-done";
+    });
+
+    // Small delay so the queued caller has non-zero wait time.
+    await new Promise((r) => setTimeout(r, 25));
+    holding[0].resolve();
+    const waited = await waitedCaptured.promise;
+    expect(waited).toBeGreaterThan(0);
+
+    // Drain.
+    holding.slice(1).forEach((g) => g.resolve());
+    await Promise.all(holdingRuns);
+    await queued;
+  });
+
+  it("releases on throw so subsequent callers still run", async () => {
+    // Fill capacity with throwers.
+    const results = await Promise.allSettled(
+      Array.from({ length: CAP }, (_, i) =>
+        withBodyBudget<never>(async () => {
+          throw new Error(`boom-${i}`);
+        })
+      )
+    );
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+
+    // A subsequent caller should acquire immediately (no leaked slots).
+    let ranAfter = false;
+    await withBodyBudget(async () => {
+      ranAfter = true;
+    });
+    expect(ranAfter).toBe(true);
+  });
+
+  it("acquire wait is 0 when the caller acquires without queuing", async () => {
+    _resetBodyBudget();
+    await withBodyBudget(async () => {});
+    expect(getLastBodyBudgetWaitMs()).toBe(0);
+  });
+});

--- a/src/server/lib/imap/body-budget.test.ts
+++ b/src/server/lib/imap/body-budget.test.ts
@@ -54,6 +54,37 @@ describe("body-budget semaphore (#726)", () => {
     expect(results).toEqual(gates.map((_, i) => `done-${i}`));
   });
 
+  it("wakes multiple queued callers in FIFO order (#727 reviewoie LOW)", async () => {
+    // Guards against a future refactor swapping shift/pop for LIFO or
+    // waking every waiter at once. Fill capacity with holders, queue
+    // three waiters A/B/C in that order, then release holders one at
+    // a time and assert the completion order is A → B → C.
+    const holding = Array.from({ length: CAP }, () => defer<void>());
+    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+
+    const completed: string[] = [];
+    const waiters = ["A", "B", "C"] as const;
+    const waiterRuns: Promise<unknown>[] = [];
+    for (const name of waiters) {
+      waiterRuns.push(
+        withBodyBudget(async () => {
+          completed.push(name);
+        })
+      );
+      // Yield so each caller's acquire hits the queue in order.
+      await nextTick();
+    }
+
+    // Release holders one by one; each wakes exactly one waiter.
+    for (const g of holding) {
+      g.resolve();
+      await nextTick();
+    }
+    await Promise.all(holdingRuns);
+    await Promise.all(waiterRuns);
+    expect(completed).toEqual(["A", "B", "C"]);
+  });
+
   it("queues an extra caller until a slot frees", async () => {
     const holding = Array.from({ length: CAP }, () => defer<void>());
     const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));

--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -1,0 +1,103 @@
+/**
+ * Global counting semaphore for large-body FETCH work.
+ *
+ * `getSharedBodyResult` (`body-buffer.ts`) already coalesces IDENTICAL
+ * concurrent body serializations for the same `(mail, sectionKey)`.
+ * PR #710 coalesced the DB read the same way. Neither bounds the
+ * NUMBER of DISTINCT concurrent large-body serializations across
+ * sockets — a common iOS Mail / K-9 pattern is one client opening
+ * several account tabs at once and issuing `UID FETCH … BODY[]` in
+ * parallel against different mailboxes / different UIDs. Each in-flight
+ * body materializes a multi-MB Buffer; the container's RSS scales
+ * linearly with distinct in-flight count and can OOM despite the
+ * two prior fixes.
+ *
+ * This module puts a hard bound on that count. Callers wrap their
+ * large-body serialization in `withBodyBudget(fn)`; if the running
+ * count is at or above `IMAP_BODY_FETCH_CONCURRENCY`, the caller
+ * queues on a FIFO wait list; when a slot frees, the next waiter
+ * runs. Metadata-only FETCH paths (BODY.PEEK[HEADER], UID FLAGS,
+ * ENVELOPE) bypass the budget entirely — they're cheap allocations
+ * the budget exists to protect.
+ *
+ * The budget is a per-process constant, NOT per-connection. That is
+ * the point: one misbehaving client shouldn't be able to squeeze the
+ * rest of the process out of memory just by opening more sockets.
+ */
+import { logger } from "server";
+
+const DEFAULT_CONCURRENCY = 3;
+
+const parseConcurrency = (): number => {
+  const raw = process.env.IMAP_BODY_FETCH_CONCURRENCY;
+  if (!raw) return DEFAULT_CONCURRENCY;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    logger.warn(
+      "[body-budget] IMAP_BODY_FETCH_CONCURRENCY invalid, falling back to default",
+      { raw, default: DEFAULT_CONCURRENCY }
+    );
+    return DEFAULT_CONCURRENCY;
+  }
+  return parsed;
+};
+
+const CAPACITY = parseConcurrency();
+
+let inFlight = 0;
+const waitQueue: Array<() => void> = [];
+
+/**
+ * The last budget wait latency, exposed so per-command diag logging
+ * can attribute FETCH latency to budget queuing vs DB / serialization.
+ * Reset by each new caller when they acquire — read it BEFORE releasing
+ * or the next caller overwrites it.
+ */
+let lastAcquireWaitMs = 0;
+
+export const getLastBodyBudgetWaitMs = (): number => lastAcquireWaitMs;
+
+const acquire = (): Promise<void> => {
+  const start = performance.now();
+  if (inFlight < CAPACITY) {
+    inFlight++;
+    lastAcquireWaitMs = 0;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waitQueue.push(() => {
+      inFlight++;
+      lastAcquireWaitMs = performance.now() - start;
+      resolve();
+    });
+  });
+};
+
+const release = (): void => {
+  inFlight--;
+  const next = waitQueue.shift();
+  if (next) next();
+};
+
+/**
+ * Run `fn` inside the body budget. Waits for a slot if `CAPACITY`
+ * large-body serializations are already in flight. Always releases,
+ * even if `fn` throws.
+ */
+export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
+  await acquire();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+};
+
+/** Exposed for tests. */
+export const _resetBodyBudget = (): void => {
+  inFlight = 0;
+  waitQueue.length = 0;
+  lastAcquireWaitMs = 0;
+};
+
+export const bodyBudgetCapacity = (): number => CAPACITY;

--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -24,6 +24,7 @@
  * the point: one misbehaving client shouldn't be able to squeeze the
  * rest of the process out of memory just by opening more sockets.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
 import { logger } from "server";
 
 const DEFAULT_CONCURRENCY = 3;
@@ -48,29 +49,40 @@ let inFlight = 0;
 const waitQueue: Array<() => void> = [];
 
 /**
- * The last budget wait latency, exposed so per-command diag logging
- * can attribute FETCH latency to budget queuing vs DB / serialization.
- * Reset by each new caller when they acquire — read it BEFORE releasing
- * or the next caller overwrites it.
+ * Per-request wait accumulator. Bound at the top of the IMAP command
+ * handler via `runInBodyBudgetContext(fn)`; every `withBodyBudget` call
+ * that runs INSIDE `fn` (even across `await` boundaries and nested
+ * async work) adds its measured wait to the SAME `{ ms }` object.
+ * The handler reads the total from `getBodyBudgetWaitMs()` at the end.
+ *
+ * Load-bearing: without AsyncLocalStorage the wait latency would sit on
+ * a module-scoped variable that concurrent handlers overwrite (handler
+ * A yields inside `await withBodyBudget`, handler B on a different
+ * socket acquires and writes its OWN wait time to the shared cell,
+ * then A resumes and reads B's value). AsyncLocalStorage keeps each
+ * request's ledger separate.
  */
-let lastAcquireWaitMs = 0;
+const waitStore = new AsyncLocalStorage<{ ms: number }>();
 
-export const getLastBodyBudgetWaitMs = (): number => lastAcquireWaitMs;
+export const runInBodyBudgetContext = <T>(fn: () => T): T =>
+  waitStore.run({ ms: 0 }, fn);
 
-const acquire = (): Promise<void> => {
-  const start = performance.now();
+export const getBodyBudgetWaitMs = (): number => waitStore.getStore()?.ms ?? 0;
+
+const acquire = async (): Promise<void> => {
   if (inFlight < CAPACITY) {
     inFlight++;
-    lastAcquireWaitMs = 0;
-    return Promise.resolve();
+    return;
   }
-  return new Promise<void>((resolve) => {
+  const start = performance.now();
+  await new Promise<void>((resolve) => {
     waitQueue.push(() => {
       inFlight++;
-      lastAcquireWaitMs = performance.now() - start;
       resolve();
     });
   });
+  const ledger = waitStore.getStore();
+  if (ledger) ledger.ms += performance.now() - start;
 };
 
 const release = (): void => {
@@ -82,7 +94,9 @@ const release = (): void => {
 /**
  * Run `fn` inside the body budget. Waits for a slot if `CAPACITY`
  * large-body serializations are already in flight. Always releases,
- * even if `fn` throws.
+ * even if `fn` throws. When the caller is inside a
+ * `runInBodyBudgetContext` scope, the wait time (0 if the acquire was
+ * immediate) is added to that scope's ledger.
  */
 export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
   await acquire();
@@ -97,7 +111,6 @@ export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
 export const _resetBodyBudget = (): void => {
   inFlight = 0;
   waitQueue.length = 0;
-  lastAcquireWaitMs = 0;
 };
 
 export const bodyBudgetCapacity = (): number => CAPACITY;

--- a/src/server/lib/imap/body-buffer.ts
+++ b/src/server/lib/imap/body-buffer.ts
@@ -1,3 +1,4 @@
+import { withBodyBudget } from "./body-budget";
 import { singleFlight } from "../postgres/repositories/mails/inflight";
 
 /**
@@ -66,11 +67,18 @@ export const getSharedBodyResult = (
   cacheKey: string,
   build: () => BodyBuildResult
 ): Promise<BodyCacheResult> =>
-  singleFlight(`body:${cacheKey}`, async () => {
-    const r = build();
-    if (r.kind !== "content") return r;
-    return { kind: "buffer", buffer: Buffer.from(r.text, "utf8") };
-  });
+  singleFlight(`body:${cacheKey}`, async () =>
+    // Budget-gate INSIDE the singleflight closure so N coalesced callers
+    // consume ONE budget slot for one build, not N slots for N waiters.
+    // A duplicate-UID storm (the shape #710/#713 addressed) would
+    // otherwise starve legitimate distinct-UID callers by pinning every
+    // slot on the same body build. See #726 / #727.
+    withBodyBudget(async () => {
+      const r = build();
+      if (r.kind !== "content") return r;
+      return { kind: "buffer", buffer: Buffer.from(r.text, "utf8") };
+    })
+  );
 
 /**
  * Cache-key shape: `<mailId>::<sectionKey>`. `mailId` scopes to a single

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -28,6 +28,7 @@ import {
   FetchDataItem,
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
+import { withBodyBudget } from "./body-budget";
 
 // ---------------------------------------------------------------------------
 // FetchResponsePart types (local to the fetch subsystem)
@@ -335,7 +336,16 @@ export async function buildBodyResponsePart(
   //    the cache would defeat the coalescing entirely for the wire
   //    check).
   if (!partial && !isHeaderLikeSection(section)) {
-    const cached = await getSharedBodyResult(
+    // Global concurrency budget for large-body serialization work: N
+    // parallel FETCH BODY[] requests against DISTINCT (mail, section)
+    // pairs (a common iOS Mail / K-9 multi-account resync pattern)
+    // would otherwise each allocate an independent multi-MB Buffer
+    // and scale RSS linearly with connection count. The budget queues
+    // excess concurrent work so peak RSS stays bounded regardless of
+    // how many sockets pipeline distinct large-body FETCHes. See
+    // `body-budget.ts` + hoiekim/inbox#726.
+    const cached = await withBodyBudget(() =>
+      getSharedBodyResult(
       bodyBufferKey(docId, sectionKey),
       () => {
         const raw = getBodyContent(mail, section, docId);
@@ -343,7 +353,7 @@ export async function buildBodyResponsePart(
         if (raw === "") return { kind: "nil" };
         return { kind: "content", text: raw + "\r\n" };
       }
-    );
+    ));
     if (cached.kind === "omit") return null;
     if (cached.kind === "nil") {
       return { type: "simple", content: `${sectionKey} NIL` };

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -29,6 +29,12 @@ import {
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
 import { withBodyBudget } from "./body-budget";
+// `getSharedBodyResult` already budget-gates INSIDE its singleflight
+// closure so coalesced callers share one slot (see body-buffer.ts +
+// hoiekim/inbox#726 / #727). The `withBodyBudget` import here is used
+// on the PARTIAL-fetch branch below, which bypasses the shared-body
+// cache but still materializes the full body via `buildFullMessage`
+// before slicing — same RSS scaling concern, so same gate.
 
 // ---------------------------------------------------------------------------
 // FetchResponsePart types (local to the fetch subsystem)
@@ -336,16 +342,10 @@ export async function buildBodyResponsePart(
   //    the cache would defeat the coalescing entirely for the wire
   //    check).
   if (!partial && !isHeaderLikeSection(section)) {
-    // Global concurrency budget for large-body serialization work: N
-    // parallel FETCH BODY[] requests against DISTINCT (mail, section)
-    // pairs (a common iOS Mail / K-9 multi-account resync pattern)
-    // would otherwise each allocate an independent multi-MB Buffer
-    // and scale RSS linearly with connection count. The budget queues
-    // excess concurrent work so peak RSS stays bounded regardless of
-    // how many sockets pipeline distinct large-body FETCHes. See
-    // `body-budget.ts` + hoiekim/inbox#726.
-    const cached = await withBodyBudget(() =>
-      getSharedBodyResult(
+    // Route through the shared body-buffer cache; getSharedBodyResult
+    // gates its build closure with `withBodyBudget` INSIDE the
+    // singleflight so N coalesced callers share one budget slot.
+    const cached = await getSharedBodyResult(
       bodyBufferKey(docId, sectionKey),
       () => {
         const raw = getBodyContent(mail, section, docId);
@@ -353,7 +353,7 @@ export async function buildBodyResponsePart(
         if (raw === "") return { kind: "nil" };
         return { kind: "content", text: raw + "\r\n" };
       }
-    ));
+    );
     if (cached.kind === "omit") return null;
     if (cached.kind === "nil") {
       return { type: "simple", content: `${sectionKey} NIL` };
@@ -366,7 +366,17 @@ export async function buildBodyResponsePart(
     };
   }
 
-  const content = getBodyContent(mail, section, docId);
+  // Partial fetch (`BODY[]<start.length>`) and header-like sections
+  // (`BODY[HEADER.FIELDS ...]`) fall through here. Partial STILL
+  // materializes the full body via `buildFullMessage` before slicing
+  // in `applyPartialFetch`, so the RSS scaling concern is the same as
+  // the shared-body path — gate through the budget. Header-like
+  // sections are cheap (≤ a few KiB) and don't need gating; hop over
+  // them with an immediate acquire/release by only gating when the
+  // request is a partial.
+  const content = partial
+    ? await withBodyBudget(() => Promise.resolve(getBodyContent(mail, section, docId)))
+    : getBodyContent(mail, section, docId);
   if (content === null) {
     return null;
   }

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -6,6 +6,7 @@ import { Socket } from "net";
 import { ImapSession } from "./session";
 import { ImapRequest } from "./types";
 import { parseCommand } from "./parsers";
+import { getLastBodyBudgetWaitMs } from "./body-budget";
 import { SOCKET_TIMEOUT_MS } from "./idle-manager";
 import { logger } from "server";
 
@@ -521,6 +522,12 @@ export class ImapRequestHandler {
         Math.abs(rssDeltaMB) >= INTERESTING_RSS_DELTA_MB ||
         durationMs >= INTERESTING_DURATION_MS ||
         responseBytes >= INTERESTING_RESPONSE_BYTES;
+      // Body-budget wait attribution (#726): when many sockets pipeline
+      // distinct large-body FETCHes concurrently, most of the caller's
+      // duration is spent WAITING for a body-budget slot rather than
+      // doing DB / serialization work. Log the wait so an OOM / latency
+      // triage can attribute FETCH latency to backpressure vs the app.
+      const waitedForBodyBudgetMs = Math.round(getLastBodyBudgetWaitMs());
       const payload = {
         component: "imap",
         tag,
@@ -532,6 +539,7 @@ export class ImapRequestHandler {
         rssDeltaMB,
         responseBytes,
         durationMs,
+        waitedForBodyBudgetMs,
       };
       if (isInteresting) {
         logger.info("IMAP command completed", payload);

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -6,7 +6,7 @@ import { Socket } from "net";
 import { ImapSession } from "./session";
 import { ImapRequest } from "./types";
 import { parseCommand } from "./parsers";
-import { getLastBodyBudgetWaitMs } from "./body-budget";
+import { getBodyBudgetWaitMs, runInBodyBudgetContext } from "./body-budget";
 import { SOCKET_TIMEOUT_MS } from "./idle-manager";
 import { logger } from "server";
 
@@ -320,25 +320,32 @@ export class ImapRequestHandler {
     const rssBefore = process.memoryUsage.rss();
     const bytesBefore = session.bytesWritten;
 
+    // Bind a body-budget wait ledger to this command's async scope so
+    // every `withBodyBudget` acquire made deeper in the FETCH path
+    // (across await boundaries + nested calls) attributes its wait to
+    // THIS command's totals, not a racing sibling command on another
+    // socket. Reads via `getBodyBudgetWaitMs()` in the finally below.
+    // See `body-budget.ts`.
+    return runInBodyBudgetContext(async () => {
     try {
       switch (request.type) {
         case "CAPABILITY":
-          this.session.capability(tag);
+          session.capability(tag);
           break;
 
         case "NOOP":
-          this.session.noop(tag);
+          session.noop(tag);
           break;
 
         case "LOGIN":
-          await this.session.login(tag, [
+          await session.login(tag, [
             request.data.username,
             request.data.password
           ]);
           break;
 
         case "AUTHENTICATE":
-          await this.session.authenticate(
+          await session.authenticate(
             tag,
             request.data.mechanism,
             request.data.initialResponse
@@ -346,14 +353,14 @@ export class ImapRequestHandler {
           break;
 
         case "LIST":
-          await this.session.listMailboxes(
+          await session.listMailboxes(
             tag,
             request.data.reference,
             request.data.pattern
           );
           break;
         case "LSUB":
-          await this.session.listSubscribedMailboxes(
+          await session.listSubscribedMailboxes(
             tag,
             request.data.reference,
             request.data.pattern
@@ -361,23 +368,23 @@ export class ImapRequestHandler {
           break;
 
         case "SELECT":
-          await this.session.selectMailbox(tag, request.data.mailbox);
+          await session.selectMailbox(tag, request.data.mailbox);
           break;
 
         case "EXAMINE":
-          await this.session.examineMailbox(tag, request.data.mailbox);
+          await session.examineMailbox(tag, request.data.mailbox);
           break;
 
         case "CREATE":
-          await this.session.createMailbox(tag, request.data.mailbox);
+          await session.createMailbox(tag, request.data.mailbox);
           break;
 
         case "DELETE":
-          await this.session.deleteMailbox(tag, request.data.mailbox);
+          await session.deleteMailbox(tag, request.data.mailbox);
           break;
 
         case "RENAME":
-          await this.session.renameMailbox(
+          await session.renameMailbox(
             tag,
             request.data.oldName,
             request.data.newName
@@ -385,15 +392,15 @@ export class ImapRequestHandler {
           break;
 
         case "SUBSCRIBE":
-          await this.session.subscribeMailbox(tag, request.data.mailbox);
+          await session.subscribeMailbox(tag, request.data.mailbox);
           break;
 
         case "UNSUBSCRIBE":
-          await this.session.unsubscribeMailbox(tag, request.data.mailbox);
+          await session.unsubscribeMailbox(tag, request.data.mailbox);
           break;
 
         case "STATUS":
-          await this.session.statusMailbox(
+          await session.statusMailbox(
             tag,
             request.data.mailbox,
             request.data.items
@@ -401,35 +408,35 @@ export class ImapRequestHandler {
           break;
 
         case "APPEND":
-          await this.session.appendMessage(tag, request.data);
+          await session.appendMessage(tag, request.data);
           break;
 
         case "IDLE":
-          await this.session.startIdle(tag);
+          await session.startIdle(tag);
           break;
 
         case "CHECK":
-          await this.session.check(tag);
+          await session.check(tag);
           break;
 
         case "FETCH":
-          await this.session.fetchMessagesTyped(tag, request.data, false);
+          await session.fetchMessagesTyped(tag, request.data, false);
           break;
 
         case "SEARCH":
-          await this.session.searchTyped(tag, request.data, false);
+          await session.searchTyped(tag, request.data, false);
           break;
 
         case "STORE":
-          await this.session.storeFlagsTyped(tag, request.data, false);
+          await session.storeFlagsTyped(tag, request.data, false);
           break;
 
         case "COPY":
-          await this.session.copyMessageTyped(tag, request.data, false);
+          await session.copyMessageTyped(tag, request.data, false);
           break;
 
         case "MOVE":
-          await this.session.moveMessageTyped(tag, request.data, false);
+          await session.moveMessageTyped(tag, request.data, false);
           break;
 
         case "UID":
@@ -437,53 +444,53 @@ export class ImapRequestHandler {
           break;
 
         case "CLOSE":
-          this.session.closeMailbox(tag);
+          session.closeMailbox(tag);
           break;
 
         case "EXPUNGE":
-          await this.session.expunge(tag);
+          await session.expunge(tag);
           break;
 
         case "LOGOUT":
-          await this.session.logout(tag);
+          await session.logout(tag);
           break;
 
         case "ID":
-          this.session.write(`* ID NIL\r\n${tag} OK ID completed\r\n`);
+          session.write(`* ID NIL\r\n${tag} OK ID completed\r\n`);
           break;
 
         case "STARTTLS":
-          await this.session.startTls(tag);
+          await session.startTls(tag);
           break;
 
         case "NAMESPACE":
           // RFC 2342: single personal namespace, no other/shared namespaces
-          this.session.write(`* NAMESPACE (("" "/")) NIL NIL\r\n${tag} OK NAMESPACE completed\r\n`);
+          session.write(`* NAMESPACE (("" "/")) NIL NIL\r\n${tag} OK NAMESPACE completed\r\n`);
           break;
 
         case "ENABLE":
           // RFC 5161 / RFC 4551 §3.7: enable CONDSTORE (the one extension we
           // support enabling) and echo back what was activated.
-          this.session.enable(tag, request.data.capabilities);
+          session.enable(tag, request.data.capabilities);
           break;
 
         case "UNSELECT":
           // RFC 3691: like CLOSE but without expunging; deselect the current mailbox
-          this.session.closeMailbox(tag, true);
+          session.closeMailbox(tag, true);
           break;
 
         case "GETQUOTAROOT":
           // RFC 2087: quota not supported, return empty quota
-          this.session.write(`${tag} NO Quota not supported\r\n`);
+          session.write(`${tag} NO Quota not supported\r\n`);
           break;
 
         default:
-          this.session.write(`${tag} BAD Unknown command\r\n`);
+          session.write(`${tag} BAD Unknown command\r\n`);
           break;
       }
     } catch (error) {
       logger.error("Error handling IMAP request", { component: "imap", tag, type: request.type }, error);
-      this.session.write(`${tag} BAD Internal server error\r\n`);
+      session.write(`${tag} BAD Internal server error\r\n`);
     } finally {
       const rssAfter = process.memoryUsage.rss();
       const socket = session.socket;
@@ -527,7 +534,10 @@ export class ImapRequestHandler {
       // duration is spent WAITING for a body-budget slot rather than
       // doing DB / serialization work. Log the wait so an OOM / latency
       // triage can attribute FETCH latency to backpressure vs the app.
-      const waitedForBodyBudgetMs = Math.round(getLastBodyBudgetWaitMs());
+      // Read from the request-scoped AsyncLocalStorage ledger — a
+      // module-global cell would race with concurrent commands on
+      // other sockets.
+      const waitedForBodyBudgetMs = Math.round(getBodyBudgetWaitMs());
       const payload = {
         component: "imap",
         tag,
@@ -547,6 +557,7 @@ export class ImapRequestHandler {
         logger.debug("IMAP command completed", payload);
       }
     }
+    });
   }
 
   /**


### PR DESCRIPTION
Closes #726.

## Problem

`hoie-inbox-1` OOM at 2026-07-29 16:35 UTC. Same client (208.82.98.54) as the 07-27/28 arc but a different pattern than what #710 / #713 already fixed:

- 3–4 concurrent IMAP connections each running large `UID FETCH … BODY` against **distinct** mailboxes / UIDs (`INBOX/accounts/craigslist`, `cycling74`, `cync`, `code`).
- Not duplicate requests for the same message.
- #710 (single-flight `getMailsByRange`) coalesces on `(user, mailbox, sent, range, useUid, fields)` — different UIDs / mailboxes don't coalesce.
- #713 (shared body-buffer + chunked writes) coalesces on `(mail_id, sectionKey)` — different mails don't share a Buffer.
- Neither bounds the NUMBER of DISTINCT concurrent large-body serializations across sockets → RSS scaled linearly with in-flight count → 256 MiB cap blown.

## Fix

New `src/server/lib/imap/body-budget.ts`: a per-process counting semaphore with a FIFO wait queue. Callers wrap their large-body serialization in `withBodyBudget(fn)`; if the running count is at or above `IMAP_BODY_FETCH_CONCURRENCY` (default **3**), the caller queues; when a slot frees, the next waiter runs. Always releases on `finally`, including on throw.

`fetch-helpers.ts:buildBodyResponsePart` wraps the **large-body serialization branch** (non-partial, non-header sections — the `BODY[]` / `BODY[TEXT]` / bare `BODY[<part>]` paths that read multi-MB payload from Postgres into RSS). Metadata-only FETCH (`BODY.PEEK[HEADER]`, `UID FLAGS`, `ENVELOPE`) bypasses the semaphore — those are cheap allocations the budget exists to protect.

`handler.ts` per-command diag gains **`waitedForBodyBudgetMs`** (read from `getLastBodyBudgetWaitMs()` immediately after the `finally` block). Under a legitimate multi-mailbox concurrent resync, most of the caller's duration under the budget is now BUDGET WAIT rather than DB/serialization work — attributes latency correctly for OOM / latency triage.

## Sizing

Default `CAPACITY = 3` from `parseIntEnv("IMAP_BODY_FETCH_CONCURRENCY", 3)`.

Reasoning: container memory limit is 256 MiB; observed max body size is ~40 MiB; a Buffer plus its in-flight socket chunks needs ~2× the mail size at peak. `256 / 40 / 2 = 3.2 → floor = 3`. Env-configurable so Hoie can retune from prod telemetry without a code change.

## Tests

`bun test src/server` → **1358/0** across 68 files. 5 new unit tests in `body-budget.test.ts`:

- Runs up to CAP callers concurrently
- Queues an extra caller until a slot frees (FIFO wait)
- Records acquire wait latency for the most recent acquire
- Releases on throw so subsequent callers still run
- Wait latency is 0 when uncontended

## Verification plan (to add before ready-for-review)

**Sandbox E2E**: 4 parallel `UID FETCH … BODY[]` connections against distinct mailboxes; monitor `waitedForBodyBudgetMs` in the diag log to confirm 1 caller runs immediately and 3 queue for the semaphore.

**Prod (post-merge)**: watch the same client's next multi-account sync via `/stats/hoie-inbox-1` — RSS trajectory should plateau at the budget-imposed ceiling instead of climbing linearly with connection count. If the ceiling still crosses the 85% `MEMORY_PRESSURE` threshold, tune down via `IMAP_BODY_FETCH_CONCURRENCY=2` in `~/inbox/.env` and `pm2 restart` — no code change needed.

## Not in this PR

- **(b) raise the 256 MiB cap** — deferred per the alarm-thread discussion. Hoie's call: do (a) first, decide on the cap after seeing post-fix RSS trajectories.
- **Memory-budget variant** (bound total in-flight body bytes instead of concurrent count) — bigger change, requires knowing body size upfront. Concurrent-count is simpler + Env-tunable to the same effect.