### PR TITLE
fix(imap): quarantine spam from the INBOX tree (#605)

### DIFF
--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -465,10 +465,13 @@ export async function selectMailbox(
     if (firstUnseenSeq) {
       write(`* OK [UNSEEN ${firstUnseenSeq}] Message ${firstUnseenSeq} is first unseen\r\n`);
     }
-    const uidNext =
-      seqState.seqToUid.length > 0
-        ? seqState.seqToUid[seqState.seqToUid.length - 1] + 1
-        : countResult.maxUid + 1 || 1;
+    // UIDNEXT comes from the mailbox's highest assigned UID, never from the
+    // last entry of `seqToUid`. The two diverge whenever the mailbox hides a
+    // message it still holds a UID for — INBOX's spam quarantine is one such
+    // case — and taking the visible tail would let UIDNEXT decrease (RFC 3501
+    // §2.3.1.1 forbids it) and disagree with the value STATUS reports off the
+    // same unfiltered `maxUid`.
+    const uidNext = countResult.maxUid + 1 || 1;
     write(`* OK [UIDVALIDITY ${uidValidity}] UIDs valid\r\n`);
     write(`* OK [UIDNEXT ${uidNext}] Predicted next UID\r\n`);
     // RFC 4551 §3.1.1: a CONDSTORE-capable server reports the mailbox's

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -58,10 +58,11 @@ export const UID_DOMAIN = "uid_domain";
 // Per-message mod-sequence for CONDSTORE (RFC 7162). Monotonically increasing
 // within a mailbox. Bumped by the IMAP write paths — new-message insert
 // (saveMail, incl. APPEND/COPY), STORE (setMailFlags), and EXPUNGE/MOVE.
-// The web-REST single-mail mutators (markMailRead / markMailSaved / markMailSpam)
-// deliberately do NOT bump it in phase 1: no client can observe modseq until
-// phase 3 (FETCH CHANGEDSINCE) lands, so there is no reader to desync. That
-// wiring is a phase-3 task — see the CONDSTORE phase-3 issue.
+// markMailSpam bumps it too: the flip moves the mail in or out of IMAP's INBOX
+// (see `quarantinesSpam`), which is a membership change a CONDSTORE client must
+// be able to detect. The remaining web-REST mutators (markMailRead /
+// markMailSaved) still do not bump it in phase 1 — they change no membership,
+// and no client can observe modseq until phase 3 (FETCH CHANGEDSINCE) lands.
 export const MODSEQ = "modseq";
 // mail_uid_counters columns
 export const UID_KIND = "uid_kind";

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -448,11 +448,11 @@ export const deleteMail = async (
  * keeps HIGHESTMODSEQ honest — without it a CONDSTORE client (RFC 7162 §3.1.2)
  * reads an unchanged value and concludes the mailbox never changed. It is not
  * on its own enough to evict the row: with no VANISHED channel, a client learns
- * the message is gone only on its next SELECT. Emitting that removal mid-session
- * is #742. As
- * on the expunge paths, the mod-sequence is reserved before the row count is
- * known; an idempotent re-mark matches no row, so the reserved value simply
- * goes unused and HIGHESTMODSEQ (a MAX over stamped rows) stays put.
+ * the message is gone only on its next SELECT. Emitting that removal
+ * mid-session is #742. As on the expunge paths, the mod-sequence is reserved
+ * before the row count is known; an idempotent re-mark matches no row, so the
+ * reserved value simply goes unused and HIGHESTMODSEQ (a MAX over stamped
+ * rows) stays put.
  */
 export const markMailSpam = async (
   user_id: string,

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -442,6 +442,14 @@ export const deleteMail = async (
  *
  * Distinguishing "no change" from "not found" lets the caller skip classifier
  * training on idempotent re-marks while still surfacing real auth failures.
+ *
+ * The flip moves the mail in or out of IMAP's INBOX (see `quarantinesSpam`), so
+ * it advances the mod-sequence the way every other membership change does —
+ * otherwise a CONDSTORE client resyncing off an unchanged HIGHESTMODSEQ (RFC
+ * 7162 §3.1.2) concludes nothing happened and keeps serving the stale row. As
+ * on the expunge paths, the mod-sequence is reserved before the row count is
+ * known; an idempotent re-mark matches no row, so the reserved value simply
+ * goes unused and HIGHESTMODSEQ (a MAX over stamped rows) stays put.
  */
 export const markMailSpam = async (
   user_id: string,
@@ -450,10 +458,10 @@ export const markMailSpam = async (
 ): Promise<{ found: boolean; changed: boolean }> => {
   try {
     const result = await pool.query(
-      `UPDATE mails SET is_spam = $1, updated = NOW()
+      `UPDATE mails SET is_spam = $1, updated = NOW(), modseq = $4
          WHERE mail_id = $2 AND user_id = $3 AND is_spam IS DISTINCT FROM $1
          RETURNING mail_id`,
-      [is_spam, mail_id, user_id]
+      [is_spam, mail_id, user_id, await getNextModseq(user_id)]
     );
     if ((result.rowCount ?? 0) > 0) return { found: true, changed: true };
     const exists = await pool.query(

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -444,9 +444,12 @@ export const deleteMail = async (
  * training on idempotent re-marks while still surfacing real auth failures.
  *
  * The flip moves the mail in or out of IMAP's INBOX (see `quarantinesSpam`), so
- * it advances the mod-sequence the way every other membership change does —
- * otherwise a CONDSTORE client resyncing off an unchanged HIGHESTMODSEQ (RFC
- * 7162 §3.1.2) concludes nothing happened and keeps serving the stale row. As
+ * it advances the mod-sequence the way every other membership change does. That
+ * keeps HIGHESTMODSEQ honest — without it a CONDSTORE client (RFC 7162 §3.1.2)
+ * reads an unchanged value and concludes the mailbox never changed. It is not
+ * on its own enough to evict the row: with no VANISHED channel, a client learns
+ * the message is gone only on its next SELECT. Emitting that removal mid-session
+ * is #742. As
  * on the expunge paths, the mod-sequence is reserved before the row count is
  * known; an idempotent re-mark matches no row, so the reserved value simply
  * goes unused and HIGHESTMODSEQ (a MAX over stamped rows) stays put.

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -1171,31 +1171,64 @@ describe("INBOX quarantines spam (#605)", () => {
       ["expungeMailsByUid", "expungeMailsByUid"],
     ];
 
-    // Minimum applications per function — one per SQL-bearing branch, so a
-    // whole-function presence check can't pass while one branch loses the
-    // rule. Dropping it from just the `mailbox === null` branch of getAllUids
-    // (INBOX's own seq->UID map) is the mutation this guards: quarantined UIDs
-    // reappear in the map past the filtered EXISTS, and `FETCH <last seq>`
-    // addresses a message the client was told does not exist.
+    // Applications per function — one per SQL-bearing branch. Counting helper
+    // CALLS is not enough: several of these call the helper once into a local
+    // and interpolate `${membership}` into two or more statements, so deleting
+    // one interpolation leaves the call (and a call-count guard) untouched.
+    // Count application SITES instead — a helper call that is not assigned to
+    // a local, plus every interpolation of a local that is. Dropping the rule
+    // from the `mailbox === null` branch of getAllUids (INBOX's own seq->UID
+    // map) is one guarded mutation: quarantined UIDs reappear past the
+    // filtered EXISTS and `FETCH <last seq>` addresses a message the client
+    // was told does not exist. Dropping it from setMailFlags' domain UID
+    // branch is the other: `UID STORE 1:* +FLAGS (\Deleted)` on INBOX followed
+    // by EXPUNGE destroys quarantined spam the client was never shown.
     const applications: Record<string, number> = {
-      countMessages: 2,
-      getMailsByRangeUncoalesced: 2,
-      setMailFlags: 4,
+      countMessages: 7,
+      getMailsByRangeUncoalesced: 5,
+      setMailFlags: 6,
       searchMailsByUid: 1,
       getAllUids: 2,
       getFirstUnseenUid: 2,
-      expungeDeletedMails: 2,
+      expungeDeletedMails: 3,
       expungeMailsByUid: 2,
+    };
+
+    const HELPERS =
+      "(?:membershipCondition|membershipExpression|quarantinesSpam)";
+
+    const applicationSites = (body: string) => {
+      const locals = new Set(
+        [...body.matchAll(new RegExp(`const\\s+(\\w+)\\s*=\\s*${HELPERS}\\(`, "g"))].map(
+          (m) => m[1]
+        )
+      );
+      // Assignments are the definition, not a use — drop them so only the
+      // sites that put the rule into SQL are counted.
+      const withoutAssignments = body.replace(
+        new RegExp(`const\\s+\\w+\\s*=\\s*${HELPERS}\\([\\s\\S]*?;`, "g"),
+        ""
+      );
+      const direct =
+        withoutAssignments.match(new RegExp(`${HELPERS}\\(`, "g"))?.length ?? 0;
+      // Count every use of a helper-derived local, not just `${…}` ones: the
+      // expunge paths consume `quarantined` as a boolean that gates an
+      // `is_spam` key in the data bag, which is an application of the rule
+      // that never appears in a template.
+      let uses = 0;
+      for (const local of locals) {
+        uses +=
+          withoutAssignments.match(new RegExp(`\\b${local}\\b`, "g"))?.length ?? 0;
+      }
+      return direct + uses;
     };
 
     it.each(fns)("%s applies the membership rule in every branch", (_name, symbol) => {
       const body = source.match(new RegExp(`const ${symbol}\\s*=[\\s\\S]*?\\n};`));
       expect(body, `body not found for ${symbol}`).not.toBeNull();
-      const hits =
-        body![0].match(
-          /membershipCondition\(|membershipExpression\(|quarantinesSpam\(/g
-        ) ?? [];
-      expect(hits.length).toBeGreaterThanOrEqual(applications[symbol]);
+      expect(applicationSites(body![0])).toBeGreaterThanOrEqual(
+        applications[symbol]
+      );
     });
 
     it("never filters MAX(uid) — UIDNEXT must not regress on a spam-mark", () => {

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -1087,3 +1087,117 @@ describe("buildCriterionClause — combinators don't orphan bound params (#672)"
     expect(values).toEqual(["user-1", false, "%x%"]);
   });
 });
+
+describe("INBOX quarantines spam (#605)", () => {
+  const load = async () => await import(".");
+
+  describe("quarantinesSpam", () => {
+    it("covers INBOX itself", async () => {
+      const { quarantinesSpam } = await load();
+      expect(quarantinesSpam(null, false)).toBe(true);
+    });
+
+    it("covers INBOX's per-account sub-views", async () => {
+      const { quarantinesSpam } = await load();
+      expect(quarantinesSpam("INBOX/accounts/alice", false)).toBe(true);
+    });
+
+    it("leaves the unified Sent view alone — sent mail is never classified", async () => {
+      const { quarantinesSpam } = await load();
+      expect(quarantinesSpam(null, true)).toBe(false);
+      expect(quarantinesSpam("Sent Messages/accounts/alice", true)).toBe(false);
+    });
+
+    it("leaves user-created mailboxes alone — an explicit COPY stays visible", async () => {
+      const { quarantinesSpam } = await load();
+      expect(quarantinesSpam("Archive", false)).toBe(false);
+      // A user-created box whose name merely starts with the folder's letters
+      // is not an accounts sub-view; only the full `INBOX/accounts/` path is.
+      expect(quarantinesSpam("INBOX/accountsish", false)).toBe(false);
+      expect(quarantinesSpam("INBOX/accounts", false)).toBe(false);
+    });
+  });
+
+  describe("SQL emitters", () => {
+    it("emit the is_spam predicate for a quarantining box", async () => {
+      const { membershipExpression, membershipCondition } = await load();
+      expect(membershipExpression(null, false)).toBe("is_spam = FALSE");
+      expect(membershipCondition(null, false)).toBe(" AND is_spam = FALSE");
+    });
+
+    it("qualify the column with the caller's alias", async () => {
+      const { membershipExpression, membershipCondition } = await load();
+      expect(membershipExpression("INBOX/accounts/alice", false, "m.")).toBe(
+        "m.is_spam = FALSE"
+      );
+      expect(membershipCondition("INBOX/accounts/alice", false, "m.")).toBe(
+        " AND m.is_spam = FALSE"
+      );
+    });
+
+    it("degrade to a no-op every non-quarantining box can interpolate", async () => {
+      const { membershipExpression, membershipCondition } = await load();
+      // `TRUE` keeps `COUNT(*) FILTER (WHERE …)` well-formed; "" appends
+      // cleanly to an existing WHERE. Neither needs a caller-side branch.
+      expect(membershipExpression("Archive", false)).toBe("TRUE");
+      expect(membershipCondition("Archive", false)).toBe("");
+      expect(membershipExpression(null, true)).toBe("TRUE");
+      expect(membershipCondition(null, true)).toBe("");
+    });
+  });
+
+  describe("every mailbox-scoped site applies the rule (source regression)", () => {
+    // One missed site desynchronises INBOX's membership: e.g. a filtered
+    // `getAllUids` (the seq→UID map) against an unfiltered `countMessages`
+    // makes EXISTS exceed the addressable sequence range.
+    let source: string;
+
+    beforeAll(async () => {
+      const fs = await import("fs/promises");
+      const path = await import("path");
+      source = await fs.readFile(path.join(import.meta.dir, "imap.ts"), "utf8");
+    });
+
+    // [public name, symbol that actually builds the SQL] — getMailsByRange is a
+    // single-flight wrapper whose query lives in the uncoalesced impl.
+    const fns: [string, string][] = [
+      ["countMessages", "countMessages"],
+      ["getMailsByRange", "getMailsByRangeUncoalesced"],
+      ["setMailFlags", "setMailFlags"],
+      ["searchMailsByUid", "searchMailsByUid"],
+      ["getAllUids", "getAllUids"],
+      ["getFirstUnseenUid", "getFirstUnseenUid"],
+      ["expungeDeletedMails", "expungeDeletedMails"],
+      ["expungeMailsByUid", "expungeMailsByUid"],
+    ];
+
+    it.each(fns)("%s consults the membership rule", (_name, symbol) => {
+      const body = source.match(new RegExp(`const ${symbol}\\s*=[\\s\\S]*?\\n};`));
+      expect(body, `body not found for ${symbol}`).not.toBeNull();
+      expect(body![0]).toMatch(
+        /membershipCondition|membershipExpression|quarantinesSpam/
+      );
+    });
+
+    it("never filters MAX(uid) — UIDNEXT must not regress on a spam-mark", () => {
+      // mailbox-ops emits `max_uid + 1` as UIDNEXT, which RFC 3501 §2.3.1.1
+      // requires to exceed every UID ever assigned and never to decrease. The
+      // counts are FILTERed; the MAX is deliberately not.
+      const body = source.match(/export const countMessages[\s\S]*?\n};/)![0];
+      expect(body).toMatch(/COUNT\(\*\) FILTER \(WHERE \$\{membership\}\)/);
+      const maxUidLines = body
+        .split("\n")
+        .filter((line) => line.includes("as max_uid"));
+      // One per branch: domain-scoped (uid_domain) and per-mailbox (x.uid).
+      expect(maxUidLines).toHaveLength(2);
+      for (const line of maxUidLines) expect(line).not.toContain("FILTER");
+    });
+
+    it("does not exclude \\Deleted mail from INBOX", () => {
+      // `mails.deleted` is the IMAP \Deleted flag; RFC 3501 §6.4.3 keeps those
+      // messages in the mailbox until EXPUNGE. Only `expunged` removes them.
+      expect(source).not.toMatch(/AND\s+\$\{?DELETED\}?\s*=\s*FALSE/);
+      expect(source).not.toMatch(/AND\s+deleted\s*=\s*FALSE/);
+    });
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -1171,12 +1171,31 @@ describe("INBOX quarantines spam (#605)", () => {
       ["expungeMailsByUid", "expungeMailsByUid"],
     ];
 
-    it.each(fns)("%s consults the membership rule", (_name, symbol) => {
+    // Minimum applications per function — one per SQL-bearing branch, so a
+    // whole-function presence check can't pass while one branch loses the
+    // rule. Dropping it from just the `mailbox === null` branch of getAllUids
+    // (INBOX's own seq->UID map) is the mutation this guards: quarantined UIDs
+    // reappear in the map past the filtered EXISTS, and `FETCH <last seq>`
+    // addresses a message the client was told does not exist.
+    const applications: Record<string, number> = {
+      countMessages: 2,
+      getMailsByRangeUncoalesced: 2,
+      setMailFlags: 4,
+      searchMailsByUid: 1,
+      getAllUids: 2,
+      getFirstUnseenUid: 2,
+      expungeDeletedMails: 2,
+      expungeMailsByUid: 2,
+    };
+
+    it.each(fns)("%s applies the membership rule in every branch", (_name, symbol) => {
       const body = source.match(new RegExp(`const ${symbol}\\s*=[\\s\\S]*?\\n};`));
       expect(body, `body not found for ${symbol}`).not.toBeNull();
-      expect(body![0]).toMatch(
-        /membershipCondition|membershipExpression|quarantinesSpam/
-      );
+      const hits =
+        body![0].match(
+          /membershipCondition\(|membershipExpression\(|quarantinesSpam\(/g
+        ) ?? [];
+      expect(hits.length).toBeGreaterThanOrEqual(applications[symbol]);
     });
 
     it("never filters MAX(uid) — UIDNEXT must not regress on a spam-mark", () => {
@@ -1203,6 +1222,21 @@ describe("INBOX quarantines spam (#605)", () => {
         expect(membershipExpression(box, false)).toBe("is_spam = FALSE");
         expect(membershipCondition(box, false)).toBe(" AND is_spam = FALSE");
       }
+    });
+
+    it("stamps a mod-sequence when a spam flip moves a mail out of INBOX", async () => {
+      // The flip is a membership change, so it has to advance HIGHESTMODSEQ or
+      // a CONDSTORE client reads an unchanged value and never resyncs. The
+      // repository's own tests mock this module, so pin the write at the source.
+      const fs = await import("fs/promises");
+      const path = await import("path");
+      const core = await fs.readFile(path.join(import.meta.dir, "core.ts"), "utf8");
+      const body = core.match(/export const markMailSpam[\s\S]*?\n};/)![0];
+      expect(body).toMatch(/modseq\s*=\s*\$4/);
+      expect(body).toContain("getNextModseq(user_id)");
+      // The idempotence guard must survive — a re-mark of the same value has to
+      // match no row so the reserved value goes unused.
+      expect(body).toContain("is_spam IS DISTINCT FROM $1");
     });
 
     it("keeps the seq-number OFFSET list in step with getAllUids", () => {

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -1193,11 +1193,28 @@ describe("INBOX quarantines spam (#605)", () => {
       for (const line of maxUidLines) expect(line).not.toContain("FILTER");
     });
 
-    it("does not exclude \\Deleted mail from INBOX", () => {
+    it("does not exclude \\Deleted mail from INBOX", async () => {
       // `mails.deleted` is the IMAP \Deleted flag; RFC 3501 §6.4.3 keeps those
-      // messages in the mailbox until EXPUNGE. Only `expunged` removes them.
-      expect(source).not.toMatch(/AND\s+\$\{?DELETED\}?\s*=\s*FALSE/);
-      expect(source).not.toMatch(/AND\s+deleted\s*=\s*FALSE/);
+      // messages in the mailbox until EXPUNGE. Assert on what the rule actually
+      // emits — `is_spam` and nothing else — rather than on the absence of a
+      // string, which would pass just as well on a file that never had one.
+      const { membershipExpression, membershipCondition } = await import(".");
+      for (const box of [null, "INBOX/accounts/alice"]) {
+        expect(membershipExpression(box, false)).toBe("is_spam = FALSE");
+        expect(membershipCondition(box, false)).toBe(" AND is_spam = FALSE");
+      }
+    });
+
+    it("keeps the seq-number OFFSET list in step with getAllUids", () => {
+      // Mapping rows outlive the expunge that hid their mail, so the OFFSET
+      // subquery has to filter `sent` and `expunged` exactly as getAllUids
+      // does — membership alone leaves every position after an expunged row
+      // off by one.
+      const body = source.match(/export const setMailFlags[\s\S]*?\n};/)![0];
+      const join = body.match(/const membershipJoin[\s\S]*?: "";/)![0];
+      expect(join).toContain("z.${SENT} = $2");
+      expect(join).toContain("z.${EXPUNGED} = FALSE");
+      expect(join).toContain('membershipExpression(mailbox, sent, "z.")');
     });
   });
 });

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -154,12 +154,17 @@ export const countMessages = async (
     let values: ParamValue[];
 
     // `total` / `unread` describe what the mailbox contains, so they honour the
-    // membership rule. `max_uid` deliberately does NOT: it backs UIDNEXT
-    // (mailbox-ops emits `max_uid + 1`), and RFC 3501 §2.3.1.1 requires UIDNEXT
-    // to be greater than every UID ever assigned in the mailbox and never to
-    // decrease. Filtering it would make UIDNEXT fall back the moment the
-    // highest-UID mail got spam-marked, and hand a later arrival a UID the
-    // client had already been promised was unused.
+    // membership rule. `max_uid` deliberately does not: it backs UIDNEXT
+    // (mailbox-ops emits `max_uid + 1`), which RFC 3501 §2.3.1.1 requires to
+    // exceed every UID assigned in the mailbox. Filtering it would drop UIDNEXT
+    // the moment the highest-UID mail got spam-marked, handing a later arrival
+    // a UID the client had been promised was unused.
+    //
+    // This keeps membership from moving UIDNEXT; it does not make UIDNEXT
+    // monotonic in general. `max_uid` is still a MAX over live rows, so an
+    // EXPUNGE or a hard delete of the highest-UID mail lowers it — a
+    // pre-existing gap that wants UIDNEXT sourced from `mail_uid_counters`
+    // instead. Tracked in #743.
     const membership = membershipExpression(mailbox, sent);
 
     if (mailbox === null) {

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -102,10 +102,11 @@ const INBOX_ACCOUNTS_PREFIX = "INBOX/accounts/";
  *
  * INBOX (`mailbox === null`, `sent = false`) has no address condition at all,
  * and its per-account sub-views match purely on delivery address, so a
- * spam-classified mail lands in both simply by having been received. The HTTP
- * client already quarantines those rows into a dedicated Spam view; excluding
- * them here gives IMAP the same inbox membership instead of showing spam
- * intermixed with ham and counting it toward EXISTS/UNSEEN.
+ * spam-classified mail lands in both simply by having been received, showing up
+ * intermixed with ham and counting toward EXISTS/UNSEEN. The web client routes
+ * those rows to a dedicated Spam view; this is the IMAP side of the same
+ * quarantine. Until a `Junk` mailbox exists, quarantined mail is reachable over
+ * the web client only.
  *
  * Deliberately narrow on two axes:
  * - **Sent is never classified.** `is_spam` is only ever written on received
@@ -561,11 +562,15 @@ export const setMailFlags = async (
         // Sequence-number path: match a single row at the OFFSETth
         // position in the mailbox's UID-ordered list.
         // A sequence number counts only the messages the mailbox shows, so this
-        // OFFSET has to walk the same filtered list `getAllUids` builds. The
-        // join onto `mails` is emitted only for a box that actually filters —
-        // every other box keeps the mapping-only scan it had.
+        // OFFSET has to walk the same list `getAllUids` builds — which means
+        // `sent` and `expunged` too, not just the membership rule: mapping rows
+        // outlive the expunge that hid their mail, so a mapping-only scan
+        // counts messages the seq map does not and shifts every position after
+        // them. The join is emitted only for a box that filters; every other
+        // box keeps the mapping-only scan it had.
         const membershipJoin = quarantinesSpam(mailbox, sent)
           ? `JOIN mails z ON z.${USER_ID} = y.${USER_ID} AND z.${MAIL_ID} = y.${MAIL_ID}
+             AND z.${SENT} = $2 AND z.${EXPUNGED} = FALSE
              AND ${membershipExpression(mailbox, sent, "z.")}`
           : "";
         const targetSubquery = `(
@@ -868,10 +873,12 @@ export const searchMailsByUid = async (
 
     // Always exclude expunged messages from search, and anything the mailbox
     // doesn't show — SEARCH must not return UIDs the client can't FETCH.
-    const conditions: string[] = ["m.user_id = $1", "m.sent = $2", "m.expunged = FALSE"];
-    if (quarantinesSpam(mailbox, sent)) {
-      conditions.push(membershipExpression(mailbox, sent, "m."));
-    }
+    const conditions: string[] = [
+      "m.user_id = $1",
+      "m.sent = $2",
+      "m.expunged = FALSE",
+      membershipExpression(mailbox, sent, "m."),
+    ];
     const values: ParamValue[] = [user_id, sent];
 
     // Base table + optional mailbox join

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -15,6 +15,7 @@ import {
   MAIL_MAILBOX_UID,
   MAILBOX,
   UID,
+  IS_SPAM,
 } from "../../models";
 import { getNextModseq } from "./counters";
 import { singleFlight } from "./inflight";
@@ -88,6 +89,60 @@ export async function* pgTextChunks(
  * stay on `mails.uid_domain` and don't participate in the per-mailbox mapping.
  */
 
+/**
+ * Prefix of the per-account received boxes (`INBOX/accounts/<local-part>`).
+ * Mirrors `ACCOUNTS_FOLDER` in `imap/util.ts`, which cannot be imported here:
+ * that module pulls from the `server` barrel, which re-exports this repository.
+ */
+const INBOX_ACCOUNTS_PREFIX = "INBOX/accounts/";
+
+/**
+ * Whether a mailbox quarantines spam-classified mail — true for the INBOX tree
+ * only.
+ *
+ * INBOX (`mailbox === null`, `sent = false`) has no address condition at all,
+ * and its per-account sub-views match purely on delivery address, so a
+ * spam-classified mail lands in both simply by having been received. The HTTP
+ * client already quarantines those rows into a dedicated Spam view; excluding
+ * them here gives IMAP the same inbox membership instead of showing spam
+ * intermixed with ham and counting it toward EXISTS/UNSEEN.
+ *
+ * Deliberately narrow on two axes:
+ * - **Sent is never classified.** `is_spam` is only ever written on received
+ *   mail, so the unified `Sent Messages` view and its sub-boxes are untouched.
+ * - **User-created mailboxes keep their contents.** A mail the user COPYed into
+ *   `Archive` is an explicit placement; the classifier does not get to hide it.
+ *
+ * Note this is not extended to `deleted`: `mails.deleted` is the IMAP
+ * `\Deleted` flag, and RFC 3501 §6.4.3 requires `\Deleted` messages to stay in
+ * the mailbox until EXPUNGE removes them. Soft-deleted mail leaving INBOX is a
+ * `Trash` mailbox question (#725), not an INBOX predicate.
+ */
+export const quarantinesSpam = (mailbox: string | null, sent: boolean): boolean =>
+  !sent && (mailbox === null || mailbox.startsWith(INBOX_ACCOUNTS_PREFIX));
+
+/**
+ * Boolean expression selecting the rows a mailbox actually contains. `TRUE` for
+ * every box that shows spam, so callers can interpolate it unconditionally.
+ * `prefix` qualifies the column for queries that alias `mails` (e.g. `"m."`).
+ */
+export const membershipExpression = (
+  mailbox: string | null,
+  sent: boolean,
+  prefix: string = ""
+): string => (quarantinesSpam(mailbox, sent) ? `${prefix}${IS_SPAM} = FALSE` : "TRUE");
+
+/**
+ * The same rule as a suffix for an existing `WHERE`, empty when the box shows
+ * spam so it appends cleanly to any clause.
+ */
+export const membershipCondition = (
+  mailbox: string | null,
+  sent: boolean,
+  prefix: string = ""
+): string =>
+  quarantinesSpam(mailbox, sent) ? ` AND ${prefix}${IS_SPAM} = FALSE` : "";
+
 export const countMessages = async (
   user_id: string,
   mailbox: string | null,
@@ -97,13 +152,22 @@ export const countMessages = async (
     let sql: string;
     let values: ParamValue[];
 
+    // `total` / `unread` describe what the mailbox contains, so they honour the
+    // membership rule. `max_uid` deliberately does NOT: it backs UIDNEXT
+    // (mailbox-ops emits `max_uid + 1`), and RFC 3501 §2.3.1.1 requires UIDNEXT
+    // to be greater than every UID ever assigned in the mailbox and never to
+    // decrease. Filtering it would make UIDNEXT fall back the moment the
+    // highest-UID mail got spam-marked, and hand a later arrival a UID the
+    // client had already been promised was unused.
+    const membership = membershipExpression(mailbox, sent);
+
     if (mailbox === null) {
       // Domain-wide count (INBOX / unified Sent Messages) — still keyed on
       // uid_domain, unchanged by #702's per-mailbox mapping migration.
       sql = `
         SELECT
-          COUNT(*) as total,
-          SUM(CASE WHEN read = FALSE THEN 1 ELSE 0 END) as unread,
+          COUNT(*) FILTER (WHERE ${membership}) as total,
+          COUNT(*) FILTER (WHERE read = FALSE AND ${membership}) as unread,
           COALESCE(MAX(${UID_DOMAIN}), 0) as max_uid
         FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
@@ -118,10 +182,11 @@ export const countMessages = async (
       // backfilled — e.g. the 140 rows the one-shot script skipped over
       // duplicate-UID collisions from a #617-era race — have no mapping
       // row and are intentionally invisible to reads.
+      const joinMembership = membershipExpression(mailbox, sent, "m.");
       sql = `
         SELECT
-          COUNT(*) as total,
-          SUM(CASE WHEN m.read = FALSE THEN 1 ELSE 0 END) as unread,
+          COUNT(*) FILTER (WHERE ${joinMembership}) as total,
+          COUNT(*) FILTER (WHERE m.read = FALSE AND ${joinMembership}) as unread,
           COALESCE(MAX(x.${UID}), 0) as max_uid
         FROM mails m
         JOIN ${MAIL_MAILBOX_UID} x
@@ -268,11 +333,12 @@ const getMailsByRangeUncoalesced = async (
         ? `, ${UID_DOMAIN} AS uid_mailbox`
         : "";
       const fieldList = `${projection}${uidMailboxAlias}${octetProjections("")}`;
+      const membership = membershipCondition(mailbox, sent);
       if (useUid) {
         sql = `
           SELECT ${fieldList} FROM mails
           WHERE user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4
-            AND expunged = FALSE${modseqDomainClause}
+            AND expunged = FALSE${membership}${modseqDomainClause}
           ORDER BY ${UID_DOMAIN} ASC
         `;
         values = [user_id, sent, start, Math.min(end, 999999999)];
@@ -280,7 +346,7 @@ const getMailsByRangeUncoalesced = async (
       } else {
         sql = `
           SELECT ${fieldList} FROM mails
-          WHERE user_id = $1 AND sent = $2 AND expunged = FALSE${modseqDomainClause}
+          WHERE user_id = $1 AND sent = $2 AND expunged = FALSE${membership}${modseqDomainClause}
           ORDER BY ${UID_DOMAIN} ASC
           OFFSET $3 LIMIT $4
         `;
@@ -304,6 +370,7 @@ const getMailsByRangeUncoalesced = async (
         qualifiedFields.length + uidMailboxAlias.length + octetsFragment.length > 0
           ? `${qualifiedFields}${uidMailboxAlias}${octetsFragment}`
           : "m.*";
+      const membership = membershipCondition(mailbox, sent, "m.");
       if (useUid) {
         sql = `
           SELECT ${fieldList} FROM mails m
@@ -313,7 +380,7 @@ const getMailsByRangeUncoalesced = async (
             AND x.${MAIL_ID} = m.${MAIL_ID}
           WHERE m.${USER_ID} = $1 AND m.${SENT} = $2
             AND x.${UID} >= $4 AND x.${UID} <= $5
-            AND m.${EXPUNGED} = FALSE${modseqMailboxClause}
+            AND m.${EXPUNGED} = FALSE${membership}${modseqMailboxClause}
           ORDER BY x.${UID} ASC
         `;
         values = [user_id, sent, mailbox, start, Math.min(end, 999999999)];
@@ -325,7 +392,7 @@ const getMailsByRangeUncoalesced = async (
             ON x.${USER_ID} = m.${USER_ID}
             AND x.${MAILBOX} = $3
             AND x.${MAIL_ID} = m.${MAIL_ID}
-          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE${modseqMailboxClause}
+          WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE${membership}${modseqMailboxClause}
           ORDER BY x.${UID} ASC
           OFFSET $4 LIMIT $5
         `;
@@ -440,10 +507,16 @@ export const setMailFlags = async (
     let updateSql: string;
     let baseValues: ParamValue[];
 
+    // A STORE addresses messages *in the selected mailbox*, so it has to see
+    // the same set the reads do — otherwise `UID STORE 1:* +FLAGS (\Deleted)`
+    // on INBOX would flag quarantined spam the client was never shown, and the
+    // following EXPUNGE would destroy it.
+    const membership = membershipCondition(mailbox, sent);
+
     if (mailbox === null) {
       const returningCols = `${UID_DOMAIN} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
       if (useUid) {
-        const whereClause = `user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4`;
+        const whereClause = `user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4${membership}`;
         selectSql = `SELECT ${returningCols} FROM mails WHERE ${whereClause}`;
         updateSql = `UPDATE mails
           SET ${setClause}, updated = CURRENT_TIMESTAMP, ${MODSEQ} = $5
@@ -453,7 +526,7 @@ export const setMailFlags = async (
       } else {
         const whereClause = `mail_id IN (
           SELECT mail_id FROM mails
-          WHERE user_id = $1 AND sent = $2
+          WHERE user_id = $1 AND sent = $2${membership}
           ORDER BY ${UID_DOMAIN} ASC
           OFFSET $3 LIMIT 1
         )`;
@@ -473,7 +546,7 @@ export const setMailFlags = async (
       if (useUid) {
         const whereClause = `m.${USER_ID} = $1 AND m.${SENT} = $2
           AND x.${USER_ID} = m.${USER_ID} AND x.${MAILBOX} = $3 AND x.${MAIL_ID} = m.${MAIL_ID}
-          AND x.${UID} >= $4 AND x.${UID} <= $5`;
+          AND x.${UID} >= $4 AND x.${UID} <= $5${membershipCondition(mailbox, sent, "m.")}`;
         selectSql = `SELECT ${returningCols} FROM mails m, ${MAIL_MAILBOX_UID} x WHERE ${whereClause}`;
         // UPDATE ... FROM syntax joins the mapping to the target mails
         // rows. Postgres semantics: rows matching the join get updated
@@ -487,8 +560,17 @@ export const setMailFlags = async (
       } else {
         // Sequence-number path: match a single row at the OFFSETth
         // position in the mailbox's UID-ordered list.
+        // A sequence number counts only the messages the mailbox shows, so this
+        // OFFSET has to walk the same filtered list `getAllUids` builds. The
+        // join onto `mails` is emitted only for a box that actually filters —
+        // every other box keeps the mapping-only scan it had.
+        const membershipJoin = quarantinesSpam(mailbox, sent)
+          ? `JOIN mails z ON z.${USER_ID} = y.${USER_ID} AND z.${MAIL_ID} = y.${MAIL_ID}
+             AND ${membershipExpression(mailbox, sent, "z.")}`
+          : "";
         const targetSubquery = `(
           SELECT y.${MAIL_ID} FROM ${MAIL_MAILBOX_UID} y
+          ${membershipJoin}
           WHERE y.${USER_ID} = $1 AND y.${MAILBOX} = $3
           ORDER BY y.${UID} ASC
           OFFSET $4 LIMIT 1
@@ -784,8 +866,12 @@ export const searchMailsByUid = async (
     // `${uidField} >= $N`, so the alias needs to be qualified.
     const uidField = mailbox === null ? UID_DOMAIN : `x.${UID}`;
 
-    // Always exclude expunged messages from search
+    // Always exclude expunged messages from search, and anything the mailbox
+    // doesn't show — SEARCH must not return UIDs the client can't FETCH.
     const conditions: string[] = ["m.user_id = $1", "m.sent = $2", "m.expunged = FALSE"];
+    if (quarantinesSpam(mailbox, sent)) {
+      conditions.push(membershipExpression(mailbox, sent, "m."));
+    }
     const values: ParamValue[] = [user_id, sent];
 
     // Base table + optional mailbox join
@@ -845,7 +931,7 @@ export const getAllUids = async (
     if (mailbox === null) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
-        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE
+        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE${membershipCondition(mailbox, sent)}
         ORDER BY ${UID_DOMAIN} ASC
       `;
       values = [user_id, sent];
@@ -856,7 +942,7 @@ export const getAllUids = async (
           ON x.${USER_ID} = m.${USER_ID}
           AND x.${MAILBOX} = $3
           AND x.${MAIL_ID} = m.${MAIL_ID}
-        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE
+        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE${membershipCondition(mailbox, sent, "m.")}
         ORDER BY x.${UID} ASC
       `;
       values = [user_id, sent, mailbox];
@@ -888,7 +974,7 @@ export const getFirstUnseenUid = async (
     if (mailbox === null) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
-        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE
+        WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE${membershipCondition(mailbox, sent)}
         ORDER BY ${UID_DOMAIN} ASC
         LIMIT 1
       `;
@@ -900,7 +986,7 @@ export const getFirstUnseenUid = async (
           ON x.${USER_ID} = m.${USER_ID}
           AND x.${MAILBOX} = $3
           AND x.${MAIL_ID} = m.${MAIL_ID}
-        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE AND m.read = FALSE
+        WHERE m.${USER_ID} = $1 AND m.${SENT} = $2 AND m.${EXPUNGED} = FALSE AND m.read = FALSE${membershipCondition(mailbox, sent, "m.")}
         ORDER BY x.${UID} ASC
         LIMIT 1
       `;
@@ -927,10 +1013,21 @@ export const expungeDeletedMails = async (
   sent: boolean
 ): Promise<number[]> => {
   try {
+    // EXPUNGE removes `\Deleted` messages *from the selected mailbox*, so a
+    // quarantined mail is out of reach here too — otherwise an INBOX EXPUNGE
+    // would collect spam the client never saw and could not have flagged.
+    const quarantined = quarantinesSpam(mailbox, sent);
+
     if (mailbox === null) {
       // Domain-wide expunge — still on uid_domain, unchanged.
       const rows = await mailsTable.updateWhere(
-        { [USER_ID]: user_id, [SENT]: sent, [DELETED]: true, [EXPUNGED]: false },
+        {
+          [USER_ID]: user_id,
+          [SENT]: sent,
+          [DELETED]: true,
+          [EXPUNGED]: false,
+          ...(quarantined ? { [IS_SPAM]: false } : {}),
+        },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
         { [EXPUNGED]: true, updated: DB_NOW, [MODSEQ]: await getNextModseq(user_id) },
@@ -951,7 +1048,7 @@ export const expungeDeletedMails = async (
         AND x.${MAILBOX} = $3
         AND x.${MAIL_ID} = m.${MAIL_ID}
       WHERE m.${USER_ID} = $1 AND m.${SENT} = $2
-        AND m.${DELETED} = TRUE AND m.${EXPUNGED} = FALSE
+        AND m.${DELETED} = TRUE AND m.${EXPUNGED} = FALSE${membershipCondition(mailbox, sent, "m.")}
     `;
     const selectResult = await pool.query(selectSql, [user_id, sent, mailbox]);
     if (selectResult.rows.length === 0) return [];
@@ -1000,6 +1097,10 @@ export const expungeMailsByUid = async (
 ): Promise<number[]> => {
   if (uids.length === 0) return [];
   try {
+    // Same membership rule as EXPUNGE: MOVE's source-side removal only ever
+    // addresses UIDs the selected mailbox actually holds.
+    const quarantined = quarantinesSpam(mailbox, sent);
+
     if (mailbox === null) {
       // Domain-wide: simple equality on user_id+sent + IN(uids).
       const rows = await mailsTable.updateWhere(
@@ -1008,6 +1109,7 @@ export const expungeMailsByUid = async (
           [SENT]: sent,
           [EXPUNGED]: false,
           [UID_DOMAIN]: { op: "IN", value: uids },
+          ...(quarantined ? { [IS_SPAM]: false } : {}),
         },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
@@ -1031,7 +1133,7 @@ export const expungeMailsByUid = async (
       WHERE m.${USER_ID} = $1
         AND m.${SENT} = $2
         AND x.${UID} IN (${uidPlaceholders})
-        AND m.${EXPUNGED} = FALSE
+        AND m.${EXPUNGED} = FALSE${membershipCondition(mailbox, sent, "m.")}
     `;
     const selectValues: ParamValue[] = [user_id, sent, mailbox, ...uids];
     const selectResult = await pool.query(selectSql, selectValues);


### PR DESCRIPTION
Part 1 of #605 (the flag-derived half). Does **not** close it — see "What this does not do".

## The bug

IMAP `INBOX` resolves to the domain-scoped view: `WHERE user_id = $N AND sent = $N AND expunged = FALSE`, with no further predicate. Its per-account sub-views (`INBOX/accounts/<local>`) match purely on delivery address. Neither has ever consulted `is_spam`, so **every spam-classified mail sits in IMAP INBOX** — intermixed with ham, with no marker, counted toward `EXISTS`/`UNSEEN`, and FETCHable.

The HTTP client already quarantines those rows into a dedicated Spam view (and #662 tightens the remaining non-spam surfaces). IMAP had no spam concept at all — `grep -rn is_spam src/server/lib/imap/` returns nothing on `main`.

This is system behaviour, not user state: `is_spam` is written by the auto-classifier on every received mail (`mails/receive.ts` → `saveMail`), so it reproduces on each newly-classified message.

## The fix

One membership rule, applied at all eight mailbox-scoped read/write sites so reads, `SEARCH`, `STORE` and `EXPUNGE` agree on what INBOX contains:

- `quarantinesSpam(mailbox, sent)` — true for the INBOX tree only.
- `membershipExpression(...)` → `is_spam = FALSE` or `TRUE` (interpolates into `COUNT(*) FILTER (WHERE …)`).
- `membershipCondition(...)` → ` AND is_spam = FALSE` or `""` (appends to an existing `WHERE`).

Both degrade to a no-op for non-quarantining boxes, so there is no caller-side branching and the non-INBOX SQL is byte-identical to before.

Sites: `countMessages`, `getMailsByRange`, `setMailFlags`, `searchMailsByUid`, `getAllUids`, `getFirstUnseenUid`, `expungeDeletedMails`, `expungeMailsByUid`.

### Three deliberate carve-outs

1. **`max_uid` is NOT filtered.** It backs `UIDNEXT` (`mailbox-ops` emits `max_uid + 1`), which RFC 3501 section 2.3.1.1 requires to exceed every UID ever assigned and never to decrease. Filtering it would roll `UIDNEXT` backwards the moment the highest-UID mail got spam-marked, then hand a later arrival a UID the client was already promised was unused. Only the counts are `FILTER`ed; a source test pins this.

2. **`\Deleted` is NOT excluded.** The earlier sketch on #605 proposed `AND is_spam = FALSE AND deleted = FALSE`. The second half is wrong: `mails.deleted` **is** the IMAP `\Deleted` flag (`imap/util.ts:322`), and RFC 3501 section 6.4.3 requires `\Deleted` messages to remain in the mailbox until `EXPUNGE`. Excluding them would hide flagged mail from the client that flagged it and strand `EXPUNGE`. Soft-deleted mail leaving INBOX is a `Trash` mailbox question (#725), not an INBOX predicate. A test pins the absence.

3. **Writes are gated too, not just reads.** `UID STORE 1:* +FLAGS (\Deleted)` on INBOX would otherwise flag quarantined spam the client was never shown, and the following `EXPUNGE` would destroy it. The sequence-number paths filter the `OFFSET` list as well, so seq numbering matches `getAllUids`.

Sent boxes and user-created mailboxes are untouched: sent mail is never classified, and a mail the user explicitly `COPY`ed into `Archive` stays visible even if the classifier flags it.

## What this does not do

- **Does not close #605.** The original symptom there is *address*-routed: a `COPY 5 Archive` copy still surfaces in INBOX because `Archive@<domain>` is a user-domain address. That half is a design fork (mapping-backed INBOX vs. a `NOT EXISTS` predicate) still awaiting a maintainer call. I will re-scope #605 to that half.
- **Does not add a `Junk` mailbox.** Until #725 lands, spam is reachable over the web client's Spam view but not over IMAP. Calling that out explicitly rather than leaving it implied — it is the intended quarantine behaviour, but it does narrow the IMAP surface in the interim, and #725's `Junk` is what restores it.
- Leaves a pre-existing gap untouched: the `setMailFlags` sequence-number paths count expunged rows, so `STORE <seq>` can target the wrong message. Unrelated to this issue — filed as #741 rather than folded in. (Latent today: every in-repo caller passes `useUid = true`, so those branches are unreachable from the live dispatch.)
- Does not fix the IDLE notifier's decreasing-`EXISTS`-without-`EXPUNGE` violation. Pre-existing (another session's `EXPUNGE` already triggers it), but a spam-mark is a new and more reachable trigger, so it is filed as #742.

## Test plan

**Automated**
- New unit tests on the exported rule: INBOX and `INBOX/accounts/<name>` quarantine; unified Sent, per-account Sent, `Archive`, and the near-miss names `INBOX/accountsish` / `INBOX/accounts` do not. Emitters checked for the predicate, for alias qualification (`m.is_spam = FALSE`), and for the `TRUE`/`""` no-op degradation.
- Source-regression tests: each of the eight sites consults the rule (a missed site desynchronises INBOX — a filtered `getAllUids` against an unfiltered `countMessages` makes `EXISTS` exceed the addressable sequence range); `max_uid` carries no `FILTER`; no `deleted = FALSE` exclusion exists anywhere in the file.
- `bun test src/server` — 1453 pass / 0 fail. typecheck clean, build clean, lint 0 errors.

**Live IMAP against the sandbox** (isolated prod clone, `SELECT`/`STATUS`/`UID FETCH`/`UID SEARCH` driven over a real socket; spam flips driven through the real `POST /api/mails/spam/mark` route, not by touching the DB)

The clone had zero spam rows, so each run marks one mail, asserts, then unmarks and re-asserts — the clone is left at zero spam rows.

INBOX, marking the highest-UID received mail:

| | EXISTS | UIDNEXT (SELECT) | UIDNEXT (STATUS) | `UID FETCH` target | `UID SEARCH ALL` |
|---|---|---|---|---|---|
| before | 12383 | 12428 | 12428 | returns it | contains it |
| marked spam | 12382 | 12428 | 12428 | no message | excluded |
| unmarked | 12383 | 12428 | 12428 | returns it | contains it |

`UID SEARCH UNSEEN` tracked the same way (1 → 0 → 1), and `[UNSEEN]` disappeared from the SELECT response while the only unread mail was quarantined.

Box-family scoping, marking one mail belonging to a per-account sub-view:

| mailbox | before | marked | unmarked |
|---|---|---|---|
| `INBOX` | 12383 | 12382 | 12383 |
| `INBOX/accounts/<acct>` | 1021 (target present) | 1020 (target absent) | 1021 (target present) |
| `Sent Messages` | 591 | 591 | 591 |

`UIDNEXT` held at 12428 / 1023 / 592 in every state — domain-scoped and per-mailbox alike.

**The two HIGH regressions above were caught live, not theorised.** Running the same script against the first commit reproduced both exactly: `SELECT INBOX` reported `UIDNEXT 12427` after the spam-mark (down from 12428, and disagreeing with STATUS's 12428), and `HIGHESTMODSEQ` stayed at 125 across a real flip. After the fix: `UIDNEXT` 12428 from both commands, and `HIGHESTMODSEQ` 125 → 126 on a real flip while an idempotent re-mark left it at 126.