### PR TITLE
perf(imap): persist text/html line counts to skip BODYSTRUCTURE materialization

### DIFF
--- a/src/common/models/mails/Mail.ts
+++ b/src/common/models/mails/Mail.ts
@@ -111,6 +111,16 @@ export interface MailType {
    * populated on their first observation; the HTTP client never reads it.
    */
   rfc822_size?: number | null;
+  /**
+   * Cached line counts for the mail's `text` / `html` columns, matching
+   * the RFC 3501 §7.4.2 BODYSTRUCTURE `lines` field. Populated at INSERT
+   * time from the incoming strings and lazily backfilled for pre-existing
+   * rows on the first BODYSTRUCTURE fetch. Optional because the DB
+   * columns start NULL for pre-migration rows; the HTTP client never
+   * reads either.
+   */
+  text_line_count?: number | null;
+  html_line_count?: number | null;
 }
 
 export class Mail extends Model<Mail> implements MailType {
@@ -137,6 +147,8 @@ export class Mail extends Model<Mail> implements MailType {
   declare uid: MailUidType;
   declare modseq?: number;
   declare rfc822_size?: number | null;
+  declare text_line_count?: number | null;
+  declare html_line_count?: number | null;
 
   constructor(data?: Partial<Mail>) {
     super(data);

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -54,6 +54,7 @@ import {
   convertSequenceSet,
   FetchResponsePart,
   FetchRequestedField,
+  FetchMailInput,
 } from "./fetch-helpers";
 import { formatEnvelope } from "./util";
 import { BodyFetch, SequenceSet } from "./types";
@@ -881,6 +882,176 @@ describe("buildFetchResponsePart BODY[] streams without materializing", () => {
 
     releases.forEach((release) => release());
     await Promise.all(held);
+  });
+});
+
+describe("getRequestedFields BODYSTRUCTURE cached-column projection (#740)", () => {
+  // The load-bearing invariant. BODYSTRUCTURE's projection MUST NOT include
+  // `text` / `html` after #740 — a bare `UID FETCH X BODYSTRUCTURE` was
+  // materializing multi-MB text/html per UID just to derive the `lines`
+  // field. Projection is now the pre-measured octet counts + persisted
+  // line-count columns (metadata-only); the cache-miss fallback loads
+  // text/html per row only when the persisted column is NULL.
+  it("projects text_octets + html_octets + line-count columns, NOT text/html", () => {
+    const fields = getRequestedFields([
+      { type: "BODYSTRUCTURE", extensible: true },
+    ]);
+    for (const f of [
+      "text_octets",
+      "html_octets",
+      "mail_id",
+      "user_id",
+      "text_line_count",
+      "html_line_count",
+      "attachments",
+    ] as const) {
+      expect(fields.has(f as FetchRequestedField)).toBe(true);
+    }
+    // The load-bearing negative — dropping these two is the whole point.
+    expect(fields.has("text")).toBe(false);
+    expect(fields.has("html")).toBe(false);
+  });
+
+  it("bare BODY (extensible=false) projects the same columns as BODYSTRUCTURE", () => {
+    // RFC 3501 §6.4.5: `BODY` is `BODYSTRUCTURE` minus the extension tail —
+    // same structure, same source columns. Both must skip text/html the
+    // same way.
+    const bare = getRequestedFields([
+      { type: "BODYSTRUCTURE", extensible: false },
+    ]);
+    const ext = getRequestedFields([
+      { type: "BODYSTRUCTURE", extensible: true },
+    ]);
+    expect([...bare].sort()).toEqual([...ext].sort());
+  });
+});
+
+describe("buildFetchResponsePart BODYSTRUCTURE cached-column short-circuit (#740)", () => {
+  const docId = "doc-bs-cached";
+  const mailbox = "INBOX";
+  const base = {
+    uid: { account: 1, domain: 1 } as MailType["uid"],
+    messageId: "<bs-cached@local>",
+    date: new Date("2026-07-31T00:00:00Z"),
+    from: { text: "alice@example.com", value: [] } as unknown as MailType["from"],
+    to: { text: "bob@example.com", value: [] } as unknown as MailType["to"],
+    subject: "bs-cached",
+    attachments: [],
+  };
+
+  it("derives size + lines from cached columns without loading text/html", async () => {
+    // The load-bearing case. Row carries the lazy projection shape only
+    // — `text_octets` (raw octet count) + `text_line_count` (persisted at
+    // INSERT). Neither `text` nor `html` string is on the mail, so
+    // formatBodyStructure MUST NOT reach for them. If the cached path
+    // were bypassed and buildTextPart fell through to computing from the
+    // absent string, `lines` would come out as 1 (empty split) — not 42.
+    const mailWithCache: FetchMailInput = {
+      ...base,
+      text_octets: 33, // 33 raw bytes → base64 encodes to ceil(33/3)*4 = 44
+      html_octets: 0,
+      text_line_count: 42,
+      html_line_count: 0,
+    };
+    const part = await buildFetchResponsePart(
+      mailWithCache,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+      // userId omitted intentionally: no persist step should fire on a hit.
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      // Single text part shape — no HTML, no attachments.
+      // Format: (TEXT PLAIN ("CHARSET" "UTF-8") NIL NIL BASE64 <size> <lines>)
+      expect(part!.content).toContain('"TEXT" "PLAIN"'.replace(/"/g, ""));
+      expect(part!.content).toContain("BASE64 44 42");
+    }
+  });
+
+  it("emits multipart/alternative from cached counts for a text+html mail with no strings loaded", async () => {
+    const mailWithCache: FetchMailInput = {
+      ...base,
+      text_octets: 6, // → base64 8
+      html_octets: 15, // → base64 20
+      text_line_count: 2,
+      html_line_count: 5,
+    };
+    const part = await buildFetchResponsePart(
+      mailWithCache,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      // Both parts + the alternative wrapper. Both must derive from cache
+      // (no strings on mail — would `NaN` or 0 on materialized fallback).
+      expect(part!.content).toContain("BASE64 8 2");
+      expect(part!.content).toContain("BASE64 20 5");
+      expect(part!.content).toContain('"alternative"');
+    }
+  });
+
+  it("materialized-caller shape (mail.text / mail.html as strings) still works — same size + lines", async () => {
+    // The util.test.ts + cache-miss fallback caller shape. When the strings
+    // ARE loaded, formatBodyStructure base64+splits them the same way it
+    // has always done. Same wire bytes as the cached path for the same
+    // input, so callers can be mixed without divergence.
+    const materialized: Partial<MailType> = {
+      ...base,
+      text: "line one\r\nline two\r\nline three",
+      html: "",
+    };
+    const cachedEquivalent: FetchMailInput = {
+      ...base,
+      // Same octets (materialized string is 30 bytes) + same line count (3).
+      text_octets: Buffer.byteLength("line one\r\nline two\r\nline three", "utf8"),
+      html_octets: 0,
+      text_line_count: 3,
+      html_line_count: 0,
+    };
+    const mat = await buildFetchResponsePart(
+      materialized,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+    );
+    const cached = await buildFetchResponsePart(
+      cachedEquivalent,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+    );
+    expect(mat!.type).toBe("simple");
+    expect(cached!.type).toBe("simple");
+    if (mat!.type === "simple" && cached!.type === "simple") {
+      expect(mat!.content).toBe(cached!.content);
+    }
+  });
+
+  it("cache miss without userId falls through — uses whatever's on the mail (no persist attempted)", async () => {
+    // The cache-miss branch is guarded by `userId`: without one there's
+    // no target row to write back to, so the handler skips the fallback
+    // load AND the persist. Assert the emit still succeeds (falls back to
+    // the materialized shape when strings ARE present, or to 0/1 defaults
+    // when nothing at all is loaded).
+    const mailNoUser: Partial<MailType> = {
+      ...base,
+      text: "hi",
+      html: "",
+    };
+    const part = await buildFetchResponsePart(
+      mailNoUser,
+      { type: "BODYSTRUCTURE", extensible: true },
+      docId,
+      mailbox
+      // userId omitted intentionally
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      expect(part!.content.startsWith("BODYSTRUCTURE ")).toBe(true);
+    }
   });
 });
 

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -212,8 +212,8 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<FetchRequest
         fields.add("html_octets");
         fields.add("mail_id");
         fields.add("user_id");
-        fields.add("text_line_count" as keyof MailType);
-        fields.add("html_line_count" as keyof MailType);
+        fields.add("text_line_count");
+        fields.add("html_line_count");
         fields.add("attachments");
         break;
 

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -33,7 +33,12 @@ import {
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
 import { withBodyBudget, withBodyBudgetStream } from "./body-budget";
-import { updateRfc822Size } from "../postgres/repositories/mails/core";
+import {
+  updateRfc822Size,
+  updateLineCounts,
+  getMailBody,
+  countLines,
+} from "../postgres/repositories/mails/core";
 // `getSharedBodyResult` already budget-gates INSIDE its singleflight
 // closure so coalesced callers share one slot (see body-buffer.ts +
 // hoiekim/inbox#726 / #727). The `withBodyBudget` import here is used
@@ -193,9 +198,22 @@ export function getRequestedFields(dataItems: FetchDataItem[]): Set<FetchRequest
         fields.add("answered");
         break;
 
+      // BODYSTRUCTURE (RFC 3501 §7.4.2) needs the `size` + `lines` count for
+      // each text/html part. Instead of projecting the multi-MB text/html
+      // columns and computing per-fetch (the last materialization gap after
+      // #731 / #739 — spiked RSS on bare `UID FETCH X BODYSTRUCTURE` batches),
+      // project the pre-measured `octet_length()` synthetics + persisted
+      // line-count columns. Cache miss (pre-migration NULL row) falls
+      // through to a targeted per-row `SELECT text, html` load in the
+      // BODYSTRUCTURE handler — see buildFetchResponsePart. Post-backfill
+      // this branch stops firing entirely.
       case "BODYSTRUCTURE":
-        fields.add("text");
-        fields.add("html");
+        fields.add("text_octets");
+        fields.add("html_octets");
+        fields.add("mail_id");
+        fields.add("user_id");
+        fields.add("text_line_count" as keyof MailType);
+        fields.add("html_line_count" as keyof MailType);
         fields.add("attachments");
         break;
 
@@ -506,8 +524,25 @@ export async function buildBodyResponsePart(
   return { type: "literal", content: finalContent, header, length };
 }
 
+/**
+ * A mail row that may carry the four synthetic streaming/measurement
+ * fields the getMailsByRange projection can add alongside the real
+ * MailModel columns: `text_octets` / `html_octets` (pre-measured
+ * `octet_length()` for the pg SUBSTRING body stream in BODY[] / RFC822,
+ * and for the BODYSTRUCTURE cached-size path here) + `mail_id` / `user_id`
+ * (identity for the same stream). Widening the fetch handler's input to
+ * this shape lets `BODYSTRUCTURE` read the octet count without a runtime
+ * cast at every access site.
+ */
+export type FetchMailInput = Partial<MailType> & {
+  text_octets?: number;
+  html_octets?: number;
+  mail_id?: string;
+  user_id?: string;
+};
+
 export async function buildFetchResponsePart(
-  mail: Partial<MailType>,
+  mail: FetchMailInput,
   item: FetchDataItem,
   docId: string,
   selectedMailbox: string,
@@ -577,7 +612,59 @@ export async function buildFetchResponsePart(
     case "BODYSTRUCTURE": {
       // extensible=false is the bare `BODY` data item: non-extensible structure
       // labelled `BODY` (RFC 3501 §6.4.5). extensible=true is full BODYSTRUCTURE.
-      const bodyStructure = formatBodyStructure(mail, item.extensible);
+      //
+      // Two-path resolution (mirrors RFC822.SIZE / #731):
+      //  1. **Cached hit** — the projection carries `text_octets` +
+      //     `html_octets` (from `octet_length()`) + persisted
+      //     `text_line_count` + `html_line_count` (populated at INSERT
+      //     time by saveMail, or by a bulk backfill). formatBodyStructure
+      //     derives `size` + `lines` from these with no string in memory:
+      //     BODYSTRUCTURE becomes a metadata-only fetch, closing the last
+      //     text/html materialization gap after #731 / #739.
+      //  2. **Cache-miss fallback** — a pre-migration row's line counts
+      //     sit NULL. Fetch just the text/html columns for THIS row
+      //     (`getMailBody` — one row, two TEXT columns, no attachments) so
+      //     formatBodyStructure has strings to base64+split. Fire-and-
+      //     forget persist backfills the row so its NEXT BODYSTRUCTURE
+      //     hits cache. Bounded per-row overhead during the transition;
+      //     after the bulk backfill this branch effectively stops firing.
+      const wantsPart = (
+        octets: number | undefined,
+        lineCount: number | null | undefined
+      ): boolean => typeof octets === "number" && octets > 0 && typeof lineCount !== "number";
+      const cacheMissText = wantsPart(mail.text_octets, mail.text_line_count);
+      const cacheMissHtml = wantsPart(mail.html_octets, mail.html_line_count);
+      let effectiveMail: Partial<MailType> & {
+        text_octets?: number;
+        html_octets?: number;
+      } = mail;
+      if (userId && (cacheMissText || cacheMissHtml)) {
+        const body = await getMailBody(userId, docId);
+        if (body) {
+          // Splice the strings onto a shallow copy so formatBodyStructure
+          // takes the materialized branch for the missing parts. The
+          // original `mail` (shared with other FETCH items in the same
+          // response) is left untouched.
+          effectiveMail = {
+            ...mail,
+            text: cacheMissText ? body.text : mail.text,
+            html: cacheMissHtml ? body.html : mail.html,
+          };
+          // Fire-and-forget: stamp the row so its next BODYSTRUCTURE hits
+          // cache. Recompute both counts unconditionally (idempotent) —
+          // one UPDATE round-trip either way.
+          const textLines = countLines(body.text);
+          const htmlLines = countLines(body.html);
+          void updateLineCounts(userId, docId, textLines, htmlLines).catch((err) => {
+            logger.warn("Failed to persist line counts", {
+              component: "imap.fetch",
+              mail_id: docId,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
+      }
+      const bodyStructure = formatBodyStructure(effectiveMail, item.extensible);
       const label = item.extensible ? "BODYSTRUCTURE" : "BODY";
       return { type: "simple", content: `${label} ${bodyStructure}` };
     }
@@ -621,7 +708,7 @@ export async function buildFetchResponsePart(
 }
 
 export async function buildFetchResponse(
-  mail: Partial<MailType>,
+  mail: FetchMailInput,
   dataItems: FetchDataItem[],
   docId: string,
   uid: number,

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -464,6 +464,17 @@ export class Store {
         if (model.rfc822_size !== undefined) {
           mail.rfc822_size = model.rfc822_size;
         }
+        // text_line_count / html_line_count: cached BODYSTRUCTURE `lines`
+        // fields. Same preserve-null-vs-undefined dance as rfc822_size —
+        // the BODYSTRUCTURE fetch handler distinguishes stored-value hit
+        // (typeof === 'number') from cache-miss fallback (load text/html
+        // + compute + persist).
+        if (model.text_line_count !== undefined) {
+          mail.text_line_count = model.text_line_count;
+        }
+        if (model.html_line_count !== undefined) {
+          mail.html_line_count = model.html_line_count;
+        }
 
         if (model.from_address) {
           mail.from = {

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -460,6 +460,36 @@ describe("IMAP util", () => {
       expect(result).toContain("PLAIN");
     });
 
+    // #740: BODYSTRUCTURE's `size` + `lines` derive from the persisted
+    // octet / line-count columns when the caller projects them (the
+    // BODYSTRUCTURE hot path — no text/html string materialization). The
+    // wire response for the same underlying content must be byte-identical
+    // whether we take the cached path or fall through to base64+split.
+    it("derives text-part size + lines from the cached synthetics with no strings loaded", () => {
+      const cached = formatBodyStructure({
+        text_octets: 30,
+        html_octets: 0,
+        text_line_count: 3,
+        html_line_count: 0,
+      });
+      // ceil(30/3)*4 = 40 octets base64, three lines.
+      expect(cached).toContain("BASE64 40 3");
+      // No HTML → single text part, not multipart.
+      expect(cached).not.toContain("alternative");
+    });
+
+    it("cached-shape output matches materialized-shape output for the same content", () => {
+      const text = "line one\r\nline two\r\nline three";
+      const materialized = formatBodyStructure({ text });
+      const cached = formatBodyStructure({
+        text_octets: Buffer.byteLength(text, "utf8"),
+        html_octets: 0,
+        text_line_count: text.split(/\r?\n/).length,
+        html_line_count: 0,
+      });
+      expect(cached).toBe(materialized);
+    });
+
     // Non-extensible form (the bare `BODY` data item, RFC 3501 §6.4.5) drops the
     // extension data: md5/disposition/language/location on single parts and
     // param-list/disposition/language/location on the multipart wrappers (#666).

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -184,7 +184,10 @@ export const formatEnvelope = (mail: Partial<MailType>): string => {
 };
 
 export const formatBodyStructure = (
-  mail: Partial<MailType>,
+  mail: Partial<MailType> & {
+    text_octets?: number;
+    html_octets?: number;
+  },
   extensible = true
 ): string => {
   /**
@@ -196,15 +199,34 @@ export const formatBodyStructure = (
    * param-list/disposition/language/location on multiparts) is the extension
    * data — present only in BODYSTRUCTURE. The bare `BODY` data item is the
    * non-extensible form (RFC 3501 §6.4.5): pass extensible=false to drop it.
+   *
+   * Two paths for the text/html `size` + `lines` fields:
+   *  - **Cached** — when the caller projects `text_octets` / `html_octets`
+   *    (from `octet_length()`) + `text_line_count` / `html_line_count`
+   *    (persisted at INSERT time; see saveMail), the fields are derived
+   *    with no string in memory. `size = ceil(octets/3)*4` matches
+   *    `Buffer.byteLength(base64(content))` exactly; `lines` reads the
+   *    cached value verbatim. This is the OOM-fix path — a bare
+   *    `UID FETCH X BODYSTRUCTURE` doesn't materialize text/html at all.
+   *  - **Materialized** — when the caller passes `mail.text` / `mail.html`
+   *    directly (legacy in-memory shape used by tests + the cache-miss
+   *    fallback in fetch-helpers), we base64-encode + split on the string
+   *    the same way this function has always done. Semantically identical
+   *    to the cached path for any non-empty part.
    */
 
   const buildTextPart = (
     subtype: "plain" | "html",
-    content: string
+    content: string | undefined,
+    octets: number | undefined,
+    lineCount: number | null | undefined
   ): string => {
-    const encoded = encodeText(content);
-    const size = Buffer.byteLength(encoded, "utf-8");
-    const lines = content.split(/\r?\n/).length;
+    const size = typeof octets === "number"
+      ? Math.ceil(octets / 3) * 4
+      : Buffer.byteLength(encodeText(content ?? ""), "utf-8");
+    const lines = typeof lineCount === "number"
+      ? lineCount
+      : (content ?? "").split(/\r?\n/).length;
 
     const parts = [
       "TEXT",
@@ -219,6 +241,10 @@ export const formatBodyStructure = (
 
     return `(${parts.join(" ")})`;
   };
+  const textPart = () =>
+    buildTextPart("plain", mail.text, mail.text_octets, mail.text_line_count);
+  const htmlPart = () =>
+    buildTextPart("html", mail.html, mail.html_octets, mail.html_line_count);
 
   const buildAttachmentPart = (attachment: AttachmentType): string => {
     const [type, subtype] = (
@@ -263,25 +289,30 @@ export const formatBodyStructure = (
   const multipartTail = (subtype: string): string =>
     extensible ? `"${subtype}" NIL NIL NIL NIL` : `"${subtype}"`;
 
-  const hasText = mail.text && mail.text.trim().length > 0;
-  const hasHtml = mail.html && mail.html.trim().length > 0;
+  // Same materialized-or-lazy shape formatHeaders uses (see
+  // hasMaterializedOrLazyBody): in lazy mode the trim() check isn't
+  // available so a whitespace-only column reads as has-content (rare
+  // real-world). Both paths agree on the has-body decision, which is
+  // load-bearing — formatHeaders and formatBodyStructure MUST take the
+  // same branch (`multipart/alternative` vs `text/plain`) or the wire
+  // response contradicts itself.
+  const hasText = hasMaterializedOrLazyBody(mail.text, mail.text_octets);
+  const hasHtml = hasMaterializedOrLazyBody(mail.html, mail.html_octets);
   const hasAttachments = mail.attachments && mail.attachments.length > 0;
 
   // Case 1: Single text part (no HTML, no attachments)
   if (hasText && !hasHtml && !hasAttachments) {
-    return buildTextPart("plain", mail.text!);
+    return textPart();
   }
 
   // Case 2: Single HTML part (no text, no attachments)
   if (!hasText && hasHtml && !hasAttachments) {
-    return buildTextPart("html", mail.html!);
+    return htmlPart();
   }
 
   // Case 3: Text and HTML (multipart/alternative)
   if (hasText && hasHtml && !hasAttachments) {
-    const textPart = buildTextPart("plain", mail.text!);
-    const htmlPart = buildTextPart("html", mail.html!);
-    return `(${textPart} ${htmlPart} ${multipartTail("alternative")})`;
+    return `(${textPart()} ${htmlPart()} ${multipartTail("alternative")})`;
   }
 
   // Case 4: Content with attachments (multipart/mixed)
@@ -290,16 +321,14 @@ export const formatBodyStructure = (
 
     // If we have both text and HTML, create a multipart/alternative first
     if (hasText && hasHtml) {
-      const textPart = buildTextPart("plain", mail.text!);
-      const htmlPart = buildTextPart("html", mail.html!);
-      const alternativePart = `(${textPart} ${htmlPart} ${multipartTail(
+      const alternativePart = `(${textPart()} ${htmlPart()} ${multipartTail(
         "alternative"
       )})`;
       bodyParts.push(alternativePart);
     } else if (hasText) {
-      bodyParts.push(buildTextPart("plain", mail.text!));
+      bodyParts.push(textPart());
     } else if (hasHtml) {
-      bodyParts.push(buildTextPart("html", mail.html!));
+      bodyParts.push(htmlPart());
     }
 
     // Add attachment parts
@@ -310,8 +339,9 @@ export const formatBodyStructure = (
     return `(${bodyParts.join(" ")} ${multipartTail("mixed")})`;
   }
 
-  // Default case: empty text part
-  return buildTextPart("plain", "");
+  // Default case: empty text part (no lazy inputs either, so the
+  // materialized shape drives the count — split("") = [""], length 1).
+  return buildTextPart("plain", "", undefined, undefined);
 };
 
 export const formatFlags = (mail: Partial<MailType>): string[] => {

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -79,6 +79,18 @@ export const IS_SPAM = "is_spam";
 // persist the result. Motivates: avoid materializing multi-MB
 // attachments per RFC822.SIZE request. See #729.
 export const RFC822_SIZE = "rfc822_size";
+// Cached line counts of the mail's `text` / `html` columns, matching the
+// RFC 3501 §7.4.2 BODYSTRUCTURE `lines` field (`content.split(/\r?\n/).length`
+// on the raw column). Populated at INSERT time from the incoming body strings
+// (cheap: one split each) and lazily backfilled on read for pre-existing
+// rows. `NULL` means "not yet computed"; readers fall back to loading the
+// text/html columns to compute + persist. Motivates: BODYSTRUCTURE's `lines`
+// field was the last text/html materialization gap after #731 / #739 — a
+// bare `UID FETCH X BODYSTRUCTURE` batch was still loading multi-MB
+// text/html per UID to derive `lines`, spiking RSS. See the 2026-07-31 07:54
+// + 09:17 UTC OOMs.
+export const TEXT_LINE_COUNT = "text_line_count";
+export const HTML_LINE_COUNT = "html_line_count";
 
 // Sessions columns
 export const SESSION_ID = "session_id";

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -35,6 +35,8 @@ import {
   SPAM_REASONS,
   IS_SPAM,
   RFC822_SIZE,
+  TEXT_LINE_COUNT,
+  HTML_LINE_COUNT,
 } from "./common";
 import { Model, ModelValidationError, createTable, validateObject } from "./base";
 
@@ -84,6 +86,8 @@ export interface MailJSON {
   spam_reasons: string[] | null;
   is_spam: boolean;
   rfc822_size: number | null;
+  text_line_count: number | null;
+  html_line_count: number | null;
 }
 
 const mailSchema = {
@@ -130,6 +134,12 @@ const mailSchema = {
   // + persists on first observation. New rows also start NULL and populate
   // on their first RFC822.SIZE / RFC822 / BODY[] fetch.
   [RFC822_SIZE]: "BIGINT",
+  // Nullable — auto-migration stamps existing rows with NULL; new rows
+  // populate at INSERT time from the split of `text` / `html` (see
+  // saveMail), so post-migration only pre-existing rows sit NULL until
+  // their first BODYSTRUCTURE observation backfills them.
+  [TEXT_LINE_COUNT]: "INTEGER",
+  [HTML_LINE_COUNT]: "INTEGER",
   [UPDATED]: "TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP",
   search_vector: "TSVECTOR",
 };
@@ -171,6 +181,8 @@ export class MailModel extends Model<MailJSON, MailSchema> {
   declare spam_reasons: string[] | null;
   declare is_spam: boolean;
   declare rfc822_size: number | null;
+  declare text_line_count: number | null;
+  declare html_line_count: number | null;
   declare updated: string;
 
   static typeChecker = {
@@ -208,6 +220,10 @@ export class MailModel extends Model<MailJSON, MailSchema> {
     spam_reasons: isNullableArray,
     is_spam: isBoolean,
     rfc822_size: (v: unknown): v is number | null =>
+      v === null || typeof v === "number",
+    text_line_count: (v: unknown): v is number | null =>
+      v === null || typeof v === "number",
+    html_line_count: (v: unknown): v is number | null =>
       v === null || typeof v === "number",
     updated: isNullableString,
     search_vector: isNullableString,
@@ -253,6 +269,8 @@ export class MailModel extends Model<MailJSON, MailSchema> {
       spam_reasons: this.spam_reasons,
       is_spam: this.is_spam,
       rfc822_size: this.rfc822_size,
+      text_line_count: this.text_line_count,
+      html_line_count: this.html_line_count,
     };
   }
 }
@@ -337,6 +355,8 @@ export class PartialMailModel {
   readonly spam_reasons?: string[] | null;
   readonly is_spam?: boolean;
   readonly rfc822_size?: number | null;
+  readonly text_line_count?: number | null;
+  readonly html_line_count?: number | null;
   readonly updated?: string;
 
   constructor(fields: string[], data: unknown) {

--- a/src/server/lib/postgres/models/models.test.ts
+++ b/src/server/lib/postgres/models/models.test.ts
@@ -64,6 +64,8 @@ function makeMailData(overrides: Record<string, unknown> = {}): Record<string, u
     spam_reasons: null,
     is_spam: false,
     rfc822_size: null,
+    text_line_count: null,
+    html_line_count: null,
     updated: "2024-01-01T00:00:00+00:00",
     search_vector: null,
     ...overrides,
@@ -267,6 +269,29 @@ describe("MailModel construction", () => {
     const data = makeMailData({ spam_reasons: ["SPAM_WORD", "BLACKLIST"] });
     const m = new MailModel(data);
     expect(m.spam_reasons).toEqual(["SPAM_WORD", "BLACKLIST"]);
+  });
+
+  // The BODYSTRUCTURE `lines` cache columns round-trip as numbers OR null
+  // (NULL for pre-migration rows that haven't been observed yet).
+  it("accepts numeric text_line_count / html_line_count", () => {
+    const m = new MailModel(makeMailData({ text_line_count: 12, html_line_count: 34 }));
+    expect(m.text_line_count).toBe(12);
+    expect(m.html_line_count).toBe(34);
+    const json = m.toJSON();
+    expect(json.text_line_count).toBe(12);
+    expect(json.html_line_count).toBe(34);
+  });
+
+  it("accepts null text_line_count / html_line_count for unbackfilled rows", () => {
+    const m = new MailModel(makeMailData({ text_line_count: null, html_line_count: null }));
+    expect(m.text_line_count).toBeNull();
+    expect(m.html_line_count).toBeNull();
+  });
+
+  it("throws when text_line_count is a non-number, non-null value", () => {
+    expect(() => new MailModel(makeMailData({ text_line_count: "12" }))).toThrow(
+      ModelValidationError
+    );
   });
 });
 

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -2,7 +2,17 @@ import crypto from "crypto";
 import { logger } from "../../../logger";
 import { pool } from "../../client";
 import { ParamValue } from "../../database";
-import { MailModel, mailsTable, MAIL_ID, USER_ID, ENVELOPE_TO, DB_NOW, RFC822_SIZE } from "../../models";
+import {
+  MailModel,
+  mailsTable,
+  MAIL_ID,
+  USER_ID,
+  ENVELOPE_TO,
+  DB_NOW,
+  RFC822_SIZE,
+  TEXT_LINE_COUNT,
+  HTML_LINE_COUNT,
+} from "../../models";
 import { getNextModseq, writeMailboxUid } from "./counters";
 
 export interface SaveMailInput {
@@ -67,14 +77,25 @@ export const saveMail = async (
     // mailbox's HIGHESTMODSEQ (CONDSTORE, RFC 7162). Reserved before the INSERT,
     // like uid_domain/uid_mailbox are in convertMail.
     const modseq = await getNextModseq(input.user_id);
+    const text = input.text ?? "";
+    const html = input.html ?? "";
     const data: Record<string, ParamValue | object | null> = {
       mail_id,
       user_id: input.user_id,
       message_id: input.message_id,
       subject: input.subject ?? "",
       date: input.date ?? new Date().toISOString(),
-      html: input.html ?? "",
-      text: input.text ?? "",
+      html,
+      text,
+      // Populated here so a mail inserted after this PR is always a
+      // BODYSTRUCTURE cache hit — never triggers the fallback string-load
+      // path in fetch-helpers. Pre-migration rows sit NULL until their
+      // first BODYSTRUCTURE observation backfills them. The `""` split
+      // yields `[""]` (length 1), matching the current buildTextPart math
+      // for an empty part; buildTextPart's `hasText` predicate skips it,
+      // so a stored 1 for an empty column is never surfaced.
+      [TEXT_LINE_COUNT]: countLines(text),
+      [HTML_LINE_COUNT]: countLines(html),
       from_address: input.from_address ? JSON.stringify(input.from_address) : null,
       from_text: input.from_text ?? null,
       to_address: input.to_address ? JSON.stringify(input.to_address) : null,
@@ -257,6 +278,66 @@ export const updateRfc822Size = async (
     { [MAIL_ID]: mail_id, [USER_ID]: user_id },
     { [RFC822_SIZE]: rfc822_size }
   );
+};
+
+/**
+ * Line count for the BODYSTRUCTURE `lines` field — the exact expression
+ * buildTextPart in imap/util.ts uses to derive the field from the raw
+ * text/html column. Kept here so INSERT-time population and read-side
+ * fallback compute agree by construction.
+ *
+ * Note: `"".split(/\r?\n/)` yields `[""]` (length 1). That matches the
+ * pre-existing buildTextPart math but the BODYSTRUCTURE emit path skips
+ * empty parts via `hasText` / `hasHtml`, so a stored 1 for an empty
+ * column is never surfaced on the wire.
+ */
+export const countLines = (content: string): number =>
+  content.split(/\r?\n/).length;
+
+/**
+ * Persist the derived `text_line_count` + `html_line_count` for a mail on
+ * the first BODYSTRUCTURE FETCH that computes them (backfill path for
+ * pre-migration rows — new rows populate at INSERT time above).
+ *
+ * Same shape + rationale as `updateRfc822Size`: no `updated` bump so the
+ * CONDSTORE mod-sequence isn't churned; idempotent, so concurrent
+ * writers of the same values collide harmlessly; fire-and-forget from
+ * the caller.
+ */
+export const updateLineCounts = async (
+  user_id: string,
+  mail_id: string,
+  text_line_count: number,
+  html_line_count: number
+): Promise<void> => {
+  await mailsTable.updateWhere(
+    { [MAIL_ID]: mail_id, [USER_ID]: user_id },
+    { [TEXT_LINE_COUNT]: text_line_count, [HTML_LINE_COUNT]: html_line_count }
+  );
+};
+
+/**
+ * Targeted body read for the BODYSTRUCTURE cache-miss fallback: pulls
+ * only the `text` + `html` columns for one mail_id. Skipped when the
+ * persisted line counts are present (the hot path — every row inserted
+ * after #740 hits cache; only pre-migration rows sit NULL). After a
+ * bulk backfill this branch effectively stops firing.
+ *
+ * Returns null when the row is gone (user deleted it mid-fetch).
+ */
+export const getMailBody = async (
+  user_id: string,
+  mail_id: string
+): Promise<{ text: string; html: string } | null> => {
+  const result = await pool.query(
+    `SELECT text, html FROM mails WHERE mail_id = $1 AND user_id = $2`,
+    [mail_id, user_id]
+  );
+  if (result.rows.length === 0) return null;
+  return {
+    text: (result.rows[0].text as string | null) ?? "",
+    html: (result.rows[0].html as string | null) ?? "",
+  };
 };
 
 export const markMailRead = async (


### PR DESCRIPTION
## Summary

Closes the last text/html materialization gap after #731 / #739. The 2026-07-31 07:54 + 09:17 UTC OOM crashes had `UID FETCH X,Y,Z (RFC822.SIZE BODYSTRUCTURE)` batches spiking +50-128 MB RSS for a few-KB response. `BODYSTRUCTURE` in `imap/util.ts` (`buildTextPart`) was still computing `size = Buffer.byteLength(base64(content))` AND `lines = content.split(/\r?\n/).length` from the actual text/html column — so every UID in the batch pulled the multi-MB body just to derive metadata fields.

This PR persists `text_line_count` + `html_line_count` on the `mails` table (mirroring the `rfc822_size` shape from #731) and swaps BODYSTRUCTURE's projection to be metadata-only.

## Mechanism

1. **Two new nullable INTEGER columns** on `mails` — `text_line_count` and `html_line_count`. Auto-migration `ADD COLUMN IF NOT EXISTS` stamps existing rows NULL; new rows populate at INSERT time by `saveMail` from the incoming `text` / `html` strings (cheap: one `split` each). See commit 1 + 2.

2. **BODYSTRUCTURE hot path (cache HIT)** — `getRequestedFields` for BODYSTRUCTURE now adds `text_octets` / `html_octets` (from `octet_length()`) + `mail_id` / `user_id` + `text_line_count` / `html_line_count` + `attachments`. Drops `text` and `html` entirely. `formatBodyStructure` derives `size = ceil(octets/3)*4` (same math `session-utils.ts:base64ByteLen` uses) and reads `lines` verbatim — no string in memory. See commit 3.

3. **Cache MISS fallback** — pre-migration rows sit NULL. When the BODYSTRUCTURE handler in `buildFetchResponsePart` sees `text_octets > 0` AND `text_line_count IS NULL`, it does a targeted per-row `SELECT text, html FROM mails WHERE mail_id = $1 AND user_id = $2` via a new `getMailBody` helper, splices the strings onto a shallow-cloned mail so the materialized `formatBodyStructure` branch runs unchanged, and fire-and-forgets an UPDATE to backfill the row. Next BODYSTRUCTURE for that row is a cache hit. Post-backfill this branch effectively stops firing.

4. **Byte-identical output.** Cached-shape and materialized-shape wire outputs match for the same underlying content — new test in `util.test.ts` asserts this directly, and the existing tests (`util.test.ts:formatBodyStructure`, `fetch-helpers.test.ts:bare BODY vs BODYSTRUCTURE`) still pass verbatim through the materialized branch.

## Template

Mirrors #731 (`rfc822_size`) beat for beat — same nullable-BIGINT-column shape, same `updateXxx` idempotent fire-and-forget helper (no `updated` bump so the CONDSTORE modseq isn't churned), same widening of the fetch handler input. Commit `7b13f98`.

## Test plan

- [x] `bun run typecheck` clean after each commit.
- [x] `bun test src/server` — 1447/1447 pass across 72 files, including the new tests below.
- [x] BODYSTRUCTURE projects `text_octets` + `html_octets` + `text_line_count` + `html_line_count` + `attachments` — NOT `text` or `html` (load-bearing negative — dropping these two is the whole point). `fetch-helpers.test.ts:"projects text_octets + html_octets + line-count columns, NOT text/html"`.
- [x] BODYSTRUCTURE with cached columns derives size + lines with no strings loaded (proves buildTextPart doesn't reach for absent strings). `fetch-helpers.test.ts:"derives size + lines from cached columns without loading text/html"`.
- [x] BODYSTRUCTURE cached-shape output byte-identical to materialized-shape output for the same underlying content. `util.test.ts:"cached-shape output matches materialized-shape output for the same content"`.
- [x] Cache miss without userId falls through cleanly (no persist attempted, no throw). `fetch-helpers.test.ts:"cache miss without userId falls through"`.
- [x] Model round-trip for numeric + null `text_line_count` / `html_line_count`; rejects non-number-non-null. `models.test.ts`.
- [ ] **Backfill script** — pre-migration rows sit NULL until natural BODYSTRUCTURE traffic backfills them (bounded per-row overhead in the meantime). A one-shot bulk backfill script (bundled `.mjs` via `bun build --target=node`, per the `bulk-data-recovery` pattern from #732) is a separate follow-up — same shape as the rfc822_size backfill from #731's follow-up. Not blocking this PR — INSERT-time population handles all new mail, and the read-side fallback handles any pre-existing row on demand.

## Anti-scope

Not touched: #730 caching / retry-storm work (separate follow-up per Hoie), #753 (held on standby).