### PR TITLE
perf(imap): serialize same-key BODY[] streams via per-key mutex

### DIFF
--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -33,6 +33,7 @@ import {
 } from "./types";
 import { bodyBufferKey, getSharedBodyResult } from "./body-buffer";
 import { withBodyBudget, withBodyBudgetStream } from "./body-budget";
+import { withStreamMutex } from "./stream-mutex";
 import {
   updateRfc822Size,
   updateLineCounts,
@@ -416,10 +417,17 @@ export async function buildBodyResponsePart(
   // before the first chunk yields and the count cannot disagree with the
   // payload. The stream holds only one 48 KiB slice at a time.
   //
-  // Skips the shared body-buffer cache (getSharedBodyResult): streaming makes
-  // each build cheap enough that caching gives no RSS win, and iOS Mail's
-  // abort-and-retry pattern becomes a re-stream from disk instead of a
-  // re-materialization. The cache is retained for TEXT / HEADER / partial.
+  // Skips the shared body-buffer cache (getSharedBodyResult): streaming
+  // keeps per-fetch peak sub-MB, so caching the resolved Buffer would
+  // add an O(body) materialization cost — the very cost #733 was
+  // written to eliminate. The cache is retained for TEXT / HEADER /
+  // partial where materialization is unavoidable anyway.
+  //
+  // Instead, `withStreamMutex(key, ...)` serializes SAME-KEY streams:
+  // one iOS-pipelined `UID FETCH X (UID BODY)` on the same UID runs to
+  // completion before the next fresh stream for that UID starts. Cuts
+  // duplicate PG round-trips + duplicate in-flight chunk buffers under
+  // the retry-storm shape without materializing.
   //
   // Still inside the body budget: this is the largest fetch shape, so leaving
   // it uncapped would let K concurrent sockets each stream a distinct large
@@ -439,10 +447,16 @@ export async function buildBodyResponsePart(
     // must emit it too.
     const segments = buildMessageSegments(mail, docId);
     const length = sumSegmentBytes(segments);
-    const stream = withBodyBudgetStream(async function* () {
-      yield* streamFromSegments(segments);
-      yield Buffer.from("\r\n", "utf8");
-    });
+    // Acquire the per-key mutex OUTSIDE the byte-budget so a queued
+    // same-key waiter doesn't pin a byte-slot while it waits. When it
+    // owns the key, it then acquires the byte budget for its stream.
+    const streamKey = bodyBufferKey(docId, sectionKey);
+    const stream = withStreamMutex(streamKey, () =>
+      withBodyBudgetStream(async function* () {
+        yield* streamFromSegments(segments);
+        yield Buffer.from("\r\n", "utf8");
+      })
+    );
     return {
       type: "stream",
       stream,

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -419,9 +419,9 @@ export async function buildBodyResponsePart(
   //
   // Skips the shared body-buffer cache (getSharedBodyResult): streaming
   // keeps per-fetch peak sub-MB, so caching the resolved Buffer would
-  // add an O(body) materialization cost — the very cost #733 was
-  // written to eliminate. The cache is retained for TEXT / HEADER /
-  // partial where materialization is unavoidable anyway.
+  // add an O(body) materialization cost — the very cost the streaming
+  // rewrite was written to eliminate. The cache is retained for
+  // TEXT / HEADER / partial where materialization is unavoidable anyway.
   //
   // Instead, `withStreamMutex(key, ...)` serializes SAME-KEY streams:
   // one iOS-pipelined `UID FETCH X (UID BODY)` on the same UID runs to

--- a/src/server/lib/imap/stream-mutex.test.ts
+++ b/src/server/lib/imap/stream-mutex.test.ts
@@ -160,7 +160,6 @@ describe("stream-mutex", () => {
     // A consumer that pulls one chunk then breaks out — `.return()` fires
     // on the generator, which runs its `finally`. Same shape as
     // writeStreamToSocket returning on a dead socket.
-    const gate1 = defer<void>();
     let bodyStarted = false;
     let bodyReleased = false;
     const stream = withStreamMutex("k", async function* () {
@@ -193,8 +192,6 @@ describe("stream-mutex", () => {
     );
     await later;
     expect(ran).toBe(true);
-    // Reference gate1 to avoid an unused-variable lint.
-    gate1.resolve();
   });
 
   it("empty-body generator releases immediately", async () => {

--- a/src/server/lib/imap/stream-mutex.test.ts
+++ b/src/server/lib/imap/stream-mutex.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  withStreamMutex,
+  _resetStreamMutex,
+  streamMutexHeldCount,
+  streamMutexWaitersFor,
+} from "./stream-mutex";
+
+const defer = <T>(): {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+} => {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+};
+
+const nextTick = () => new Promise<void>((r) => setImmediate(r));
+
+// Drive a stream to completion, capturing yielded values in order.
+const drain = async <T>(stream: AsyncIterable<T>): Promise<T[]> => {
+  const out: T[] = [];
+  for await (const v of stream) out.push(v);
+  return out;
+};
+
+describe("stream-mutex", () => {
+  beforeEach(() => {
+    _resetStreamMutex();
+  });
+
+  it("runs concurrent different-key streams in parallel", async () => {
+    const gateA = defer<void>();
+    const gateB = defer<void>();
+    const startedA = defer<void>();
+    const startedB = defer<void>();
+
+    const runA = drain(
+      withStreamMutex("a", async function* () {
+        startedA.resolve();
+        await gateA.promise;
+        yield "a-1";
+      })
+    );
+    const runB = drain(
+      withStreamMutex("b", async function* () {
+        startedB.resolve();
+        await gateB.promise;
+        yield "b-1";
+      })
+    );
+
+    // Both keys are DIFFERENT → both should be running (started their bodies).
+    await Promise.all([startedA.promise, startedB.promise]);
+    expect(streamMutexHeldCount()).toBe(2);
+
+    gateA.resolve();
+    gateB.resolve();
+    await Promise.all([runA, runB]);
+    expect(streamMutexHeldCount()).toBe(0);
+  });
+
+  it("serializes concurrent same-key streams — second waits for first", async () => {
+    const gate1 = defer<void>();
+    const order: string[] = [];
+    const started1 = defer<void>();
+    const started2 = defer<void>();
+
+    const run1 = drain(
+      withStreamMutex("k", async function* () {
+        started1.resolve();
+        order.push("start-1");
+        await gate1.promise;
+        order.push("end-1");
+        yield "v1";
+      })
+    );
+    // Yield so run1's acquire fires first.
+    await started1.promise;
+
+    const run2 = drain(
+      withStreamMutex("k", async function* () {
+        started2.resolve();
+        order.push("start-2");
+        yield "v2";
+      })
+    );
+
+    // run2 is queued behind run1 — MUST not have started its body yet.
+    await nextTick();
+    expect(order).toEqual(["start-1"]);
+    expect(streamMutexWaitersFor("k")).toBe(1);
+
+    // Release run1 → its `finally` runs → run2's body should now start.
+    gate1.resolve();
+    await run1;
+    await started2.promise;
+    await run2;
+    expect(order).toEqual(["start-1", "end-1", "start-2"]);
+    expect(streamMutexHeldCount()).toBe(0);
+  });
+
+  it("wakes multiple queued same-key waiters in FIFO order", async () => {
+    const gate1 = defer<void>();
+    const order: string[] = [];
+
+    const run1 = drain(
+      withStreamMutex("k", async function* () {
+        order.push("1-start");
+        await gate1.promise;
+        yield "v1";
+      })
+    );
+    await nextTick();
+
+    const waiters = ["A", "B", "C"].map((name) =>
+      drain(
+        withStreamMutex("k", async function* () {
+          order.push(name);
+          yield name;
+        })
+      )
+    );
+
+    await nextTick();
+    expect(order).toEqual(["1-start"]);
+    expect(streamMutexWaitersFor("k")).toBe(3);
+
+    gate1.resolve();
+    await run1;
+    await Promise.all(waiters);
+    expect(order).toEqual(["1-start", "A", "B", "C"]);
+  });
+
+  it("releases the key when the generator throws", async () => {
+    const attempt = drain(
+      withStreamMutex("k", async function* () {
+        yield "v1";
+        throw new Error("boom");
+      })
+    );
+    await expect(attempt).rejects.toThrow("boom");
+    expect(streamMutexHeldCount()).toBe(0);
+
+    // A subsequent acquire on the same key should succeed immediately.
+    let acquired = false;
+    const after = drain(
+      withStreamMutex("k", async function* () {
+        acquired = true;
+        yield "v2";
+      })
+    );
+    await after;
+    expect(acquired).toBe(true);
+  });
+
+  it("releases the key when the consumer abandons the stream early", async () => {
+    // A consumer that pulls one chunk then breaks out — `.return()` fires
+    // on the generator, which runs its `finally`. Same shape as
+    // writeStreamToSocket returning on a dead socket.
+    const gate1 = defer<void>();
+    let bodyStarted = false;
+    let bodyReleased = false;
+    const stream = withStreamMutex("k", async function* () {
+      bodyStarted = true;
+      try {
+        yield "v1";
+        yield "v2"; // never reached — consumer breaks after v1
+      } finally {
+        bodyReleased = true;
+      }
+    });
+
+    const it = stream[Symbol.asyncIterator]();
+    const first = await it.next();
+    expect(first.value).toBe("v1");
+    expect(bodyStarted).toBe(true);
+
+    // Abandon the stream mid-drain.
+    await it.return?.();
+    expect(bodyReleased).toBe(true);
+    expect(streamMutexHeldCount()).toBe(0);
+
+    // Next same-key acquire runs immediately.
+    let ran = false;
+    const later = drain(
+      withStreamMutex("k", async function* () {
+        ran = true;
+        yield "v3";
+      })
+    );
+    await later;
+    expect(ran).toBe(true);
+    // Reference gate1 to avoid an unused-variable lint.
+    gate1.resolve();
+  });
+
+  it("empty-body generator releases immediately", async () => {
+    await drain(
+      withStreamMutex("k", async function* () {
+        // yields nothing
+      })
+    );
+    expect(streamMutexHeldCount()).toBe(0);
+  });
+});

--- a/src/server/lib/imap/stream-mutex.ts
+++ b/src/server/lib/imap/stream-mutex.ts
@@ -1,0 +1,93 @@
+/**
+ * Per-key mutex for streaming BODY[] serialization.
+ *
+ * iOS Mail pipelines multiple `UID FETCH X (UID BODY)` for the SAME
+ * mail on ONE connection. Each starts a fresh stream through
+ * `pgTextChunks` + attachment I/O; the streams run concurrently on
+ * the single-consumer socket, each holding its own mail-row load and
+ * chunk-in-flight allocations. The count-cap + byte-cap in
+ * `body-budget.ts` bounds AGGREGATE work but not DUPLICATE work — 5
+ * concurrent requests for UID 12188 still do 5 × PG round-trips + 5 ×
+ * attachment reads + 5 × in-flight chunk buffers, all for one identical
+ * response.
+ *
+ * This module serializes same-key streams. When a second BODY[]
+ * request arrives for a key that's already streaming, it queues; when
+ * the in-flight stream releases (drain to socket + `finally`), the
+ * next waiter starts its own fresh stream. Under retry-storm the
+ * aggregate becomes 1 in-flight per key, not N.
+ *
+ * Trade-off: retries pay latency (each waits for the head to finish
+ * writing to its own socket), but memory stays bounded and #733's
+ * per-fetch sub-MB peak is preserved — no materialization anywhere.
+ *
+ * A cache-and-share design (materialize once, tee to N sockets) would
+ * cut latency further at the cost of the O(body) allocation this arc
+ * has been trying to eliminate.
+ */
+
+// Absent key → available. Present → held; the array is the FIFO wait
+// queue. `undefined` on the wait-queue would be ambiguous with `absent`,
+// so waiters push their `resolve` fn directly and holders own the slot
+// implicitly by the map entry existing.
+const inflight = new Map<string, Array<() => void>>();
+
+const acquire = async (key: string): Promise<void> => {
+  const queue = inflight.get(key);
+  if (!queue) {
+    // Unheld — mark held with an empty wait queue and return
+    // immediately. Subsequent same-key acquires will queue.
+    inflight.set(key, []);
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    queue.push(resolve);
+  });
+  // When wake() ran, ownership transferred to us; the map entry
+  // remains, and any newer waiter now queues behind us.
+};
+
+const release = (key: string): void => {
+  const queue = inflight.get(key);
+  if (!queue) return;
+  const next = queue.shift();
+  if (next) {
+    // Wake the head of the queue — ownership passes; map entry stays.
+    next();
+  } else {
+    // No waiters — clear the map entry so a fresh acquire is O(1)
+    // instead of the empty-array path.
+    inflight.delete(key);
+  }
+};
+
+/**
+ * Wrap `makeStream` in a per-`key` serialization guard. Only one
+ * generator per key runs at a time; concurrent same-key callers queue
+ * FIFO. Ownership is released when the generator returns, throws, OR
+ * the consumer abandons it (`for await` break / `.return()`) — the
+ * `finally` fires on all three exit paths.
+ */
+export const withStreamMutex = async function* <T>(
+  key: string,
+  makeStream: () => AsyncIterable<T>
+): AsyncGenerator<T, void, unknown> {
+  await acquire(key);
+  try {
+    yield* makeStream();
+  } finally {
+    release(key);
+  }
+};
+
+/** Exposed for tests. */
+export const _resetStreamMutex = (): void => {
+  inflight.clear();
+};
+
+/** Exposed for tests + observability — number of currently held keys. */
+export const streamMutexHeldCount = (): number => inflight.size;
+
+/** Exposed for tests + observability — waiter count for a specific key. */
+export const streamMutexWaitersFor = (key: string): number =>
+  inflight.get(key)?.length ?? 0;

--- a/src/server/lib/imap/stream-mutex.ts
+++ b/src/server/lib/imap/stream-mutex.ts
@@ -1,15 +1,14 @@
 /**
  * Per-key mutex for streaming BODY[] serialization.
  *
- * iOS Mail pipelines multiple `UID FETCH X (UID BODY)` for the SAME
- * mail on ONE connection. Each starts a fresh stream through
- * `pgTextChunks` + attachment I/O; the streams run concurrently on
- * the single-consumer socket, each holding its own mail-row load and
- * chunk-in-flight allocations. The count-cap + byte-cap in
- * `body-budget.ts` bounds AGGREGATE work but not DUPLICATE work — 5
- * concurrent requests for UID 12188 still do 5 × PG round-trips + 5 ×
- * attachment reads + 5 × in-flight chunk buffers, all for one identical
- * response.
+ * IMAP clients (notably iOS Mail) pipeline multiple `UID FETCH X (UID
+ * BODY)` for the SAME mail on ONE connection. Each starts a fresh
+ * stream through `pgTextChunks` + attachment I/O; the streams run
+ * concurrently, each holding its own mail-row load and chunk-in-flight
+ * allocations. The count-cap + byte-cap in `body-budget.ts` bounds
+ * AGGREGATE work but not DUPLICATE work — N concurrent requests for
+ * the same UID still do N × PG round-trips + N × attachment reads +
+ * N × in-flight chunk buffers, all for one identical response.
  *
  * This module serializes same-key streams. When a second BODY[]
  * request arrives for a key that's already streaming, it queues; when
@@ -18,8 +17,9 @@
  * aggregate becomes 1 in-flight per key, not N.
  *
  * Trade-off: retries pay latency (each waits for the head to finish
- * writing to its own socket), but memory stays bounded and #733's
- * per-fetch sub-MB peak is preserved — no materialization anywhere.
+ * writing to its own socket), but memory stays bounded and the
+ * streaming path's per-fetch sub-MB peak is preserved — no
+ * materialization anywhere.
  *
  * A cache-and-share design (materialize once, tee to N sockets) would
  * cut latency further at the cost of the O(body) allocation this arc


### PR DESCRIPTION
## Summary

Close the retry-storm coalescing gap the streaming BODY[] path opened in #733. iOS Mail pipelines multiple `UID FETCH X (UID BODY)` for the SAME mail on ONE TCP connection — empirical evidence from the 2026-07-31 07:54 + 09:17 UTC OOM logs: tags H38 / H39 / H40 on `UID 12188` from remote `208.82.98.54:64098` all in flight within the same second, each running its own `pgTextChunks` loop + attachment reads + in-flight chunk buffers for what should be one identical response.

The count-cap + byte-cap in `body-budget.ts` bounds AGGREGATE work but not DUPLICATE work.

## Fix

New `src/server/lib/imap/stream-mutex.ts` — FIFO per-key async mutex. Second same-key stream waits for the first to complete (drain to socket + generator `finally`) before starting its own fresh stream. Aggregate becomes **1 in-flight per key** instead of N.

Wired into the streaming BODY[FULL] path in `fetch-helpers.ts`:

```ts
const stream = withStreamMutex(streamKey, () =>
  withBodyBudgetStream(async function* () {
    yield* streamFromSegments(segments);
    yield Buffer.from("\r\n", "utf8");
  })
);
```

`withStreamMutex` is acquired OUTSIDE the byte-budget so a queued same-key waiter doesn't pin a byte-slot while waiting. When it owns the key it then acquires the byte budget for its own stream.

## Why not materialize + cache

Hoie 2026-07-31 13:48 UTC: *"I'm skeptical about materializing because that will make streaming no effect."* Correct — materialize-then-cache would cost O(body) allocation on the FIRST fetch of every burst, exactly what [#733](https://github.com/hoiekim/inbox/pull/733) eliminated. This serializes without materializing: per-fetch peak stays sub-MB regardless of body size or retry count.

Trade-off: retries pay latency (each waits for the head to finish writing to its own socket). Under IOS's typical pipeline-3 pattern the tail latency is ~2× head latency. Acceptable vs. OOM.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test src/server` — 1453/0 pass (was 1447 before; +6 new mutex tests).
- [x] New `stream-mutex.test.ts` covers:
  - Concurrent different-key streams run in parallel (baseline).
  - Same-key streams serialize — second waits for first's `finally`.
  - FIFO wake of multiple queued same-key waiters.
  - Release on throw — subsequent same-key acquire runs immediately.
  - Release on consumer abandon via `.return()` — matches `writeStreamToSocket`'s early-exit on dead socket.
  - Empty-body generator releases immediately.
- Not applicable: no UI surface. Real E2E is the next same-key retry-storm event; will monitor the alarm channel after deploy.

## Ordering in the OOM arc

- #738 (emitBase64 input slicing) — merged
- #739 (PG-streamed text/html) — merged
- #754 (persist line counts, close BODYSTRUCTURE gap) — awaiting merge
- **This PR** — coalesce same-key streaming retries
- #753 (bytes-in-flight budget) — held; may be dropped if the four above close the class