### PR TITLE
perf(imap): persist rfc822_size on mails to skip full-body materialization (#729)

### DIFF
--- a/src/common/models/mails/Mail.ts
+++ b/src/common/models/mails/Mail.ts
@@ -103,6 +103,14 @@ export interface MailType {
    * the HTTP client never reads it, hence optional.
    */
   modseq?: number;
+  /**
+   * Cached byte count of the serialized RFC 822 form (i.e. what BODY[] /
+   * RFC822 returns). Server-populated lazily on the first FETCH that
+   * derives it (see fetch-helpers RFC822.SIZE / RFC822 cases). Optional
+   * because the DB column starts NULL for existing rows and gets
+   * populated on their first observation; the HTTP client never reads it.
+   */
+  rfc822_size?: number | null;
 }
 
 export class Mail extends Model<Mail> implements MailType {
@@ -128,6 +136,7 @@ export class Mail extends Model<Mail> implements MailType {
   declare insight?: Insight;
   declare uid: MailUidType;
   declare modseq?: number;
+  declare rfc822_size?: number | null;
 
   constructor(data?: Partial<Mail>) {
     super(data);

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -142,15 +142,26 @@ describe("getRequestedFields", () => {
   });
 
   describe("RFC822.SIZE (inbox #654)", () => {
-    it("requests the full-message columns its size computation serializes", () => {
+    it("requests the full-message columns its size computation serializes, plus the cached column", () => {
       // RFC822.SIZE is derived from the FULL-body serializer, so a bare
       // `FETCH n RFC822.SIZE` must load the header columns too — otherwise
       // formatHeaders omits those lines and the size under-reports vs BODY[].
+      // Post-#729: also request `rfc822_size` (the cached-column short-circuit)
+      // so the fetch handler can skip buildFullMessage when the value is
+      // already persisted. The set is a STRICT SUPERSET of BODY[]'s.
       const size = getRequestedFields([{ type: "RFC822.SIZE" }]);
       const body = getRequestedFields([
         { type: "BODY", peek: true, section: { type: "FULL" } }
       ]);
-      expect([...size].sort()).toEqual([...body].sort());
+      // Every BODY[] field must be present for the fallback compute path
+      // (first observation of a mail — cached column is NULL).
+      for (const f of body) {
+        expect(size.has(f)).toBe(true);
+      }
+      // Plus the cached-column short-circuit.
+      expect(size.has("rfc822_size" as never)).toBe(true);
+      // And no other fields — the difference is exactly one column.
+      expect(size.size).toBe(body.size + 1);
       for (const f of [
         "text",
         "html",
@@ -362,6 +373,99 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
       }
     });
   }
+});
+
+describe("buildFetchResponsePart RFC822.SIZE cached-column short-circuit (#729)", () => {
+  const docId = "doc-cached";
+  const mailbox = "INBOX";
+  const base = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<cached@local>",
+    date: new Date("2026-07-30T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "cached",
+    text: "irrelevant — buildFullMessage MUST NOT run when rfc822_size is set",
+    html: "",
+    attachments: [],
+  };
+
+  it("returns the cached column value verbatim without calling buildFullMessage", async () => {
+    // The load-bearing invariant. When `mail.rfc822_size` is set (populated
+    // by getMailsByRange's SELECT for a previously-observed mail), the
+    // fetch handler skips the FULL-body serializer entirely — no
+    // buildFullMessage call, no attachment materialization, no ~100MB
+    // allocation. We prove this by setting the cached value to a number
+    // that DOES NOT match what buildFullMessage would produce; if the
+    // handler fell through to compute, the returned value would differ.
+    const mailWithCache: Partial<MailType> = {
+      ...base,
+      rfc822_size: 999_999_999,
+    };
+    const part = await buildFetchResponsePart(
+      mailWithCache,
+      { type: "RFC822.SIZE" },
+      docId,
+      mailbox
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      expect(part!.content).toBe("RFC822.SIZE 999999999");
+    }
+  });
+
+  it("falls through to compute when rfc822_size is null (not yet populated)", async () => {
+    // The DB stores NULL for rows that haven't been observed yet. Handler
+    // must fall through to the FULL-body compute — reported size matches
+    // what BODY[] would emit.
+    const mailNoCache: Partial<MailType> = {
+      ...base,
+      rfc822_size: null,
+    };
+    const size = await buildFetchResponsePart(
+      mailNoCache,
+      { type: "RFC822.SIZE" },
+      docId,
+      mailbox
+      // userId omitted intentionally — persist step is fire-and-forget
+      // and skipped without a userId; the fetch response is independent
+      // of the persist outcome.
+    );
+    const body = await buildFetchResponsePart(
+      mailNoCache,
+      { type: "BODY", peek: true, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(size!.type).toBe("simple");
+    expect(body!.type).toBe("literal");
+    if (size!.type === "simple" && body!.type === "literal") {
+      const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
+      expect(reported).toBe(body!.length);
+    }
+  });
+
+  it("falls through to compute when rfc822_size is absent (field not projected)", async () => {
+    // Symmetric with the null case but for callers whose SELECT didn't
+    // include `rfc822_size` (e.g. a FETCH that only asked for FLAGS but
+    // downstream code still routes through buildFetchResponsePart with a
+    // partial mail). typeof undefined !== 'number' guards this branch.
+    const mailNoField: Partial<MailType> = { ...base };
+    delete (mailNoField as { rfc822_size?: number | null }).rfc822_size;
+    const size = await buildFetchResponsePart(
+      mailNoField,
+      { type: "RFC822.SIZE" },
+      docId,
+      mailbox
+    );
+    expect(size!.type).toBe("simple");
+    if (size!.type === "simple") {
+      expect(size!.content.startsWith("RFC822.SIZE ")).toBe(true);
+      const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
+      // Non-zero — the compute path actually ran.
+      expect(reported).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe("buildBodyResponsePart header terminators (inbox #645)", () => {

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -29,6 +29,7 @@ import {
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
 import { withBodyBudget } from "./body-budget";
+import { updateRfc822Size } from "../postgres/repositories/mails/core";
 // `getSharedBodyResult` already budget-gates INSIDE its singleflight
 // closure so coalesced callers share one slot (see body-buffer.ts +
 // hoiekim/inbox#726 / #727). The `withBodyBudget` import here is used
@@ -176,9 +177,14 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<keyof MailTy
       // RFC822.SIZE is derived from the full-message serializer (it must equal
       // len(BODY[]) per §2.3.4), so it needs every column that serializer
       // reads — headers included, not just the body parts. Request the same
-      // columns a FULL body fetch does.
+      // columns a FULL body fetch does. Also request `rfc822_size` (nullable
+      // cached column) so the fetch handler can short-circuit — a hit skips
+      // buildFullMessage entirely, saving the ~100MB attachment materialization
+      // per request (see #729 K836 spike). The body columns stay in the
+      // projection for the fallback path (first observation of a mail).
       case "RFC822.SIZE":
         addBodyFields({ type: "BODY", peek: true, section: { type: "FULL" } }, fields);
+        fields.add("rfc822_size" as keyof MailType);
         break;
 
       // RFC822* alias the matching BODY[...] sections (§6.4.5); request the
@@ -417,7 +423,8 @@ export async function buildFetchResponsePart(
   mail: Partial<MailType>,
   item: FetchDataItem,
   docId: string,
-  selectedMailbox: string
+  selectedMailbox: string,
+  userId?: string
 ): Promise<FetchResponsePart | null> {
   switch (item.type) {
     case "UID": {
@@ -440,12 +447,26 @@ export async function buildFetchResponsePart(
     case "RFC822.SIZE": {
       // RFC 3501 §2.3.4: RFC822.SIZE is the octet count of the message in RFC
       // 2822 format — i.e. it must equal the number of octets BODY[] / RFC822
-      // returns for the same message. Deriving it from the same FULL-body
-      // serializer BODY[] uses (buildBodyResponsePart) makes the two agree by
-      // construction, including the RFC-2822 header block, all MIME framing,
-      // and the exact base64 encoding of every part. The previous ad-hoc
-      // formula summed only the base64 body parts (no headers, no boundaries),
-      // so it under-reported and drifted from BODY[] in both directions.
+      // returns for the same message.
+      //
+      // Two-path resolution:
+      //  1. **Cached column hit** — `mails.rfc822_size` is a nullable BIGINT
+      //     stamped on first observation. When present, return it verbatim:
+      //     no buildFullMessage, no attachment materialization, no ~100MB
+      //     transient allocation per request. This is the K836-spike fix in
+      //     #729 — a metadata-scan fetch (`UID FETCH X (UID RFC822.SIZE
+      //     BODYSTRUCTURE)`) becomes an in-memory number lookup for
+      //     already-observed mails.
+      //  2. **Fallback compute + persist** — for mails that haven't been
+      //     observed yet (cold rows from before this PR, or brand-new
+      //     inserts), derive via buildBodyResponsePart (same FULL-body
+      //     serializer BODY[] uses, so the two agree by construction) and
+      //     write the result back to the row. The write is fire-and-forget
+      //     (`.catch(logger.warn)` — the FETCH response doesn't wait for
+      //     the persist round-trip).
+      if (typeof mail.rfc822_size === "number") {
+        return { type: "simple", content: `RFC822.SIZE ${mail.rfc822_size}` };
+      }
       const fullBody = await buildBodyResponsePart(
         mail,
         { type: "BODY", peek: true, section: { type: "FULL" } },
@@ -453,6 +474,22 @@ export async function buildFetchResponsePart(
         selectedMailbox
       );
       const size = fullBody?.type === "literal" ? fullBody.length : 0;
+      // Persist for future requests. `userId` is threaded from the
+      // top-level FETCH handler (buildFetchResponse → buildFetchResponsePart)
+      // — the mail row itself doesn't expose user_id on the client-facing
+      // MailType. Fire-and-forget: a persist failure surfaces as a log line
+      // and the same fetch re-computes next time; nothing is broken.
+      // Callers without a userId (unit-test callers, internal fetchers)
+      // skip the persist step silently.
+      if (userId) {
+        void updateRfc822Size(userId, docId, size).catch((err) => {
+          logger.warn("Failed to persist rfc822_size", {
+            component: "imap.fetch",
+            mail_id: docId,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        });
+      }
       return { type: "simple", content: `RFC822.SIZE ${size}` };
     }
 
@@ -514,7 +551,8 @@ export async function buildFetchResponse(
   uid: number,
   isUidFetch: boolean,
   selectedMailbox: string,
-  condstoreEnabled: boolean = false
+  condstoreEnabled: boolean = false,
+  userId?: string
 ): Promise<FetchResponsePart[]> {
   const parts: FetchResponsePart[] = [];
 
@@ -528,7 +566,7 @@ export async function buildFetchResponse(
     // this dedups an explicit `(MODSEQ)` request against the implicit
     // post-ENABLE emission and keeps a single `MODSEQ (n)` in the response.
     if (item.type === "MODSEQ") continue;
-    const part = await buildFetchResponsePart(mail, item, docId, selectedMailbox);
+    const part = await buildFetchResponsePart(mail, item, docId, selectedMailbox, userId);
     if (part) parts.push(part);
   }
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -206,7 +206,8 @@ async function _processFetchMessages(
         uid,
         isUidFetch,
         selectedMailbox,
-        condstoreEnabled
+        condstoreEnabled,
+        store.getUser().id
       );
       await writeFetchResponse(write, writeChunked, seqNum, response);
 

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -428,6 +428,15 @@ export class Store {
         if (model.modseq !== undefined) {
           mail.modseq = model.modseq;
         }
+        // rfc822_size: cached BODY[] byte count. `null` on the DB row means
+        // "not computed yet"; `undefined` on the model means "not
+        // requested" (getRequestedFields didn't add it, e.g. FLAGS-only
+        // fetch). Preserve both — the RFC822.SIZE fetch handler
+        // distinguishes stored-value hit (typeof === 'number') from
+        // fall-through (compute + persist).
+        if (model.rfc822_size !== undefined) {
+          mail.rfc822_size = model.rfc822_size;
+        }
 
         if (model.from_address) {
           mail.from = {

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -70,6 +70,15 @@ export const LAST_UID = "last_uid";
 export const SPAM_SCORE = "spam_score";
 export const SPAM_REASONS = "spam_reasons";
 export const IS_SPAM = "is_spam";
+// Cached byte count of the mail's serialized RFC 822 form. Populated
+// lazily on the first FETCH that requests RFC822.SIZE (or an equivalent
+// full-body derivation) and never invalidated — mail body content
+// (text/html/attachments/headers) is immutable after insert, so the
+// size is a stable derived value. `NULL` means "not yet computed";
+// readers fall back to the on-the-fly `buildFullMessage` compute and
+// persist the result. Motivates: avoid materializing multi-MB
+// attachments per RFC822.SIZE request. See #729.
+export const RFC822_SIZE = "rfc822_size";
 
 // Sessions columns
 export const SESSION_ID = "session_id";

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -34,6 +34,7 @@ import {
   SPAM_SCORE,
   SPAM_REASONS,
   IS_SPAM,
+  RFC822_SIZE,
 } from "./common";
 import { Model, ModelValidationError, createTable, validateObject } from "./base";
 
@@ -82,6 +83,7 @@ export interface MailJSON {
   spam_score: number;
   spam_reasons: string[] | null;
   is_spam: boolean;
+  rfc822_size: number | null;
 }
 
 const mailSchema = {
@@ -123,6 +125,11 @@ const mailSchema = {
   [SPAM_SCORE]: "INTEGER NOT NULL DEFAULT 0",
   [SPAM_REASONS]: "JSONB",
   [IS_SPAM]: "BOOLEAN NOT NULL DEFAULT FALSE",
+  // Nullable — auto-migration ADD COLUMN IF NOT EXISTS stamps existing rows
+  // with NULL, and the read path (fetch-helpers RFC822.SIZE case) computes
+  // + persists on first observation. New rows also start NULL and populate
+  // on their first RFC822.SIZE / RFC822 / BODY[] fetch.
+  [RFC822_SIZE]: "BIGINT",
   [UPDATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
   search_vector: "TSVECTOR",
 };
@@ -163,6 +170,7 @@ export class MailModel extends Model<MailJSON, MailSchema> {
   declare spam_score: number;
   declare spam_reasons: string[] | null;
   declare is_spam: boolean;
+  declare rfc822_size: number | null;
   declare updated: string;
 
   static typeChecker = {
@@ -199,6 +207,8 @@ export class MailModel extends Model<MailJSON, MailSchema> {
     spam_score: isNumber,
     spam_reasons: isNullableArray,
     is_spam: isBoolean,
+    rfc822_size: (v: unknown): v is number | null =>
+      v === null || typeof v === "number",
     updated: isNullableString,
     search_vector: isNullableString,
   };
@@ -242,6 +252,7 @@ export class MailModel extends Model<MailJSON, MailSchema> {
       spam_score: this.spam_score,
       spam_reasons: this.spam_reasons,
       is_spam: this.is_spam,
+      rfc822_size: this.rfc822_size,
     };
   }
 }
@@ -316,6 +327,7 @@ export class PartialMailModel {
   readonly spam_score?: number;
   readonly spam_reasons?: string[] | null;
   readonly is_spam?: boolean;
+  readonly rfc822_size?: number | null;
   readonly updated?: string;
 
   constructor(fields: string[], data: unknown) {

--- a/src/server/lib/postgres/models/models.test.ts
+++ b/src/server/lib/postgres/models/models.test.ts
@@ -63,6 +63,7 @@ function makeMailData(overrides: Record<string, unknown> = {}): Record<string, u
     spam_score: 0,
     spam_reasons: null,
     is_spam: false,
+    rfc822_size: null,
     updated: "2024-01-01T00:00:00+00:00",
     search_vector: null,
     ...overrides,

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -2,7 +2,7 @@ import crypto from "crypto";
 import { logger } from "../../../logger";
 import { pool } from "../../client";
 import { ParamValue } from "../../database";
-import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO, DB_NOW } from "../../models";
+import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO, DB_NOW, RFC822_SIZE } from "../../models";
 import { getNextModseq, writeMailboxUid } from "./counters";
 
 export interface SaveMailInput {
@@ -229,6 +229,34 @@ export const getMailById = async (
     logger.error("Failed to get mail by ID", {}, error);
     return null;
   }
+};
+
+/**
+ * Persist the derived `rfc822_size` for a mail on the first FETCH that
+ * computes it. Deliberately does NOT bump `updated` — this is metadata
+ * derivation, not a semantic edit; touching `updated` would trip the
+ * CONDSTORE/HIGHESTMODSEQ change-tracking that clients use to detect
+ * real mail mutations, generating spurious wake-ups on every first-observation.
+ *
+ * Idempotent: mail body content (text/html/attachments/headers) is
+ * immutable after insert, so the derived size is stable; concurrent
+ * callers writing the same value is a no-op collision. Deliberately
+ * unconditional — a `WHERE rfc822_size IS NULL` guard would race with
+ * a parallel writer for the same mail, and the same-value write is
+ * cheap.
+ *
+ * Fire-and-forget from the caller: a failure here logs but does not
+ * fail the FETCH response.
+ */
+export const updateRfc822Size = async (
+  user_id: string,
+  mail_id: string,
+  rfc822_size: number
+): Promise<void> => {
+  await mailsTable.updateWhere(
+    { [MAIL_ID]: mail_id, [USER_ID]: user_id },
+    { [RFC822_SIZE]: rfc822_size }
+  );
 };
 
 export const markMailRead = async (


### PR DESCRIPTION
Companion to #730. Together they close both OOM classes surfaced in #729.

## Problem

Same OOM arc as #730 (TTL body-buffer cache), the OTHER class: K836-style metadata-scan fetches `UID FETCH X (UID RFC822.SIZE BODYSTRUCTURE)` allocate ~+66MB per batch because `RFC822.SIZE` computes its value by calling \`buildBodyResponsePart\` for the FULL body — loading every attachment into memory and base64-encoding it, just to report the resulting octet count.

iOS Mail issues one of these for every mail in every mailbox on every sync. A lot of wasted work — and the wasted work is exactly the OOM-inducing allocation.

## Fix

Persist the derived RFC822.SIZE on `mails.rfc822_size` (nullable BIGINT) on the FIRST fetch that computes it. Subsequent RFC822.SIZE requests read the cached column — no `buildFullMessage`, no attachment materialization, no allocation.

### Read path (fetch-helpers RFC822.SIZE case)

Two paths:
1. **Cached column hit** (`typeof mail.rfc822_size === "number"`) → return the stored value verbatim. No compute, no allocation.
2. **Fallback** — derive via `buildBodyResponsePart` (same FULL-body serializer BODY[] uses, so RFC 3501 §2.3.4's "SIZE equals BODY[] byte count" invariant holds by construction). Fire-and-forget UPDATE persists the computed value; a persist failure logs a warning but doesn't fail the fetch response.

### Write path

**Untouched.** Mail body content (text/html/attachments/headers) is immutable after insert — grep of the mails repository confirms only `saveMail` writes these fields; every other write path modifies flags/spam/deleted/etc. So the derived size is stable per-mail forever after first observation. No invalidation on flag updates, STORE, EXPUNGE, MOVE, spam re-scoring, etc.

### Schema

- `mails.rfc822_size BIGINT` (nullable). Auto-migration `ADD COLUMN IF NOT EXISTS` stamps existing rows with NULL; the read path fills them lazily on first observation.

### `user_id` threading

`buildFetchResponse` and `buildFetchResponsePart` gain an optional `userId` param, threaded from `message-ops.ts` (`store.getUser().id`). Optional so unit-test callers and internal fetchers (which don't run the persist branch) don't need to provide it.

## Interaction with #730 (TTL body-buffer cache)

Complementary — closes both OOM classes surfaced in #729:

- **K836 metadata-scan spike** (this PR): first fetch materializes the body once; every subsequent RFC822.SIZE fetch reads the column. Steady-state metadata sync becomes free.
- **K842 / K843 sequential BODY[] retry spike** (#730): the actual body Buffer stays cached for `IMAP_BODY_BUFFER_TTL_MS` so iOS's abort-and-retry sequence reuses it instead of paying ~100MB twice.

Neither PR blocks the other; both can land independently.

## Backfill

Not in this PR. Lazy-populate covers existing rows on their first FETCH. If we want to eliminate the "first fetch pays the cost" tail entirely, a one-off backfill script can walk the table and pre-populate offline — worth a separate follow-up.

## Test coverage additions

- **Cached-column hit**: `mail.rfc822_size = 999_999_999` → response is exactly `RFC822.SIZE 999999999`. Proves `buildFullMessage` is NOT called (the value doesn't match what compute would produce).
- **Cached-column miss (null)**: falls through to compute; reported size equals `BODY[].length` for the same mail — the existing #654 invariant is preserved.
- **Cached-column absent (field not projected)**: symmetric — the `typeof !== "number"` guard covers `undefined`.
- MailModel construction test fixture updated with `rfc822_size: null`.
- `getRequestedFields` test asserts the new set is a STRICT SUPERSET of BODY[]'s (one extra column, `rfc822_size`).

`bun test src/server` → **1363 pass / 0 fail** (was 1360; +3 new short-circuit tests).
`bunx tsc --noEmit` → clean.

## Test plan

- [ ] After deploy, cold-observe a mail via `UID FETCH n (UID RFC822.SIZE)` — first fetch spikes RSS (buildFullMessage runs), stores the size async.
- [ ] Repeat the same fetch — RSS delta is ~0 (cached column hit).
- [ ] `SELECT COUNT(*) FROM mails WHERE rfc822_size IS NOT NULL` grows over time as mails get their first observation.
- [ ] Under an iOS Mail sync that issues K836-style metadata scans across all mailboxes, RSS spike is proportional to NEWLY-observed mails only — not proportional to total inbox size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)