### PR TITLE
perf(mails): persist rfc822_size at INSERT

### DIFF
--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -130,9 +130,10 @@ const mailSchema = {
   [SPAM_REASONS]: "JSONB",
   [IS_SPAM]: "BOOLEAN NOT NULL DEFAULT FALSE",
   // Nullable — auto-migration ADD COLUMN IF NOT EXISTS stamps existing rows
-  // with NULL, and the read path (fetch-helpers RFC822.SIZE case) computes
-  // + persists on first observation. New rows also start NULL and populate
-  // on their first RFC822.SIZE / RFC822 / BODY[] fetch.
+  // with NULL. New rows populate at INSERT via saveMail
+  // (`computeFullMessageSize` on the lazy-body synthetics, same predicate
+  // FETCH uses). The lazy-populate fallback in `fetch-helpers.ts` stays as
+  // a safety net for pre-migration rows.
   [RFC822_SIZE]: "BIGINT",
   // Nullable — auto-migration stamps existing rows with NULL; new rows
   // populate at INSERT time from the split of `text` / `html` (see

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -15,7 +15,10 @@ import {
   HTML_LINE_COUNT,
 } from "../../models";
 import { getNextModseq, writeMailboxUid } from "./counters";
-import { computeFullMessageSize } from "../../../imap/session-utils";
+import {
+  computeFullMessageSize,
+  type FetchMailInput,
+} from "../../../imap/session-utils";
 
 export interface SaveMailInput {
   user_id: string;
@@ -81,18 +84,28 @@ export const saveMail = async (
     const modseq = await getNextModseq(input.user_id);
     const text = input.text ?? "";
     const html = input.html ?? "";
-    // Reconstruct just the MailType shape that `computeFullMessageSize`
-    // touches — `formatHeaders` reads `.text` from each address, plus
-    // subject/messageId/date; `buildMessageSegments` reads text/html/
-    // attachments. Attachments are already on disk by the time
-    // saveMail is called (saveBuffer in receive.ts:355 completes before
-    // pgSaveMail), so the internal `fs.statSync` per attachment works.
-    const mailForSize: Partial<MailType> = {
+    const date = input.date ?? new Date().toISOString();
+    // Reconstruct just the shape `computeFullMessageSize` touches, using
+    // the LAZY-BODY synthetics (text_octets / html_octets / mail_id /
+    // user_id) with text/html left undefined. This forces
+    // `wantsLazyBodies` true, so `hasText`/`hasHtml` derive from octet
+    // counts — the same predicate every subsequent FETCH uses on the
+    // row returned by `getMailsByRange` (session-utils.ts:207-215). A
+    // materialized shape here would take the `.trim()` branch and drift
+    // on whitespace-only bodies (SIZE would omit the part, FETCH BODY[]
+    // would include it — SIZE ≠ {N}).
+    //
+    // Attachments are already on disk by the time saveMail is called
+    // (saveBuffer in receive.ts:355 completes before pgSaveMail), so
+    // the internal `fs.statSync` per attachment works.
+    const mailForSize: FetchMailInput = {
       messageId: input.message_id,
-      date: input.date ?? new Date().toISOString(),
+      date,
       subject: input.subject,
-      text,
-      html,
+      text_octets: Buffer.byteLength(text, "utf8"),
+      html_octets: Buffer.byteLength(html, "utf8"),
+      mail_id,
+      user_id: input.user_id,
       attachments: input.attachments as MailType["attachments"] | undefined,
       from: input.from_text ? { value: [], text: input.from_text } : undefined,
       to: input.to_text ? { value: [], text: input.to_text } : undefined,
@@ -108,7 +121,7 @@ export const saveMail = async (
       user_id: input.user_id,
       message_id: input.message_id,
       subject: input.subject ?? "",
-      date: input.date ?? new Date().toISOString(),
+      date,
       html,
       text,
       // Populated here so a mail inserted after this PR is always a

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -1,4 +1,5 @@
 import crypto from "crypto";
+import { MailType } from "common";
 import { logger } from "../../../logger";
 import { pool } from "../../client";
 import { ParamValue } from "../../database";
@@ -14,6 +15,7 @@ import {
   HTML_LINE_COUNT,
 } from "../../models";
 import { getNextModseq, writeMailboxUid } from "./counters";
+import { computeFullMessageSize } from "../../../imap/session-utils";
 
 export interface SaveMailInput {
   user_id: string;
@@ -79,6 +81,28 @@ export const saveMail = async (
     const modseq = await getNextModseq(input.user_id);
     const text = input.text ?? "";
     const html = input.html ?? "";
+    // Reconstruct just the MailType shape that `computeFullMessageSize`
+    // touches — `formatHeaders` reads `.text` from each address, plus
+    // subject/messageId/date; `buildMessageSegments` reads text/html/
+    // attachments. Attachments are already on disk by the time
+    // saveMail is called (saveBuffer in receive.ts:355 completes before
+    // pgSaveMail), so the internal `fs.statSync` per attachment works.
+    const mailForSize: Partial<MailType> = {
+      messageId: input.message_id,
+      date: input.date ?? new Date().toISOString(),
+      subject: input.subject,
+      text,
+      html,
+      attachments: input.attachments as MailType["attachments"] | undefined,
+      from: input.from_text ? { value: [], text: input.from_text } : undefined,
+      to: input.to_text ? { value: [], text: input.to_text } : undefined,
+      cc: input.cc_text ? { value: [], text: input.cc_text } : undefined,
+      bcc: input.bcc_text ? { value: [], text: input.bcc_text } : undefined,
+      replyTo: input.reply_to_text
+        ? { value: [], text: input.reply_to_text }
+        : undefined,
+    };
+    const rfc822_size = computeFullMessageSize(mailForSize, mail_id);
     const data: Record<string, ParamValue | object | null> = {
       mail_id,
       user_id: input.user_id,
@@ -96,6 +120,11 @@ export const saveMail = async (
       // so a stored 1 for an empty column is never surfaced.
       [TEXT_LINE_COUNT]: countLines(text),
       [HTML_LINE_COUNT]: countLines(html),
+      // Same shape as line counts: populate at INSERT so the RFC822.SIZE
+      // fetch handler's cache-hit branch fires from the first observation.
+      // The lazy-populate fallback in fetch-helpers stays as a safety net
+      // for pre-migration rows.
+      [RFC822_SIZE]: rfc822_size,
       from_address: input.from_address ? JSON.stringify(input.from_address) : null,
       from_text: input.from_text ?? null,
       to_address: input.to_address ? JSON.stringify(input.to_address) : null,


### PR DESCRIPTION
## Summary

Close the last first-fetch-materialization surface. `saveMail` now populates `rfc822_size` at INSERT alongside `text_line_count` + `html_line_count` (from #754), so new mail is always an RFC822.SIZE cache hit — never triggers the lazy `updateRfc822Size` fire-and-forget on first fetch.

Per Hoie 2026-07-31 19:35 UTC: line counts were persisted at INSERT (from #754) but rfc822_size was still lazy-only from #731. Inconsistent given the OOM-arc lesson (first-fetch materialization IS the risk).

## Mechanism

`computeFullMessageSize(mailForSize, mail_id)` is called on the small Partial<MailType> shape rebuilt from `SaveMailInput`. `mail_id` doubles as the docId for the MIME boundary string, matching what `buildBodyResponsePart` uses at fetch time — so the persisted size is byte-exact vs a fresh compute.

Attachments are on disk by the time `saveMail` runs (`saveBuffer` in receive.ts:355 completes before `pgSaveMail`), so the internal `fs.statSync` per attachment inside `computeFullMessageSize` works.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test src/server` — 1453/0 pass (existing coverage — the READ-path tests already verify the cache-hit shape with populated `rfc822_size`; the write-path plumbing is a mirror of the line-count populate from #754 which followed the same test-coverage precedent).
- Not applicable: no UI surface. The next SMTP delivery post-deploy is the real E2E; the RFC822.SIZE column should be populated on the row without any fetch touching it.

## Backfill

Not needed — Hoie confirmed 2026-07-31 19:40 UTC that existing rows are already backfilled (from the earlier #731 rfc822_size backfill I sent via Discord CDN).

## Ordering

Independent of the pending OOM-arc PRs. Safe to land any time after main.