### PR TITLE
fix(server): exit process on fatal startup failure

### DIFF
--- a/src/server/lib/startup-failure.test.ts
+++ b/src/server/lib/startup-failure.test.ts
@@ -5,7 +5,6 @@ import {
   beforeEach,
   afterEach,
   spyOn,
-  mock,
 } from "bun:test";
 import * as alarm from "./alarm";
 import {

--- a/src/server/lib/startup-failure.test.ts
+++ b/src/server/lib/startup-failure.test.ts
@@ -1,0 +1,87 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  spyOn,
+  mock,
+} from "bun:test";
+import * as alarm from "./alarm";
+import {
+  handleStartupFailure,
+  STARTUP_ALARM_TIMEOUT_MS,
+} from "./startup-failure";
+
+describe("handleStartupFailure", () => {
+  let exitSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    // Swallow the exit so the test process doesn't die; throw a tagged
+    // sentinel so the awaited handler unwinds after the exit call.
+    exitSpy = spyOn(process, "exit").mockImplementation(((): never => {
+      throw new Error("__test_process_exit__");
+    }) as never);
+    errorSpy = spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  const runHandler = async (error: unknown): Promise<number | undefined> => {
+    try {
+      await handleStartupFailure(error);
+    } catch (e) {
+      if ((e as Error).message !== "__test_process_exit__") throw e;
+    }
+    return exitSpy.mock.calls[0]?.[0] as number | undefined;
+  };
+
+  it("exits with code 1 after the alarm delivers", async () => {
+    const sendSpy = spyOn(alarm, "sendAlarm").mockResolvedValue(undefined);
+    const code = await runHandler(new Error("initializePostgres timed out"));
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const [title, detail] = sendSpy.mock.calls[0]!;
+    expect(title).toBe("Startup Failed");
+    expect(detail).toContain("initializePostgres timed out");
+    expect(code).toBe(1);
+    sendSpy.mockRestore();
+  });
+
+  it("still exits when the alarm rejects — never blocks the crash path", async () => {
+    const sendSpy = spyOn(alarm, "sendAlarm").mockRejectedValue(
+      new Error("webhook 500"),
+    );
+    const code = await runHandler(new Error("boom"));
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(code).toBe(1);
+    sendSpy.mockRestore();
+  });
+
+  it("bounds wait on a hung alarm at STARTUP_ALARM_TIMEOUT_MS + exits anyway", async () => {
+    // Never resolves — simulates a fetch stuck against a slow/down webhook.
+    const sendSpy = spyOn(alarm, "sendAlarm").mockImplementation(
+      () => new Promise<void>(() => undefined),
+    );
+    const started = Date.now();
+    const code = await runHandler(new Error("hang test"));
+    const elapsed = Date.now() - started;
+    expect(code).toBe(1);
+    // Give a generous ceiling (CI jitter) — the point is we DID exit, not
+    // that we exited at exactly the timeout.
+    expect(elapsed).toBeGreaterThanOrEqual(STARTUP_ALARM_TIMEOUT_MS - 100);
+    expect(elapsed).toBeLessThan(STARTUP_ALARM_TIMEOUT_MS + 2_000);
+    sendSpy.mockRestore();
+  }, 10_000);
+
+  it("stringifies a non-Error rejection value into the alarm message", async () => {
+    const sendSpy = spyOn(alarm, "sendAlarm").mockResolvedValue(undefined);
+    await runHandler("plain string reason");
+    const [, detail] = sendSpy.mock.calls[0]!;
+    expect(detail).toContain("plain string reason");
+    sendSpy.mockRestore();
+  });
+});

--- a/src/server/lib/startup-failure.ts
+++ b/src/server/lib/startup-failure.ts
@@ -1,0 +1,33 @@
+import { sendAlarm } from "./alarm";
+
+/**
+ * Max time we wait for the "Startup Failed" alarm to deliver before we
+ * exit anyway. Guarantees the process exits promptly even if the Discord
+ * webhook is slow or unreachable — otherwise a stuck fetch inside
+ * sendAlarm would replace one zombie-hang with another and defeat the
+ * whole point of the .catch handler in start.ts.
+ */
+export const STARTUP_ALARM_TIMEOUT_MS = 5_000;
+
+/**
+ * `start()`'s .catch handler. Log the fatal error, race the alarm delivery
+ * against `STARTUP_ALARM_TIMEOUT_MS`, then `process.exit(1)` so docker's
+ * restart policy (restart:always) can bring the container back up. Without
+ * the exit, an early `initializePostgres()` rejection leaves the process
+ * alive but pre-bind, and the container hangs "unhealthy" indefinitely.
+ */
+export const handleStartupFailure = async (error: unknown): Promise<never> => {
+  console.error("Fatal error during startup:", error);
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? (error.stack ?? "") : "";
+  await Promise.race([
+    sendAlarm(
+      "Startup Failed",
+      `**Message:** ${message}\n\`\`\`\n${stack.slice(0, 1000)}\n\`\`\``,
+    ).catch(() => undefined),
+    new Promise<void>((resolve) =>
+      setTimeout(resolve, STARTUP_ALARM_TIMEOUT_MS),
+    ),
+  ]);
+  process.exit(1);
+};

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -87,4 +87,13 @@ const start = async () => {
   process.on("SIGINT", () => shutdown("SIGINT"));
 };
 
