### PR TITLE
fix(imap): emitBase64 slices input at SLICE_RAW_BYTES too

### DIFF
--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -666,10 +666,10 @@ describe("getBodyPartHeaders", () => {
 });
 
 // ---------------------------------------------------------------------------
-// streamFromSegments + emitBase64 — regression coverage for the 2026-07-30
-// OOM. `emitBase64` used to allocate the whole raw source Buffer up front,
-// so a 500 KiB HTML body pinned 500 KiB per in-flight fetch. Now the input
-// is sliced too — peak transient must stay O(SLICE_RAW_BYTES).
+// streamFromSegments — emitBase64 input chunking. Peak transient must stay
+// O(SLICE_RAW_BYTES) (no full-source Buffer materialization) AND the emitted
+// bytes must round-trip to the source exactly, including at UTF-16 surrogate
+// pair boundaries and at non-multiple-of-3 slice boundaries.
 // ---------------------------------------------------------------------------
 
 describe("streamFromSegments — emitBase64 input chunking", () => {
@@ -743,11 +743,7 @@ describe("streamFromSegments — emitBase64 input chunking", () => {
     expect(decoded).toBe(text);
   });
 
-  it("handles multi-byte UTF-8 across slice boundaries", async () => {
-    // A body of emojis (each 4 UTF-8 bytes as a surrogate pair, 2 UTF-16 units)
-    // sized to straddle SLICE_RAW_BYTES. If the code-unit slicing miscounted
-    // the UTF-8 expansion, chunks could either be too big or split a codepoint.
-    // Rocket emoji: 🚀 = 4 UTF-8 bytes (2 UTF-16 units).
+  it("handles multi-byte UTF-8 (emoji) across slice boundaries", async () => {
     const emoji = "🚀".repeat(20000); // 80 000 UTF-8 bytes = 40 000 UTF-16 units
     const mail: Partial<MailType> = { text: emoji };
     const segments = buildMessageSegments(mail, "emoji");
@@ -760,6 +756,36 @@ describe("streamFromSegments — emitBase64 input chunking", () => {
     expect(bodyMatch).not.toBeNull();
     const decoded = Buffer.from(bodyMatch![1], "base64").toString("utf8");
     expect(decoded).toBe(emoji);
+  });
+
+  it("keeps a surrogate pair whole when it straddles a chunk boundary — no U+FFFD injection", async () => {
+    // CHUNK_CODE_UNITS = SLICE_RAW_BYTES / 3 = 49152 / 3 = 16384 code units.
+    // Place a surrogate pair EXACTLY at positions 16383 (high) + 16384 (low)
+    // so a naive `source.slice(0, 16384)` would split it. Each half would
+    // encode to U+FFFD (3 UTF-8 bytes) instead of the pair's 4 bytes,
+    // overshooting the pre-measured {N} by 2 bytes and desyncing the wire.
+    const filler = "a".repeat(16383);
+    const tail = "b".repeat(100);
+    const text = filler + "🚀" + tail;
+    const mail: Partial<MailType> = { text };
+    const segments = buildMessageSegments(mail, "surrogate-split");
+
+    // 1. Stream output must round-trip byte-for-byte, including the emoji.
+    const { concatenated } = await drainToBuffer(streamFromSegments(segments));
+    const wire = concatenated.toString("utf8");
+    const bodyMatch = wire.match(/base64\r\n\r\n([\s\S]*?)\r\n$/);
+    expect(bodyMatch).not.toBeNull();
+    const decoded = Buffer.from(bodyMatch![1], "base64").toString("utf8");
+    expect(decoded).toBe(text);
+    // Zero U+FFFD replacement characters in the decoded body.
+    expect(decoded.indexOf("�")).toBe(-1);
+
+    // 2. Emitted body byte-length must equal the pre-measured length —
+    // otherwise {N} desyncs and corrupts the IMAP connection.
+    const emittedBodyBytes = Buffer.byteLength(bodyMatch![1], "utf8");
+    const rawBytes = Buffer.byteLength(text, "utf8");
+    const expectedBodyBytes = Math.ceil(rawBytes / 3) * 4;
+    expect(emittedBodyBytes).toBe(expectedBodyBytes);
   });
 
   it("empty body yields no base64 output (short-circuit path)", async () => {

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -51,6 +51,8 @@ import {
   getBodySectionKey,
   shouldMarkAsRead,
   buildFullMessage,
+  buildMessageSegments,
+  streamFromSegments,
   getBodyPart,
   getBodyPartHeaders
 } from "./session-utils";
@@ -662,3 +664,127 @@ describe("getBodyPartHeaders", () => {
     expect(getBodyPartHeaders(mail, "3")).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// streamFromSegments + emitBase64 — regression coverage for the 2026-07-30
+// OOM. `emitBase64` used to allocate the whole raw source Buffer up front,
+// so a 500 KiB HTML body pinned 500 KiB per in-flight fetch. Now the input
+// is sliced too — peak transient must stay O(SLICE_RAW_BYTES).
+// ---------------------------------------------------------------------------
+
+describe("streamFromSegments — emitBase64 input chunking", () => {
+  const SLICE_RAW_BYTES = 48 * 1024; // must match the constant in session-utils.ts
+
+  const drainToBuffer = async (
+    stream: AsyncIterable<Buffer>
+  ): Promise<{ concatenated: Buffer; maxChunkBytes: number; chunkCount: number }> => {
+    const chunks: Buffer[] = [];
+    let maxChunkBytes = 0;
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+      if (chunk.byteLength > maxChunkBytes) maxChunkBytes = chunk.byteLength;
+    }
+    return {
+      concatenated: Buffer.concat(chunks),
+      maxChunkBytes,
+      chunkCount: chunks.length,
+    };
+  };
+
+  it("produces byte-identical output to base64(source) for a small text mail", async () => {
+    const mail: Partial<MailType> = { text: "Hello, streaming world!" };
+    const segments = buildMessageSegments(mail, "small-text");
+    const { concatenated } = await drainToBuffer(streamFromSegments(segments));
+    const expectedBody = Buffer.from(mail.text!, "utf8").toString("base64");
+    expect(concatenated.toString("utf8")).toContain(expectedBody);
+  });
+
+  it("yields multiple chunks and never emits > ~64 KiB per chunk for a 200 KiB HTML body (input isn't materialized whole)", async () => {
+    // 200 KiB of ASCII HTML — larger than SLICE_RAW_BYTES (48 KiB), so if the
+    // pre-fix `Buffer.from(source, "utf8")` regressed back in, we'd see either
+    // one giant chunk or peak transient tracking the source size. The
+    // post-fix contract is: each yielded chunk stays in the ~64 KiB ballpark
+    // (SLICE_RAW_BYTES raw → base64 expansion ≈ 4/3 → ~64 KiB out).
+    const html = "<p>" + "x".repeat(200 * 1024 - 8) + "</p>";
+    const mail: Partial<MailType> = { html };
+    const segments = buildMessageSegments(mail, "big-html");
+    const { concatenated, maxChunkBytes, chunkCount } = await drainToBuffer(
+      streamFromSegments(segments)
+    );
+
+    // Chunk count must scale with body size — one giant chunk (the pre-fix
+    // shape) would be `chunkCount === headers-count + 1 attachment-part`.
+    expect(chunkCount).toBeGreaterThanOrEqual(4);
+    // No single chunk should be anywhere near the source size.
+    expect(maxChunkBytes).toBeLessThan(80 * 1024);
+    // Reassembled body must round-trip back to the original HTML.
+    const wire = concatenated.toString("utf8");
+    const bodyMatch = wire.match(/base64\r\n\r\n([\s\S]*?)\r\n$/);
+    expect(bodyMatch).not.toBeNull();
+    const decoded = Buffer.from(bodyMatch![1], "base64").toString("utf8");
+    expect(decoded).toBe(html);
+  });
+
+  it("handles a body whose UTF-8 length is NOT a multiple of 3 across many slices without corrupting the round-trip", async () => {
+    // Pick a length that will straddle SLICE_RAW_BYTES boundaries and land on
+    // various byte-count residuals — the carry logic between slices is what
+    // could corrupt the base64 if buggy.
+    // 100003 = 100 KiB + 3 bytes, distributed across multiple SLICE_RAW_BYTES
+    // slices, ending with `len % 3 == 1` (100003 / 3 = 33334 remainder 1).
+    const text = "a".repeat(100003);
+    const mail: Partial<MailType> = { text };
+    const segments = buildMessageSegments(mail, "misaligned");
+    const { concatenated } = await drainToBuffer(streamFromSegments(segments));
+    const wire = concatenated.toString("utf8");
+    const bodyMatch = wire.match(/base64\r\n\r\n([\s\S]*?)\r\n$/);
+    expect(bodyMatch).not.toBeNull();
+    // Round-trip must recover the exact original bytes.
+    const decoded = Buffer.from(bodyMatch![1], "base64").toString("utf8");
+    expect(decoded).toBe(text);
+  });
+
+  it("handles multi-byte UTF-8 across slice boundaries", async () => {
+    // A body of emojis (each 4 UTF-8 bytes as a surrogate pair, 2 UTF-16 units)
+    // sized to straddle SLICE_RAW_BYTES. If the code-unit slicing miscounted
+    // the UTF-8 expansion, chunks could either be too big or split a codepoint.
+    // Rocket emoji: 🚀 = 4 UTF-8 bytes (2 UTF-16 units).
+    const emoji = "🚀".repeat(20000); // 80 000 UTF-8 bytes = 40 000 UTF-16 units
+    const mail: Partial<MailType> = { text: emoji };
+    const segments = buildMessageSegments(mail, "emoji");
+    const { concatenated, maxChunkBytes } = await drainToBuffer(
+      streamFromSegments(segments)
+    );
+    expect(maxChunkBytes).toBeLessThan(80 * 1024);
+    const wire = concatenated.toString("utf8");
+    const bodyMatch = wire.match(/base64\r\n\r\n([\s\S]*?)\r\n$/);
+    expect(bodyMatch).not.toBeNull();
+    const decoded = Buffer.from(bodyMatch![1], "base64").toString("utf8");
+    expect(decoded).toBe(emoji);
+  });
+
+  it("empty body yields no base64 output (short-circuit path)", async () => {
+    const mail: Partial<MailType> = { text: "" };
+    const segments = buildMessageSegments(mail, "empty-text");
+    const { concatenated } = await drainToBuffer(streamFromSegments(segments));
+    const wire = concatenated.toString("utf8");
+    // Headers-only, no body segment output between headers and terminating CRLF.
+    expect(wire).toContain("MIME-Version: 1.0");
+    expect(wire).not.toMatch(/base64\r\n\r\n[A-Za-z0-9+/=]+/);
+  });
+
+  it("preserves byte-for-byte parity with buildFullMessage for the same mail", async () => {
+    // The materializing path (`buildFullMessage`) and the streaming path
+    // (`streamFromSegments`) must produce identical output — otherwise
+    // `RFC822.SIZE` (cached from computeFullMessageSize) can disagree with
+    // what BODY[] emits, breaking the {N} literal invariant.
+    const mail: Partial<MailType> = {
+      text: "plain body text",
+      html: "<p>rich body</p>".repeat(3000), // ~48 KiB — crosses one slice boundary
+    };
+    const segments = buildMessageSegments(mail, "parity-test");
+    const { concatenated } = await drainToBuffer(streamFromSegments(segments));
+    const materialized = buildFullMessage(mail, "parity-test");
+    expect(concatenated.toString("utf8")).toBe(materialized);
+  });
+});
+

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -325,52 +325,54 @@ async function* emitLiteral(value: string): AsyncGenerator<Buffer, void, unknown
 }
 
 /**
- * Emit `source` base64-encoded, one SLICE_RAW_BYTES slice at a time — with
- * the INPUT chunked too, so the raw source is never fully materialized as
- * one Buffer. Peak transient stays O(SLICE_RAW_BYTES) regardless of source
- * length, matching `emitAttachment`'s streaming shape.
+ * Emit `source` base64-encoded in sub-SLICE_RAW_BYTES slices. Peak transient
+ * is O(SLICE_RAW_BYTES) regardless of source length — both input and output
+ * are chunked, matching `emitAttachment`'s streaming shape.
  *
- * A previous version did `const raw = Buffer.from(source, "utf8")` up front,
- * which allocated the whole source (500+ KiB for large HTML mails) and held
- * it for the fetch's entire lifetime. Under concurrent iOS BODY[] fetches
- * that was the primary contributor to the 137→285 MB RSS climb on the
- * 2026-07-30 23:52 UTC OOM.
- *
- * Base64 constraint: each intermediate slice must be a multiple of 3 raw
- * bytes to avoid `=` padding chars mid-stream (padded slices concatenated
- * ≠ base64 of the concatenated raw). We encode into a fixed scratch Buffer,
- * emit the largest 3-byte-aligned prefix, and carry the 0–2 residual bytes
- * to the next iteration. The final slice is emitted whole (padding at the
- * end is legal).
+ * Two invariants the chunking has to preserve:
+ * 1. **Surrogate pairs stay whole.** `source` is UTF-16; slicing at code-
+ *    unit boundaries can land between the high and low half of an emoji.
+ *    Each isolated half round-trips to U+FFFD (3 bytes), so a split pair
+ *    emits 6 bytes where the whole encodes to 4 — a 2-byte wire overrun vs.
+ *    the pre-measured `{N}` literal, corrupting every subsequent response
+ *    on the connection. `end` is nudged back one code unit when it would
+ *    land after a high surrogate.
+ * 2. **Intermediate slices are 3-byte-aligned raw.** Base64 encodes 3 raw
+ *    bytes to 4 chars; a non-multiple-of-3 slice emits `=` padding, and
+ *    padded slices concatenated ≠ base64 of the concatenated raw. Residual
+ *    (0–2 bytes) carries to the next iteration; the final slice is emitted
+ *    whole (padding at the end is legal).
  */
 async function* emitBase64(source: string): AsyncGenerator<Buffer, void, unknown> {
   if (source.length === 0) return;
-  // Worst-case UTF-8 expansion of a JS string is 3 bytes per BMP code unit
-  // (surrogate pairs are 2 units → 4 bytes = 2 bytes/unit, cheaper). Slicing
-  // by SLICE_RAW_BYTES/3 code units guarantees the encoded chunk fits under
-  // SLICE_RAW_BYTES without over-shooting. Under-shooting a bit (vs. filling
-  // scratch to the brim) is fine — the emit granularity is still ~48 KiB.
+  // Worst-case UTF-8 expansion is 3 bytes per BMP code unit (surrogate pairs
+  // are 2 units → 4 bytes = 2 bytes/unit, cheaper). Slicing by
+  // SLICE_RAW_BYTES/3 code units guarantees the encoded chunk stays under
+  // SLICE_RAW_BYTES.
   const CHUNK_CODE_UNITS = Math.floor(SLICE_RAW_BYTES / 3);
   let carry: Buffer | null = null;
   let offset = 0;
   while (offset < source.length) {
-    const end = Math.min(offset + CHUNK_CODE_UNITS, source.length);
+    let end = Math.min(offset + CHUNK_CODE_UNITS, source.length);
+    // If `end` lands after a high surrogate and there's a next slice, the
+    // low surrogate would go to the next slice and both halves would
+    // encode to U+FFFD. Back off one code unit so the whole pair goes in
+    // the next slice.
+    if (end < source.length && isHighSurrogate(source.charCodeAt(end - 1))) {
+      end -= 1;
+    }
     let bytes = Buffer.from(source.slice(offset, end), "utf8");
     offset = end;
     if (carry) {
-      // Prepend the 0–2 unencoded residual bytes from the previous slice.
-      // Small concat (≤ SLICE_RAW_BYTES+2 bytes), unavoidable to keep the
-      // base64 alignment invariant. Cast to Uint8Array[] because Node's
-      // Buffer.concat signature is Uint8Array<ArrayBufferLike>[]-typed and
-      // Buffer's ArrayBuffer parameter doesn't line up under the current @types/node.
       bytes = Buffer.concat([carry, bytes] as unknown as Uint8Array[]);
       carry = null;
     }
     if (offset < source.length) {
-      // Not the final slice — align to a multiple of 3 and carry the residual.
+      // Align to multiple-of-3 and carry the residual to keep base64
+      // concatenation lossless.
       const residualLen = bytes.byteLength % 3;
       if (residualLen > 0) {
-        // Copy the trailing 1-2 bytes out so `bytes` can be GC'd; otherwise a
+        // Copy the trailing 1–2 bytes out so `bytes` can be GC'd — a
         // `subarray` view would pin the whole underlying ArrayBuffer.
         const tail = bytes.subarray(bytes.byteLength - residualLen);
         carry = Buffer.from(tail as unknown as Uint8Array);
@@ -381,6 +383,9 @@ async function* emitBase64(source: string): AsyncGenerator<Buffer, void, unknown
     yield Buffer.from(bytes.toString("base64"), "utf8");
   }
 }
+
+const isHighSurrogate = (charCode: number): boolean =>
+  charCode >= 0xd800 && charCode <= 0xdbff;
 
 /**
  * Emit an attachment base64-encoded, reading the file in slices through a

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -325,16 +325,60 @@ async function* emitLiteral(value: string): AsyncGenerator<Buffer, void, unknown
 }
 
 /**
- * Emit `source` base64-encoded, one SLICE_RAW_BYTES slice at a time, so the
- * encoded form never exists as a single allocation. Peak transient per slice
- * is the raw slice view + the ~64 KiB encoded string + its Buffer.
+ * Emit `source` base64-encoded, one SLICE_RAW_BYTES slice at a time — with
+ * the INPUT chunked too, so the raw source is never fully materialized as
+ * one Buffer. Peak transient stays O(SLICE_RAW_BYTES) regardless of source
+ * length, matching `emitAttachment`'s streaming shape.
+ *
+ * A previous version did `const raw = Buffer.from(source, "utf8")` up front,
+ * which allocated the whole source (500+ KiB for large HTML mails) and held
+ * it for the fetch's entire lifetime. Under concurrent iOS BODY[] fetches
+ * that was the primary contributor to the 137→285 MB RSS climb on the
+ * 2026-07-30 23:52 UTC OOM.
+ *
+ * Base64 constraint: each intermediate slice must be a multiple of 3 raw
+ * bytes to avoid `=` padding chars mid-stream (padded slices concatenated
+ * ≠ base64 of the concatenated raw). We encode into a fixed scratch Buffer,
+ * emit the largest 3-byte-aligned prefix, and carry the 0–2 residual bytes
+ * to the next iteration. The final slice is emitted whole (padding at the
+ * end is legal).
  */
 async function* emitBase64(source: string): AsyncGenerator<Buffer, void, unknown> {
-  const raw = Buffer.from(source, "utf8");
-  if (raw.byteLength === 0) return;
-  for (let offset = 0; offset < raw.byteLength; offset += SLICE_RAW_BYTES) {
-    const slice = raw.subarray(offset, Math.min(offset + SLICE_RAW_BYTES, raw.byteLength));
-    yield Buffer.from(slice.toString("base64"), "utf8");
+  if (source.length === 0) return;
+  // Worst-case UTF-8 expansion of a JS string is 3 bytes per BMP code unit
+  // (surrogate pairs are 2 units → 4 bytes = 2 bytes/unit, cheaper). Slicing
+  // by SLICE_RAW_BYTES/3 code units guarantees the encoded chunk fits under
+  // SLICE_RAW_BYTES without over-shooting. Under-shooting a bit (vs. filling
+  // scratch to the brim) is fine — the emit granularity is still ~48 KiB.
+  const CHUNK_CODE_UNITS = Math.floor(SLICE_RAW_BYTES / 3);
+  let carry: Buffer | null = null;
+  let offset = 0;
+  while (offset < source.length) {
+    const end = Math.min(offset + CHUNK_CODE_UNITS, source.length);
+    let bytes = Buffer.from(source.slice(offset, end), "utf8");
+    offset = end;
+    if (carry) {
+      // Prepend the 0–2 unencoded residual bytes from the previous slice.
+      // Small concat (≤ SLICE_RAW_BYTES+2 bytes), unavoidable to keep the
+      // base64 alignment invariant. Cast to Uint8Array[] because Node's
+      // Buffer.concat signature is Uint8Array<ArrayBufferLike>[]-typed and
+      // Buffer's ArrayBuffer parameter doesn't line up under the current @types/node.
+      bytes = Buffer.concat([carry, bytes] as unknown as Uint8Array[]);
+      carry = null;
+    }
+    if (offset < source.length) {
+      // Not the final slice — align to a multiple of 3 and carry the residual.
+      const residualLen = bytes.byteLength % 3;
+      if (residualLen > 0) {
+        // Copy the trailing 1-2 bytes out so `bytes` can be GC'd; otherwise a
+        // `subarray` view would pin the whole underlying ArrayBuffer.
+        const tail = bytes.subarray(bytes.byteLength - residualLen);
+        carry = Buffer.from(tail as unknown as Uint8Array);
+        bytes = bytes.subarray(0, bytes.byteLength - residualLen);
+      }
+    }
+    if (bytes.byteLength === 0) continue;
+    yield Buffer.from(bytes.toString("base64"), "utf8");
   }
 }
 


### PR DESCRIPTION
## Summary

Root cause of the 2026-07-30 23:52 UTC OOM (`hoie-inbox-1` RSS 137→285 MB → cgroup kill) despite [#733](https://github.com/hoiekim/inbox/pull/733)'s streaming path. `emitBase64` in `session-utils.ts` materialized the entire source Buffer up front (`const raw = Buffer.from(source, "utf8")`) and then iterated in `SLICE_RAW_BYTES` chunks. Output was streamed; input was not. A 500 KiB HTML mail pinned ~500 KiB per in-flight fetch for the fetch's whole duration.

The attachment path never had this bug — `emitAttachment` already reads the file in `SLICE_RAW_BYTES` slices via `fs.readSync`, so multi-MB attachments stream cleanly. Only text/html-heavy mails hit the leak.

## Fix

Iterate the source string in code-unit chunks whose UTF-8 encoding fits in `SLICE_RAW_BYTES` (worst case 3 bytes / BMP unit → `SLICE_RAW_BYTES / 3` code units guarantees fit), encode each chunk separately, and carry the 0–2 trailing unencoded bytes to the next iteration.

Base64 requires 3-byte-aligned input to avoid `=` padding mid-stream (padded slices concatenated ≠ base64 of the concatenated raw). The carry preserves alignment. The final slice is emitted whole (trailing padding is legal at the end).

Peak transient per fetch drops from O(source-size) to O(SLICE_RAW_BYTES). Sub-MB regardless of mail size, matching the attachment path's shape.

## Empirical evidence for the root cause

`journalctl` on `hoie-inbox-1` from 2026-07-30 23:50–23:53 UTC. 22 concurrent `UID FETCH X (BODY[])` calls with ~786 KB responses each, RSS climb of ~7 MB per fetch on a ~800 KB response (~8-9× amplification vs. the sub-MB shape #733 claimed). Only text/html-heavy mails; attachment-only fetches stayed sub-MB as designed.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test src/server` — 1405/0 pass (was 1399 before; +6 for the new streaming tests).
- [x] New tests in `session-utils.test.ts` cover:
  1. 200 KiB HTML body yields multiple ≤80 KiB chunks, no single giant chunk (regression guard).
  2. Round-trip parity when byte count is NOT a multiple of 3 across many slices (carry logic).
  3. Multi-byte UTF-8 (🚀 × 20 000) across slice boundaries — no split codepoints.
  4. Empty body short-circuit.
  5. Byte-for-byte parity with `buildFullMessage` (materializing path) — the `RFC822.SIZE` == `len(BODY[])` invariant must hold.
- Not applicable: no UI surface. The next OOM alarm on hoie-inbox-1 is the real E2E; will monitor after merge + deploy.

## Not in scope

The mail row itself is still loaded whole from PG (text+html strings inline), so it contributes ~O(body) per in-flight fetch even after this fix. That's the (b) follow-up per Hoie 2026-07-31 00:29 UTC — separate PR splitting text/html into a lazy PG load.