### PR TITLE
perf(imap): bytes-in-flight budget alongside the concurrency cap

### DIFF
--- a/src/server/lib/imap/body-budget.test.ts
+++ b/src/server/lib/imap/body-budget.test.ts
@@ -6,6 +6,8 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import {
   withBodyBudget,
   bodyBudgetCapacity,
+  bodyBudgetMemoryCap,
+  bodyBudgetBytesInFlight,
   runInBodyBudgetContext,
   getBodyBudgetWaitMs,
   _resetBodyBudget,
@@ -38,7 +40,7 @@ describe("body-budget semaphore (#726)", () => {
     const gates = Array.from({ length: CAP }, () => defer<string>());
     const running: string[] = [];
     const wrapped = gates.map((g, i) =>
-      withBodyBudget(async () => {
+      withBodyBudget(0, async () => {
         running.push(`start-${i}`);
         return await g.promise;
       })
@@ -60,14 +62,14 @@ describe("body-budget semaphore (#726)", () => {
     // three waiters A/B/C in that order, then release holders one at
     // a time and assert the completion order is A → B → C.
     const holding = Array.from({ length: CAP }, () => defer<void>());
-    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+    const holdingRuns = holding.map((g) => withBodyBudget(0, () => g.promise));
 
     const completed: string[] = [];
     const waiters = ["A", "B", "C"] as const;
     const waiterRuns: Promise<unknown>[] = [];
     for (const name of waiters) {
       waiterRuns.push(
-        withBodyBudget(async () => {
+        withBodyBudget(0, async () => {
           completed.push(name);
         })
       );
@@ -87,10 +89,10 @@ describe("body-budget semaphore (#726)", () => {
 
   it("queues an extra caller until a slot frees", async () => {
     const holding = Array.from({ length: CAP }, () => defer<void>());
-    const holdingRuns = holding.map((g) => withBodyBudget(() => g.promise));
+    const holdingRuns = holding.map((g) => withBodyBudget(0, () => g.promise));
 
     let extraStarted = false;
-    const extra = withBodyBudget(async () => {
+    const extra = withBodyBudget(0, async () => {
       extraStarted = true;
       return "extra-done";
     });
@@ -118,7 +120,7 @@ describe("body-budget semaphore (#726)", () => {
     // race on and overwrite.
     const holding = Array.from({ length: CAP }, () => defer<void>());
     const holdingRuns = holding.map((g) =>
-      runInBodyBudgetContext(() => withBodyBudget(() => g.promise))
+      runInBodyBudgetContext(() => withBodyBudget(0, () => g.promise))
     );
 
     // Queue scope A first — it'll acquire the first slot freed by a
@@ -127,7 +129,7 @@ describe("body-budget semaphore (#726)", () => {
     const aWait = defer<number>();
     const bWait = defer<number>();
     const scopeA = runInBodyBudgetContext(async () => {
-      await withBodyBudget(async () => {
+      await withBodyBudget(0, async () => {
         aWait.resolve(getBodyBudgetWaitMs());
         await new Promise((r) => setTimeout(r, 40));
       });
@@ -135,7 +137,7 @@ describe("body-budget semaphore (#726)", () => {
     // Yield so A's acquire hits the queue before B's.
     await nextTick();
     const scopeB = runInBodyBudgetContext(async () => {
-      await withBodyBudget(async () => {
+      await withBodyBudget(0, async () => {
         bWait.resolve(getBodyBudgetWaitMs());
       });
     });
@@ -163,7 +165,7 @@ describe("body-budget semaphore (#726)", () => {
     // Fill capacity with throwers.
     const results = await Promise.allSettled(
       Array.from({ length: CAP }, (_, i) =>
-        withBodyBudget<never>(async () => {
+        withBodyBudget<never>(0, async () => {
           throw new Error(`boom-${i}`);
         })
       )
@@ -172,7 +174,7 @@ describe("body-budget semaphore (#726)", () => {
 
     // A subsequent caller should acquire immediately (no leaked slots).
     let ranAfter = false;
-    await withBodyBudget(async () => {
+    await withBodyBudget(0, async () => {
       ranAfter = true;
     });
     expect(ranAfter).toBe(true);
@@ -181,12 +183,101 @@ describe("body-budget semaphore (#726)", () => {
   it("wait ledger stays at 0 when the caller acquires without queuing", async () => {
     _resetBodyBudget();
     await runInBodyBudgetContext(async () => {
-      await withBodyBudget(async () => {});
+      await withBodyBudget(0, async () => {});
       expect(getBodyBudgetWaitMs()).toBe(0);
     });
   });
 
   it("getBodyBudgetWaitMs outside a context returns 0 (no throw)", () => {
     expect(getBodyBudgetWaitMs()).toBe(0);
+  });
+});
+
+describe("body-budget memory cap", () => {
+  beforeEach(() => {
+    _resetBodyBudget();
+  });
+
+  it("queues a caller whose bytes would exceed the memory cap even though the count slot is free", async () => {
+    // First caller takes ~90% of the cap — well under CAP count, well under
+    // memory cap. Second caller wants another ~20% — count would fit (2/CAP),
+    // memory would not (110% > 100%). Must queue.
+    const CAP_BYTES = bodyBudgetMemoryCap();
+    const first = defer<void>();
+    const firstBytes = Math.floor(CAP_BYTES * 0.9);
+    const secondBytes = Math.floor(CAP_BYTES * 0.2);
+
+    const inflight1 = withBodyBudget(firstBytes, () => first.promise);
+    await nextTick();
+    expect(bodyBudgetBytesInFlight()).toBe(firstBytes);
+
+    let secondStarted = false;
+    const inflight2 = withBodyBudget(secondBytes, async () => {
+      secondStarted = true;
+    });
+    await nextTick();
+    expect(secondStarted).toBe(false); // queued behind first
+
+    first.resolve();
+    await inflight1;
+    await inflight2;
+    expect(secondStarted).toBe(true);
+    expect(bodyBudgetBytesInFlight()).toBe(0);
+  });
+
+  it("does NOT skip past a queued big caller to serve a smaller one that would fit — starvation guard", async () => {
+    const CAP_BYTES = bodyBudgetMemoryCap();
+    const first = defer<void>();
+    const firstBytes = Math.floor(CAP_BYTES * 0.7);
+
+    const holdA = withBodyBudget(firstBytes, () => first.promise);
+    await nextTick();
+
+    // Big waiter — wants 40% but only 30% is free → queued.
+    const bigOrder: string[] = [];
+    const bigWaiter = withBodyBudget(Math.floor(CAP_BYTES * 0.4), async () => {
+      bigOrder.push("big");
+    });
+    await nextTick();
+
+    // Small waiter arrives AFTER — wants 10% (would fit if it jumped the
+    // queue). Must NOT run before the big waiter.
+    const smallWaiter = withBodyBudget(Math.floor(CAP_BYTES * 0.1), async () => {
+      bigOrder.push("small");
+    });
+    await nextTick();
+    expect(bigOrder).toEqual([]); // neither ran — head-of-queue block
+
+    first.resolve();
+    await holdA;
+    await bigWaiter;
+    await smallWaiter;
+    expect(bigOrder).toEqual(["big", "small"]); // FIFO
+  });
+
+  it("oversized single caller (bytes > cap) bypasses the memory check + logs — never deadlocks", async () => {
+    const CAP_BYTES = bodyBudgetMemoryCap();
+    // 2× cap: must NOT wait — release would never free enough on its own.
+    const oversize = CAP_BYTES * 2;
+    const started = defer<void>();
+
+    const promise = withBodyBudget(oversize, async () => {
+      started.resolve();
+      return "done";
+    });
+    await started.promise; // proves the acquire returned without queuing
+    const result = await promise;
+    expect(result).toBe("done");
+    expect(bodyBudgetBytesInFlight()).toBe(0);
+  });
+
+  it("releases bytes on throw so the counter doesn't leak", async () => {
+    const bytes = Math.floor(bodyBudgetMemoryCap() * 0.5);
+    await expect(
+      withBodyBudget(bytes, async () => {
+        throw new Error("boom");
+      })
+    ).rejects.toThrow("boom");
+    expect(bodyBudgetBytesInFlight()).toBe(0);
   });
 });

--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -1,24 +1,45 @@
 /**
- * Global counting semaphore for large-body FETCH work.
+ * Global bounded semaphore for large-body FETCH work.
  *
  * The per-key stream mutex (`stream-mutex.ts`) serializes IDENTICAL
  * concurrent body streams for the same `(mail, sectionKey)`, and
  * PR #710 coalesced the DB read the same way. Neither bounds the
- * NUMBER of DISTINCT concurrent large-body serializations across
- * sockets — a common iOS Mail / K-9 pattern is one client opening
- * several account tabs at once and issuing `UID FETCH … BODY[]` in
- * parallel against different mailboxes / different UIDs. Each in-flight
- * body allocates its per-chunk emitter transient; the container's RSS
- * scales linearly with distinct in-flight count and can OOM despite the
- * per-key coalescing.
+ * AGGREGATE bytes in flight across DISTINCT concurrent large-body work
+ * — a common iOS Mail / K-9 pattern is one client opening several
+ * account tabs at once and issuing `UID FETCH … BODY[]` in parallel
+ * against different mailboxes / different UIDs. Under a count-only cap
+ * (`IMAP_BODY_FETCH_CONCURRENCY=3`) three concurrent ~100 MB body
+ * builds still crossed the 256 MiB cgroup and OOM-killed the container
+ * (2026-07-30 23:52 UTC).
  *
- * This module puts a hard bound on that count. Callers wrap their
- * large-body serialization in `withBodyBudget(fn)`; if the running
- * count is at or above `IMAP_BODY_FETCH_CONCURRENCY`, the caller
- * queues on a FIFO wait list; when a slot frees, the next waiter
- * runs. Metadata-only FETCH paths (BODY.PEEK[HEADER], UID FLAGS,
- * ENVELOPE) bypass the budget entirely — they're cheap allocations
- * the budget exists to protect.
+ * This module holds two independent caps that acquires must both fit
+ * under:
+ *
+ * 1. **Count** — `IMAP_BODY_FETCH_CONCURRENCY` (default 3). Bounds the
+ *    NUMBER of concurrent large-body builds, cheap under normal load
+ *    where each is small.
+ * 2. **Bytes in flight** — `IMAP_BODY_FETCH_MEMORY_MB` (default 128 MiB,
+ *    half the 256 MiB cgroup). Bounds the AGGREGATE bytes reserved by
+ *    in-flight builds — the case count alone doesn't catch.
+ *
+ * Callers wrap large-body work in `withBodyBudget(bytes, fn)` (or
+ * `withBodyBudgetStream(bytes, makeStream)` for streams) and pass the
+ * pre-measured size of the wire body they're about to build. If either
+ * cap would be exceeded, the caller queues on a FIFO wait list. When a
+ * slot frees, the head of the queue runs if its `bytes` now fits;
+ * otherwise it stays at the head and further releases keep waking it
+ * until enough room is available. Metadata-only FETCH paths
+ * (BODY.PEEK[HEADER], UID FLAGS, ENVELOPE) bypass the budget entirely
+ * — they're cheap allocations the budget exists to protect.
+ *
+ * **Oversized single acquire**: if a caller's `bytes` exceeds the
+ * bytes cap, waiting would deadlock (no future release can free
+ * enough). Such acquires log a warning and pass through the bytes
+ * check (they still count against the count cap and against
+ * `bytesInFlight`, so other callers see the true pressure). This
+ * matches the "large body still gets served, just possibly with a
+ * cgroup kill" behavior we had pre-budget, without a hard block on
+ * an outlier the operator can neither reject nor cap.
  *
  * The budget is a per-process constant, NOT per-connection. That is
  * the point: one misbehaving client shouldn't be able to squeeze the
@@ -28,39 +49,50 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { logger } from "server";
 
 const DEFAULT_CONCURRENCY = 3;
+const DEFAULT_MEMORY_MB = 128;
+const BYTES_PER_MIB = 1024 * 1024;
 
-const parseConcurrency = (): number => {
-  const raw = process.env.IMAP_BODY_FETCH_CONCURRENCY;
-  if (!raw) return DEFAULT_CONCURRENCY;
+const parsePositiveInt = (
+  raw: string | undefined,
+  fallback: number,
+  name: string
+): number => {
+  if (!raw) return fallback;
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 1) {
-    logger.warn(
-      "[body-budget] IMAP_BODY_FETCH_CONCURRENCY invalid, falling back to default",
-      { raw, default: DEFAULT_CONCURRENCY }
-    );
-    return DEFAULT_CONCURRENCY;
+    logger.warn(`[body-budget] ${name} invalid, falling back to default`, {
+      raw,
+      default: fallback,
+    });
+    return fallback;
   }
   return parsed;
 };
 
-const CAPACITY = parseConcurrency();
+const CAPACITY = parsePositiveInt(
+  process.env.IMAP_BODY_FETCH_CONCURRENCY,
+  DEFAULT_CONCURRENCY,
+  "IMAP_BODY_FETCH_CONCURRENCY"
+);
+const MEMORY_CAP_BYTES =
+  parsePositiveInt(
+    process.env.IMAP_BODY_FETCH_MEMORY_MB,
+    DEFAULT_MEMORY_MB,
+    "IMAP_BODY_FETCH_MEMORY_MB"
+  ) * BYTES_PER_MIB;
 
 let inFlight = 0;
-const waitQueue: Array<() => void> = [];
+let bytesInFlight = 0;
+
+interface Waiter {
+  bytes: number;
+  wake: () => void;
+}
+const waitQueue: Waiter[] = [];
 
 /**
- * Per-request wait accumulator. Bound at the top of the IMAP command
- * handler via `runInBodyBudgetContext(fn)`; every `withBodyBudget` call
- * that runs INSIDE `fn` (even across `await` boundaries and nested
- * async work) adds its measured wait to the SAME `{ ms }` object.
- * The handler reads the total from `getBodyBudgetWaitMs()` at the end.
- *
- * Load-bearing: without AsyncLocalStorage the wait latency would sit on
- * a module-scoped variable that concurrent handlers overwrite (handler
- * A yields inside `await withBodyBudget`, handler B on a different
- * socket acquires and writes its OWN wait time to the shared cell,
- * then A resumes and reads B's value). AsyncLocalStorage keeps each
- * request's ledger separate.
+ * Per-request wait accumulator. Same shape as before — the memory cap
+ * addition didn't alter its contract.
  */
 const waitStore = new AsyncLocalStorage<{ ms: number }>();
 
@@ -69,73 +101,117 @@ export const runInBodyBudgetContext = <T>(fn: () => T): T =>
 
 export const getBodyBudgetWaitMs = (): number => waitStore.getStore()?.ms ?? 0;
 
-const acquire = async (): Promise<void> => {
-  if (inFlight < CAPACITY) {
+const hasRoom = (bytes: number): boolean => {
+  if (inFlight >= CAPACITY) return false;
+  // Oversized single acquires bypass the memory check (see docstring):
+  // waiting for `bytes > MEMORY_CAP_BYTES` would deadlock. They still
+  // occupy a count slot and add to `bytesInFlight`, so pressure is
+  // visible.
+  if (bytes > MEMORY_CAP_BYTES) return true;
+  return bytesInFlight + bytes <= MEMORY_CAP_BYTES;
+};
+
+const acquire = async (bytes: number): Promise<void> => {
+  // Non-negative sanity — a negative estimate would decrement
+  // `bytesInFlight` on acquire and leak the counter.
+  const safeBytes = Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
+  if (safeBytes > MEMORY_CAP_BYTES) {
+    logger.warn(
+      "[body-budget] oversized acquire — bypassing memory check (see docstring)",
+      { bytes: safeBytes, cap: MEMORY_CAP_BYTES }
+    );
+  }
+  // FIFO fairness: if anyone is queued, a new small acquire must NOT
+  // overtake a queued big one that couldn't fit, else the big one starves.
+  // Once the queue drains, later small acquires take the fast path again.
+  if (waitQueue.length === 0 && hasRoom(safeBytes)) {
     inFlight++;
+    bytesInFlight += safeBytes;
     return;
   }
   const start = performance.now();
   await new Promise<void>((resolve) => {
-    waitQueue.push(() => {
-      inFlight++;
-      resolve();
+    waitQueue.push({
+      bytes: safeBytes,
+      wake: () => {
+        inFlight++;
+        bytesInFlight += safeBytes;
+        resolve();
+      },
     });
   });
   const ledger = waitStore.getStore();
   if (ledger) ledger.ms += performance.now() - start;
 };
 
-const release = (): void => {
+const release = (bytes: number): void => {
+  const safeBytes = Number.isFinite(bytes) && bytes >= 0 ? bytes : 0;
   inFlight--;
-  const next = waitQueue.shift();
-  if (next) next();
-};
-
-/**
- * Run `fn` inside the body budget. Waits for a slot if `CAPACITY`
- * large-body serializations are already in flight. Always releases,
- * even if `fn` throws. When the caller is inside a
- * `runInBodyBudgetContext` scope, the wait time (0 if the acquire was
- * immediate) is added to that scope's ledger.
- */
-export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
-  await acquire();
-  try {
-    return await fn();
-  } finally {
-    release();
+  bytesInFlight -= safeBytes;
+  // Wake the queue head IF it can now fit. A big waiter at the head
+  // that still doesn't fit stays there — later releases keep firing
+  // until enough room is available. Do NOT skip past the head to serve
+  // a smaller waiter (starvation).
+  while (waitQueue.length > 0) {
+    const head = waitQueue[0];
+    if (!hasRoom(head.bytes)) break;
+    waitQueue.shift();
+    head.wake();
   }
 };
 
 /**
- * Hold a budget slot for the whole lifetime of a stream.
+ * Run `fn` inside the body budget. Waits for room under BOTH the count
+ * cap AND the aggregate-bytes cap. `bytes` is the pre-measured size the
+ * caller expects to allocate — the streaming BODY[] path passes
+ * `sumSegmentBytes(segments)`, the materializing path passes
+ * `Buffer.byteLength(fullMessage)`.
  *
- * The streaming BODY[] path is the LARGEST fetch shape, so it must be inside
- * the same bound as the materializing paths — otherwise K concurrent sockets
- * each stream a distinct large body with no cap and the budget covers only the
- * cheaper shapes. `withBodyBudget` cannot express this: it releases when its
- * promise settles, which for a generator is before the consumer has read a
- * single chunk.
+ * Always releases (both count and bytes), even if `fn` throws. When
+ * the caller is inside a `runInBodyBudgetContext` scope, the wait time
+ * (0 if immediate) is added to that scope's ledger.
+ */
+export const withBodyBudget = async <T>(
+  bytes: number,
+  fn: () => Promise<T>
+): Promise<T> => {
+  await acquire(bytes);
+  try {
+    return await fn();
+  } finally {
+    release(bytes);
+  }
+};
+
+/**
+ * Hold a budget slot (both count and bytes) for the whole lifetime of
+ * a stream. The streaming BODY[] path is the LARGEST fetch shape, so
+ * it must be inside the same bound as the materializing paths.
  *
- * The slot is released in `finally`, which a generator runs on completion, on
- * throw, AND when the consumer abandons it early (`for await` breaking on a
- * dead socket calls `.return()`), so an aborted FETCH cannot leak a slot.
+ * The slot is released in `finally`, which a generator runs on
+ * completion, on throw, AND when the consumer abandons it early
+ * (`for await` breaking on a dead socket calls `.return()`), so an
+ * aborted FETCH cannot leak a slot.
  */
 export const withBodyBudgetStream = async function* <T>(
+  bytes: number,
   makeStream: () => AsyncIterable<T>
 ): AsyncGenerator<T, void, unknown> {
-  await acquire();
+  await acquire(bytes);
   try {
     yield* makeStream();
   } finally {
-    release();
+    release(bytes);
   }
 };
 
 /** Exposed for tests. */
 export const _resetBodyBudget = (): void => {
   inFlight = 0;
+  bytesInFlight = 0;
   waitQueue.length = 0;
 };
 
 export const bodyBudgetCapacity = (): number => CAPACITY;
+export const bodyBudgetMemoryCap = (): number => MEMORY_CAP_BYTES;
+export const bodyBudgetBytesInFlight = (): number => bytesInFlight;

--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -5,12 +5,12 @@
  * concurrent body streams for the same `(mail, sectionKey)`, and
  * PR #710 coalesced the DB read the same way. Neither bounds the
  * AGGREGATE bytes in flight across DISTINCT concurrent large-body work
- * — a common iOS Mail / K-9 pattern is one client opening several
+ * — the common iOS Mail / K-9 pattern is one client opening several
  * account tabs at once and issuing `UID FETCH … BODY[]` in parallel
- * against different mailboxes / different UIDs. Under a count-only cap
- * (`IMAP_BODY_FETCH_CONCURRENCY=3`) three concurrent ~100 MB body
- * builds still crossed the 256 MiB cgroup and OOM-killed the container
- * (2026-07-30 23:52 UTC).
+ * against different mailboxes / different UIDs. A count-only cap of N
+ * concurrent builds still lets N × per-build peak RSS cross the
+ * container's cgroup ceiling, and no local per-build optimization
+ * prevents the aggregate from OOM-killing the container.
  *
  * This module holds two independent caps that acquires must both fit
  * under:
@@ -20,7 +20,7 @@
  *    where each is small.
  * 2. **Bytes in flight** — `IMAP_BODY_FETCH_MEMORY_MB` (default 128 MiB,
  *    half the 256 MiB cgroup). Bounds the AGGREGATE bytes reserved by
- *    in-flight builds — the case count alone doesn't catch.
+ *    in-flight builds — what the count cap alone doesn't catch.
  *
  * Callers wrap large-body work in `withBodyBudget(bytes, fn)` (or
  * `withBodyBudgetStream(bytes, makeStream)` for streams) and pass the
@@ -91,8 +91,18 @@ interface Waiter {
 const waitQueue: Waiter[] = [];
 
 /**
- * Per-request wait accumulator. Same shape as before — the memory cap
- * addition didn't alter its contract.
+ * Per-request wait accumulator. Bound at the top of the IMAP command
+ * handler via `runInBodyBudgetContext(fn)`; every `withBodyBudget` call
+ * that runs INSIDE `fn` (even across `await` boundaries and nested
+ * async work) adds its measured wait to the SAME `{ ms }` object.
+ * The handler reads the total from `getBodyBudgetWaitMs()` at the end.
+ *
+ * Load-bearing: without AsyncLocalStorage the wait latency would sit on
+ * a module-scoped variable that concurrent handlers overwrite (handler
+ * A yields inside `await withBodyBudget`, handler B on a different
+ * socket acquires and writes its OWN wait time to the shared cell,
+ * then A resumes and reads B's value). AsyncLocalStorage keeps each
+ * request's ledger separate.
  */
 const waitStore = new AsyncLocalStorage<{ ms: number }>();
 

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -845,7 +845,7 @@ describe("buildFetchResponsePart BODY[] streams without materializing", () => {
   const saturateAllButOne = () => {
     const releases: Array<() => void> = [];
     const held = Array.from({ length: bodyBudgetCapacity() - 1 }, () =>
-      withBodyBudget(() => new Promise<void>((resolve) => releases.push(resolve)))
+      withBodyBudget(0, () => new Promise<void>((resolve) => releases.push(resolve)))
     );
     return { releases, held };
   };
@@ -873,7 +873,7 @@ describe("buildFetchResponsePart BODY[] streams without materializing", () => {
 
     // The stream now owns the last slot, so a further acquire must wait.
     let extraRan = false;
-    const pending = withBodyBudget(async () => {
+    const pending = withBodyBudget(0, async () => {
       extraRan = true;
     });
     await flush();
@@ -896,7 +896,7 @@ describe("buildFetchResponsePart BODY[] streams without materializing", () => {
     const iterator = await startStream();
 
     let extraRan = false;
-    const pending = withBodyBudget(async () => {
+    const pending = withBodyBudget(0, async () => {
       extraRan = true;
     });
     await flush();

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -501,7 +501,10 @@ export async function buildBodyResponsePart(
     const partialAddressableBytes = totalBodyLength - WIRE_TRAILER;
     // Acquire the per-key mutex OUTSIDE the byte-budget so a queued
     // same-key waiter doesn't pin a byte-slot while it waits. When it
-    // owns the key, it then acquires the byte budget for its stream.
+    // owns the key, it then acquires the byte budget for its stream, with
+    // the pre-measured `{N}` — the wire bytes this stream is about to
+    // reserve — as the amount, so aggregate in-flight body bytes stay
+    // under the memory cap.
     const streamKey = `${docId}::${sectionKey}`;
     if (partial) {
       // RFC 3501 §6.4.5: `BODY[]<start.length>` returns bytes
@@ -518,7 +521,7 @@ export async function buildBodyResponsePart(
         partialAddressableBytes - start
       );
       const partialStream = withStreamMutex(streamKey, () =>
-        withBodyBudgetStream(async function* () {
+        withBodyBudgetStream(emittedLength, async function* () {
           yield* streamPartialFromSegments(segments, start, emittedLength);
         })
       );
@@ -533,7 +536,7 @@ export async function buildBodyResponsePart(
       };
     }
     const stream = withStreamMutex(streamKey, () =>
-      withBodyBudgetStream(async function* () {
+      withBodyBudgetStream(totalBodyLength, async function* () {
         yield* streamFromSegments(segments);
         yield Buffer.from("\r\n", "utf8");
       })
@@ -565,7 +568,7 @@ export async function buildBodyResponsePart(
     }
     const streamKey = `${docId}::${sectionKey}`;
     const stream = withStreamMutex(streamKey, () =>
-      withBodyBudgetStream(async function* () {
+      withBodyBudgetStream(bodyBytes + WIRE_TRAILER, async function* () {
         yield* streamBodyFromSegments(segments);
         yield Buffer.from("\r\n", "utf8");
       })
@@ -605,7 +608,7 @@ export async function buildBodyResponsePart(
       }
       const streamKey = `${docId}::${sectionKey}`;
       const stream = withStreamMutex(streamKey, () =>
-        withBodyBudgetStream(async function* () {
+        withBodyBudgetStream(partBytes + WIRE_TRAILER, async function* () {
           yield* streamPartBodyFromSegments(segments, partPath);
           yield Buffer.from("\r\n", "utf8");
         })
@@ -626,9 +629,12 @@ export async function buildBodyResponsePart(
   // the shared-body path — gate through the budget. Header-like
   // sections are cheap (≤ a few KiB) and don't need gating; hop over
   // them with an immediate acquire/release by only gating when the
-  // request is a partial.
+  // request is a partial. The reservation uses the pre-measured full-message
+  // size, since that whole body is what gets materialized before slicing.
   const content = partial
-    ? await withBodyBudget(() => Promise.resolve(getBodyContent(mail, section, docId)))
+    ? await withBodyBudget(computeFullMessageSize(mail, docId), () =>
+        Promise.resolve(getBodyContent(mail, section, docId))
+      )
     : getBodyContent(mail, section, docId);
   if (content === null) {
     return null;


### PR DESCRIPTION
## Summary

Count-only body budget (#727) bounds three concurrent large-body builds — but three ~100 MB peaks still cross the 256 MiB cgroup. That was the shape of the 2026-07-30 23:52 UTC OOM crash on hoie-inbox-1: three concurrent iOS `UID FETCH X (BODY[])` for ~800 KB mails × ~30 MB heap-side allocation each × GC lag = RSS 137 → 285 MB → SIGKILL.

Adds a **second cap on aggregate bytes reserved by in-flight builds**, alongside the existing count cap.

## What changes

- `withBodyBudget(bytes, fn)` / `withBodyBudgetStream(bytes, makeStream)` now take the pre-measured wire size and check BOTH caps before acquiring a slot.
- `IMAP_BODY_FETCH_MEMORY_MB` env var (default 128 MiB, half the 256 MiB cgroup) bounds aggregate bytes reserved by in-flight builds.
- Count cap (`IMAP_BODY_FETCH_CONCURRENCY=3`) still applies — the union of both caps holds.
- Callers pass their exact byte count:
  - Streaming BODY[] FULL → `sumSegmentBytes(segments)` (the pre-measured `{N}` literal).
  - Partial BODY[]`<start.length>` stream → `emittedLength`, the clamped octet count the stream actually emits.
  - BODY[TEXT] → `sumBodyBytes(segments) + WIRE_TRAILER`.
  - BODY[&lt;part&gt;] → `sumPartBodyBytes(segments, partPath) + WIRE_TRAILER`.
  - Materializing fall-through partial (`buildFullMessage` then slice) → `computeFullMessageSize(mail, docId)`, since the whole body is built before slicing.
- **FIFO fairness**: once ANY waiter is queued, later small acquires also queue — otherwise a queued big caller starves behind a stream of smaller ones. Once the queue drains, the fast path resumes.
- **Oversized single acquire** (bytes > memory cap): logs a warning + bypasses the bytes check. Waiting would deadlock (no future release can free enough). It still occupies a count slot and adds to `bytesInFlight`, so aggregate pressure remains visible to other callers.

## Rebase onto the segment-walk refactor

Merged #770 deleted the `body-buffer.ts` shared-body cache and rewrote TEXT / MIME_PART to stream via segment-walk. This branch was rebased onto that head:

- The `getSharedBodyResult` reservation this PR originally added is gone with the cache. TEXT and MIME_PART now reserve their own exact segment-measured byte counts rather than the `computeFullMessageSize` upper bound — strictly tighter, since the estimate no longer has to cover "the largest section we might return."
- Every `withBodyBudget` / `withBodyBudgetStream` call site on the new head passes a byte amount; the count-only signature is gone.
- The module docstring no longer references the deleted cache.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — 0 errors (18 pre-existing warnings, all in files this PR doesn't touch).
- [x] `bun test src/server` — 1507 pass / 0 fail across 75 files, on the rebased head.
- [x] New tests in `body-budget.test.ts` under `describe("body-budget memory cap")`:
  1. Second caller queues when memory cap would be exceeded even though the count slot is free.
  2. **Starvation guard** — small waiter that arrives AFTER a queued big waiter does NOT overtake it, even when small would fit.
  3. Oversized single acquire (bytes > cap) never deadlocks — bypasses check, runs immediately.
  4. Releases bytes on throw so `bytesInFlight` doesn't leak.
- Existing count-cap tests continue to pass — the count-only invariants are unchanged.
- Not applicable: no UI surface. The next OOM alarm on hoie-inbox-1 (or its absence) under concurrent-BODY load is the real E2E; will monitor after deploy.

## Interaction with prior OOM-arc PRs

- #727 (count cap) still fires first under high-concurrency small-body load.
- #733 (streaming BODY[]) — the stream path holds a slot for the whole lifetime; the new bytes cap ensures three streams of large mails can't overlap.
- #738 (emitBase64 input slicing) + #739 (PG-streamed text/html) — reduce per-fetch peak transient; the bytes budget provides the aggregate-in-flight bound those local fixes don't cover.
- #770 (segment-walk TEXT / MIME_PART, body-buffer deleted) — this PR rebases onto it; see the rebase note above.