-start();
+start().catch((error) => {
+  console.error("Fatal error during startup:", error);
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? (error.stack ?? "") : "";
+  sendAlarm(
+    "Startup Failed",
+    `**Message:** ${message}\n\`\`\`\n${stack.slice(0, 1000)}\n\`\`\``,
+  ).catch(() => undefined);
+  process.exit(1);
+});

--- a/src/server/start.ts
+++ b/src/server/start.ts
@@ -11,6 +11,7 @@ import {
 } from "server";
 import { pool } from "server";
 import { sendAlarm } from "./lib/alarm";
+import { handleStartupFailure } from "./lib/startup-failure";
 
 // Process-level error handlers (centralised here alongside SIGTERM/SIGINT)
 // Note: These fire before IMAP/SMTP servers are shut down. The alarm call is
@@ -87,13 +88,4 @@ const start = async () => {
   process.on("SIGINT", () => shutdown("SIGINT"));
 };
 
-start().catch((error) => {
-  console.error("Fatal error during startup:", error);
-  const message = error instanceof Error ? error.message : String(error);
-  const stack = error instanceof Error ? (error.stack ?? "") : "";
-  sendAlarm(
-    "Startup Failed",
-    `**Message:** ${message}\n\`\`\`\n${stack.slice(0, 1000)}\n\`\`\``,
-  ).catch(() => undefined);
-  process.exit(1);
-});
+start().catch(handleStartupFailure);


### PR DESCRIPTION
## Summary
- `start()` in `src/server/start.ts` ran with no `.catch()`. When a startup step (e.g. `initializePostgres()`) rejects, the rejection fell through to the top-level `unhandledRejection` handler, which only logs + alarms — it never calls `process.exit()`, unlike the sibling `uncaughtException` handler which does `exit(1)`.
- Result: on a startup failure, the process stays alive with no HTTP/IMAP/SMTP server bound. Docker's `restart: always` only fires on container **exit**, so a hung-but-alive PID 1 never gets recycled — the container sits `unhealthy` indefinitely with no auto-recovery.
- This is what happened in production: hoie-inbox-1 hit a transient `Query read timeout` during `CREATE TABLE` right after a deploy restart, and stayed down for 10+ minutes with zero new log lines until a manual restart, because nothing ever called `process.exit`.
- Fix: `start().catch(handleStartupFailure)` (extracted to `src/server/lib/startup-failure.ts` for testability). `handleStartupFailure` logs the fatal error, races alarm delivery against a 5s bound (`STARTUP_ALARM_TIMEOUT_MS`), then `process.exit(1)` — so a slow/unreachable Discord webhook can't turn one zombie-hang into another, and `restart: always` gets a clean exit to act on.
- A fire-and-forget-alarm-then-immediately-exit shape was tried first and dropped the alarm entirely (verified: a child process that POSTs and exits in the same tick never delivers against a local webhook harness). The `Promise.race` shape fixes that.
- Known pre-existing sibling bug (same lost-alarm race, in `uncaughtException`) is out of scope here — filed as hoiekim/inbox#736.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 new errors/warnings (repo baseline unchanged)
- [x] `bun test src/server` — 1399 pass / 0 fail, including `startup-failure.test.ts`'s 4 cases (exit code, alarm resolves, alarm rejects, alarm hangs past the timeout, non-Error reason)
- [x] Reproduced the bug on unpatched code: pointed `POSTGRES_PORT` at an unreachable port, ran `bun src/server/start.ts` directly — confirmed the process stays running (not exited) 65s+ after the connection-retry loop exhausts and throws, matching the exact zombie state seen in prod.
- [x] Verified the fix on the head commit against the same broken-port setup: process exits with code 1 as soon as `initializePostgres()` rejects, instead of hanging.
- [x] Verified alarm delivery specifically: fire-and-forget-then-exit drops the POST (repro'd against a local webhook harness); the `Promise.race` shape on the head commit delivers it.
- Not applicable: no UI/browser surface — this is a server startup control-flow fix with no rendered path to E2E through Playwright.