### PR TITLE
perf(imap): true stream-to-socket for BODY[] / RFC822 (#729)

### DIFF
--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -107,6 +107,31 @@ export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
   }
 };
 
+/**
+ * Hold a budget slot for the whole lifetime of a stream.
+ *
+ * The streaming BODY[] path is the LARGEST fetch shape, so it must be inside
+ * the same bound as the materializing paths — otherwise K concurrent sockets
+ * each stream a distinct large body with no cap and the budget covers only the
+ * cheaper shapes. `withBodyBudget` cannot express this: it releases when its
+ * promise settles, which for a generator is before the consumer has read a
+ * single chunk.
+ *
+ * The slot is released in `finally`, which a generator runs on completion, on
+ * throw, AND when the consumer abandons it early (`for await` breaking on a
+ * dead socket calls `.return()`), so an aborted FETCH cannot leak a slot.
+ */
+export const withBodyBudgetStream = async function* <T>(
+  makeStream: () => AsyncIterable<T>
+): AsyncGenerator<T, void, unknown> {
+  await acquire();
+  try {
+    yield* makeStream();
+  } finally {
+    release();
+  }
+};
+
 /** Exposed for tests. */
 export const _resetBodyBudget = (): void => {
   inFlight = 0;

--- a/src/server/lib/imap/chunked-write.ts
+++ b/src/server/lib/imap/chunked-write.ts
@@ -31,6 +31,58 @@ export interface ChunkedWriteSocket extends EventEmitter {
 
 export const CHUNK_BYTES = 64 * 1024; // matches typical TCP high-water mark
 
+/**
+ * Consume an async iterable of `Buffer` chunks and write each to the
+ * socket with the same backpressure discipline as `writeChunkedToSocket`
+ * (await `drain` when `socket.write` reports its high-water mark).
+ *
+ * Distinct from `writeChunkedToSocket` because the source is a stream
+ * (produced by `buildFullMessageStream` for BODY[] fetches) rather than
+ * a pre-materialized Buffer: chunk boundaries are determined by the
+ * producer, not by fixed CHUNK_BYTES slicing. Producer is expected to
+ * yield chunks in the CHUNK_BYTES ballpark so socket writes align
+ * naturally with the high-water mark.
+ *
+ * Same close-during-drain guard as writeChunkedToSocket: if the socket
+ * dies mid-write, return early with the partial count instead of
+ * hanging on a drain that will never fire.
+ */
+export const writeStreamToSocket = async (
+  socket: ChunkedWriteSocket,
+  chunks: AsyncIterable<Buffer>,
+  onError: (err: unknown) => void
+): Promise<number> => {
+  if (socket.destroyed || !socket.writable) return 0;
+  let written = 0;
+  for await (const chunk of chunks) {
+    if (socket.destroyed || !socket.writable) return written;
+    let ok: boolean;
+    try {
+      ok = socket.write(chunk as unknown as Uint8Array);
+    } catch (error) {
+      onError(error);
+      return written;
+    }
+    written += chunk.byteLength;
+    if (!ok) {
+      await new Promise<void>((resolve) => {
+        const onDrain = () => {
+          socket.off("close", onClose);
+          resolve();
+        };
+        const onClose = () => {
+          socket.off("drain", onDrain);
+          resolve();
+        };
+        socket.once("drain", onDrain);
+        socket.once("close", onClose);
+      });
+      if (socket.destroyed || !socket.writable) return written;
+    }
+  }
+  return written;
+};
+
 export const writeChunkedToSocket = async (
   socket: ChunkedWriteSocket,
   payload: Buffer,

--- a/src/server/lib/imap/condstore.test.ts
+++ b/src/server/lib/imap/condstore.test.ts
@@ -480,6 +480,9 @@ const runFetch = async (
     async (payload: Buffer) => {
       lines.push(payload.toString("utf8"));
     },
+    async (chunks: AsyncIterable<Buffer>) => {
+      for await (const chunk of chunks) lines.push(chunk.toString("utf8"));
+    },
     condstoreEnabled
   );
   return { captured, out: lines.join("") };

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -546,6 +546,45 @@ describe("BODY[] {N} holds when the attachment file disagrees with the mail row"
     expect(decodePart(wire, "a.bin").equals(original)).toBe(true);
   });
 
+  it("segment list is built ONCE per BODY[] fetch — length + stream cannot desync (#733 reviewoie HIGH)", async () => {
+    // Reproduces the reviewoie HIGH: previously buildFullMessageStream
+    // rebuilt segments independently from computeFullMessageSize, so each
+    // pass ran its own `fs.statSync` on the attachment. If the file
+    // grew between the two stats, `{N}` (from the first) < emitted bytes
+    // (from the second), corrupting the wire literal — reviewoie
+    // reproduced "declared 1833, emitted 67165".
+    //
+    // The fix hoists `buildMessageSegments` to `buildBodyResponsePart`
+    // so ONE list drives both measurement and emit. This test proves it
+    // by growing the file AFTER the fetch part is constructed (which
+    // freezes the segment list) but BEFORE the stream drains — before
+    // the fix, the stream would `stat` the grown file and emit more
+    // bytes than declared. After the fix, the emit is clamped by the
+    // segment's stored `rawSize`.
+    const id = "att-grows-mid-fetch";
+    const initial = Buffer.alloc(1024, 7);
+    writeAttachment(id, initial);
+    const mail = withAttachment(id, 1024);
+    const part = await buildFetchResponsePart(
+      mail,
+      { type: "BODY", peek: true, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(part!.type).toBe("stream");
+    if (part!.type !== "stream") throw new Error("shape");
+    const declared = part.length;
+
+    // Grow the file well past the initial size. If segments were
+    // re-built inside the stream, this would leak into the emit.
+    const grown = Buffer.alloc(64 * 1024, 9);
+    fs.writeFileSync(attachmentPath(id), grown);
+
+    let emitted = 0;
+    for await (const chunk of part.stream) emitted += chunk.byteLength;
+    expect(emitted).toBe(declared);
+  });
+
   it("stored size zero (Attachment ctor default for a falsy incoming size)", async () => {
     const id = "att-zero";
     const original = Buffer.alloc(50_000, 3);

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -9,18 +9,42 @@
  *    seq/UID range like `3:1` must resolve the same as `1:3` (RFC 3501 §9).
  */
 
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, afterAll } from "bun:test";
+import fs from "node:fs";
+import {
+  ATTACHMENT_FOLDER,
+  getAttachmentFilePath,
+  getAttachment
+} from "../mails/util";
 
-// fetch-helpers only pulls `logger` from the server barrel; stub it so the
-// import does not drag in the full server (DB, etc.).
+// Stub the server barrel so the import does not drag in the full server (DB,
+// etc.). `mock.module` is process-global in Bun and reaches the leaf module the
+// barrel re-exports, so the attachment helpers are forwarded VERBATIM rather
+// than redirected — swapping ATTACHMENT_FOLDER for a temp dir here broke
+// mails/util.test.ts's constant assertions in the same run.
 mock.module("server", () => ({
   logger: {
     warn: mock(() => {}),
     error: mock(() => {}),
     info: mock(() => {}),
     debug: mock(() => {})
-  }
+  },
+  ATTACHMENT_FOLDER,
+  getAttachmentFilePath,
+  getAttachment
 }));
+
+// Attachment bodies are measured (stat) and read from the same path, so these
+// tests write real files under the real folder and remove exactly those.
+const TEST_ID_PREFIX = "fetch-helpers-test-";
+const attachmentPath = (id: string) => getAttachmentFilePath(TEST_ID_PREFIX + id);
+const writtenIds = new Set<string>();
+const writeAttachment = (id: string, data: Buffer): Buffer => {
+  fs.mkdirSync(ATTACHMENT_FOLDER, { recursive: true });
+  fs.writeFileSync(attachmentPath(id), data);
+  writtenIds.add(id);
+  return data;
+};
 
 import {
   getRequestedFields,
@@ -31,7 +55,16 @@ import {
 } from "./fetch-helpers";
 import { formatEnvelope } from "./util";
 import { BodyFetch, SequenceSet } from "./types";
+import {
+  withBodyBudget,
+  bodyBudgetCapacity,
+  _resetBodyBudget
+} from "./body-budget";
 import type { MailType } from "common";
+
+afterAll(() => {
+  for (const id of writtenIds) fs.rmSync(attachmentPath(id), { force: true });
+});
 
 // Wire content is `string | Buffer` — large non-partial body payloads flow
 // through the shared body-buffer cache and land as Buffer. Every test in
@@ -218,7 +251,7 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
     );
     expect(rfc).not.toBeNull();
     // Both RFC822 and BODY[] FULL route through the stream part after
-    // #733; length + wire bytes match, header label differs.
+    // Length + wire bytes match; only the header label differs.
     expect(rfc!.type === "stream" || rfc!.type === "literal").toBe(true);
     expect(body!.type === "stream" || body!.type === "literal").toBe(true);
     if (
@@ -371,7 +404,7 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
   ];
 
   for (const [label, mail] of shapes) {
-    it(`RFC822.SIZE equals BODY[] length for ${label}`, async () => {
+    it(`RFC822.SIZE equals the octets BODY[] actually emits for ${label}`, async () => {
       const size = await buildFetchResponsePart(
         mail,
         { type: "RFC822.SIZE" },
@@ -385,27 +418,251 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
         mailbox
       );
       expect(size!.type).toBe("simple");
-      // BODY[] FULL now routes through the stream part (peak allocation
-      // stays sub-MB regardless of body size — see #733). The RFC822.SIZE
-      // invariant is unchanged: `computeFullMessageSize` (backing SIZE)
-      // and `buildFullMessageStream` (backing BODY[]) share the same
-      // per-part byte-length math by construction.
-      expect(body!.type === "stream" || body!.type === "literal").toBe(true);
-      if (
-        size!.type === "simple" &&
-        (body!.type === "literal" || body!.type === "stream")
-      ) {
-        const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
-        expect(reported).toBe(body!.length);
-      }
+      // A FULL section is deterministically a stream part; accepting "literal"
+      // here would also pass if the branch silently fell back, which is the
+      // regression most worth catching.
+      expect(body!.type).toBe("stream");
+      if (size!.type !== "simple" || body!.type !== "stream") return;
+
+      const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
+      expect(reported).toBe(body!.length);
+
+      // The load-bearing assertion. Comparing `reported` to `body.length` alone
+      // is a tautology — both read `computeFullMessageSize`. Only draining the
+      // generator proves the `{N}` literal matches the octets that arrive; a
+      // mismatch desyncs every later response on the connection.
+      let emitted = 0;
+      for await (const chunk of body!.stream) emitted += chunk.byteLength;
+      expect(emitted).toBe(reported);
     });
   }
 });
 
-describe("buildFetchResponsePart BODY[] streams without materializing (#733)", () => {
-  // #733 replaces the shared-Buffer path for FULL sections with an async
-  // generator that yields Buffer chunks straight to the writer. Peak
-  // transient allocation stays sub-MB regardless of body size.
+describe("BODY[] {N} holds when the attachment file disagrees with the mail row", () => {
+  // The shapes above all have stored sizes that happen to match. These are the
+  // ones that diverge: the literal count is advertised before a single byte is
+  // read, so anything derived from the stored `size` while the payload comes
+  // from disk can desync the stream.
+  const docId = "doc-divergent";
+  const mailbox = "INBOX";
+  const base = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<divergent@local>",
+    date: new Date("2026-07-30T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "divergent",
+    text: "see attached",
+    html: ""
+  };
+
+  /** attachments field for an already-prefixed attachment id. */
+  const attList = (prefixedId: string) => ({
+    attachments: [
+      {
+        filename: "a.bin",
+        contentType: "application/octet-stream",
+        size: 60_000,
+        content: { data: prefixedId }
+      }
+    ] as unknown as MailType["attachments"]
+  });
+
+  const withAttachment = (id: string, storedSize: number): Partial<MailType> => ({
+    ...base,
+    attachments: [
+      {
+        filename: "a.bin",
+        contentType: "application/octet-stream",
+        size: storedSize,
+        content: { data: TEST_ID_PREFIX + id }
+      }
+    ] as unknown as MailType["attachments"]
+  });
+
+  /** The base64 payload the wire carried for `filename`, decoded. */
+  const decodePart = (wire: string, filename: string): Buffer => {
+    const marker = `filename="${filename}"\r\n\r\n`;
+    const start = wire.indexOf(marker);
+    if (start === -1) throw new Error(`part ${filename} not on the wire`);
+    const from = start + marker.length;
+    const end = wire.indexOf("\r\n--", from);
+    return Buffer.from(wire.slice(from, end === -1 ? undefined : end), "base64");
+  };
+
+  const drain = async (mail: Partial<MailType>) => {
+    const size = await buildFetchResponsePart(mail, { type: "RFC822.SIZE" }, docId, mailbox);
+    const body = await buildFetchResponsePart(
+      mail,
+      { type: "BODY", peek: true, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(size!.type).toBe("simple");
+    expect(body!.type).toBe("stream");
+    if (size!.type !== "simple" || body!.type !== "stream") throw new Error("shape");
+    const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
+    const parts: Buffer[] = [];
+    let emitted = 0;
+    for await (const chunk of body!.stream) {
+      emitted += chunk.byteLength;
+      parts.push(Buffer.from(chunk));
+    }
+    const wire = Buffer.concat(parts).toString("utf8");
+    return { reported, declared: body!.length, emitted, wire };
+  };
+
+  it("stored size LARGER than the file on disk", async () => {
+    const id = "att-too-big";
+    const original = Buffer.alloc(1024, 7);
+    writeAttachment(id, original);
+    const { reported, declared, emitted, wire } = await drain(withAttachment(id, 999_999));
+    expect(emitted).toBe(reported);
+    expect(emitted).toBe(declared);
+    // The count holding is not enough: measuring the stored size while emitting
+    // the file pads the payload out to a size the attachment never had, so the
+    // client decodes a corrupt attachment. The size must follow the file.
+    expect(decodePart(wire, "a.bin").equals(original)).toBe(true);
+  });
+
+  it("stored size SMALLER than the file on disk", async () => {
+    const id = "att-too-small";
+    const original = Buffer.alloc(200_000, 9);
+    writeAttachment(id, original);
+    const { reported, declared, emitted, wire } = await drain(withAttachment(id, 11));
+    expect(emitted).toBe(reported);
+    expect(emitted).toBe(declared);
+    // Understating the size truncates the attachment mid-stream.
+    expect(decodePart(wire, "a.bin").equals(original)).toBe(true);
+  });
+
+  it("stored size zero (Attachment ctor default for a falsy incoming size)", async () => {
+    const id = "att-zero";
+    const original = Buffer.alloc(50_000, 3);
+    writeAttachment(id, original);
+    const { reported, emitted, wire } = await drain(withAttachment(id, 0));
+    expect(emitted).toBe(reported);
+    expect(decodePart(wire, "a.bin").equals(original)).toBe(true);
+  });
+
+  it("attachment file missing entirely", async () => {
+    const { reported, declared, emitted } = await drain(
+      withAttachment("att-does-not-exist", 1_398_738)
+    );
+    expect(emitted).toBe(reported);
+    expect(emitted).toBe(declared);
+    expect(Number.isFinite(reported)).toBe(true);
+  });
+
+  it("stored size undefined does not advertise NaN", async () => {
+    const id = "att-undef-size";
+    writeAttachment(id, Buffer.alloc(4096, 1));
+    const mail: Partial<MailType> = {
+      ...base,
+      attachments: [
+        {
+          filename: "a.bin",
+          contentType: "application/octet-stream",
+          content: { data: TEST_ID_PREFIX + id }
+        }
+      ] as unknown as MailType["attachments"]
+    };
+    const { reported, emitted, wire } = await drain(mail);
+    expect(Number.isNaN(reported)).toBe(false);
+    expect(emitted).toBe(reported);
+    expect(decodePart(wire, "a.bin").equals(Buffer.alloc(4096, 1))).toBe(true);
+  });
+
+  it("multiple attachments, mixed present and missing", async () => {
+    const present = "att-multi-present";
+    writeAttachment(present, Buffer.alloc(120_000, 5));
+    const mail: Partial<MailType> = {
+      ...base,
+      attachments: [
+        {
+          filename: "present.bin",
+          contentType: "application/octet-stream",
+          size: 120_000,
+          content: { data: TEST_ID_PREFIX + present }
+        },
+        {
+          filename: "gone.bin",
+          contentType: "application/octet-stream",
+          size: 777_777,
+          content: { data: TEST_ID_PREFIX + "att-multi-missing" }
+        }
+      ] as unknown as MailType["attachments"]
+    };
+    const { reported, emitted, wire } = await drain(mail);
+    expect(emitted).toBe(reported);
+    expect(decodePart(wire, "present.bin").equals(Buffer.alloc(120_000, 5))).toBe(true);
+  });
+
+  // MED 4 in review: the MIME layout used to be hand-parallel across the
+  // measure/emit/materialize functions, so a shape covered by only one of them
+  // could drift. These walk every branch of the layout with a real file on disk.
+  const layoutShapes: Array<[string, (id: string) => Partial<MailType>]> = [
+    [
+      "text + html + attachment (alternative nested in mixed)",
+      (id) => ({ ...base, text: "plain", html: "<p>rich</p>", ...attList(id) })
+    ],
+    ["html + attachment", (id) => ({ ...base, text: "", html: "<p>rich</p>", ...attList(id) })],
+    ["attachment only", (id) => ({ ...base, text: "", html: "", ...attList(id) })],
+    [
+      "multibyte text + attachment",
+      (id) => ({ ...base, text: "café ☕ 日本語 😀", html: "", ...attList(id) })
+    ]
+  ];
+
+  for (const [label, make] of layoutShapes) {
+    it(`{N} matches emitted octets for ${label}`, async () => {
+      const id = `att-layout-${label.replace(/[^a-z]/gi, "")}`;
+      const original = Buffer.alloc(60_000, 11);
+      writeAttachment(id, original);
+      const { reported, declared, emitted, wire } = await drain(
+        make(TEST_ID_PREFIX + id) as Partial<MailType>
+      );
+      expect(emitted).toBe(reported);
+      expect(emitted).toBe(declared);
+      expect(decodePart(wire, "a.bin").equals(original)).toBe(true);
+    });
+  }
+
+  it("a multi-slice attachment round-trips byte-for-byte", async () => {
+    // A 200 KB attachment crosses several 48 KiB slice boundaries. If the slice
+    // size were not divisible by 3, base64 would inject '=' padding mid-stream
+    // and the decode would not match — corrupting the payload for the client on
+    // top of breaking the ceil(n/3)*4 total the literal advertises.
+    const id = "att-slice-boundary";
+    const original = Buffer.alloc(200_000);
+    for (let i = 0; i < original.length; i += 1) original[i] = i % 251;
+    writeAttachment(id, original);
+
+    const body = await buildFetchResponsePart(
+      withAttachment(id, original.length),
+      { type: "BODY", peek: true, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    if (body?.type !== "stream") throw new Error("expected stream");
+    const parts: Buffer[] = [];
+    for await (const chunk of body.stream) parts.push(Buffer.from(chunk));
+    const wire = Buffer.concat(parts).toString("utf8");
+
+    const marker = `filename="a.bin"\r\n\r\n`;
+    const start = wire.indexOf(marker) + marker.length;
+    const end = wire.indexOf("\r\n--", start);
+    expect(start).toBeGreaterThan(marker.length - 1);
+    expect(end).toBeGreaterThan(start);
+    const encoded = wire.slice(start, end);
+    expect(encoded.length).toBe(Math.ceil(original.length / 3) * 4);
+    expect(Buffer.from(encoded, "base64").equals(original)).toBe(true);
+  });
+});
+
+describe("buildFetchResponsePart BODY[] streams without materializing", () => {
+  // FULL sections yield Buffer chunks straight to the writer, so peak transient
+  // allocation stays bounded by the chunk size rather than the body size.
 
   const docId = "doc-stream";
   const mailbox = "INBOX";
@@ -446,22 +703,111 @@ describe("buildFetchResponsePart BODY[] streams without materializing (#733)", (
     }
   });
 
-  it("stream chunks are individually small (peak-alloc invariant)", async () => {
-    // Not a hard-enforced max but a signal that the producer isn't
-    // materializing the full body into a single Buffer. Any chunk
-    // above ~256 KiB indicates a regression toward monolithic build.
+  it("stream chunks stay small for a LARGE body, not just a small one", async () => {
+    // The previous version of this test used a 10-byte body, so its 256 KiB
+    // ceiling could never fire. Sizing text and html into the megabytes is what
+    // makes the assertion mean anything: an unchunked part yields one Buffer of
+    // ~4/3 the source size and fails here.
+    const large = {
+      ...base,
+      text: "t".repeat(4 * 1024 * 1024),
+      html: `<p>${"h".repeat(4 * 1024 * 1024)}</p>`
+    };
+    const body = await buildFetchResponsePart(
+      large,
+      { type: "BODY", peek: false, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(body!.type).toBe("stream");
+    if (body!.type !== "stream") return;
+
+    const maxChunk = 256 * 1024;
+    let chunks = 0;
+    let biggest = 0;
+    let emitted = 0;
+    for await (const chunk of body!.stream) {
+      chunks += 1;
+      biggest = Math.max(biggest, chunk.byteLength);
+      emitted += chunk.byteLength;
+    }
+    expect(biggest).toBeLessThanOrEqual(maxChunk);
+    expect(chunks).toBeGreaterThan(100);
+    expect(emitted).toBe(body!.length);
+  });
+
+  // The budget tests below deliberately saturate capacity BEFORE starting the
+  // stream. Asserting only "capacity is free after draining" would pass whether
+  // or not the stream ever acquired a slot — the same vacuous shape this file's
+  // size assertions used to have.
+  const saturateAllButOne = () => {
+    const releases: Array<() => void> = [];
+    const held = Array.from({ length: bodyBudgetCapacity() - 1 }, () =>
+      withBodyBudget(() => new Promise<void>((resolve) => releases.push(resolve)))
+    );
+    return { releases, held };
+  };
+
+  const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+  const startStream = async () => {
     const body = await buildFetchResponsePart(
       base,
       { type: "BODY", peek: false, section: { type: "FULL" } },
       docId,
       mailbox
     );
-    if (body?.type === "stream") {
-      const maxChunk = 256 * 1024;
-      for await (const chunk of body.stream) {
-        expect(chunk.byteLength).toBeLessThanOrEqual(maxChunk);
-      }
+    if (body?.type !== "stream") throw new Error("expected stream");
+    const iterator = body.stream[Symbol.asyncIterator]();
+    // The first `next()` is what awaits the budget acquire.
+    await iterator.next();
+    return iterator;
+  };
+
+  it("holds a budget slot while the stream is in flight", async () => {
+    _resetBodyBudget();
+    const { releases, held } = saturateAllButOne();
+    const iterator = await startStream();
+
+    // The stream now owns the last slot, so a further acquire must wait.
+    let extraRan = false;
+    const pending = withBodyBudget(async () => {
+      extraRan = true;
+    });
+    await flush();
+    expect(extraRan).toBe(false);
+
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) break;
     }
+    await pending;
+    expect(extraRan).toBe(true);
+
+    releases.forEach((release) => release());
+    await Promise.all(held);
+  });
+
+  it("releases the slot when the consumer abandons the stream early", async () => {
+    _resetBodyBudget();
+    const { releases, held } = saturateAllButOne();
+    const iterator = await startStream();
+
+    let extraRan = false;
+    const pending = withBodyBudget(async () => {
+      extraRan = true;
+    });
+    await flush();
+    expect(extraRan).toBe(false);
+
+    // Mirrors writeStreamToSocket breaking out on a dead socket: the generator's
+    // finally must run and hand the slot back, or an aborted FETCH leaks it.
+    await iterator.return?.(undefined);
+    await pending;
+    expect(extraRan).toBe(true);
+
+    releases.forEach((release) => release());
+    await Promise.all(held);
   });
 });
 

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -389,6 +389,16 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
         ] as unknown as MailType["attachments"],
       },
     ],
+    // The has-text / has-html predicates use `.trim()` while the emit uses the
+    // untrimmed source, so a whitespace-only part is the shape where a
+    // measure/emit split would show up.
+    ["whitespace-only text", { ...base, text: "   \r\n  ", html: "", attachments: [] }],
+    [
+      "whitespace-only text with real html",
+      { ...base, text: "   ", html: "<p>rich</p>", attachments: [] }
+    ],
+    ["whitespace-only text and html", { ...base, text: "  ", html: "   ", attachments: [] }],
+    ["no body at all", { ...base, text: "", html: "", attachments: [] }],
     // Multibyte UTF-8: octet count != character count, so any path that
     // measured string `.length` instead of `Buffer.byteLength` would diverge.
     [

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -41,6 +41,19 @@ const contentAsString = (
 ): string =>
   Buffer.isBuffer(part.content) ? part.content.toString("utf8") : part.content;
 
+// Stream parts don't materialize a `.content` field — iterate the async
+// generator to collect chunks, concat, and stringify. Tests treat both
+// shapes uniformly; the wire bytes are what matters.
+const contentAsStringAny = async (
+  part: FetchResponsePart
+): Promise<string> => {
+  if (part.type === "simple") return part.content;
+  if (part.type === "literal") return contentAsString(part);
+  const chunks: Buffer[] = [];
+  for await (const chunk of part.stream) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+};
+
 describe("getRequestedFields", () => {
   describe("FLAGS", () => {
     it("requests every flag-backing column, including answered", () => {
@@ -204,9 +217,15 @@ describe("buildFetchResponsePart RFC822 aliases (inbox #587)", () => {
       mailbox
     );
     expect(rfc).not.toBeNull();
-    expect(rfc!.type).toBe("literal");
-    if (rfc!.type === "literal" && body!.type === "literal") {
-      expect(contentAsString(rfc)).toBe(contentAsString(body));
+    // Both RFC822 and BODY[] FULL route through the stream part after
+    // #733; length + wire bytes match, header label differs.
+    expect(rfc!.type === "stream" || rfc!.type === "literal").toBe(true);
+    expect(body!.type === "stream" || body!.type === "literal").toBe(true);
+    if (
+      (rfc!.type === "literal" || rfc!.type === "stream") &&
+      (body!.type === "literal" || body!.type === "stream")
+    ) {
+      expect(await contentAsStringAny(rfc!)).toBe(await contentAsStringAny(body!));
       expect(rfc!.length).toBe(body!.length);
       expect(rfc!.header).toBe("RFC822");
       expect(body!.header).toBe("BODY[]");
@@ -366,13 +385,84 @@ describe("buildFetchResponsePart RFC822.SIZE == BODY[] octet count (inbox #654)"
         mailbox
       );
       expect(size!.type).toBe("simple");
-      expect(body!.type).toBe("literal");
-      if (size!.type === "simple" && body!.type === "literal") {
+      // BODY[] FULL now routes through the stream part (peak allocation
+      // stays sub-MB regardless of body size — see #733). The RFC822.SIZE
+      // invariant is unchanged: `computeFullMessageSize` (backing SIZE)
+      // and `buildFullMessageStream` (backing BODY[]) share the same
+      // per-part byte-length math by construction.
+      expect(body!.type === "stream" || body!.type === "literal").toBe(true);
+      if (
+        size!.type === "simple" &&
+        (body!.type === "literal" || body!.type === "stream")
+      ) {
         const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
         expect(reported).toBe(body!.length);
       }
     });
   }
+});
+
+describe("buildFetchResponsePart BODY[] streams without materializing (#733)", () => {
+  // #733 replaces the shared-Buffer path for FULL sections with an async
+  // generator that yields Buffer chunks straight to the writer. Peak
+  // transient allocation stays sub-MB regardless of body size.
+
+  const docId = "doc-stream";
+  const mailbox = "INBOX";
+  const base = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<stream@local>",
+    date: new Date("2026-07-30T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "stream",
+    text: "plain body",
+    html: "<p>rich body</p>",
+    attachments: [] as unknown as MailType["attachments"],
+  };
+
+  it("BODY[] returns a stream part with pre-computed length", async () => {
+    const body = await buildFetchResponsePart(
+      base,
+      { type: "BODY", peek: false, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    expect(body).not.toBeNull();
+    expect(body!.type).toBe("stream");
+    if (body!.type === "stream") {
+      expect(body!.length).toBeGreaterThan(0);
+      expect(body!.header).toBe("BODY[]");
+      // Sum of chunk byte-lengths equals the declared `length`. Load-
+      // bearing: without this invariant, the IMAP `{N}` literal would
+      // desync from the octet count that arrives, corrupting the wire
+      // response.
+      let seen = 0;
+      for await (const chunk of body!.stream) {
+        expect(Buffer.isBuffer(chunk)).toBe(true);
+        seen += chunk.byteLength;
+      }
+      expect(seen).toBe(body!.length);
+    }
+  });
+
+  it("stream chunks are individually small (peak-alloc invariant)", async () => {
+    // Not a hard-enforced max but a signal that the producer isn't
+    // materializing the full body into a single Buffer. Any chunk
+    // above ~256 KiB indicates a regression toward monolithic build.
+    const body = await buildFetchResponsePart(
+      base,
+      { type: "BODY", peek: false, section: { type: "FULL" } },
+      docId,
+      mailbox
+    );
+    if (body?.type === "stream") {
+      const maxChunk = 256 * 1024;
+      for await (const chunk of body.stream) {
+        expect(chunk.byteLength).toBeLessThanOrEqual(maxChunk);
+      }
+    }
+  });
 });
 
 describe("buildFetchResponsePart RFC822.SIZE cached-column short-circuit (#729)", () => {
@@ -438,8 +528,11 @@ describe("buildFetchResponsePart RFC822.SIZE cached-column short-circuit (#729)"
       mailbox
     );
     expect(size!.type).toBe("simple");
-    expect(body!.type).toBe("literal");
-    if (size!.type === "simple" && body!.type === "literal") {
+    expect(body!.type === "stream" || body!.type === "literal").toBe(true);
+    if (
+      size!.type === "simple" &&
+      (body!.type === "literal" || body!.type === "stream")
+    ) {
       const reported = Number(size!.content.replace("RFC822.SIZE ", ""));
       expect(reported).toBe(body!.length);
     }

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -18,6 +18,8 @@ import {
 import {
   applyPartialFetch,
   buildFullMessage,
+  buildFullMessageStream,
+  computeFullMessageSize,
   getBodyPart,
   getBodyPartHeaders,
   getBodySectionKey,
@@ -46,9 +48,23 @@ import { updateRfc822Size } from "../postgres/repositories/mails/core";
 // cache — one Buffer reference is shared across every coalesced FETCH
 // handler for the same (mail, section), so heap footprint stays flat under
 // duplicate-FETCH storms. See `body-buffer.ts`.
+//
+// **stream** variant: BODY[] / RFC822 for a fetch that streams its bytes
+// directly to the socket via `buildFullMessageStream`, never materializing
+// the full body in memory. `length` is pre-computed by
+// `computeFullMessageSize` (pure math on stored attachment sizes — no
+// disk I/O) so the writer can advertise `{N}` before the first chunk
+// yields. Sum of yielded chunk byte-lengths equals `length` by
+// construction (parallel case blocks in the two functions).
 export type FetchResponsePart =
   | { type: "simple"; content: string }
-  | { type: "literal"; content: string | Buffer; header: string; length: number };
+  | { type: "literal"; content: string | Buffer; header: string; length: number }
+  | {
+      type: "stream";
+      stream: AsyncIterable<Buffer>;
+      header: string;
+      length: number;
+    };
 
 // ---------------------------------------------------------------------------
 // Body content extraction
@@ -347,10 +363,47 @@ export async function buildBodyResponsePart(
   //    matches the emitted octets — building the CRLF per caller after
   //    the cache would defeat the coalescing entirely for the wire
   //    check).
+  // FULL section (BODY[] / RFC822): stream the body directly to the
+  // socket. `computeFullMessageSize` pre-computes the `{N}` literal
+  // from stored attachment sizes (no disk I/O) so the writer can
+  // advertise the length before the first chunk yields. The stream
+  // itself materializes only ONE 48 KiB base64 slice at a time — peak
+  // transient allocation stays sub-MB regardless of body size.
+  //
+  // Skips the shared body-buffer cache path (getSharedBodyResult):
+  // streaming makes each build cheap enough that caching gives no RSS
+  // win. iOS Mail's abort-and-retry pattern (#729 K843) that motivated
+  // the TTL cache in #730 becomes a re-stream from disk instead of a
+  // re-materialization of a multi-MB string — orders of magnitude
+  // cheaper either way. Cache is retained for TEXT / HEADER / partial
+  // paths that still go through `getSharedBodyResult`.
+  if (!partial && !isHeaderLikeSection(section) && section.type === "FULL") {
+    // `computeFullMessageSize` includes the trailing CRLF the wire
+    // response appends (matches the pre-#733 shape where
+    // `getSharedBodyResult`'s closure emitted `text + "\r\n"` before
+    // caching). The stream must emit the same trailer or the {N}
+    // literal won't match the byte count that arrives — hence the
+    // extra `\r\n` chunk after the generator finishes.
+    const length = computeFullMessageSize(mail, docId);
+    async function* streamWithTrailer(): AsyncGenerator<Buffer, void, unknown> {
+      for await (const chunk of buildFullMessageStream(mail, docId)) {
+        yield chunk;
+      }
+      yield Buffer.from("\r\n", "utf8");
+    }
+    return {
+      type: "stream",
+      stream: streamWithTrailer(),
+      header: sectionKey,
+      length,
+    };
+  }
+
   if (!partial && !isHeaderLikeSection(section)) {
-    // Route through the shared body-buffer cache; getSharedBodyResult
-    // gates its build closure with `withBodyBudget` INSIDE the
-    // singleflight so N coalesced callers share one budget slot.
+    // Non-FULL, non-partial, non-header-like sections (currently
+    // TEXT / MIME_PART body): route through the shared body-buffer
+    // cache. TEXT is bounded by html+text size (rarely large); the
+    // cache still earns its keep here on repeated FETCH BODY[TEXT].
     const cached = await getSharedBodyResult(
       bodyBufferKey(docId, sectionKey),
       () => {
@@ -449,38 +502,28 @@ export async function buildFetchResponsePart(
       // 2822 format — i.e. it must equal the number of octets BODY[] / RFC822
       // returns for the same message.
       //
-      // Two-path resolution:
+      // Three-path resolution:
       //  1. **Cached column hit** — `mails.rfc822_size` is a nullable BIGINT
-      //     stamped on first observation. When present, return it verbatim:
-      //     no buildFullMessage, no attachment materialization, no ~100MB
-      //     transient allocation per request. This is the K836-spike fix in
-      //     #729 — a metadata-scan fetch (`UID FETCH X (UID RFC822.SIZE
-      //     BODYSTRUCTURE)`) becomes an in-memory number lookup for
-      //     already-observed mails.
-      //  2. **Fallback compute + persist** — for mails that haven't been
-      //     observed yet (cold rows from before this PR, or brand-new
-      //     inserts), derive via buildBodyResponsePart (same FULL-body
-      //     serializer BODY[] uses, so the two agree by construction) and
-      //     write the result back to the row. The write is fire-and-forget
-      //     (`.catch(logger.warn)` — the FETCH response doesn't wait for
-      //     the persist round-trip).
+      //     stamped on first observation (#731). When present, return it
+      //     verbatim: zero work.
+      //  2. **Compute + persist** — for mails that haven't been observed
+      //     yet, derive via `computeFullMessageSize` (pure math on stored
+      //     attachment sizes — no disk read, no body materialization). The
+      //     value equals `Buffer.byteLength(buildFullMessageStream output)`
+      //     by construction so it agrees with what BODY[] would emit.
+      //     Fire-and-forget UPDATE persists the value for next time.
+      //     Skips the earlier `buildBodyResponsePart(BODY[])` call that
+      //     materialized the whole body just to read its length — that
+      //     was the K836 +66 MB spike in #729.
       if (typeof mail.rfc822_size === "number") {
         return { type: "simple", content: `RFC822.SIZE ${mail.rfc822_size}` };
       }
-      const fullBody = await buildBodyResponsePart(
-        mail,
-        { type: "BODY", peek: true, section: { type: "FULL" } },
-        docId,
-        selectedMailbox
-      );
-      const size = fullBody?.type === "literal" ? fullBody.length : 0;
-      // Persist for future requests. `userId` is threaded from the
-      // top-level FETCH handler (buildFetchResponse → buildFetchResponsePart)
-      // — the mail row itself doesn't expose user_id on the client-facing
-      // MailType. Fire-and-forget: a persist failure surfaces as a log line
-      // and the same fetch re-computes next time; nothing is broken.
-      // Callers without a userId (unit-test callers, internal fetchers)
-      // skip the persist step silently.
+      const size = computeFullMessageSize(mail, docId);
+      // Persist for future requests. `userId` is threaded from the top-level
+      // FETCH handler; callers without a userId (unit-test / internal)
+      // skip the persist step silently. Fire-and-forget — a persist
+      // failure surfaces as a log line and the same fetch re-computes
+      // next time; nothing is broken.
       if (userId) {
         void updateRfc822Size(userId, docId, size).catch((err) => {
           logger.warn("Failed to persist rfc822_size", {
@@ -591,9 +634,18 @@ export async function buildFetchResponse(
  */
 export type WriteChunked = (payload: Buffer) => Promise<void>;
 
+/**
+ * Consume an async iterable of chunks and write each to the socket with
+ * backpressure. Called for `stream` parts (BODY[] / RFC822 fetches wired
+ * through `buildFullMessageStream`). Peak in-flight allocation stays at
+ * one chunk (~64 KiB) — no full-body Buffer is ever materialized.
+ */
+export type WriteStream = (chunks: AsyncIterable<Buffer>) => Promise<void>;
+
 export async function writeFetchResponse(
   write: (data: string) => boolean | undefined,
   writeChunked: WriteChunked,
+  writeStream: WriteStream,
   seqNum: number,
   parts: FetchResponsePart[]
 ): Promise<void> {
@@ -612,6 +664,13 @@ export async function writeFetchResponse(
       } else {
         write(part.content);
       }
+    } else if (part.type === "stream") {
+      // {N} literal advertises the sum of upcoming chunk byte-lengths
+      // (guaranteed by `computeFullMessageSize` matching the stream's
+      // emit-set), then the generator's chunks flow through the
+      // stream writer with backpressure.
+      write(`${part.header} {${part.length}}\r\n`);
+      await writeStream(part.stream);
     } else {
       write(part.content);
     }

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -30,7 +30,7 @@ import {
   FetchDataItem,
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
-import { withBodyBudget } from "./body-budget";
+import { withBodyBudget, withBodyBudgetStream } from "./body-budget";
 import { updateRfc822Size } from "../postgres/repositories/mails/core";
 // `getSharedBodyResult` already budget-gates INSIDE its singleflight
 // closure so coalesced callers share one slot (see body-buffer.ts +
@@ -363,37 +363,32 @@ export async function buildBodyResponsePart(
   //    matches the emitted octets — building the CRLF per caller after
   //    the cache would defeat the coalescing entirely for the wire
   //    check).
-  // FULL section (BODY[] / RFC822): stream the body directly to the
-  // socket. `computeFullMessageSize` pre-computes the `{N}` literal
-  // from stored attachment sizes (no disk I/O) so the writer can
-  // advertise the length before the first chunk yields. The stream
-  // itself materializes only ONE 48 KiB base64 slice at a time — peak
-  // transient allocation stays sub-MB regardless of body size.
+  // FULL section (BODY[] / RFC822): stream the body directly to the socket.
+  // `computeFullMessageSize` measures the same segment list the stream emits
+  // (one `stat` per attachment, no reads), so the writer can advertise `{N}`
+  // before the first chunk yields and the count cannot disagree with the
+  // payload. The stream holds only one 48 KiB slice at a time.
   //
-  // Skips the shared body-buffer cache path (getSharedBodyResult):
-  // streaming makes each build cheap enough that caching gives no RSS
-  // win. iOS Mail's abort-and-retry pattern (#729 K843) that motivated
-  // the TTL cache in #730 becomes a re-stream from disk instead of a
-  // re-materialization of a multi-MB string — orders of magnitude
-  // cheaper either way. Cache is retained for TEXT / HEADER / partial
-  // paths that still go through `getSharedBodyResult`.
+  // Skips the shared body-buffer cache (getSharedBodyResult): streaming makes
+  // each build cheap enough that caching gives no RSS win, and iOS Mail's
+  // abort-and-retry pattern becomes a re-stream from disk instead of a
+  // re-materialization. The cache is retained for TEXT / HEADER / partial.
+  //
+  // Still inside the body budget: this is the largest fetch shape, so leaving
+  // it uncapped would let K concurrent sockets each stream a distinct large
+  // body while the budget covered only the cheaper paths. The slot is held for
+  // the stream's whole lifetime and released even if the consumer abandons it.
   if (!partial && !isHeaderLikeSection(section) && section.type === "FULL") {
-    // `computeFullMessageSize` includes the trailing CRLF the wire
-    // response appends (matches the pre-#733 shape where
-    // `getSharedBodyResult`'s closure emitted `text + "\r\n"` before
-    // caching). The stream must emit the same trailer or the {N}
-    // literal won't match the byte count that arrives — hence the
-    // extra `\r\n` chunk after the generator finishes.
+    // The wire response ends with a CRLF after the body serialization, which
+    // `computeFullMessageSize` counts, so the stream must emit it too.
     const length = computeFullMessageSize(mail, docId);
-    async function* streamWithTrailer(): AsyncGenerator<Buffer, void, unknown> {
-      for await (const chunk of buildFullMessageStream(mail, docId)) {
-        yield chunk;
-      }
+    const stream = withBodyBudgetStream(async function* () {
+      yield* buildFullMessageStream(mail, docId);
       yield Buffer.from("\r\n", "utf8");
-    }
+    });
     return {
       type: "stream",
-      stream: streamWithTrailer(),
+      stream,
       header: sectionKey,
       length,
     };
@@ -512,9 +507,8 @@ export async function buildFetchResponsePart(
       //     value equals `Buffer.byteLength(buildFullMessageStream output)`
       //     by construction so it agrees with what BODY[] would emit.
       //     Fire-and-forget UPDATE persists the value for next time.
-      //     Skips the earlier `buildBodyResponsePart(BODY[])` call that
-      //     materialized the whole body just to read its length — that
-      //     was the K836 +66 MB spike in #729.
+      //     Derived without materializing the body, which is the point: a
+      //     BODY[] build just to read its length is a multi-MB allocation.
       if (typeof mail.rfc822_size === "number") {
         return { type: "simple", content: `RFC822.SIZE ${mail.rfc822_size}` };
       }

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -19,7 +19,10 @@ import {
   applyPartialFetch,
   buildFullMessage,
   buildFullMessageStream,
+  buildMessageSegments,
   computeFullMessageSize,
+  streamFromSegments,
+  sumSegmentBytes,
   getBodyPart,
   getBodyPartHeaders,
   getBodySectionKey,
@@ -379,11 +382,21 @@ export async function buildBodyResponsePart(
   // body while the budget covered only the cheaper paths. The slot is held for
   // the stream's whole lifetime and released even if the consumer abandons it.
   if (!partial && !isHeaderLikeSection(section) && section.type === "FULL") {
-    // The wire response ends with a CRLF after the body serialization, which
-    // `computeFullMessageSize` counts, so the stream must emit it too.
-    const length = computeFullMessageSize(mail, docId);
+    // Build the segment list ONCE — reproducing it inside the stream
+    // would `stat` attachment files a second time, and a file whose size
+    // changed between calls (upload-in-progress, mid-write race, etc.)
+    // would make `{N}` disagree with the emitted octets — the exact
+    // #733 reviewoie HIGH ("declared 1833, emitted 67165"). Sharing one
+    // segment list between the size measurement and the stream is what
+    // makes `{N}` byte-exact by construction.
+    //
+    // The wire response ends with a CRLF after the body serialization,
+    // which `sumSegmentBytes` counts (via WIRE_TRAILER), so the stream
+    // must emit it too.
+    const segments = buildMessageSegments(mail, docId);
+    const length = sumSegmentBytes(segments);
     const stream = withBodyBudgetStream(async function* () {
-      yield* buildFullMessageStream(mail, docId);
+      yield* streamFromSegments(segments);
       yield Buffer.from("\r\n", "utf8");
     });
     return {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -30,6 +30,7 @@ import {
   getRequestedFields,
   convertSequenceSet,
   WriteChunked,
+  WriteStream,
 } from "./fetch-helpers";
 import {
   resolveSeqRangeToUids,
@@ -53,6 +54,7 @@ export async function fetchMessagesTyped(
   seqState: SequenceState,
   write: (data: string) => boolean | undefined,
   writeChunked: WriteChunked,
+  writeStream: WriteStream,
   condstoreEnabled: boolean = false
 ): Promise<void> {
   const isFlagsOnly = fetchRequest.dataItems.every(
@@ -99,6 +101,7 @@ export async function fetchMessagesTyped(
       seqState,
       write,
       writeChunked,
+      writeStream,
       condstoreEnabled
     );
     write(`${tag} OK FETCH completed\r\n`);
@@ -180,6 +183,7 @@ async function _processFetchMessages(
   seqState: SequenceState,
   write: (data: string) => boolean | undefined,
   writeChunked: WriteChunked,
+  writeStream: WriteStream,
   condstoreEnabled: boolean
 ): Promise<void> {
   const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
@@ -209,7 +213,7 @@ async function _processFetchMessages(
         condstoreEnabled,
         store.getUser().id
       );
-      await writeFetchResponse(write, writeChunked, seqNum, response);
+      await writeFetchResponse(write, writeChunked, writeStream, seqNum, response);
 
       if (shouldMarkAsRead(fetchRequest.dataItems)) {
         await markRead(store.getUser().id, id);

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -3,11 +3,23 @@
  * Covers inbox #341
  */
 
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
+import fs from "node:fs";
+import {
+  ATTACHMENT_FOLDER,
+  getAttachmentFilePath,
+  getAttachment
+} from "../mails/util";
 
-// Mock the "server" module before importing session-utils
+// Mock the "server" module before importing session-utils. `mock.module` is
+// process-global in Bun and reaches the leaf module the barrel re-exports, so
+// the attachment helpers are forwarded VERBATIM rather than redirected at a temp
+// dir — redirecting them broke mails/util.test.ts's constant assertions in the
+// same run.
 mock.module("server", () => ({
-  getAttachment: mock(() => undefined),
+  ATTACHMENT_FOLDER,
+  getAttachmentFilePath,
+  getAttachment,
   logger: {
     warn: mock(() => {}),
     error: mock(() => {}),
@@ -15,6 +27,24 @@ mock.module("server", () => ({
     debug: mock(() => {})
   }
 }));
+
+// Attachment bodies are measured (stat) and read from the same path, so these
+// tests write real files rather than stubbing a reader — a stub would let the
+// measured size and the emitted bytes disagree, which is exactly the bug class
+// this module has to make impossible.
+const TEST_ID_PREFIX = "session-utils-test-";
+const attachmentPath = (id: string) => getAttachmentFilePath(TEST_ID_PREFIX + id);
+const writtenIds = new Set<string>();
+const writeAttachment = (id: string, data: Buffer): Buffer => {
+  fs.mkdirSync(ATTACHMENT_FOLDER, { recursive: true });
+  fs.writeFileSync(attachmentPath(id), data);
+  writtenIds.add(id);
+  return data;
+};
+
+afterAll(() => {
+  for (const id of writtenIds) fs.rmSync(attachmentPath(id), { force: true });
+});
 
 import {
   applyPartialFetch,
@@ -30,12 +60,6 @@ import type {
   PartialRange
 } from "./types";
 import type { MailType } from "common";
-
-// Helper: get the mocked getAttachment from the mocked module
-async function getMockedGetAttachment() {
-  const serverMod = await import("server");
-  return serverMod.getAttachment as ReturnType<typeof mock>;
-}
 
 // ---------------------------------------------------------------------------
 // applyPartialFetch
@@ -350,20 +374,21 @@ describe("buildFullMessage", () => {
     expect(result).toContain("--boundary_test-doc-123--");
   });
 
-  it("returns multipart/mixed for text+html+attachment mail", async () => {
-    const mockGetAttachment = await getMockedGetAttachment();
-    const fakeAttachmentData = Buffer.from("PDF_BINARY_DATA");
-    mockGetAttachment.mockImplementation(() => fakeAttachmentData);
+  it("returns multipart/mixed for text+html+attachment mail", () => {
+    const fakeAttachmentData = writeAttachment(
+      "att-file-id-1",
+      Buffer.from("PDF_BINARY_DATA")
+    );
 
     const mail: Partial<MailType> = {
       text: "See attached",
       html: "<p>See attached</p>",
       attachments: [
         {
-          content: { data: "att-file-id-1" },
+          content: { data: TEST_ID_PREFIX + "att-file-id-1" },
           contentType: "application/pdf",
           filename: "document.pdf",
-          size: 1024
+          size: fakeAttachmentData.byteLength
         }
       ]
     };
@@ -376,19 +401,17 @@ describe("buildFullMessage", () => {
     expect(result).toContain("--boundary_doc-mixed-1--");
   });
 
-  it("returns multipart/mixed for text-only+attachment mail", async () => {
-    const mockGetAttachment = await getMockedGetAttachment();
-    const fakeData = Buffer.from("SOME_DATA");
-    mockGetAttachment.mockImplementation(() => fakeData);
+  it("returns multipart/mixed for text-only+attachment mail", () => {
+    const fakeData = writeAttachment("att-file-id-2", Buffer.from("SOME_DATA"));
 
     const mail: Partial<MailType> = {
       text: "See attached",
       attachments: [
         {
-          content: { data: "att-file-id-2" },
+          content: { data: TEST_ID_PREFIX + "att-file-id-2" },
           contentType: "text/plain",
           filename: "notes.txt",
-          size: 50
+          size: fakeData.byteLength
         }
       ]
     };
@@ -507,16 +530,14 @@ describe("getBodyPart", () => {
     expect(result).toBe(Buffer.from("<p>Body HTML</p>", "utf8").toString("base64"));
   });
 
-  it("returns attachment data for part 2 in mail with attachment", async () => {
-    const mockGetAttachment = await getMockedGetAttachment();
-    const attData = Buffer.from("ATTACHMENT_BYTES");
-    mockGetAttachment.mockImplementation(() => attData);
+  it("returns attachment data for part 2 in mail with attachment", () => {
+    const attData = writeAttachment("att-file-xyz", Buffer.from("ATTACHMENT_BYTES"));
 
     const mail: Partial<MailType> = {
       text: "Body",
       attachments: [
         {
-          content: { data: "att-file-xyz" },
+          content: { data: TEST_ID_PREFIX + "att-file-xyz" },
           contentType: "image/png",
           filename: "photo.png",
           size: 200
@@ -527,15 +548,13 @@ describe("getBodyPart", () => {
     expect(result).toBe(attData.toString("base64"));
   });
 
-  it("returns null for attachment when getAttachment returns undefined", async () => {
-    const mockGetAttachment = await getMockedGetAttachment();
-    mockGetAttachment.mockImplementation(() => undefined);
+  it("returns null for an attachment whose file is missing", () => {
 
     const mail: Partial<MailType> = {
       text: "Body",
       attachments: [
         {
-          content: { data: "missing-file" },
+          content: { data: TEST_ID_PREFIX + "missing-file" },
           contentType: "image/png",
           filename: "photo.png",
           size: 200

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -72,7 +72,315 @@ export const shouldMarkAsRead = (dataItems: FetchDataItem[]): boolean => {
 };
 
 /**
- * Build complete RFC822 message from mail data
+ * Byte length of `4 * ceil(n/3)`-format base64 encoding of `n` input octets.
+ * No I/O; used by `computeFullMessageSize` to pre-compute the RFC822.SIZE
+ * / `{N}` literal length for a mail without materializing its body.
+ */
+const base64ByteLen = (rawBytes: number): number =>
+  Math.ceil(rawBytes / 3) * 4;
+
+/**
+ * The stable boundary strings a build for this mail would generate. Shared
+ * between `computeFullMessageSize` (which needs their lengths) and
+ * `buildFullMessageStream` (which emits them) so the byte counts agree by
+ * construction.
+ */
+const boundariesFor = (
+  mail: Partial<MailType>,
+  headers: string,
+  docId?: string
+): { boundary: string; altBoundary: string } => {
+  const boundaryMatch = headers.match(/boundary="([^"]+)"/);
+  const stableId = docId || mail.messageId || "default";
+  const boundary = boundaryMatch ? boundaryMatch[1] : "boundary_" + stableId;
+  const altBoundary =
+    "alt_" + stableId.replace(/[^a-zA-Z0-9_]/g, "_");
+  return { boundary, altBoundary };
+};
+
+/**
+ * Header block after the multipart Content-Type substitution — same string
+ * `buildFullMessage`/`buildFullMessageStream` would emit as their first
+ * chunk. Extracted so `computeFullMessageSize` measures the exact bytes
+ * that will be sent, not an approximation.
+ */
+const rewriteContentType = (headers: string, replacement: string): string =>
+  headers.replace(/Content-Type: [^\r\n]+/, replacement);
+
+/**
+ * Compute the exact WIRE byte count IMAP `{N}` literal advertises for
+ * `BODY[]` — i.e. the byte length of the RFC 822 serialization the mail
+ * would produce, PLUS the trailing `\r\n` the wire response appends
+ * after the multipart terminator (matches the pre-#733 shape where
+ * `getSharedBodyResult`'s closure appended `text + "\r\n"` before
+ * emitting the literal). This IS the value RFC822.SIZE reports and
+ * `{N}` literal advertises — the two agree by construction.
+ *
+ * Attachments are measured via the base64 length formula
+ * (`ceil(size/3)*4`) applied to their stored `size` — no disk read, no
+ * allocation. That's the whole point of this function: SIZE / `{N}`
+ * without materializing bodies.
+ */
+export const computeFullMessageSize = (
+  mail: Partial<MailType>,
+  docId?: string
+): number => {
+  const headers = formatHeaders(mail, docId);
+  const hasText = mail.text && mail.text.trim().length > 0;
+  const hasHtml = mail.html && mail.html.trim().length > 0;
+  const hasAttachments = mail.attachments && mail.attachments.length > 0;
+
+  const utf8 = (s: string): number => Buffer.byteLength(s, "utf8");
+  // Trailing wire CRLF appended after the pure-body serialization —
+  // matches `getSharedBodyResult`'s closure that emitted `text + "\r\n"`
+  // before building the response Buffer (see body-buffer.ts). Every
+  // BODY[]/RFC822 wire response ends with this extra CRLF; RFC822.SIZE
+  // includes it so `SIZE == {N}` holds.
+  const WIRE_TRAILER = 2;
+
+  if (!hasText && !hasHtml && !hasAttachments) {
+    return utf8(`${headers}\r\n\r\n`) + WIRE_TRAILER;
+  }
+  if (hasText && !hasHtml && !hasAttachments) {
+    return utf8(`${headers}\r\n\r\n${encodeText(mail.text!)}\r\n`) + WIRE_TRAILER;
+  }
+  if (!hasText && hasHtml && !hasAttachments) {
+    return utf8(`${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`) + WIRE_TRAILER;
+  }
+
+  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
+  let bytes = 0;
+
+  if (hasText && hasHtml && !hasAttachments) {
+    const updatedHeaders = rewriteContentType(
+      headers,
+      `Content-Type: multipart/alternative; boundary="${boundary}"`
+    );
+    bytes += utf8(`${updatedHeaders}\r\n\r\n`);
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
+    bytes += utf8(`--${boundary}--`);
+    return bytes + WIRE_TRAILER;
+  }
+
+  // hasAttachments — multipart/mixed
+  const updatedHeaders = rewriteContentType(
+    headers,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`
+  );
+  bytes += utf8(`${updatedHeaders}\r\n\r\n`);
+
+  if (hasText && hasHtml) {
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
+    bytes += utf8(`--${altBoundary}\r\n`);
+    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
+    bytes += utf8(`--${altBoundary}\r\n`);
+    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
+    bytes += utf8(`--${altBoundary}--\r\n`);
+  } else if (hasText) {
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
+  } else if (hasHtml) {
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
+  }
+
+  // Attachments — sum header + base64_len(raw size) + trailing CRLF
+  // per attachment. `att.size` is the RAW attachment byte count stored
+  // on the mail row; base64 length formula converts to the encoded
+  // length WITHOUT ever reading the file. This is the whole point of
+  // this function — RFC822.SIZE / {N} without materializing bodies.
+  for (const att of mail.attachments!) {
+    bytes += utf8(`--${boundary}\r\n`);
+    bytes += utf8(`Content-Type: ${att.contentType}\r\n`);
+    bytes += utf8(`Content-Transfer-Encoding: base64\r\n`);
+    bytes += utf8(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
+    bytes += base64ByteLen(att.size);
+    bytes += utf8(`\r\n`);
+  }
+  bytes += utf8(`--${boundary}--`);
+  return bytes + WIRE_TRAILER;
+};
+
+/**
+ * Stream the RFC 822 serialization of a mail as `Buffer` chunks. Each
+ * yielded chunk is small (header block, one part header, one base64-
+ * encoded slice of an attachment) so peak transient allocation stays
+ * O(chunk-size) regardless of total body size — the whole point of the
+ * streaming path.
+ *
+ * Attachments are base64-encoded in 48 KiB raw slices (~64 KiB encoded)
+ * so a multi-MB attachment never materializes as a single base64 string.
+ * `Buffer.toString("base64")` on a 48 KiB slice returns a ~64 KiB string
+ * which is immediately wrapped in a Buffer and yielded — the temporary
+ * string is GC-eligible before the next slice runs.
+ *
+ * The consumer (writer) must have advertised `{N}` where N ==
+ * `computeFullMessageSize(mail, docId)` BEFORE iterating this stream —
+ * both functions read from `mail.text` / `mail.html` / `mail.attachments`
+ * with identical formulas, so the sum of yielded chunk byte-lengths
+ * equals N by construction.
+ */
+const ATTACHMENT_SLICE_BYTES = 48 * 1024;
+
+export async function* buildFullMessageStream(
+  mail: Partial<MailType>,
+  docId?: string
+): AsyncGenerator<Buffer, void, unknown> {
+  const headers = formatHeaders(mail, docId);
+  const hasText = mail.text && mail.text.trim().length > 0;
+  const hasHtml = mail.html && mail.html.trim().length > 0;
+  const hasAttachments = mail.attachments && mail.attachments.length > 0;
+
+  const emit = (s: string): Buffer => Buffer.from(s, "utf8");
+
+  if (!hasText && !hasHtml && !hasAttachments) {
+    yield emit(`${headers}\r\n\r\n`);
+    return;
+  }
+  if (hasText && !hasHtml && !hasAttachments) {
+    yield emit(`${headers}\r\n\r\n${encodeText(mail.text!)}\r\n`);
+    return;
+  }
+  if (!hasText && hasHtml && !hasAttachments) {
+    yield emit(`${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`);
+    return;
+  }
+
+  if (!docId) {
+    logger.warn(
+      "docId is missing in buildFullMessageStream, falling back to messageId",
+      { component: "imap", messageId: mail.messageId }
+    );
+  }
+  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
+
+  if (hasText && hasHtml && !hasAttachments) {
+    const updatedHeaders = rewriteContentType(
+      headers,
+      `Content-Type: multipart/alternative; boundary="${boundary}"`
+    );
+    yield emit(`${updatedHeaders}\r\n\r\n`);
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.text!)}\r\n`);
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.html!)}\r\n`);
+    yield emit(`--${boundary}--`);
+    return;
+  }
+
+  // hasAttachments — multipart/mixed
+  const updatedHeaders = rewriteContentType(
+    headers,
+    `Content-Type: multipart/mixed; boundary="${boundary}"`
+  );
+  yield emit(`${updatedHeaders}\r\n\r\n`);
+
+  if (hasText && hasHtml) {
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
+    yield emit(`--${altBoundary}\r\n`);
+    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.text!)}\r\n`);
+    yield emit(`--${altBoundary}\r\n`);
+    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.html!)}\r\n`);
+    yield emit(`--${altBoundary}--\r\n`);
+  } else if (hasText) {
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.text!)}\r\n`);
+  } else if (hasHtml) {
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    yield emit(`${encodeText(mail.html!)}\r\n`);
+  }
+
+  for (const att of mail.attachments!) {
+    yield emit(`--${boundary}\r\n`);
+    yield emit(`Content-Type: ${att.contentType}\r\n`);
+    yield emit(`Content-Transfer-Encoding: base64\r\n`);
+    yield emit(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
+
+    const raw =
+      getAttachment(att.content.data) ||
+      Buffer.from("Attachment data not found");
+
+    // Slice size chosen so base64 encoding of the slice is `~64 KiB`
+    // (matches CHUNK_BYTES in chunked-write.ts) — one write per slice
+    // aligns naturally with the socket's high-water mark. `att.size`
+    // in `computeFullMessageSize` uses the STORED size which for a
+    // real attachment matches `raw.byteLength`; on a missing-file
+    // fallback (`Buffer.from("Attachment data not found")`) the two
+    // will disagree. Callers should treat rfc822_size derivation
+    // separately from stream-emit in that pathological case.
+    for (
+      let offset = 0;
+      offset < raw.byteLength;
+      offset += ATTACHMENT_SLICE_BYTES
+    ) {
+      const sliceEnd = Math.min(offset + ATTACHMENT_SLICE_BYTES, raw.byteLength);
+      const slice = raw.subarray(offset, sliceEnd);
+      // `slice.toString("base64")` returns a fresh ~64 KiB string that
+      // becomes GC-eligible right after `Buffer.from(...)` copies its
+      // bytes into a new Buffer. Peak transient per slice: raw slice
+      // (48 KiB, borrowed view) + intermediate string (~64 KiB) +
+      // emitted Buffer (~64 KiB) = ~128 KiB. No growing accumulator.
+      yield Buffer.from(slice.toString("base64"), "utf8");
+    }
+    yield emit(`\r\n`);
+  }
+  yield emit(`--${boundary}--`);
+}
+
+/**
+ * Build complete RFC822 message from mail data as a single string.
+ *
+ * Legacy consumer-facing API — the stream-native path
+ * (`buildFullMessageStream` + `computeFullMessageSize`) is preferred
+ * for BODY[] / RFC822 fetches because it keeps peak allocation at
+ * O(chunk-size). This function collects every stream chunk into an
+ * array and joins at the end — the pragmatic middle ground for the
+ * remaining callers that need a materialized string:
+ *
+ * - `getBodyContent` for the TEXT section: takes the full message
+ *   string, `indexOf("\r\n\r\n") + substring` to extract the body.
+ *   Small-mail-friendly; large-attachment mails still pay the
+ *   materialization here.
+ * - `scripts/backfill-rfc822-size.ts` for the one-off backfill —
+ *   though that script really wants `Buffer.byteLength(full, "utf8")`,
+ *   which is exactly `computeFullMessageSize` without materializing.
+ *   A follow-up can migrate the backfill to `computeFullMessageSize`
+ *   and drop this function's dependency on the string materialization
+ *   for that path.
+ *
+ * Uses `chunks.push(str) + chunks.join("")` internally instead of the
+ * earlier `let body = ""; body += X;` chain — `Array#join` is a single
+ * O(total_length) allocation vs the quadratic rope-realloc buildup
+ * that made this the OOM offender on #729's K836 case.
  */
 export const buildFullMessage = (
   mail: Partial<MailType>,
@@ -95,86 +403,80 @@ export const buildFullMessage = (
     return `${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`;
   }
 
-  // For multipart messages, extract boundary from headers or use deterministic one
-  const boundaryMatch = headers.match(/boundary="([^"]+)"/);
   if (!docId) {
     logger.warn("docId is missing in buildFullMessage, falling back to messageId", {
       component: "imap",
       messageId: mail.messageId
     });
   }
-  const stableId = docId || mail.messageId || "default";
-  const boundary = boundaryMatch ? boundaryMatch[1] : "boundary_" + stableId;
-  let body = "";
+  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
+  const chunks: string[] = [];
 
   if (hasText && hasHtml && !hasAttachments) {
     // multipart/alternative
-    const updatedHeaders = headers.replace(
-      /Content-Type: [^\r\n]+/,
+    const updatedHeaders = rewriteContentType(
+      headers,
       `Content-Type: multipart/alternative; boundary="${boundary}"`
     );
 
-    body = `${updatedHeaders}\r\n\r\n`;
-    body += `--${boundary}\r\n`;
-    body += `Content-Type: text/plain; charset=utf-8\r\n`;
-    body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-    body += `${encodeText(mail.text!)}\r\n`;
-    body += `--${boundary}\r\n`;
-    body += `Content-Type: text/html; charset=utf-8\r\n`;
-    body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-    body += `${encodeText(mail.html!)}\r\n`;
-    body += `--${boundary}--`;
+    chunks.push(`${updatedHeaders}\r\n\r\n`);
+    chunks.push(`--${boundary}\r\n`);
+    chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
+    chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    chunks.push(`${encodeText(mail.text!)}\r\n`);
+    chunks.push(`--${boundary}\r\n`);
+    chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
+    chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    chunks.push(`${encodeText(mail.html!)}\r\n`);
+    chunks.push(`--${boundary}--`);
   } else if (hasAttachments) {
     // multipart/mixed
-    const updatedHeaders = headers.replace(
-      /Content-Type: [^\r\n]+/,
+    const updatedHeaders = rewriteContentType(
+      headers,
       `Content-Type: multipart/mixed; boundary="${boundary}"`
     );
 
-    body = `${updatedHeaders}\r\n\r\n`;
+    chunks.push(`${updatedHeaders}\r\n\r\n`);
 
-    // Add text/html parts
     if (hasText && hasHtml) {
-      const altBoundary = "alt_" + (docId || mail.messageId || "default").replace(/[^a-zA-Z0-9_]/g, "_");
-      body += `--${boundary}\r\n`;
-      body += `Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`;
-      body += `--${altBoundary}\r\n`;
-      body += `Content-Type: text/plain; charset=utf-8\r\n`;
-      body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-      body += `${encodeText(mail.text!)}\r\n`;
-      body += `--${altBoundary}\r\n`;
-      body += `Content-Type: text/html; charset=utf-8\r\n`;
-      body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-      body += `${encodeText(mail.html!)}\r\n`;
-      body += `--${altBoundary}--\r\n`;
+      chunks.push(`--${boundary}\r\n`);
+      chunks.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
+      chunks.push(`--${altBoundary}\r\n`);
+      chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
+      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+      chunks.push(`${encodeText(mail.text!)}\r\n`);
+      chunks.push(`--${altBoundary}\r\n`);
+      chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
+      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+      chunks.push(`${encodeText(mail.html!)}\r\n`);
+      chunks.push(`--${altBoundary}--\r\n`);
     } else if (hasText) {
-      body += `--${boundary}\r\n`;
-      body += `Content-Type: text/plain; charset=utf-8\r\n`;
-      body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-      body += `${encodeText(mail.text!)}\r\n`;
+      chunks.push(`--${boundary}\r\n`);
+      chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
+      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+      chunks.push(`${encodeText(mail.text!)}\r\n`);
     } else if (hasHtml) {
-      body += `--${boundary}\r\n`;
-      body += `Content-Type: text/html; charset=utf-8\r\n`;
-      body += `Content-Transfer-Encoding: base64\r\n\r\n`;
-      body += `${encodeText(mail.html!)}\r\n`;
+      chunks.push(`--${boundary}\r\n`);
+      chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
+      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
+      chunks.push(`${encodeText(mail.html!)}\r\n`);
     }
 
-    // Add attachments
-    mail.attachments!.forEach((att) => {
-      body += `--${boundary}\r\n`;
-      body += `Content-Type: ${att.contentType}\r\n`;
-      body += `Content-Transfer-Encoding: base64\r\n`;
-      body += `Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`;
+    for (const att of mail.attachments!) {
+      chunks.push(`--${boundary}\r\n`);
+      chunks.push(`Content-Type: ${att.contentType}\r\n`);
+      chunks.push(`Content-Transfer-Encoding: base64\r\n`);
+      chunks.push(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
       const attachmentData =
         getAttachment(att.content.data) ||
         Buffer.from("Attachment data not found");
-      body += `${attachmentData.toString("base64")}\r\n`;
-    });
+      chunks.push(`${attachmentData.toString("base64")}\r\n`);
+    }
 
-    body += `--${boundary}--`;
+    chunks.push(`--${boundary}--`);
   }
 
-  return body;
+  return chunks.join("");
 };
 
 /**

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -3,11 +3,13 @@
  * These are pure functions that don't require session state
  */
 
+import fs from "node:fs";
 import { MailType } from "common";
 import { PartialRange, BodySection, FetchDataItem, HeaderFieldsSection } from "./types";
-import { formatHeaders, encodeText } from "./util";
-import { getAttachment } from "server";
+import { formatHeaders } from "./util";
+import { getAttachment, getAttachmentFilePath } from "server";
 import { logger } from "server";
+import { CHUNK_BYTES } from "./chunked-write";
 
 /**
  * Apply partial fetch range to content
@@ -72,18 +74,61 @@ export const shouldMarkAsRead = (dataItems: FetchDataItem[]): boolean => {
 };
 
 /**
- * Byte length of `4 * ceil(n/3)`-format base64 encoding of `n` input octets.
- * No I/O; used by `computeFullMessageSize` to pre-compute the RFC822.SIZE
- * / `{N}` literal length for a mail without materializing its body.
+ * One piece of the RFC 822 serialization.
+ *
+ * `buildMessageSegments` is the SINGLE definition of the MIME layout.
+ * `computeFullMessageSize` measures the segments and
+ * `buildFullMessageStream` emits them, so the `{N}` literal the writer
+ * advertises and the octets that follow it are derived from one source
+ * and cannot disagree. Keeping the layout in one place is the invariant,
+ * not an aesthetic choice: three hand-parallel copies (measure, emit,
+ * materialize) is how the count and the payload drift apart, and a
+ * literal whose count is wrong desyncs every subsequent response on the
+ * connection.
  */
-const base64ByteLen = (rawBytes: number): number =>
-  Math.ceil(rawBytes / 3) * 4;
+type MessageSegment =
+  /** Emitted verbatim; measured with `Buffer.byteLength`. */
+  | { kind: "literal"; value: string }
+  /** `source` base64-encoded; sliced so the encoded form is never one allocation. */
+  | { kind: "base64"; source: string }
+  /** An attachment file, base64-encoded, read and emitted in slices. */
+  | { kind: "attachment"; dataId: string; rawSize: number; filename: string };
 
 /**
- * The stable boundary strings a build for this mail would generate. Shared
- * between `computeFullMessageSize` (which needs their lengths) and
- * `buildFullMessageStream` (which emits them) so the byte counts agree by
- * construction.
+ * Byte length of `4 * ceil(n/3)`-format base64 encoding of `n` input octets.
+ * Exact, and with no line folding — `encodeText` produces unfolded base64,
+ * so this is the true encoded length rather than an estimate.
+ */
+const base64ByteLen = (rawBytes: number): number => Math.ceil(rawBytes / 3) * 4;
+
+/**
+ * Raw byte count emitted for an attachment whose file cannot be read.
+ * Measured and emitted through the same constant so the two agree.
+ */
+const MISSING_ATTACHMENT_NOTICE = "Attachment data not found";
+
+/**
+ * Raw size of an attachment as it will actually be emitted.
+ *
+ * `stat` rather than the `size` stored on the mail row: the stored value is
+ * what the sender declared at receipt, and when it disagrees with the file on
+ * disk (or the file is gone) it is the file that gets streamed. Measuring the
+ * stored value while emitting the file's bytes is exactly the divergence that
+ * corrupts the literal. `stat` is a metadata call — no read, no allocation —
+ * so this keeps `RFC822.SIZE` free of body materialization.
+ */
+const resolveAttachmentRawSize = (dataId: string): number => {
+  try {
+    const stats = fs.statSync(getAttachmentFilePath(dataId));
+    if (stats.isFile()) return stats.size;
+  } catch {
+    // Missing / unreadable — fall through to the notice length below.
+  }
+  return Buffer.byteLength(MISSING_ATTACHMENT_NOTICE, "utf8");
+};
+
+/**
+ * The stable boundary strings a build for this mail would generate.
  */
 const boundariesFor = (
   mail: Partial<MailType>,
@@ -93,390 +138,334 @@ const boundariesFor = (
   const boundaryMatch = headers.match(/boundary="([^"]+)"/);
   const stableId = docId || mail.messageId || "default";
   const boundary = boundaryMatch ? boundaryMatch[1] : "boundary_" + stableId;
-  const altBoundary =
-    "alt_" + stableId.replace(/[^a-zA-Z0-9_]/g, "_");
+  const altBoundary = "alt_" + stableId.replace(/[^a-zA-Z0-9_]/g, "_");
   return { boundary, altBoundary };
 };
 
-/**
- * Header block after the multipart Content-Type substitution — same string
- * `buildFullMessage`/`buildFullMessageStream` would emit as their first
- * chunk. Extracted so `computeFullMessageSize` measures the exact bytes
- * that will be sent, not an approximation.
- */
 const rewriteContentType = (headers: string, replacement: string): string =>
   headers.replace(/Content-Type: [^\r\n]+/, replacement);
 
 /**
- * Compute the exact WIRE byte count IMAP `{N}` literal advertises for
- * `BODY[]` — i.e. the byte length of the RFC 822 serialization the mail
- * would produce, PLUS the trailing `\r\n` the wire response appends
- * after the multipart terminator (matches the pre-#733 shape where
- * `getSharedBodyResult`'s closure appended `text + "\r\n"` before
- * emitting the literal). This IS the value RFC822.SIZE reports and
- * `{N}` literal advertises — the two agree by construction.
+ * The RFC 822 serialization of `mail`, as an ordered segment list.
  *
- * Attachments are measured via the base64 length formula
- * (`ceil(size/3)*4`) applied to their stored `size` — no disk read, no
- * allocation. That's the whole point of this function: SIZE / `{N}`
- * without materializing bodies.
+ * Attachment bodies are referenced by id + resolved size, never read, so
+ * building the list costs one `stat` per attachment regardless of mail size.
  */
-export const computeFullMessageSize = (
+const buildMessageSegments = (
   mail: Partial<MailType>,
   docId?: string
-): number => {
+): MessageSegment[] => {
   const headers = formatHeaders(mail, docId);
-  const hasText = mail.text && mail.text.trim().length > 0;
-  const hasHtml = mail.html && mail.html.trim().length > 0;
-  const hasAttachments = mail.attachments && mail.attachments.length > 0;
+  const hasText = !!mail.text && mail.text.trim().length > 0;
+  const hasHtml = !!mail.html && mail.html.trim().length > 0;
+  const hasAttachments = !!mail.attachments && mail.attachments.length > 0;
 
-  const utf8 = (s: string): number => Buffer.byteLength(s, "utf8");
-  // Trailing wire CRLF appended after the pure-body serialization —
-  // matches `getSharedBodyResult`'s closure that emitted `text + "\r\n"`
-  // before building the response Buffer (see body-buffer.ts). Every
-  // BODY[]/RFC822 wire response ends with this extra CRLF; RFC822.SIZE
-  // includes it so `SIZE == {N}` holds.
-  const WIRE_TRAILER = 2;
+  const segments: MessageSegment[] = [];
+  const literal = (value: string): void => {
+    segments.push({ kind: "literal", value });
+  };
+  const base64 = (source: string): void => {
+    segments.push({ kind: "base64", source });
+  };
 
   if (!hasText && !hasHtml && !hasAttachments) {
-    return utf8(`${headers}\r\n\r\n`) + WIRE_TRAILER;
+    literal(`${headers}\r\n\r\n`);
+    return segments;
   }
   if (hasText && !hasHtml && !hasAttachments) {
-    return utf8(`${headers}\r\n\r\n${encodeText(mail.text!)}\r\n`) + WIRE_TRAILER;
+    literal(`${headers}\r\n\r\n`);
+    base64(mail.text!);
+    literal(`\r\n`);
+    return segments;
   }
   if (!hasText && hasHtml && !hasAttachments) {
-    return utf8(`${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`) + WIRE_TRAILER;
-  }
-
-  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
-  let bytes = 0;
-
-  if (hasText && hasHtml && !hasAttachments) {
-    const updatedHeaders = rewriteContentType(
-      headers,
-      `Content-Type: multipart/alternative; boundary="${boundary}"`
-    );
-    bytes += utf8(`${updatedHeaders}\r\n\r\n`);
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
-    bytes += utf8(`--${boundary}--`);
-    return bytes + WIRE_TRAILER;
-  }
-
-  // hasAttachments — multipart/mixed
-  const updatedHeaders = rewriteContentType(
-    headers,
-    `Content-Type: multipart/mixed; boundary="${boundary}"`
-  );
-  bytes += utf8(`${updatedHeaders}\r\n\r\n`);
-
-  if (hasText && hasHtml) {
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
-    bytes += utf8(`--${altBoundary}\r\n`);
-    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
-    bytes += utf8(`--${altBoundary}\r\n`);
-    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
-    bytes += utf8(`--${altBoundary}--\r\n`);
-  } else if (hasText) {
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: text/plain; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.text!)}\r\n`);
-  } else if (hasHtml) {
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: text/html; charset=utf-8\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    bytes += utf8(`${encodeText(mail.html!)}\r\n`);
-  }
-
-  // Attachments — sum header + base64_len(raw size) + trailing CRLF
-  // per attachment. `att.size` is the RAW attachment byte count stored
-  // on the mail row; base64 length formula converts to the encoded
-  // length WITHOUT ever reading the file. This is the whole point of
-  // this function — RFC822.SIZE / {N} without materializing bodies.
-  for (const att of mail.attachments!) {
-    bytes += utf8(`--${boundary}\r\n`);
-    bytes += utf8(`Content-Type: ${att.contentType}\r\n`);
-    bytes += utf8(`Content-Transfer-Encoding: base64\r\n`);
-    bytes += utf8(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
-    bytes += base64ByteLen(att.size);
-    bytes += utf8(`\r\n`);
-  }
-  bytes += utf8(`--${boundary}--`);
-  return bytes + WIRE_TRAILER;
-};
-
-/**
- * Stream the RFC 822 serialization of a mail as `Buffer` chunks. Each
- * yielded chunk is small (header block, one part header, one base64-
- * encoded slice of an attachment) so peak transient allocation stays
- * O(chunk-size) regardless of total body size — the whole point of the
- * streaming path.
- *
- * Attachments are base64-encoded in 48 KiB raw slices (~64 KiB encoded)
- * so a multi-MB attachment never materializes as a single base64 string.
- * `Buffer.toString("base64")` on a 48 KiB slice returns a ~64 KiB string
- * which is immediately wrapped in a Buffer and yielded — the temporary
- * string is GC-eligible before the next slice runs.
- *
- * The consumer (writer) must have advertised `{N}` where N ==
- * `computeFullMessageSize(mail, docId)` BEFORE iterating this stream —
- * both functions read from `mail.text` / `mail.html` / `mail.attachments`
- * with identical formulas, so the sum of yielded chunk byte-lengths
- * equals N by construction.
- */
-const ATTACHMENT_SLICE_BYTES = 48 * 1024;
-
-export async function* buildFullMessageStream(
-  mail: Partial<MailType>,
-  docId?: string
-): AsyncGenerator<Buffer, void, unknown> {
-  const headers = formatHeaders(mail, docId);
-  const hasText = mail.text && mail.text.trim().length > 0;
-  const hasHtml = mail.html && mail.html.trim().length > 0;
-  const hasAttachments = mail.attachments && mail.attachments.length > 0;
-
-  const emit = (s: string): Buffer => Buffer.from(s, "utf8");
-
-  if (!hasText && !hasHtml && !hasAttachments) {
-    yield emit(`${headers}\r\n\r\n`);
-    return;
-  }
-  if (hasText && !hasHtml && !hasAttachments) {
-    yield emit(`${headers}\r\n\r\n${encodeText(mail.text!)}\r\n`);
-    return;
-  }
-  if (!hasText && hasHtml && !hasAttachments) {
-    yield emit(`${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`);
-    return;
+    literal(`${headers}\r\n\r\n`);
+    base64(mail.html!);
+    literal(`\r\n`);
+    return segments;
   }
 
   if (!docId) {
-    logger.warn(
-      "docId is missing in buildFullMessageStream, falling back to messageId",
-      { component: "imap", messageId: mail.messageId }
-    );
-  }
-  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
-
-  if (hasText && hasHtml && !hasAttachments) {
-    const updatedHeaders = rewriteContentType(
-      headers,
-      `Content-Type: multipart/alternative; boundary="${boundary}"`
-    );
-    yield emit(`${updatedHeaders}\r\n\r\n`);
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.text!)}\r\n`);
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.html!)}\r\n`);
-    yield emit(`--${boundary}--`);
-    return;
-  }
-
-  // hasAttachments — multipart/mixed
-  const updatedHeaders = rewriteContentType(
-    headers,
-    `Content-Type: multipart/mixed; boundary="${boundary}"`
-  );
-  yield emit(`${updatedHeaders}\r\n\r\n`);
-
-  if (hasText && hasHtml) {
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
-    yield emit(`--${altBoundary}\r\n`);
-    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.text!)}\r\n`);
-    yield emit(`--${altBoundary}\r\n`);
-    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.html!)}\r\n`);
-    yield emit(`--${altBoundary}--\r\n`);
-  } else if (hasText) {
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: text/plain; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.text!)}\r\n`);
-  } else if (hasHtml) {
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: text/html; charset=utf-8\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    yield emit(`${encodeText(mail.html!)}\r\n`);
-  }
-
-  for (const att of mail.attachments!) {
-    yield emit(`--${boundary}\r\n`);
-    yield emit(`Content-Type: ${att.contentType}\r\n`);
-    yield emit(`Content-Transfer-Encoding: base64\r\n`);
-    yield emit(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
-
-    const raw =
-      getAttachment(att.content.data) ||
-      Buffer.from("Attachment data not found");
-
-    // Slice size chosen so base64 encoding of the slice is `~64 KiB`
-    // (matches CHUNK_BYTES in chunked-write.ts) — one write per slice
-    // aligns naturally with the socket's high-water mark. `att.size`
-    // in `computeFullMessageSize` uses the STORED size which for a
-    // real attachment matches `raw.byteLength`; on a missing-file
-    // fallback (`Buffer.from("Attachment data not found")`) the two
-    // will disagree. Callers should treat rfc822_size derivation
-    // separately from stream-emit in that pathological case.
-    for (
-      let offset = 0;
-      offset < raw.byteLength;
-      offset += ATTACHMENT_SLICE_BYTES
-    ) {
-      const sliceEnd = Math.min(offset + ATTACHMENT_SLICE_BYTES, raw.byteLength);
-      const slice = raw.subarray(offset, sliceEnd);
-      // `slice.toString("base64")` returns a fresh ~64 KiB string that
-      // becomes GC-eligible right after `Buffer.from(...)` copies its
-      // bytes into a new Buffer. Peak transient per slice: raw slice
-      // (48 KiB, borrowed view) + intermediate string (~64 KiB) +
-      // emitted Buffer (~64 KiB) = ~128 KiB. No growing accumulator.
-      yield Buffer.from(slice.toString("base64"), "utf8");
-    }
-    yield emit(`\r\n`);
-  }
-  yield emit(`--${boundary}--`);
-}
-
-/**
- * Build complete RFC822 message from mail data as a single string.
- *
- * Legacy consumer-facing API — the stream-native path
- * (`buildFullMessageStream` + `computeFullMessageSize`) is preferred
- * for BODY[] / RFC822 fetches because it keeps peak allocation at
- * O(chunk-size). This function collects every stream chunk into an
- * array and joins at the end — the pragmatic middle ground for the
- * remaining callers that need a materialized string:
- *
- * - `getBodyContent` for the TEXT section: takes the full message
- *   string, `indexOf("\r\n\r\n") + substring` to extract the body.
- *   Small-mail-friendly; large-attachment mails still pay the
- *   materialization here.
- * - `scripts/backfill-rfc822-size.ts` for the one-off backfill —
- *   though that script really wants `Buffer.byteLength(full, "utf8")`,
- *   which is exactly `computeFullMessageSize` without materializing.
- *   A follow-up can migrate the backfill to `computeFullMessageSize`
- *   and drop this function's dependency on the string materialization
- *   for that path.
- *
- * Uses `chunks.push(str) + chunks.join("")` internally instead of the
- * earlier `let body = ""; body += X;` chain — `Array#join` is a single
- * O(total_length) allocation vs the quadratic rope-realloc buildup
- * that made this the OOM offender on #729's K836 case.
- */
-export const buildFullMessage = (
-  mail: Partial<MailType>,
-  docId?: string
-): string => {
-  const headers = formatHeaders(mail, docId);
-  const hasText = mail.text && mail.text.trim().length > 0;
-  const hasHtml = mail.html && mail.html.trim().length > 0;
-  const hasAttachments = mail.attachments && mail.attachments.length > 0;
-
-  if (!hasText && !hasHtml && !hasAttachments) {
-    return `${headers}\r\n\r\n`;
-  }
-
-  if (hasText && !hasHtml && !hasAttachments) {
-    return `${headers}\r\n\r\n${encodeText(mail.text!)}\r\n`;
-  }
-
-  if (!hasText && hasHtml && !hasAttachments) {
-    return `${headers}\r\n\r\n${encodeText(mail.html!)}\r\n`;
-  }
-
-  if (!docId) {
-    logger.warn("docId is missing in buildFullMessage, falling back to messageId", {
+    logger.warn("docId is missing in buildMessageSegments, falling back to messageId", {
       component: "imap",
       messageId: mail.messageId
     });
   }
   const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
-  const chunks: string[] = [];
+
+  /** One base64 body part: boundary, part headers, encoded payload, CRLF. */
+  const bodyPart = (delimiter: string, contentType: string, source: string): void => {
+    literal(`--${delimiter}\r\n`);
+    literal(`Content-Type: ${contentType}; charset=utf-8\r\n`);
+    literal(`Content-Transfer-Encoding: base64\r\n\r\n`);
+    base64(source);
+    literal(`\r\n`);
+  };
 
   if (hasText && hasHtml && !hasAttachments) {
-    // multipart/alternative
-    const updatedHeaders = rewriteContentType(
-      headers,
-      `Content-Type: multipart/alternative; boundary="${boundary}"`
+    literal(
+      `${rewriteContentType(
+        headers,
+        `Content-Type: multipart/alternative; boundary="${boundary}"`
+      )}\r\n\r\n`
     );
-
-    chunks.push(`${updatedHeaders}\r\n\r\n`);
-    chunks.push(`--${boundary}\r\n`);
-    chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
-    chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    chunks.push(`${encodeText(mail.text!)}\r\n`);
-    chunks.push(`--${boundary}\r\n`);
-    chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
-    chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-    chunks.push(`${encodeText(mail.html!)}\r\n`);
-    chunks.push(`--${boundary}--`);
-  } else if (hasAttachments) {
-    // multipart/mixed
-    const updatedHeaders = rewriteContentType(
-      headers,
-      `Content-Type: multipart/mixed; boundary="${boundary}"`
-    );
-
-    chunks.push(`${updatedHeaders}\r\n\r\n`);
-
-    if (hasText && hasHtml) {
-      chunks.push(`--${boundary}\r\n`);
-      chunks.push(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
-      chunks.push(`--${altBoundary}\r\n`);
-      chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
-      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-      chunks.push(`${encodeText(mail.text!)}\r\n`);
-      chunks.push(`--${altBoundary}\r\n`);
-      chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
-      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-      chunks.push(`${encodeText(mail.html!)}\r\n`);
-      chunks.push(`--${altBoundary}--\r\n`);
-    } else if (hasText) {
-      chunks.push(`--${boundary}\r\n`);
-      chunks.push(`Content-Type: text/plain; charset=utf-8\r\n`);
-      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-      chunks.push(`${encodeText(mail.text!)}\r\n`);
-    } else if (hasHtml) {
-      chunks.push(`--${boundary}\r\n`);
-      chunks.push(`Content-Type: text/html; charset=utf-8\r\n`);
-      chunks.push(`Content-Transfer-Encoding: base64\r\n\r\n`);
-      chunks.push(`${encodeText(mail.html!)}\r\n`);
-    }
-
-    for (const att of mail.attachments!) {
-      chunks.push(`--${boundary}\r\n`);
-      chunks.push(`Content-Type: ${att.contentType}\r\n`);
-      chunks.push(`Content-Transfer-Encoding: base64\r\n`);
-      chunks.push(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
-      const attachmentData =
-        getAttachment(att.content.data) ||
-        Buffer.from("Attachment data not found");
-      chunks.push(`${attachmentData.toString("base64")}\r\n`);
-    }
-
-    chunks.push(`--${boundary}--`);
+    bodyPart(boundary, "text/plain", mail.text!);
+    bodyPart(boundary, "text/html", mail.html!);
+    literal(`--${boundary}--`);
+    return segments;
   }
 
-  return chunks.join("");
+  // hasAttachments — multipart/mixed
+  literal(
+    `${rewriteContentType(
+      headers,
+      `Content-Type: multipart/mixed; boundary="${boundary}"`
+    )}\r\n\r\n`
+  );
+
+  if (hasText && hasHtml) {
+    literal(`--${boundary}\r\n`);
+    literal(`Content-Type: multipart/alternative; boundary="${altBoundary}"\r\n\r\n`);
+    bodyPart(altBoundary, "text/plain", mail.text!);
+    bodyPart(altBoundary, "text/html", mail.html!);
+    literal(`--${altBoundary}--\r\n`);
+  } else if (hasText) {
+    bodyPart(boundary, "text/plain", mail.text!);
+  } else if (hasHtml) {
+    bodyPart(boundary, "text/html", mail.html!);
+  }
+
+  for (const att of mail.attachments!) {
+    literal(`--${boundary}\r\n`);
+    literal(`Content-Type: ${att.contentType}\r\n`);
+    literal(`Content-Transfer-Encoding: base64\r\n`);
+    literal(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
+    segments.push({
+      kind: "attachment",
+      dataId: att.content.data,
+      rawSize: resolveAttachmentRawSize(att.content.data),
+      filename: att.filename
+    });
+    literal(`\r\n`);
+  }
+  literal(`--${boundary}--`);
+  return segments;
+};
+
+/** Exact wire byte count of one segment. No I/O, no allocation. */
+const segmentByteLength = (segment: MessageSegment): number => {
+  switch (segment.kind) {
+    case "literal":
+      return Buffer.byteLength(segment.value, "utf8");
+    case "base64":
+      return base64ByteLen(Buffer.byteLength(segment.source, "utf8"));
+    case "attachment":
+      return base64ByteLen(segment.rawSize);
+  }
+};
+
+/**
+ * Trailing `\r\n` the wire response appends after the body serialization.
+ * `RFC822.SIZE` includes it so `SIZE == {N}` holds for `BODY[]`.
+ */
+const WIRE_TRAILER = 2;
+
+/**
+ * Exact WIRE byte count the IMAP `{N}` literal advertises for `BODY[]`, and
+ * the value `RFC822.SIZE` reports. Measures the same segment list
+ * `buildFullMessageStream` emits, so the two agree by construction rather
+ * than by two implementations happening to match.
+ */
+export const computeFullMessageSize = (
+  mail: Partial<MailType>,
+  docId?: string
+): number =>
+  buildMessageSegments(mail, docId).reduce(
+    (bytes, segment) => bytes + segmentByteLength(segment),
+    WIRE_TRAILER
+  );
+
+/**
+ * Raw bytes per base64 slice. MUST be divisible by 3: base64 pads any input
+ * whose length is not a multiple of 3, so a non-multiple slice size would
+ * inject `=` padding at every slice boundary — corrupting the payload for the
+ * client AND breaking the `ceil(n/3)*4` total the `{N}` literal advertises.
+ * 48 KiB raw encodes to ~64 KiB, matching CHUNK_BYTES in chunked-write.ts so
+ * one emitted chunk is roughly one socket write.
+ */
+const SLICE_RAW_BYTES = 48 * 1024;
+
+if (SLICE_RAW_BYTES % 3 !== 0) {
+  throw new Error(
+    `SLICE_RAW_BYTES must be divisible by 3 to avoid mid-stream base64 padding, got ${SLICE_RAW_BYTES}`
+  );
+}
+
+/** Emit `value` as byte-bounded chunks so one huge literal is not one write. */
+async function* emitLiteral(value: string): AsyncGenerator<Buffer, void, unknown> {
+  const buffer = Buffer.from(value, "utf8");
+  if (buffer.byteLength <= CHUNK_BYTES) {
+    yield buffer;
+    return;
+  }
+  for (let offset = 0; offset < buffer.byteLength; offset += CHUNK_BYTES) {
+    yield buffer.subarray(offset, Math.min(offset + CHUNK_BYTES, buffer.byteLength));
+  }
+}
+
+/**
+ * Emit `source` base64-encoded, one SLICE_RAW_BYTES slice at a time, so the
+ * encoded form never exists as a single allocation. Peak transient per slice
+ * is the raw slice view + the ~64 KiB encoded string + its Buffer.
+ */
+async function* emitBase64(source: string): AsyncGenerator<Buffer, void, unknown> {
+  const raw = Buffer.from(source, "utf8");
+  if (raw.byteLength === 0) return;
+  for (let offset = 0; offset < raw.byteLength; offset += SLICE_RAW_BYTES) {
+    const slice = raw.subarray(offset, Math.min(offset + SLICE_RAW_BYTES, raw.byteLength));
+    yield Buffer.from(slice.toString("base64"), "utf8");
+  }
+}
+
+/**
+ * Emit an attachment base64-encoded, reading the file in slices through a
+ * single descriptor so a multi-MB attachment never materializes whole.
+ *
+ * Emits EXACTLY `base64ByteLen(rawSize)` octets — the count already advertised
+ * in `{N}`. If the file disagrees with the size resolved at measure time (it
+ * changed, vanished, or became unreadable in between), the shortfall is padded
+ * with newlines, which are legal inside a base64 body and ignored by decoders.
+ * The client then sees one damaged attachment; emitting the true length instead
+ * would desync the literal and corrupt every later response on the connection.
+ * This function must never throw for the same reason: `{N}` is already on the
+ * wire by the time it runs.
+ */
+async function* emitAttachment(
+  segment: Extract<MessageSegment, { kind: "attachment" }>
+): AsyncGenerator<Buffer, void, unknown> {
+  const advertised = base64ByteLen(segment.rawSize);
+  let emitted = 0;
+
+  const emit = function* (encoded: string): Generator<Buffer, void, unknown> {
+    const remaining = advertised - emitted;
+    if (remaining <= 0) return;
+    const buffer = Buffer.from(encoded, "utf8");
+    const usable =
+      buffer.byteLength > remaining ? buffer.subarray(0, remaining) : buffer;
+    emitted += usable.byteLength;
+    yield usable;
+  };
+
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(getAttachmentFilePath(segment.dataId), "r");
+    const scratch = Buffer.allocUnsafe(SLICE_RAW_BYTES);
+    // Cast because Node's `readSync` types constrain the backing ArrayBuffer
+    // more tightly than `Buffer.allocUnsafe`'s return; same idiom as
+    // chunked-write.ts's `socket.write` call.
+    const target = scratch as unknown as Uint8Array;
+    let position = 0;
+    for (;;) {
+      const read = fs.readSync(fd, target, 0, SLICE_RAW_BYTES, position);
+      if (read <= 0) break;
+      position += read;
+      yield* emit(scratch.subarray(0, read).toString("base64"));
+      if (emitted >= advertised) break;
+    }
+  } catch (error) {
+    logger.warn("Attachment unreadable while streaming BODY[]", {
+      component: "imap",
+      filename: segment.filename,
+      err: error instanceof Error ? error.message : String(error)
+    });
+    yield* emit(Buffer.from(MISSING_ATTACHMENT_NOTICE, "utf8").toString("base64"));
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        // Nothing actionable; the descriptor is already gone.
+      }
+    }
+  }
+
+  if (emitted < advertised) {
+    logger.error("Attachment shorter than measured size; padding to hold the literal", {
+      component: "imap",
+      filename: segment.filename,
+      advertised,
+      emitted
+    });
+    yield Buffer.alloc(advertised - emitted, "\n");
+  }
+}
+
+/**
+ * Stream the RFC 822 serialization of a mail as `Buffer` chunks.
+ *
+ * The sum of yielded byte-lengths is exactly `computeFullMessageSize(mail,
+ * docId) - WIRE_TRAILER`; the caller appends the trailer. Both walk the same
+ * segment list, and every segment's emit is length-clamped to its measured
+ * size, so the `{N}` literal holds even when the filesystem changes underneath.
+ */
+export async function* buildFullMessageStream(
+  mail: Partial<MailType>,
+  docId?: string
+): AsyncGenerator<Buffer, void, unknown> {
+  for (const segment of buildMessageSegments(mail, docId)) {
+    switch (segment.kind) {
+      case "literal":
+        yield* emitLiteral(segment.value);
+        break;
+      case "base64":
+        yield* emitBase64(segment.source);
+        break;
+      case "attachment":
+        yield* emitAttachment(segment);
+        break;
+    }
+  }
+}
+
+/**
+ * Build the complete RFC 822 message as a single string.
+ *
+ * Materializing consumer for `getBodyContent`'s TEXT section, which needs
+ * `indexOf("\r\n\r\n") + substring` over the whole message. Prefer
+ * `buildFullMessageStream` + `computeFullMessageSize` for BODY[] / RFC822 —
+ * this function's peak allocation is O(message), which is what #729 was about.
+ */
+export const buildFullMessage = (mail: Partial<MailType>, docId?: string): string => {
+  const parts: string[] = [];
+  for (const segment of buildMessageSegments(mail, docId)) {
+    switch (segment.kind) {
+      case "literal":
+        parts.push(segment.value);
+        break;
+      case "base64":
+        parts.push(Buffer.from(segment.source, "utf8").toString("base64"));
+        break;
+      case "attachment": {
+        // Same length clamp as the streaming path, so a string built here and a
+        // stream emitted there are byte-identical and both match `{N}`.
+        const advertised = base64ByteLen(segment.rawSize);
+        let encoded: string;
+        try {
+          encoded = fs
+            .readFileSync(getAttachmentFilePath(segment.dataId))
+            .toString("base64");
+        } catch {
+          encoded = Buffer.from(MISSING_ATTACHMENT_NOTICE, "utf8").toString("base64");
+        }
+        if (encoded.length > advertised) encoded = encoded.slice(0, advertised);
+        else if (encoded.length < advertised)
+          encoded += "\n".repeat(advertised - encoded.length);
+        parts.push(encoded);
+        break;
+      }
+    }
+  }
+  return parts.join("");
 };
 
 /**

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -86,7 +86,7 @@ export const shouldMarkAsRead = (dataItems: FetchDataItem[]): boolean => {
  * literal whose count is wrong desyncs every subsequent response on the
  * connection.
  */
-type MessageSegment =
+export type MessageSegment =
   /** Emitted verbatim; measured with `Buffer.byteLength`. */
   | { kind: "literal"; value: string }
   /** `source` base64-encoded; sliced so the encoded form is never one allocation. */
@@ -151,7 +151,7 @@ const rewriteContentType = (headers: string, replacement: string): string =>
  * Attachment bodies are referenced by id + resolved size, never read, so
  * building the list costs one `stat` per attachment regardless of mail size.
  */
-const buildMessageSegments = (
+export const buildMessageSegments = (
   mail: Partial<MailType>,
   docId?: string
 ): MessageSegment[] => {
@@ -271,19 +271,30 @@ const segmentByteLength = (segment: MessageSegment): number => {
 const WIRE_TRAILER = 2;
 
 /**
+ * Sum the exact WIRE byte count for an already-built segment list. Used by
+ * callers that need BOTH the size and the stream to derive from the SAME
+ * segment list — building once, then measuring + streaming the same
+ * segments — so no `stat` race can make the `{N}` literal disagree with the
+ * emitted octets. See `buildBodyResponsePart` FULL branch.
+ */
+export const sumSegmentBytes = (segments: MessageSegment[]): number =>
+  segments.reduce(
+    (bytes, segment) => bytes + segmentByteLength(segment),
+    WIRE_TRAILER
+  );
+
+/**
  * Exact WIRE byte count the IMAP `{N}` literal advertises for `BODY[]`, and
- * the value `RFC822.SIZE` reports. Measures the same segment list
- * `buildFullMessageStream` emits, so the two agree by construction rather
- * than by two implementations happening to match.
+ * the value `RFC822.SIZE` reports. Convenience wrapper that builds + sums in
+ * one call — safe for RFC822.SIZE (single build, no stream to disagree
+ * with). For BODY[] the caller MUST share ONE segment list between
+ * `sumSegmentBytes` (for `{N}`) and `streamFromSegments` (for the octets)
+ * — see `buildBodyResponsePart` for the correct pattern.
  */
 export const computeFullMessageSize = (
   mail: Partial<MailType>,
   docId?: string
-): number =>
-  buildMessageSegments(mail, docId).reduce(
-    (bytes, segment) => bytes + segmentByteLength(segment),
-    WIRE_TRAILER
-  );
+): number => sumSegmentBytes(buildMessageSegments(mail, docId));
 
 /**
  * Raw bytes per base64 slice. MUST be divisible by 3: base64 pads any input
@@ -401,18 +412,21 @@ async function* emitAttachment(
 }
 
 /**
- * Stream the RFC 822 serialization of a mail as `Buffer` chunks.
+ * Stream a pre-built segment list as `Buffer` chunks. Sum of yielded
+ * byte-lengths equals `sumSegmentBytes(segments) - WIRE_TRAILER` — the
+ * caller appends the wire trailer.
  *
- * The sum of yielded byte-lengths is exactly `computeFullMessageSize(mail,
- * docId) - WIRE_TRAILER`; the caller appends the trailer. Both walk the same
- * segment list, and every segment's emit is length-clamped to its measured
- * size, so the `{N}` literal holds even when the filesystem changes underneath.
+ * **Load-bearing invariant:** the caller must share ONE segment list with
+ * `sumSegmentBytes` for its `{N}` — reproducing the segment list here
+ * (via `buildMessageSegments`) would `stat` files a second time and can
+ * race the measurement pass, corrupting the wire response by up to
+ * whatever the file's size changed by. That was hoiekim/inbox#733
+ * reviewoie HIGH.
  */
-export async function* buildFullMessageStream(
-  mail: Partial<MailType>,
-  docId?: string
+export async function* streamFromSegments(
+  segments: MessageSegment[]
 ): AsyncGenerator<Buffer, void, unknown> {
-  for (const segment of buildMessageSegments(mail, docId)) {
+  for (const segment of segments) {
     switch (segment.kind) {
       case "literal":
         yield* emitLiteral(segment.value);
@@ -425,6 +439,21 @@ export async function* buildFullMessageStream(
         break;
     }
   }
+}
+
+/**
+ * Legacy convenience wrapper — builds segments then streams them.
+ * DEPRECATED for BODY[] callers because it builds the segment list
+ * independently from `computeFullMessageSize`, letting `stat` races
+ * corrupt the wire literal. Prefer `buildMessageSegments` + share the
+ * result between `sumSegmentBytes` (for `{N}`) and `streamFromSegments`
+ * (for the octets). Kept for tests that only need the stream shape.
+ */
+export async function* buildFullMessageStream(
+  mail: Partial<MailType>,
+  docId?: string
+): AsyncGenerator<Buffer, void, unknown> {
+  yield* streamFromSegments(buildMessageSegments(mail, docId));
 }
 
 /**

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -22,7 +22,7 @@ import {
 } from "./idle-manager";
 import { getCapabilities } from "./capabilities";
 import { ImapRequestHandler } from "./handler";
-import { writeChunkedToSocket } from "./chunked-write";
+import { writeChunkedToSocket, writeStreamToSocket } from "./chunked-write";
 
 // Extracted module helpers
 import { handleAuthenticate, handleLogin } from "./auth";
@@ -152,6 +152,36 @@ export class ImapSession {
     const written = await writeChunkedToSocket(this.socket, payload, (error) =>
       logger.error(
         "Error in writeChunked socket.write",
+        { component: "imap" },
+        error
+      )
+    );
+    this.bytesWritten += written;
+  };
+
+  /**
+   * Stream an async iterable of `Buffer` chunks straight to the socket
+   * with backpressure. Used by BODY[] / RFC822 fetches wired through
+   * `buildFullMessageStream` — the full body is never materialized in
+   * memory; each chunk (~64 KiB base64 slice of one attachment) is
+   * emitted, written, and released before the next runs. Peak transient
+   * allocation stays sub-MB regardless of body size.
+   *
+   * Distinct from `writeChunked` because the source is a stream (the
+   * chunks are produced lazily by the generator) rather than a
+   * pre-materialized Buffer. Both share the same backpressure
+   * discipline via `chunked-write.ts`.
+   */
+  writeStream = async (chunks: AsyncIterable<Buffer>): Promise<void> => {
+    if (this.socket.destroyed || !this.socket.writable) {
+      logger.warn("Attempted to writeStream to destroyed/unwritable socket", {
+        component: "imap",
+      });
+      return;
+    }
+    const written = await writeStreamToSocket(this.socket, chunks, (error) =>
+      logger.error(
+        "Error in writeStream socket.write",
         { component: "imap" },
         error
       )
@@ -376,6 +406,7 @@ export class ImapSession {
       this.seqState,
       this.write,
       this.writeChunked,
+      this.writeStream,
       this.condstoreEnabled
     );
   };


### PR DESCRIPTION
Rewrite of the earlier chunk-array PR into **true stream-to-socket** per Hoie's request. Peak transient allocation drops from ~100MB (intermediate JS string + full Buffer materialization) to O(largest source body part) — attachments no longer materialize at all, and no part is ever copied into a base64 string plus a template-literal copy plus a Buffer.

> **Corrected after review.** An earlier version of this description claimed a flat ~128 KB peak "regardless of body size," and that `{N}` could be derived from the `att.size` stored on the mail row. Both were wrong: `text`/`html` already sit in memory on the mail row, so O(source part) is the floor here, and measuring the stored size while streaming the file desynced the IMAP literal. See the Tradeoffs section and the review thread.

## Architecture

1. **`buildMessageSegments(mail, docId): MessageSegment[]`** — the **single** definition of the MIME layout. A segment is either a literal string, a base64-encoded source string, or an attachment referenced by id + resolved raw size. Measuring and emitting both walk this one list, so the count and the payload cannot drift apart. The layout used to exist as three hand-parallel copies (measure / emit / materialize), which is how `{N}` desynced.

2. **`computeFullMessageSize(mail, docId): number`** — sums the segment lengths (`4*ceil(n/3)` for base64 parts). Attachment sizes come from a `stat` of the same path the bytes are read from — metadata only, no read, no allocation — so this still returns the exact wire byte count with no body materialization. RFC822.SIZE calls it directly instead of building the whole body to read `.length`, **killing the K836-style ~+66MB spike from #729** on the first-fetch path (the #731 cached-column hit path is unchanged).

3. **`buildFullMessageStream(mail, docId): AsyncGenerator<Buffer>`** — emits the same segment list as small Buffer chunks. Attachments are read through a single descriptor in 48 KiB positional reads and base64-encoded per slice, so **a multi-MB attachment never materializes**; `text`/`html` are slice-encoded the same way rather than emitted as one Buffer per part. `SLICE_RAW_BYTES` asserts divisibility by 3 at load, since a non-multiple would inject base64 padding at every slice boundary. Each attachment emit is **clamped to its measured length**, so a file that changes underneath yields one damaged attachment instead of a desynced connection, and the emit path never throws (`{N}` is already on the wire by then).

4. **`FetchResponsePart` gains a `stream` variant**: `{ type: "stream"; stream: AsyncIterable<Buffer>; header: string; length: number }`. Sum of yielded chunk byte-lengths equals `.length` by construction.

5. **`writeStreamToSocket`** in `chunked-write.ts` — same backpressure discipline as `writeChunkedToSocket` (await `drain` on high-water, exit on socket close), consumes iterable directly.

6. **`session.writeStream`** wraps it, threaded through `fetchMessages → _processFetchMessages → writeFetchResponse` next to `writeChunked`.

7. **`buildBodyResponsePart` FULL branch** routes through the stream, wrapped in **`withBodyBudgetStream`** so the largest fetch shape stays inside the `IMAP_BODY_FETCH_CONCURRENCY` cap for the stream's whole lifetime (`withBodyBudget` releases when its promise settles, which for a generator is before the consumer reads a chunk). The slot is released in `finally`, so an aborted FETCH cannot leak it. TEXT / MIME_PART / partial / header-like sections keep the shared body-buffer cache (small payloads, TTL still earns its keep). RFC822 (aliased BODY[] FULL) inherits streaming automatically.

8. **`buildFullMessage` now walks the same segment list** as the stream and the size computation, so the string it materializes is byte-identical to what the stream emits. Public signature preserved (returns `string`) so the TEXT-section slice consumer works unchanged.

## Kills

- ~50-100MB transient JS-string spike on every BODY[] / RFC822 build.
- ~+66MB K836 spike from RFC822.SIZE materialization.
- TTL cache re-materialization on iOS retry (#729 K843 class): with streaming, re-stream from disk is a few reads + base64 encodes, no rebuild of a ~26MB string.
- The uncapped-concurrency hole this PR briefly opened: BODY[] FULL is back inside the body budget.

## Test coverage additions

Two of the guards this PR originally shipped could not fail, which is why HIGH 1 got past a green suite:

- `RFC822.SIZE equals BODY[] length` compared `computeFullMessageSize` to `computeFullMessageSize`. Every shape now **drains the generator** and asserts summed octets against the reported size, and asserts `type === "stream"` exactly rather than `stream || literal`.
- The peak-allocation guard used a 10-byte body, so its 256 KiB ceiling never fired. It now uses a multi-megabyte body and also asserts the chunk count.

New coverage, all against real files on disk (a stubbed reader is what lets the measured size and the emitted bytes disagree in the first place):

- **Stored-size divergence**: larger than the file, smaller, zero (the `Attachment` ctor default for a falsy incoming size), `undefined` (must not advertise `NaN`), file missing entirely, and mixed present/missing across two attachments. Each asserts the octet count AND decodes the part back to compare against the file — with the length clamp in place the count holds even with the bug, so content fidelity is the assertion that actually distinguishes them.
- **Every MIME layout branch**: text+html+attachment (alternative nested in mixed), html+attachment, attachment-only, multibyte text+attachment.
- **Multi-slice round-trip**: a 200 KB attachment crossing several slice boundaries decodes byte-for-byte, with the encoded length equal to `ceil(n/3)*4`.
- **Body budget**: a slot is held while the stream is in flight (capacity is saturated first, then a further acquire must block until the stream finishes) and released when the consumer abandons the generator early.

Each fix is **mutation-verified**, not just asserted green:

| Mutation | Failing tests |
|---|---|
| `rawSize: att.size` (re-introduce HIGH 1) | 3 |
| Emit a body part as one Buffer (un-chunk) | 1 |
| Drop the `withBodyBudgetStream` wrap | 2 |

The first version of the budget tests passed under all three mutations — vacuous in exactly the way HIGH 2 describes — and was rewritten.

`bun test src/server` → **1379 pass / 0 fail** · `bun run typecheck` clean · `bun --bun eslint src` 0 errors.

## Tradeoffs

- **No shared-Buffer coalescing** for concurrent identical BODY[] callers on the same UID. Each caller gets its own generator + attachment reads. Rare in practice (iOS Mail dispatches per connection serially). Memory ceiling saved > disk reads gained.
- **TTL cache in `body-buffer.ts` stays** for non-FULL sections.
- **Peak is O(largest source part), not a flat ~128 KiB.** The earlier description of this PR claimed the latter; it was wrong. `text` and `html` are now slice-encoded rather than emitted as one Buffer per part, and attachments are read through a single descriptor in 48 KiB positional reads instead of `readFileSync` — so the peak is the source part itself rather than source + base64 copy + template copy. The mail row already holds `text`/`html` in memory, so O(source) is the floor without changing where body content comes from.
- **A file that changes between measure and emit yields a damaged attachment**, deliberately: the emit is clamped to the advertised length so the connection stays in sync. Emitting the true length instead would desync the literal and corrupt every later response. Logged at error level when it happens.

## Test plan

Pre-merge, at head `ec09554`:

- [x] `bun run typecheck` — clean
- [x] `bun --bun eslint src` — 0 errors (17 pre-existing warnings, none in changed files)
- [x] `bun test src/server` — 1379 pass / 0 fail across 68 files
- [x] `{N}`-vs-emitted-octets agreement drained for every MIME layout branch and six stored-size divergence cases, against real attachment files
- [x] Mutation testing per the table above, confirming each guard fails when its fix is removed

Not done, and not claimed: **no live IMAP-socket drive at this head.** These are protocol internals with no browser-reachable surface, so verification is the unit level plus the mutation testing. A raw-socket fetch against the sandbox would still be worth doing before merge for the exact-octet and mid-literal-disconnect cases.

Post-merge observation (unchanged from the original plan):

- [ ] Repro a large-body BODY[] fetch on prod — observe `rssDeltaMB` in the per-command diag log.
- [ ] Repro a K836-style `UID FETCH X (UID RFC822.SIZE BODYSTRUCTURE)`.
- [ ] Verify iOS Mail sync completes without OOM signals from the K843 sequential-retry class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

