### PR TITLE
cleanup(imap): drop dead buildFullMessageStream export

### DIFF
--- a/src/server/lib/imap/chunked-write.ts
+++ b/src/server/lib/imap/chunked-write.ts
@@ -37,7 +37,7 @@ export const CHUNK_BYTES = 64 * 1024; // matches typical TCP high-water mark
  * (await `drain` when `socket.write` reports its high-water mark).
  *
  * Distinct from `writeChunkedToSocket` because the source is a stream
- * (produced by `buildFullMessageStream` for BODY[] fetches) rather than
+ * (produced by `streamFromSegments` for BODY[] fetches) rather than
  * a pre-materialized Buffer: chunk boundaries are determined by the
  * producer, not by fixed CHUNK_BYTES slicing. Producer is expected to
  * yield chunks in the CHUNK_BYTES ballpark so socket writes align

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -547,12 +547,13 @@ describe("BODY[] {N} holds when the attachment file disagrees with the mail row"
   });
 
   it("segment list is built ONCE per BODY[] fetch — length + stream cannot desync (#733 reviewoie HIGH)", async () => {
-    // Reproduces the reviewoie HIGH: previously buildFullMessageStream
-    // rebuilt segments independently from computeFullMessageSize, so each
-    // pass ran its own `fs.statSync` on the attachment. If the file
-    // grew between the two stats, `{N}` (from the first) < emitted bytes
-    // (from the second), corrupting the wire literal — reviewoie
-    // reproduced "declared 1833, emitted 67165".
+    // Reproduces the reviewoie HIGH: the stream side previously called
+    // `buildMessageSegments` independently from `computeFullMessageSize`,
+    // so each pass ran its own `fs.statSync` on the attachment. If the
+    // file grew between the two stats, `{N}` (from the first) < emitted
+    // bytes (from the second), corrupting the wire literal — reviewoie
+    // reproduced "declared 1833, emitted 67165". Fix hoisted segments to
+    // the caller so both size + stream derive from ONE list.
     //
     // The fix hoists `buildMessageSegments` to `buildBodyResponsePart`
     // so ONE list drives both measurement and emit. This test proves it

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -18,7 +18,6 @@ import {
 import {
   applyPartialFetch,
   buildFullMessage,
-  buildFullMessageStream,
   buildMessageSegments,
   computeFullMessageSize,
   streamFromSegments,
@@ -53,12 +52,12 @@ import { updateRfc822Size } from "../postgres/repositories/mails/core";
 // duplicate-FETCH storms. See `body-buffer.ts`.
 //
 // **stream** variant: BODY[] / RFC822 for a fetch that streams its bytes
-// directly to the socket via `buildFullMessageStream`, never materializing
-// the full body in memory. `length` is pre-computed by
-// `computeFullMessageSize` (pure math on stored attachment sizes — no
+// directly to the socket via `streamFromSegments`, never materializing
+// the full body in memory. `length` is pre-computed by `sumSegmentBytes`
+// on the SAME segment list (pure math on stored attachment sizes — no
 // disk I/O) so the writer can advertise `{N}` before the first chunk
 // yields. Sum of yielded chunk byte-lengths equals `length` by
-// construction (parallel case blocks in the two functions).
+// construction (both derive from the same segment list).
 export type FetchResponsePart =
   | { type: "simple"; content: string }
   | { type: "literal"; content: string | Buffer; header: string; length: number }
@@ -517,7 +516,7 @@ export async function buildFetchResponsePart(
       //  2. **Compute + persist** — for mails that haven't been observed
       //     yet, derive via `computeFullMessageSize` (pure math on stored
       //     attachment sizes — no disk read, no body materialization). The
-      //     value equals `Buffer.byteLength(buildFullMessageStream output)`
+      //     value equals `Buffer.byteLength(streamFromSegments output)`
       //     by construction so it agrees with what BODY[] would emit.
       //     Fire-and-forget UPDATE persists the value for next time.
       //     Derived without materializing the body, which is the point: a
@@ -644,7 +643,7 @@ export type WriteChunked = (payload: Buffer) => Promise<void>;
 /**
  * Consume an async iterable of chunks and write each to the socket with
  * backpressure. Called for `stream` parts (BODY[] / RFC822 fetches wired
- * through `buildFullMessageStream`). Peak in-flight allocation stays at
+ * through `streamFromSegments`). Peak in-flight allocation stays at
  * one chunk (~64 KiB) — no full-body Buffer is ever materialized.
  */
 export type WriteStream = (chunks: AsyncIterable<Buffer>) => Promise<void>;

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -77,10 +77,10 @@ export const shouldMarkAsRead = (dataItems: FetchDataItem[]): boolean => {
  * One piece of the RFC 822 serialization.
  *
  * `buildMessageSegments` is the SINGLE definition of the MIME layout.
- * `computeFullMessageSize` measures the segments and
- * `buildFullMessageStream` emits them, so the `{N}` literal the writer
- * advertises and the octets that follow it are derived from one source
- * and cannot disagree. Keeping the layout in one place is the invariant,
+ * `sumSegmentBytes` measures the segments and `streamFromSegments`
+ * emits them, so the `{N}` literal the writer advertises and the
+ * octets that follow it are derived from one source and cannot
+ * disagree. Keeping the layout in one place is the invariant,
  * not an aesthetic choice: three hand-parallel copies (measure, emit,
  * materialize) is how the count and the payload drift apart, and a
  * literal whose count is wrong desyncs every subsequent response on the
@@ -442,27 +442,13 @@ export async function* streamFromSegments(
 }
 
 /**
- * Legacy convenience wrapper — builds segments then streams them.
- * DEPRECATED for BODY[] callers because it builds the segment list
- * independently from `computeFullMessageSize`, letting `stat` races
- * corrupt the wire literal. Prefer `buildMessageSegments` + share the
- * result between `sumSegmentBytes` (for `{N}`) and `streamFromSegments`
- * (for the octets). Kept for tests that only need the stream shape.
- */
-export async function* buildFullMessageStream(
-  mail: Partial<MailType>,
-  docId?: string
-): AsyncGenerator<Buffer, void, unknown> {
-  yield* streamFromSegments(buildMessageSegments(mail, docId));
-}
-
-/**
  * Build the complete RFC 822 message as a single string.
  *
  * Materializing consumer for `getBodyContent`'s TEXT section, which needs
  * `indexOf("\r\n\r\n") + substring` over the whole message. Prefer
- * `buildFullMessageStream` + `computeFullMessageSize` for BODY[] / RFC822 —
- * this function's peak allocation is O(message), which is what #729 was about.
+ * `streamFromSegments` (paired with `sumSegmentBytes` on the same
+ * `buildMessageSegments` result) for BODY[] / RFC822 — this function's
+ * peak allocation is O(message), which is what #729 was about.
  */
 export const buildFullMessage = (mail: Partial<MailType>, docId?: string): string => {
   const parts: string[] = [];

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -162,7 +162,7 @@ export class ImapSession {
   /**
    * Stream an async iterable of `Buffer` chunks straight to the socket
    * with backpressure. Used by BODY[] / RFC822 fetches wired through
-   * `buildFullMessageStream` — the full body is never materialized in
+   * `streamFromSegments` — the full body is never materialized in
    * memory; each chunk (~64 KiB base64 slice of one attachment) is
    * emitted, written, and released before the next runs. Peak transient
    * allocation stays sub-MB regardless of body size.


### PR DESCRIPTION
## Summary

Reviewoie LOW on [#733](https://github.com/hoiekim/inbox/pull/733): after that PR hoisted the segment list build to \`buildBodyResponsePart\` FULL branch — so \`sumSegmentBytes\` (for \`{N}\`) and \`streamFromSegments\` (for the octets) share one list — the \`buildFullMessageStream\` wrapper was no longer called. Its deprecation comment said "kept for tests," but no test or non-test caller actually uses the export; \`fetch-helpers.ts\` still imported the name without invoking it.

Cleanup:
- Remove \`buildFullMessageStream\` (function + doc comment) from \`session-utils.ts\`.
- Remove the unused import in \`fetch-helpers.ts\`.
- Update \`MessageSegment\` type doc + \`buildFullMessage\` doc + 3 breadcrumb comments in \`fetch-helpers.ts\` + one each in \`session.ts\` and \`chunked-write.ts\` to point at the actual current emitter (\`streamFromSegments\`).
- Rewrite the historical bug comment in the \`fetch-helpers.test.ts\` regression test to name \`buildMessageSegments\` (the twice-called function) instead of the deleted wrapper — one indirection closer to the actual root cause.

Zero grep hits for \`buildFullMessageStream\` remain across \`src/\`.

## Test plan
- [x] \`bun run typecheck\` — clean.
- [x] \`bun test src/server/lib/imap\` — 726/0 pass.
- Not applicable: no behavior change — dead-symbol removal + comment updates only. Existing \#733 regression test (\`segment list is built ONCE per BODY[] fetch\`) still guards the actual invariant.