### PR TITLE
perf(imap): TTL cache for BODY[] buffers — catch sequential-retry OOM (#729)

### DIFF
--- a/src/server/lib/imap/body-buffer.test.ts
+++ b/src/server/lib/imap/body-buffer.test.ts
@@ -1,26 +1,37 @@
 /**
- * getSharedBodyResult coalescing + tri-state invariants:
+ * getSharedBodyResult coalescing + TTL + tri-state invariants:
  *  1. Concurrent identical (cacheKey, build) calls share ONE result —
  *     only the first `build()` runs.
  *  2. Different cacheKeys build independently — no cross-key contamination.
- *  3. After the promise settles, the cache entry drops (singleflight
- *     lifetime); a later caller with the same key re-builds. Intentional:
- *     the OOM comes from CONCURRENT duplicate serializations, not
- *     sequential ones.
+ *  3. **Post-settle TTL cache (#729):** after the promise settles, the
+ *     resolved value stays cached for `IMAP_BODY_BUFFER_TTL_MS`. A caller
+ *     arriving within the window reuses the cached Buffer directly — no
+ *     rebuild, no singleflight round-trip. This addresses iOS Mail's
+ *     sequential-retry OOM shape (aborted response → immediate retry on
+ *     the same connection — dispatched serially, so singleflight alone
+ *     never catches it).
  *  4. Tri-state: `{ kind: "content", text }` → Buffer;
  *     `{ kind: "nil" }` → `nil` result (caller emits `NIL` simple part);
  *     `{ kind: "omit" }` → `omit` result (caller drops the part).
  *     These three shapes preserve the pre-cache behavior of
  *     `buildBodyResponsePart` on empty-body and nonexistent-part paths.
+ *     All three variants participate in the TTL cache.
  *  5. Content result is a Buffer — `socket.write(buffer)` skips the
  *     UTF-8 conversion and V8 can GC the intermediate JS string.
  */
 import { describe, it, expect, beforeEach } from "bun:test";
-import { getSharedBodyResult, bodyBufferKey } from "./body-buffer";
+import {
+  getSharedBodyResult,
+  bodyBufferKey,
+  _bodyBufferCacheSize,
+  _resetBodyBufferCache,
+  _bodyBufferTtlMs,
+} from "./body-buffer";
 import { inflightReset, inflightSize } from "../postgres/repositories/mails/inflight";
 
 beforeEach(() => {
   inflightReset();
+  _resetBodyBufferCache();
 });
 
 describe("getSharedBodyResult", () => {
@@ -72,7 +83,11 @@ describe("getSharedBodyResult", () => {
     expect(r.buffer.byteLength).not.toBe(src.length);
   });
 
-  it("cache entry drops on settle so a later caller re-builds", async () => {
+  it("sequential caller within TTL window reuses the cached Buffer (#729)", async () => {
+    // The load-bearing invariant for #729. iOS Mail's abort-and-retry
+    // shape sends the second FETCH AFTER the first settles — singleflight
+    // alone (the pre-#729 shape) would rebuild. With the post-settle TTL
+    // cache, the retry hits the cache and pays 0 additional allocation.
     let builds = 0;
     const run = () => getSharedBodyResult("k", () => {
       builds += 1;
@@ -81,10 +96,36 @@ describe("getSharedBodyResult", () => {
     const first = await run();
     if (first.kind !== "buffer") throw new Error();
     expect(first.buffer.toString("utf8")).toBe("run-1");
-    // singleflight semantics: entry cleared post-settle. Not a cache.
+    // singleflight entry cleared post-settle, but TTL cache holds the result.
     expect(inflightSize()).toBe(0);
+    expect(_bodyBufferCacheSize()).toBe(1);
     const second = await run();
     if (second.kind !== "buffer") throw new Error();
+    // Same content — build DID NOT re-run.
+    expect(second.buffer.toString("utf8")).toBe("run-1");
+    // Same Buffer identity — proof the cache returned the exact object.
+    expect(second.buffer).toBe(first.buffer);
+    expect(builds).toBe(1);
+  });
+
+  it("cache expires and later caller rebuilds after TTL fires", async () => {
+    // Test relies on the default TTL being > 0. `IMAP_BODY_BUFFER_TTL_MS=0`
+    // would disable the cache entirely — assert we're not in that mode.
+    expect(_bodyBufferTtlMs()).toBeGreaterThan(0);
+    let builds = 0;
+    const run = () => getSharedBodyResult("k", () => {
+      builds += 1;
+      return { kind: "content", text: `run-${builds}` };
+    });
+    const first = await run();
+    if (first.kind !== "buffer") throw new Error();
+    expect(first.buffer.toString("utf8")).toBe("run-1");
+    // Simulate TTL fire without waiting real seconds.
+    _resetBodyBufferCache();
+    expect(_bodyBufferCacheSize()).toBe(0);
+    const second = await run();
+    if (second.kind !== "buffer") throw new Error();
+    // Post-expiry: fresh build produced fresh content.
     expect(second.buffer.toString("utf8")).toBe("run-2");
     expect(builds).toBe(2);
   });

--- a/src/server/lib/imap/body-buffer.ts
+++ b/src/server/lib/imap/body-buffer.ts
@@ -2,24 +2,36 @@ import { withBodyBudget } from "./body-budget";
 import { singleFlight } from "../postgres/repositories/mails/inflight";
 
 /**
- * Coalesce identical BODY-content serializations across concurrent FETCH
- * handlers.
+ * Coalesce identical BODY-content serializations across FETCH handlers,
+ * with a short-TTL post-settle cache so a sequential retry within the
+ * window reuses the built Buffer instead of paying the multi-MB build
+ * a second time.
  *
  * `getMailsByRange` (postgres/repositories/mails/imap.ts) already single-
  * flights the DB read — coalesced callers share one `PartialMailModel`
  * instance and, transitively, one `mail.html` / `mail.text` string. But
  * each handler was independently calling `buildFullMessage(mail)` and
  * base64-encoding the shared body, producing N distinct multi-MB JS
- * strings on top of the shared source. Under a client that pipelines
- * duplicate `UID FETCH X (BODY)` (observed: iOS Mail hammering a slow
- * response across a double-socket setup), those N strings pushed the
- * container's RSS past the OOM cap.
+ * strings on top of the shared source. This cache coalesces the
+ * SERIALIZATION step too — concurrent identical builds share one
+ * `Buffer`; every coalesced caller `writeChunked`s the same Buffer
+ * reference (`socket.write(buffer)` doesn't copy — it enqueues a
+ * reference), so heap footprint stays at O(distinct-in-flight-bodies)
+ * instead of O(callers).
  *
- * This cache coalesces the SERIALIZATION step too. Concurrent identical
- * body-content builds share one `Buffer`; every coalesced caller
- * `writeChunked`s the same Buffer reference (`socket.write(buffer)` doesn't
- * copy — it enqueues a reference), so heap footprint stays at
- * O(distinct-in-flight-bodies) instead of O(callers).
+ * **Post-settle TTL (#729):** the earlier version deleted the cache
+ * entry on `.finally` — correct for the concurrent-caller shape
+ * (`getSharedBodyResult` originally addressed a duplicate-UID storm
+ * where retries arrived WHILE the first build was in flight), but blind
+ * to the shape iOS Mail actually generates: a fresh `UID FETCH X
+ * (BODY[])` sent AFTER the previous response finished (aborted or
+ * complete). IMAP command dispatch is strictly serialized per
+ * connection (`handler.ts:239` awaits `handleRequest`), so the retry
+ * arrives after the first build's promise has already settled and the
+ * cache entry has been cleared. Keeping the resolved Buffer in a
+ * bounded-TTL post-settle cache means the retry hits the cache and the
+ * ~100MB peak allocation is not paid twice — avoiding the stacking
+ * that OOM-killed the container on 2026-07-30 01:06:26 UTC.
  *
  * The tri-state result (buffer / nil / omit) preserves the three IMAP
  * response shapes `buildBodyResponsePart` had to distinguish BEFORE this
@@ -45,10 +57,6 @@ import { singleFlight } from "../postgres/repositories/mails/inflight";
  *   immediately after the encode.
  * - `socket.write(buffer)` skips the per-write UTF-8 conversion Node
  *   otherwise runs on string writes.
- *
- * Cache lifetime is the singleflight window: the entry deletes on
- * settle. That's the correct scope — the OOM comes from CONCURRENT
- * duplicate serializations; sequential callers can freely re-build.
  */
 
 /** What the closure passed to `getSharedBodyResult` may return. */
@@ -63,11 +71,63 @@ export type BodyCacheResult =
   | { kind: "nil" }
   | { kind: "omit" };
 
+/**
+ * How long a resolved Buffer stays cached after the build settles. Long
+ * enough to catch iOS Mail's sequential retry (empirically within ~1s
+ * of the aborted first response), short enough that memory-held Buffers
+ * for one-off requests don't linger.
+ *
+ * Retune via `IMAP_BODY_BUFFER_TTL_MS`. Set to `0` to disable the
+ * post-settle cache and fall back to singleflight-only behavior (the
+ * pre-#729 shape).
+ */
+const DEFAULT_TTL_MS = 10_000;
+
+const parseTtl = (): number => {
+  const raw = process.env.IMAP_BODY_BUFFER_TTL_MS;
+  if (!raw) return DEFAULT_TTL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_TTL_MS;
+  return parsed;
+};
+
+const TTL_MS = parseTtl();
+
+interface CacheEntry {
+  result: BodyCacheResult;
+  timer: NodeJS.Timeout;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+const setCached = (key: string, result: BodyCacheResult): void => {
+  if (TTL_MS <= 0) return;
+  const existing = cache.get(key);
+  if (existing) clearTimeout(existing.timer);
+  const timer = setTimeout(() => cache.delete(key), TTL_MS);
+  // `unref` so a pending expiry timer doesn't block Node from exiting
+  // (tests + graceful shutdown).
+  timer.unref?.();
+  cache.set(key, { result, timer });
+};
+
+// NOT `async` — two concurrent cache-miss callers with the same key must
+// receive the SAME Promise reference so singleflight coalescing works at
+// the identity level. An `async` wrapper would produce a fresh promise per
+// call that awaits the coalesced one, still running work once but breaking
+// the invariant that both callers hold the exact same promise object.
 export const getSharedBodyResult = (
   cacheKey: string,
   build: () => BodyBuildResult
-): Promise<BodyCacheResult> =>
-  singleFlight(`body:${cacheKey}`, async () =>
+): Promise<BodyCacheResult> => {
+  const key = `body:${cacheKey}`;
+
+  // Post-settle cache: sequential retries within TTL reuse the resolved
+  // Buffer directly — no rebuild, no singleflight, no budget slot.
+  const cached = cache.get(key);
+  if (cached) return Promise.resolve(cached.result);
+
+  return singleFlight(key, async () =>
     // Budget-gate INSIDE the singleflight closure so N coalesced callers
     // consume ONE budget slot for one build, not N slots for N waiters.
     // A duplicate-UID storm (the shape #710/#713 addressed) would
@@ -75,10 +135,15 @@ export const getSharedBodyResult = (
     // slot on the same body build. See #726 / #727.
     withBodyBudget(async () => {
       const r = build();
-      if (r.kind !== "content") return r;
-      return { kind: "buffer", buffer: Buffer.from(r.text, "utf8") };
+      const result: BodyCacheResult =
+        r.kind === "content"
+          ? { kind: "buffer", buffer: Buffer.from(r.text, "utf8") }
+          : r;
+      setCached(key, result);
+      return result;
     })
   );
+};
 
 /**
  * Cache-key shape: `<mailId>::<sectionKey>`. `mailId` scopes to a single
@@ -88,3 +153,11 @@ export const getSharedBodyResult = (
  */
 export const bodyBufferKey = (mailId: string, sectionKey: string): string =>
   `${mailId}::${sectionKey}`;
+
+/** Exposed for tests: current TTL cache size + reset. */
+export const _bodyBufferCacheSize = (): number => cache.size;
+export const _resetBodyBufferCache = (): void => {
+  for (const entry of cache.values()) clearTimeout(entry.timer);
+  cache.clear();
+};
+export const _bodyBufferTtlMs = (): number => TTL_MS;


### PR DESCRIPTION
Closes #729.

## Problem

hoie-inbox-1 OOM at 2026-07-30 01:06:26 UTC:

```
K842 UID FETCH 12 (UID BODY[])  rss 207→307MB  Δ=+100MB
K843 UID FETCH 12 (UID BODY[])  rss 207→307MB  Δ=+100MB   → OOM at 256MB cap
```

Same TCP connection, same UID, same section. iOS Mail's abort-and-retry shape — it starts receiving the response (~26MB body with 3 mp3 attachments totalling 19.9MB), reads ~768KB, decides it's too slow, drops the connection, retries.

## Why PR #713's singleflight didn't apply

- `handler.ts:239` `await this.handleRequest(...)` — commands per connection are strictly serialized. K843 CANNOT begin until K842's handler returns.
- `inflight.ts:36` `.finally(() => inflight.delete(key))` — the moment K842 settles, the singleflight cache entry disappears.

So K843 arrives AFTER the entry is empty → does a fresh 100MB build. V8 hasn't reclaimed K842's spike yet → sum crosses the cgroup cap → OOM.

PR #713 was correct for CONCURRENT identical requests (the #710 investigation shape). It's blind to sequential retries.

## Fix

Keep the resolved `BodyCacheResult` in a bounded-TTL post-settle cache. A sequential retry within `IMAP_BODY_BUFFER_TTL_MS` (default `10_000`, i.e. 10s) hits the cache and skips the rebuild — no singleflight round-trip, no budget slot consumed, no ~100MB peak paid twice.

- **`cache: Map<string, {result, timer}>`** with per-entry `setTimeout` that `.unref()`s so a pending expiry timer doesn't hold Node's event loop (matters for tests + graceful shutdown).
- On cache miss, delegate to the existing singleflight path; on the way out, `setCached()` puts the resolved value in the TTL cache. Timer is cleared + reset if a new build for the same key populates the cache (idempotent update).
- **`getSharedBodyResult` stays NON-async** so two concurrent cache-miss callers still receive the SAME Promise reference from singleflight (identity-level coalescing — the existing "coalesces two concurrent callers" test asserts `p1 === p2`, kept passing).
- All three tri-state variants (`buffer` / `nil` / `omit`) participate in the cache; `nil`/`omit` caching is cheap so this is a strict superset of the pre-#729 behavior.
- **`IMAP_BODY_BUFFER_TTL_MS=0` disables the cache entirely** (fallback to pre-#729 singleflight-only behavior — kept as an escape hatch if the cache ever surprises us).

## What NOT in this PR

Sibling PR (up next): persist `RFC822.SIZE` on the mails table so a fetch-metadata storm (K836-style `UID FETCH 4,12,14 (UID RFC822.SIZE BODYSTRUCTURE)`) doesn't materialize every mail's full body just to report its size. That's a separate OOM class (the +66MB spike on K836 before K842 even started); combined with this PR, both classes are closed.

## Test coverage additions

- **Sequential caller within TTL reuses the cached Buffer** (same `.buffer` identity; build call count stays at 1). This is the load-bearing #729 invariant.
- **Cache expires and later caller rebuilds** (simulated via `_resetBodyBufferCache()` — avoids real-time waits so the suite stays fast).
- Existing coalescing / cross-key / tri-state tests continue to pass.

`bun test src/server/lib/imap/` → **697 pass / 0 fail** across 30 files.
`bunx tsc --noEmit` → clean.

## Tradeoffs

- **RSS**: bounded steady-state memory (up to N cached bodies × their size, for TTL_MS window). In the observed prod pattern, at most 1-2 distinct bodies are in the cache at a time. If ever it becomes a concern, cap `cache.size` with LRU eviction — deferred until we see the shape.
- **Freshness**: 10s is far shorter than any mail-content mutation window (mails don't get edited server-side between fetches). Safe.
- **Timers**: one `setTimeout` per cached entry, all `.unref()`ed. No leak; entries + their timers are cleared in `_resetBodyBufferCache` for tests.

## Test plan

- [ ] `bun test src/server/lib/imap/` (697 pass, 0 fail) — done locally
- [ ] `bunx tsc --noEmit` — done locally
- [ ] Prod verification post-deploy: repeat the K842/K843 shape from an IMAP client, confirm second command shows `rssDeltaMB: 0` (or close to it) instead of `+100MB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)