### PR TITLE
fix(imap): derive the updated auto-column from the table schema so CREATE works

### DIFF
--- a/src/server/lib/postgres/database.test.ts
+++ b/src/server/lib/postgres/database.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for the SQL builders in `database.ts`, focused on the `updated`
+ * auto-column.
+ *
+ * `buildInsert` / `buildUpsert` stamp `updated = CURRENT_TIMESTAMP` on every
+ * generated INSERT. That is correct for every table whose DDL declares an
+ * `updated` column and a hard failure for any table that does not — Postgres
+ * rejects the statement with `column "updated" of relation "<t>" does not
+ * exist`. `mailboxes` was in exactly that state, so every IMAP
+ * `CREATE <mailbox>` failed (#687).
+ *
+ * The last test is the regression guard: it walks the real table registry and
+ * asserts the builders can only emit columns that the table's own DDL
+ * declares, so a future builder-written table missing `updated` fails here
+ * rather than at runtime.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildInsert, buildUpsert } from "./database";
+import { tables } from "./initialize";
+
+/** Column list between the first parenthesised group of an INSERT. */
+const insertColumns = (sql: string): string[] => {
+  const m = sql.match(/INSERT INTO \S+ \(([^)]*)\)/);
+  if (!m) throw new Error(`not an INSERT: ${sql}`);
+  return m[1].split(",").map((c) => c.trim());
+};
+
+describe("buildInsert — updated auto-column", () => {
+  it("stamps updated = CURRENT_TIMESTAMP by default", () => {
+    const { sql, values } = buildInsert("users", { user_id: "u1", username: "a" });
+    expect(insertColumns(sql)).toEqual(["updated", "user_id", "username"]);
+    expect(sql).toContain("VALUES (CURRENT_TIMESTAMP, $1, $2)");
+    expect(values).toEqual(["u1", "a"]);
+  });
+
+  it("stamps updated when the option is explicitly true", () => {
+    const { sql } = buildInsert("users", { user_id: "u1" }, undefined, {
+      stampUpdated: true,
+    });
+    expect(insertColumns(sql)).toEqual(["updated", "user_id"]);
+  });
+
+  it("omits updated when stampUpdated is false", () => {
+    const { sql, values } = buildInsert("mailboxes", { user_id: "u1", name: "Archive" }, undefined, {
+      stampUpdated: false,
+    });
+    expect(insertColumns(sql)).toEqual(["user_id", "name"]);
+    expect(sql).not.toContain("updated");
+    expect(sql).toContain("VALUES ($1, $2)");
+    expect(values).toEqual(["u1", "Archive"]);
+  });
+
+  it("keeps placeholder numbering 1-based when updated is omitted", () => {
+    const { sql } = buildInsert("mailboxes", { a: 1, b: 2, c: 3 }, undefined, {
+      stampUpdated: false,
+    });
+    expect(sql).toContain("VALUES ($1, $2, $3)");
+  });
+
+  it("still honours the RETURNING clause with updated omitted", () => {
+    const { sql } = buildInsert("mailboxes", { name: "Archive" }, ["*"], {
+      stampUpdated: false,
+    });
+    expect(sql).toContain("RETURNING *");
+  });
+});
+
+describe("buildUpsert — updated auto-column", () => {
+  it("stamps updated in both the column list and the DO UPDATE SET by default", () => {
+    const { sql } = buildUpsert("users", "user_id", { user_id: "u1", username: "a" }, {
+      updateColumns: ["username"],
+    });
+    expect(insertColumns(sql)).toEqual(["updated", "user_id", "username"]);
+    expect(sql).toContain("DO UPDATE SET username = EXCLUDED.username, updated = CURRENT_TIMESTAMP");
+  });
+
+  it("omits updated from both places when stampUpdated is false", () => {
+    const { sql } = buildUpsert("mailboxes", "mailbox_id", { mailbox_id: "m1", name: "Archive" }, {
+      updateColumns: ["name"],
+      stampUpdated: false,
+    });
+    expect(insertColumns(sql)).toEqual(["mailbox_id", "name"]);
+    expect(sql).toContain("DO UPDATE SET name = EXCLUDED.name");
+    expect(sql).not.toContain("updated");
+  });
+
+  it("degrades to DO NOTHING when omitting updated leaves an empty SET list", () => {
+    // Every requested update column is the conflict key, so after the
+    // primary-key filter nothing is left to write. An empty `SET` list is a
+    // syntax error; DO NOTHING is the correct degenerate form.
+    const { sql } = buildUpsert("mailboxes", "mailbox_id", { mailbox_id: "m1" }, {
+      updateColumns: ["mailbox_id"],
+      stampUpdated: false,
+    });
+    expect(sql).toContain("ON CONFLICT (mailbox_id) DO NOTHING");
+    expect(sql).not.toContain("DO UPDATE SET");
+  });
+
+  it("still emits DO NOTHING when updateColumns is empty, regardless of stampUpdated", () => {
+    for (const stampUpdated of [true, false]) {
+      const { sql } = buildUpsert("t", "id", { id: "1", a: "x" }, { stampUpdated });
+      expect(sql).toContain("ON CONFLICT (id) DO NOTHING");
+    }
+  });
+});
+
+describe("builder columns vs. table DDL (regression guard for #687)", () => {
+  it("registers at least the known tables", () => {
+    // Guards against an empty import silently passing the sweep below.
+    expect(tables.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("only emits columns the table's own schema declares", () => {
+    const offenders: string[] = [];
+    for (const table of tables) {
+      const declared = new Set(Object.keys(table.schema));
+      // A single non-primary-key column is enough to exercise the auto-column
+      // prefix; the per-row columns come straight from the caller's data.
+      const probe = Object.keys(table.schema).find((c) => c !== table.primaryKey);
+      if (!probe) continue;
+      const { sql } = buildInsert(table.name, { [probe]: "x" }, undefined, {
+        stampUpdated: "updated" in table.schema,
+      });
+      for (const column of insertColumns(sql)) {
+        if (!declared.has(column)) offenders.push(`${table.name}.${column}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("mailboxes declares no updated column, so its INSERT must not stamp one", () => {
+    // Pins the specific shape of #687: the bug was invisible because the unit
+    // tests mocked the pool, so the generated SQL never met the real schema.
+    const mailboxes = tables.find((t) => t.name === "mailboxes");
+    expect(mailboxes).toBeDefined();
+    expect("updated" in mailboxes!.schema).toBe(false);
+    const { sql } = buildInsert(mailboxes!.name, { name: "Archive" }, undefined, {
+      stampUpdated: "updated" in mailboxes!.schema,
+    });
+    expect(sql).not.toContain("updated");
+  });
+});

--- a/src/server/lib/postgres/database.test.ts
+++ b/src/server/lib/postgres/database.test.ts
@@ -1,143 +1,220 @@
 /**
- * Tests for the SQL builders in `database.ts`, focused on the `updated`
- * auto-column.
- *
- * `buildInsert` / `buildUpsert` stamp `updated = CURRENT_TIMESTAMP` on every
- * generated INSERT. That is correct for every table whose DDL declares an
- * `updated` column and a hard failure for any table that does not — Postgres
- * rejects the statement with `column "updated" of relation "<t>" does not
- * exist`. `mailboxes` was in exactly that state, so every IMAP
- * `CREATE <mailbox>` failed (#687).
- *
- * The last test is the regression guard: it walks the real table registry and
- * asserts the builders can only emit columns that the table's own DDL
- * declares, so a future builder-written table missing `updated` fails here
- * rather than at runtime.
+ * The `updated` / `is_deleted` auto-columns are appended by the SQL builders,
+ * so a table whose DDL declares neither must not get them — Postgres rejects
+ * the whole statement. These tests drive the real `Table` methods (via the pg
+ * FakePool seam) so removing the schema derivation fails here, not at runtime.
  */
 
-import { describe, it, expect } from "bun:test";
-import { buildInsert, buildUpsert } from "./database";
-import { tables } from "./initialize";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, mock } from "bun:test";
+import { restoreLeaves } from "test-helpers";
+import { buildUpsert } from "./database";
 
-/** Column list between the first parenthesised group of an INSERT. */
+const queries: { sql: string; values?: unknown[] }[] = [];
+
+const mockQuery = mock(async (sql: string, values?: unknown[]) => {
+  queries.push({ sql, values });
+  return { rows: [] as unknown[], rowCount: 0 as number | null };
+});
+
+class FakePool {
+  query = mockQuery;
+  end = async () => {};
+  connect = async () => ({ query: mockQuery, release: () => {} });
+  on() {}
+}
+
+const pgMock = () => ({
+  Pool: FakePool,
+  types: { setTypeParser: () => {}, builtins: {}, getTypeParser: () => null },
+  default: { Pool: FakePool, types: { setTypeParser: () => {} } },
+});
+
+mock.module("pg", pgMock);
+
+// Import the subjects only after the pg mock is registered, so the lazy pool in
+// `postgres/client.ts` instantiates FakePool instead of a real connection.
+const { tables } = await import("./initialize");
+const { usersTable, sessionsTable, mailboxesTable } = await import("./models");
+const { resetPool } = await import("./client");
+
+beforeAll(() => {
+  mock.module("pg", pgMock);
+  resetPool();
+});
+
+afterAll(() => {
+  restoreLeaves();
+  resetPool();
+});
+
+beforeEach(() => {
+  queries.length = 0;
+  resetPool();
+});
+
+/** The SQL of the single statement the method under test issued. */
+const lastSql = (): string => {
+  if (queries.length !== 1) {
+    throw new Error(`expected exactly 1 query, got ${queries.length}`);
+  }
+  return queries[0].sql;
+};
+
+/** Columns of an `INSERT INTO t (a, b, c)` column list. */
 const insertColumns = (sql: string): string[] => {
   const m = sql.match(/INSERT INTO \S+ \(([^)]*)\)/);
   if (!m) throw new Error(`not an INSERT: ${sql}`);
   return m[1].split(",").map((c) => c.trim());
 };
 
-describe("buildInsert — updated auto-column", () => {
-  it("stamps updated = CURRENT_TIMESTAMP by default", () => {
-    const { sql, values } = buildInsert("users", { user_id: "u1", username: "a" });
+/** Left-hand columns of an `UPDATE t SET a = $1, b = ...` assignment list. */
+const setColumns = (sql: string): string[] => {
+  const m = sql.match(/\bSET\s+(.*?)(?:\s+WHERE\b|\s+RETURNING\b|$)/s);
+  if (!m) throw new Error(`no SET clause: ${sql}`);
+  return m[1].split(",").map((c) => c.split("=")[0].trim());
+};
+
+describe("Table.insert — updated auto-column", () => {
+  it("stamps updated for a table whose schema declares it", async () => {
+    await usersTable.insert({ user_id: "u1", username: "alice" });
+    const sql = lastSql();
     expect(insertColumns(sql)).toEqual(["updated", "user_id", "username"]);
     expect(sql).toContain("VALUES (CURRENT_TIMESTAMP, $1, $2)");
-    expect(values).toEqual(["u1", "a"]);
   });
 
-  it("stamps updated when the option is explicitly true", () => {
-    const { sql } = buildInsert("users", { user_id: "u1" }, undefined, {
-      stampUpdated: true,
-    });
-    expect(insertColumns(sql)).toEqual(["updated", "user_id"]);
-  });
-
-  it("omits updated when stampUpdated is false", () => {
-    const { sql, values } = buildInsert("mailboxes", { user_id: "u1", name: "Archive" }, undefined, {
-      stampUpdated: false,
-    });
+  it("omits updated for mailboxes, which declares no such column", async () => {
+    await mailboxesTable.insert({ user_id: "u1", name: "Archive" }, ["*"]);
+    const sql = lastSql();
     expect(insertColumns(sql)).toEqual(["user_id", "name"]);
     expect(sql).not.toContain("updated");
     expect(sql).toContain("VALUES ($1, $2)");
-    expect(values).toEqual(["u1", "Archive"]);
-  });
-
-  it("keeps placeholder numbering 1-based when updated is omitted", () => {
-    const { sql } = buildInsert("mailboxes", { a: 1, b: 2, c: 3 }, undefined, {
-      stampUpdated: false,
-    });
-    expect(sql).toContain("VALUES ($1, $2, $3)");
-  });
-
-  it("still honours the RETURNING clause with updated omitted", () => {
-    const { sql } = buildInsert("mailboxes", { name: "Archive" }, ["*"], {
-      stampUpdated: false,
-    });
     expect(sql).toContain("RETURNING *");
   });
 });
 
-describe("buildUpsert — updated auto-column", () => {
-  it("stamps updated in both the column list and the DO UPDATE SET by default", () => {
-    const { sql } = buildUpsert("users", "user_id", { user_id: "u1", username: "a" }, {
-      updateColumns: ["username"],
-    });
-    expect(insertColumns(sql)).toEqual(["updated", "user_id", "username"]);
-    expect(sql).toContain("DO UPDATE SET username = EXCLUDED.username, updated = CURRENT_TIMESTAMP");
+describe("Table.update — updated auto-column", () => {
+  it("stamps updated for a table whose schema declares it", async () => {
+    await usersTable.update("u1", { username: "alice" });
+    expect(setColumns(lastSql())).toEqual(["updated", "username"]);
   });
 
-  it("omits updated from both places when stampUpdated is false", () => {
-    const { sql } = buildUpsert("mailboxes", "mailbox_id", { mailbox_id: "m1", name: "Archive" }, {
-      updateColumns: ["name"],
-      stampUpdated: false,
-    });
-    expect(insertColumns(sql)).toEqual(["mailbox_id", "name"]);
-    expect(sql).toContain("DO UPDATE SET name = EXCLUDED.name");
+  it("omits updated for mailboxes (the IMAP RENAME path)", async () => {
+    await mailboxesTable.update("m1", { name: "Renamed", uid_validity: 2 });
+    const sql = lastSql();
+    expect(setColumns(sql)).toEqual(["name", "uid_validity"]);
     expect(sql).not.toContain("updated");
+    expect(sql).toContain("WHERE mailbox_id = $3");
+    expect(queries[0].values).toEqual(["Renamed", 2, "m1"]);
   });
 
-  it("degrades to DO NOTHING when omitting updated leaves an empty SET list", () => {
-    // Every requested update column is the conflict key, so after the
-    // primary-key filter nothing is left to write. An empty `SET` list is a
-    // syntax error; DO NOTHING is the correct degenerate form.
-    const { sql } = buildUpsert("mailboxes", "mailbox_id", { mailbox_id: "m1" }, {
-      updateColumns: ["mailbox_id"],
-      stampUpdated: false,
-    });
-    expect(sql).toContain("ON CONFLICT (mailbox_id) DO NOTHING");
-    expect(sql).not.toContain("DO UPDATE SET");
-  });
-
-  it("still emits DO NOTHING when updateColumns is empty, regardless of stampUpdated", () => {
-    for (const stampUpdated of [true, false]) {
-      const { sql } = buildUpsert("t", "id", { id: "1", a: "x" }, { stampUpdated });
-      expect(sql).toContain("ON CONFLICT (id) DO NOTHING");
-    }
+  it("returns null without querying when the caller supplies no column", async () => {
+    expect(await mailboxesTable.update("m1", {})).toBeNull();
+    expect(await usersTable.update("u1", {})).toBeNull();
+    expect(queries).toHaveLength(0);
   });
 });
 
-describe("builder columns vs. table DDL (regression guard for #687)", () => {
+describe("Table.upsert — updated auto-column", () => {
+  it("stamps updated in both the column list and the DO UPDATE SET", async () => {
+    await sessionsTable.upsert({ session_id: "s1", session_username: "alice" });
+    const sql = lastSql();
+    expect(insertColumns(sql)).toEqual(["updated", "session_id", "session_username"]);
+    expect(sql).toContain(
+      "DO UPDATE SET session_username = EXCLUDED.session_username, updated = CURRENT_TIMESTAMP"
+    );
+  });
+
+  it("omits updated from both places for mailboxes", async () => {
+    await mailboxesTable.upsert({ mailbox_id: "m1", name: "Archive" });
+    const sql = lastSql();
+    expect(insertColumns(sql)).toEqual(["mailbox_id", "name"]);
+    expect(sql).toContain("DO UPDATE SET name = EXCLUDED.name");
+    expect(sql).not.toContain("updated");
+    expect(sql).toContain("RETURNING *");
+  });
+});
+
+describe("Table.softDelete — auto-columns", () => {
+  it("sets is_deleted and stamps updated where both are declared", async () => {
+    await usersTable.softDelete("u1");
+    expect(setColumns(lastSql())).toEqual(["is_deleted", "updated"]);
+  });
+
+  it("throws instead of emitting SQL for a table without is_deleted", async () => {
+    await expect(mailboxesTable.softDelete("m1")).rejects.toThrow(
+      /mailboxes declares no is_deleted column/
+    );
+    expect(queries).toHaveLength(0);
+  });
+});
+
+describe("buildUpsert — empty SET degradation", () => {
+  it("re-assigns the conflict key so RETURNING still yields the row", () => {
+    // Every requested update column is the conflict key and the table has no
+    // `updated`: DO NOTHING here would drop RETURNING and make upsert() null.
+    const { sql } = buildUpsert("mailboxes", "mailbox_id", { mailbox_id: "m1" }, {
+      updateColumns: ["mailbox_id"],
+      stampUpdated: false,
+      returning: ["*"],
+    });
+    expect(sql).toContain(
+      "ON CONFLICT (mailbox_id) DO UPDATE SET mailbox_id = EXCLUDED.mailbox_id"
+    );
+    expect(sql).toContain("RETURNING *");
+    expect(sql).not.toContain("DO NOTHING");
+  });
+
+  it("keeps DO NOTHING when the caller asks for no update columns", () => {
+    const { sql } = buildUpsert("t", "id", { id: "1", a: "x" }, { updateColumns: [] });
+    expect(sql).toContain("ON CONFLICT (id) DO NOTHING");
+  });
+});
+
+describe("every registered table, through the real Table methods", () => {
   it("registers at least the known tables", () => {
-    // Guards against an empty import silently passing the sweep below.
+    // Guards against an empty import silently passing the sweeps below.
     expect(tables.length).toBeGreaterThanOrEqual(10);
   });
 
-  it("only emits columns the table's own schema declares", () => {
+  it("emits only columns the table's own schema declares", async () => {
     const offenders: string[] = [];
     for (const table of tables) {
       const declared = new Set(Object.keys(table.schema));
-      // A single non-primary-key column is enough to exercise the auto-column
-      // prefix; the per-row columns come straight from the caller's data.
+      // One non-primary-key column is enough: the auto-columns are what the
+      // builders add on top of whatever the caller passes.
       const probe = Object.keys(table.schema).find((c) => c !== table.primaryKey);
       if (!probe) continue;
-      const { sql } = buildInsert(table.name, { [probe]: "x" }, undefined, {
-        stampUpdated: "updated" in table.schema,
-      });
-      for (const column of insertColumns(sql)) {
-        if (!declared.has(column)) offenders.push(`${table.name}.${column}`);
+      const check = (columns: string[], method: string) => {
+        for (const column of columns) {
+          if (!declared.has(column)) offenders.push(`${table.name}.${column} (${method})`);
+        }
+      };
+
+      queries.length = 0;
+      await table.insert({ [probe]: "x" });
+      check(insertColumns(lastSql()), "insert");
+
+      queries.length = 0;
+      await table.upsert({ [table.primaryKey]: "pk", [probe]: "x" });
+      check(insertColumns(lastSql()), "upsert");
+
+      queries.length = 0;
+      await table.update("pk", { [probe]: "x" });
+      check(setColumns(lastSql()), "update");
+
+      if ("is_deleted" in table.schema) {
+        queries.length = 0;
+        await table.softDelete("pk");
+        check(setColumns(lastSql()), "softDelete");
       }
     }
     expect(offenders).toEqual([]);
   });
 
-  it("mailboxes declares no updated column, so its INSERT must not stamp one", () => {
-    // Pins the specific shape of #687: the bug was invisible because the unit
-    // tests mocked the pool, so the generated SQL never met the real schema.
-    const mailboxes = tables.find((t) => t.name === "mailboxes");
-    expect(mailboxes).toBeDefined();
-    expect("updated" in mailboxes!.schema).toBe(false);
-    const { sql } = buildInsert(mailboxes!.name, { name: "Archive" }, undefined, {
-      stampUpdated: "updated" in mailboxes!.schema,
-    });
-    expect(sql).not.toContain("updated");
+  it("declares supportsSoftDelete iff the schema has an is_deleted column", () => {
+    const mismatched = tables
+      .filter((t) => t.supportsSoftDelete !== ("is_deleted" in t.schema))
+      .map((t) => t.name);
+    expect(mismatched).toEqual([]);
   });
 });

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -30,6 +30,8 @@ export interface UpdateOptions {
 export interface UpsertOptions {
   updateColumns?: string[];
   returning?: string[];
+  /** See `StampUpdatedOption`. Defaults to `true`. */
+  stampUpdated?: boolean;
 }
 
 // Type guards
@@ -103,13 +105,29 @@ export function prepareQuery(
   return { sql, values };
 }
 
+/**
+ * Whether the generated INSERT should stamp `updated = CURRENT_TIMESTAMP`.
+ * Only tables whose DDL declares an `updated` column may — Postgres rejects
+ * the INSERT outright otherwise. `Table.insert` / `Table.upsert` derive this
+ * from their own schema; the default stays `true` so a caller that predates
+ * the option keeps its existing SQL.
+ */
+export interface StampUpdatedOption {
+  stampUpdated?: boolean;
+}
+
+const autoColumns = (stampUpdated: boolean) =>
+  stampUpdated
+    ? { columns: ["updated"], placeholders: ["CURRENT_TIMESTAMP"] }
+    : { columns: [] as string[], placeholders: [] as string[] };
+
 export function buildInsert(
   tableName: string,
   data: Record<string, ParamValue>,
-  returning?: string[]
+  returning?: string[],
+  options: StampUpdatedOption = {}
 ): PreparedQuery {
-  const columns: string[] = ["updated"];
-  const placeholders: string[] = ["CURRENT_TIMESTAMP"];
+  const { columns, placeholders } = autoColumns(options.stampUpdated !== false);
   const values: ParamValue[] = [];
   let paramIndex = 1;
 
@@ -178,10 +196,9 @@ export function buildUpsert(
   data: QueryData,
   options: UpsertOptions = {}
 ): PreparedQuery {
-  const { updateColumns = [], returning = [primaryKey] } = options;
+  const { updateColumns = [], returning = [primaryKey], stampUpdated = true } = options;
 
-  const columns: string[] = ["updated"];
-  const placeholders: string[] = ["CURRENT_TIMESTAMP"];
+  const { columns, placeholders } = autoColumns(stampUpdated);
   const values: ParamValue[] = [];
   let paramIndex = 1;
 
@@ -199,8 +216,16 @@ export function buildUpsert(
     const updateClauses = updateColumns
       .filter((col) => col !== primaryKey)
       .map((col) => `${col} = EXCLUDED.${col}`);
-    updateClauses.push("updated = CURRENT_TIMESTAMP");
-    sql += ` ON CONFLICT (${primaryKey}) DO UPDATE SET ${updateClauses.join(", ")}`;
+    if (stampUpdated) updateClauses.push("updated = CURRENT_TIMESTAMP");
+    // An empty SET list is a syntax error. Reachable only when the table has
+    // no `updated` column AND every requested update column is the conflict
+    // key — nothing is left to write, so DO NOTHING is the right degenerate
+    // form. (With `stampUpdated` the timestamp always kept the list non-empty,
+    // which is why this branch could not arise before.)
+    sql +=
+      updateClauses.length > 0
+        ? ` ON CONFLICT (${primaryKey}) DO UPDATE SET ${updateClauses.join(", ")}`
+        : ` ON CONFLICT (${primaryKey}) DO NOTHING`;
   } else {
     sql += ` ON CONFLICT (${primaryKey}) DO NOTHING`;
   }

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -22,16 +22,27 @@ export interface WhereOptions {
   excludeDeleted?: boolean;
 }
 
-export interface UpdateOptions {
+/**
+ * Set `stampUpdated: false` for a table whose DDL declares no `updated` column —
+ * Postgres rejects the whole statement otherwise. `Table` derives it from its own
+ * schema; the default `true` keeps the SQL of callers that predate the option.
+ */
+export interface StampUpdatedOption {
+  stampUpdated?: boolean;
+}
+
+export interface UpdateOptions extends StampUpdatedOption {
   additionalWhere?: { column: string; value: ParamValue };
   returning?: string[];
 }
 
-export interface UpsertOptions {
+export interface UpsertOptions extends StampUpdatedOption {
   updateColumns?: string[];
   returning?: string[];
-  /** See `StampUpdatedOption`. Defaults to `true`. */
-  stampUpdated?: boolean;
+}
+
+export interface SoftDeleteOptions extends StampUpdatedOption {
+  additionalWhere?: { column: string; value: ParamValue };
 }
 
 // Type guards
@@ -105,17 +116,6 @@ export function prepareQuery(
   return { sql, values };
 }
 
-/**
- * Whether the generated INSERT should stamp `updated = CURRENT_TIMESTAMP`.
- * Only tables whose DDL declares an `updated` column may — Postgres rejects
- * the INSERT outright otherwise. `Table.insert` / `Table.upsert` derive this
- * from their own schema; the default stays `true` so a caller that predates
- * the option keeps its existing SQL.
- */
-export interface StampUpdatedOption {
-  stampUpdated?: boolean;
-}
-
 const autoColumns = (stampUpdated: boolean) =>
   stampUpdated
     ? { columns: ["updated"], placeholders: ["CURRENT_TIMESTAMP"] }
@@ -155,9 +155,11 @@ export function buildUpdate(
   data: QueryData,
   options: UpdateOptions = {}
 ): PreparedQuery | null {
-  const setClauses: string[] = ["updated = CURRENT_TIMESTAMP"];
+  const stampUpdated = options.stampUpdated !== false;
+  const setClauses: string[] = stampUpdated ? ["updated = CURRENT_TIMESTAMP"] : [];
   const values: ParamValue[] = [];
   let paramIndex = 1;
+  let dataColumns = 0;
 
   for (const [key, value] of Object.entries(data)) {
     if (key === "raw") continue;
@@ -165,9 +167,12 @@ export function buildUpdate(
     setClauses.push(`${key} = $${paramIndex}`);
     values.push(prepareParamValue(value as ParamValue));
     paramIndex++;
+    dataColumns++;
   }
 
-  if (setClauses.length === 1) {
+  // Nothing the caller asked to write: a no-op update. Without the count an
+  // unstamped table would emit an empty SET list, which is a syntax error.
+  if (dataColumns === 0) {
     return null;
   }
 
@@ -217,15 +222,14 @@ export function buildUpsert(
       .filter((col) => col !== primaryKey)
       .map((col) => `${col} = EXCLUDED.${col}`);
     if (stampUpdated) updateClauses.push("updated = CURRENT_TIMESTAMP");
-    // An empty SET list is a syntax error. Reachable only when the table has
-    // no `updated` column AND every requested update column is the conflict
-    // key — nothing is left to write, so DO NOTHING is the right degenerate
-    // form. (With `stampUpdated` the timestamp always kept the list non-empty,
-    // which is why this branch could not arise before.)
-    sql +=
-      updateClauses.length > 0
-        ? ` ON CONFLICT (${primaryKey}) DO UPDATE SET ${updateClauses.join(", ")}`
-        : ` ON CONFLICT (${primaryKey}) DO NOTHING`;
+    // Every requested column was the conflict key and there is no `updated` to
+    // stamp, so nothing is left to write. An empty SET list is a syntax error;
+    // re-assigning the conflict key is the no-op that keeps `DO UPDATE` — and
+    // therefore `RETURNING` — so the caller still gets the conflicting row.
+    if (updateClauses.length === 0) {
+      updateClauses.push(`${primaryKey} = EXCLUDED.${primaryKey}`);
+    }
+    sql += ` ON CONFLICT (${primaryKey}) DO UPDATE SET ${updateClauses.join(", ")}`;
   } else {
     sql += ` ON CONFLICT (${primaryKey}) DO NOTHING`;
   }
@@ -241,10 +245,14 @@ export function buildSoftDelete(
   tableName: string,
   primaryKey: string,
   primaryKeyValue: ParamValue,
-  additionalWhere?: { column: string; value: ParamValue }
+  options: SoftDeleteOptions = {}
 ): PreparedQuery {
+  const { additionalWhere, stampUpdated = true } = options;
+  const setClauses = ["is_deleted = TRUE"];
+  if (stampUpdated) setClauses.push("updated = CURRENT_TIMESTAMP");
+
   const values: ParamValue[] = [primaryKeyValue];
-  let sql = `UPDATE ${tableName} SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP WHERE ${primaryKey} = $1`;
+  let sql = `UPDATE ${tableName} SET ${setClauses.join(", ")} WHERE ${primaryKey} = $1`;
 
   if (additionalWhere) {
     values.push(additionalWhere.value);

--- a/src/server/lib/postgres/initialize.ts
+++ b/src/server/lib/postgres/initialize.ts
@@ -22,7 +22,8 @@ import {
 export const version = "1";
 export const index = "inbox" + (version ? `-${version}` : "");
 
-const tables: Table<unknown, Schema>[] = [
+/** Every table the app owns, in DDL-creation order (FK dependencies first). */
+export const tables: Table<unknown, Schema>[] = [
   usersTable,
   sessionsTable,
   mailboxesTable, // Must be before mails due to foreign key reference

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -203,15 +203,7 @@ export abstract class Table<
     return result.rows.length > 0 ? new this.ModelClass(result.rows[0]) : null;
   }
 
-  /**
-   * Whether this table's DDL declares an `updated` column. The INSERT builders
-   * stamp `updated = CURRENT_TIMESTAMP` by default, which Postgres rejects for
-   * a table that has no such column — `mailboxes` was the one builder-written
-   * table in that state, so every `CREATE <mailbox>` failed with
-   * `column "updated" of relation "mailboxes" does not exist` (#687).
-   * Deriving the flag from the schema keeps the two in sync for future tables
-   * instead of re-encoding the assumption at each call site.
-   */
+  /** The builders stamp `updated` only where the DDL declares the column. */
   private get stampUpdated(): boolean {
     return "updated" in this.schema;
   }
@@ -237,6 +229,7 @@ export abstract class Table<
   ): Promise<Record<string, unknown> | null> {
     const query = buildUpdate(this.name, this.primaryKey, primaryKeyValue, data, {
       returning: returning ?? [this.primaryKey],
+      stampUpdated: this.stampUpdated,
     });
     if (!query) return null;
     const result = await pool.query(query.sql, query.values);
@@ -258,10 +251,16 @@ export abstract class Table<
   }
 
   async softDelete(primaryKeyValue: ParamValue): Promise<boolean> {
+    if (!("is_deleted" in this.schema)) {
+      throw new Error(
+        `${this.name} declares no is_deleted column — use hardDelete or deleteWhere`
+      );
+    }
     const { sql, values } = buildSoftDelete(
       this.name,
       this.primaryKey,
-      primaryKeyValue
+      primaryKeyValue,
+      { stampUpdated: this.stampUpdated }
     );
     const result = await pool.query(sql, values);
     return result.rowCount !== null && result.rowCount > 0;

--- a/src/server/lib/postgres/models/base.ts
+++ b/src/server/lib/postgres/models/base.ts
@@ -203,6 +203,19 @@ export abstract class Table<
     return result.rows.length > 0 ? new this.ModelClass(result.rows[0]) : null;
   }
 
+  /**
+   * Whether this table's DDL declares an `updated` column. The INSERT builders
+   * stamp `updated = CURRENT_TIMESTAMP` by default, which Postgres rejects for
+   * a table that has no such column — `mailboxes` was the one builder-written
+   * table in that state, so every `CREATE <mailbox>` failed with
+   * `column "updated" of relation "mailboxes" does not exist` (#687).
+   * Deriving the flag from the schema keeps the two in sync for future tables
+   * instead of re-encoding the assumption at each call site.
+   */
+  private get stampUpdated(): boolean {
+    return "updated" in this.schema;
+  }
+
   async insert(
     data: QueryData,
     returning?: string[]
@@ -210,7 +223,8 @@ export abstract class Table<
     const { sql, values } = buildInsert(
       this.name,
       data as Record<string, ParamValue>,
-      returning ?? [this.primaryKey]
+      returning ?? [this.primaryKey],
+      { stampUpdated: this.stampUpdated }
     );
     const result = await pool.query(sql, values);
     return result.rows.length > 0 ? result.rows[0] : null;
@@ -237,6 +251,7 @@ export abstract class Table<
       updateColumns:
         updateColumns ?? Object.keys(data).filter((k) => k !== this.primaryKey),
       returning: ["*"],
+      stampUpdated: this.stampUpdated,
     });
     const result = await pool.query(sql, values);
     return result.rows.length > 0 ? result.rows[0] : null;


### PR DESCRIPTION
Closes #687

## Root cause

The SQL builders in `database.ts` append auto-columns that only *some* tables declare:

```ts
const columns: string[] = ["updated"];                       // buildInsert / buildUpsert
const setClauses: string[] = ["updated = CURRENT_TIMESTAMP"]; // buildUpdate
`SET is_deleted = TRUE, updated = CURRENT_TIMESTAMP`          // buildSoftDelete
```

`mailboxes` declares neither `updated` nor `is_deleted` (it has `created` only), so every builder-generated statement against it is rejected outright:

```
mailbox_id, user_id, name, address, parent_id, uid_validity, uid_next, subscribed, special_use, created
```

`createMailbox` → `mailboxesTable.insert` → `column "updated" of relation "mailboxes" does not exist` → `NO CREATE failed`, deterministically, on every correctly-initialized DB. `renameMailbox` → `mailboxesTable.update` fails identically, and `softDelete` fails on `is_deleted`. On main the RENAME path was unreachable (IMAP CREATE is the only writer of `mailboxes` rows, so the table stays empty and RENAME returns `not_found`) — fixing CREATE is exactly what makes it reachable, so both had to land together.

## The fix — schema-derived, not per-call-site

Every builder that appends an auto-column now takes the flag, and `Table` derives it from its own schema for `insert` / `update` / `upsert` / `softDelete` alike:

```ts
private get stampUpdated(): boolean {
  return "updated" in this.schema;
}
```

- `UpdateOptions` / `UpsertOptions` / `SoftDeleteOptions` all extend `StampUpdatedOption`.
- `Table.softDelete` throws `<table> declares no is_deleted column — use hardDelete or deleteWhere` instead of emitting SQL Postgres will reject. Only `users` declares the column today, and it is the only caller (`repositories/users.ts`).
- `buildUpdate` returns `null` when the caller supplies no column (unchanged behaviour for stamped tables — the old `setClauses.length === 1` check meant the same thing), which also keeps an unstamped table from emitting an empty `SET` list.
- `buildUpsert`'s empty-`SET` degradation now emits `DO UPDATE SET <pk> = EXCLUDED.<pk>` rather than `DO NOTHING`, so `RETURNING` survives. Note this branch is reachable only via the explicit 2-argument `buildUpsert(data, [pk])` form, which nothing in `src` uses: `Table.upsert` filters the pk out of `updateColumns`, so its list is never `[pk]`. The null-returning path `Table.upsert` actually takes on a conflict is the unchanged `DO NOTHING` branch, which this PR does not address.

**The default stays `true`**, so every caller that predates the option generates byte-identical SQL — only the five tables without `updated` (`mailboxes`, `spam_allowlist`, `spam_training`, `mail_uid_counters`, `mail_mailbox_uid`) change.

Two reasons this shape over the alternative in the issue body (adding an `updated` column to the mailbox model):

- It covers any *future* builder-written table, not just this one. The model fix would leave the same trap armed for the next table.
- It avoids adding a column, a `MailboxJSON` field, a `toJSON` entry and a type-guard that no consumer reads, purely to satisfy a builder assumption. No migration needed either.

If you'd rather have the column, say so and I'll swap it — the change is small either way.

## Regression guard

`database.test.ts` (14 tests) drives the **real `Table` methods** through the pg `FakePool` seam (the `users.test.ts` pattern) and asserts on the SQL each one emits, so the tests fail if the derivation is removed from `models/base.ts` rather than passing on a re-derived flag. Verified by deleting it:

| Removed from `base.ts` | Result |
|---|---|
| `{ stampUpdated: this.stampUpdated }` in `insert` | 2 fail |
| `stampUpdated: this.stampUpdated` in `update` | 2 fail |
| the `is_deleted` guard in `softDelete` | 1 fail |
| nothing (restored) | 14 pass |

The registry sweep walks the real `tables` array from `initialize.ts` and runs `insert` / `upsert` / `update` (and `softDelete` where `is_deleted` exists) for **every** table, asserting the emitted SQL names only columns that table's own DDL declares. A separate case asserts `supportsSoftDelete` matches `"is_deleted" in schema` for every table, so the select-side `excludeDeleted` gate can't drift from the DDL either.

The original bug was invisible to tests because `createMailbox`'s unit tests mock the pg pool, so the generated SQL never met a real schema — which is why the verification below runs against real Postgres.

## Test plan

### Real Postgres, scratch DB, real `Table` + repository methods

`FakePool` unit tests are exactly the seam that let the bug ship, so the primary verification is a throwaway database (`inbox_fix734`, schema built by the real `initializePostgres()` from the model DDL, dropped afterwards — the real `inbox` DB was only ever read from).

**Baseline first — same scratch DB, `upstream/main` worktree, same repository functions:**

```
ERROR createMailbox (IMAP CREATE)   → column "updated" of relation "mailboxes" does not exist
seeded row directly: BaseBox        ← makes RENAME reachable, as this branch's CREATE fix does
ERROR renameMailbox (IMAP RENAME)   → column "updated" of relation "mailboxes" does not exist
ERROR mailboxesTable.softDelete     → column "is_deleted" of relation "mailboxes" does not exist
name after failed RENAME: BaseBox   ← rename silently did not apply
```

**This branch — 38 assertions, 38 pass / 0 fail.** Mailbox command set, driven through `repositories/mailboxes` (the functions the IMAP command handlers call):

| Check | Result |
|---|---|
| `CREATE ProbeBox` | row created |
| re-`CREATE ProbeBox` | `null` → `[ALREADYEXISTS]`, not a duplicate |
| `CREATE ProbeBox/Sub` with `parent_id` | nested row links the parent |
| `RENAME ProbeBox → ProbeBoxRenamed` | `renamed` |
| read after RENAME | new name resolves, old name returns `null` |
| `uid_validity` after RENAME | 1 → 2 (RFC 3501 re-sync) |
| `RENAME NoSuchBox` | `not_found` (existence gate from #595/#601 intact) |
| `UNSUBSCRIBE` / `SUBSCRIBE` (`updateWhere`) | both persist, verified by re-read |
| `mailboxesTable.softDelete` | throws the named error, emits no SQL |
| `mailboxesTable.upsert` | returns the row (`RETURNING *`) on the unstamped table |
| empty-`SET` upsert degradation | `ON CONFLICT (mailbox_id) DO UPDATE SET mailbox_id = EXCLUDED.mailbox_id RETURNING *` returns 1 row |
| `DELETE` (`hardDelete`) | `deleted`, child row cascaded, `NoSuchBox` → `not_found` |

Generalization — other registry tables on the same DB, to prove the derivation isn't a `mailboxes` special case:

| Table | `updated` | `is_deleted` | Verified |
|---|---|---|---|
| `users` | yes | yes | `insert` stamps, `update` bumps the stamp, `softDelete` sets `is_deleted` + stamps, soft-deleted row disappears from `queryOne` while a live row stays visible |
| `sessions` | yes | no | `upsert` insert path + conflict path (stamp bumped, column updated), `update` stamps, `softDelete` throws |
| `push_subscriptions` | yes | no | `insert` stamps, `update` succeeds |
| `spam_allowlist` | no | no | `insert` + `update` succeed with no auto-column |
| `spam_training` | no | no | `insert` + `update` succeed with no auto-column |
| `mailboxes` | no | no | full command set above |

Also asserted against `information_schema`: `mailboxes` still has **no** `updated` and **no** `is_deleted` column — the fix is in the builders, so no migration runs.

Not re-run at this head: the raw-IMAP-over-socket drive (`CREATE` / `SELECT` / `STATUS` over a live server socket) from the CREATE-only commit `de4961b`. This head is verified at the repository + `Table` layer instead, which is where the RENAME / softDelete regressions live.

### Checks

`bun run typecheck` clean · `bun run lint` 0 errors (17 pre-existing warnings, none in the changed files) · `bun test src/server` → **1378 pass / 0 fail** across 69 files (full server tree, not a subdir, per the process-global `mock.module` hoisting hazard).

