### PR TITLE
fix(pgTextChunks): pin ::int overload so SUBSTRING doesn't hit SIMILAR TO

### DIFF
--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -37,6 +37,16 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     substringCalls.push({ column, take, returnedChars: chunk.length });
     return { rows: [{ chunk }], rowCount: 1 };
   }
+  // Fail loud on unrecognized SUBSTRING — mirrors the guard in
+  // session-utils-lazy-text.test.ts. A silent {rows: []} would surface as
+  // downstream body-vs-empty assertion failures rather than "the mock
+  // regex is stale."
+  if (/SUBSTRING/i.test(sql)) {
+    throw new Error(
+      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks SQL. ` +
+      `Expected /SUBSTRING\\((text|html)\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
+    );
+  }
   // Any other query (e.g. rfc822_size persist) just no-ops with an empty
   // result — the fetch test doesn't need to persist anywhere.
   return { rows: [], rowCount: 0 };

--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -27,7 +27,7 @@ const substringCalls: Array<{ column: "text" | "html"; take: number; returnedCha
 const columnStore = new Map<string, string>();
 
 const mockQuery = mock(async (sql: string, values: unknown[]) => {
-  const substringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3\s+FOR\s+\$4\)/);
+  const substringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/);
   if (substringMatch) {
     const column = substringMatch[1] as "text" | "html";
     const [mail_id, , offset, take] = values as [string, string, number, number];

--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -35,6 +35,17 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const chunk = stored.slice(start, start + take);
     return { rows: [{ chunk }], rowCount: 1 };
   }
+  // Fail loud if a SUBSTRING call arrives in a shape the mock doesn't
+  // recognize — silently returning empty rows would surface as "body vs
+  // empty string" downstream, which reads as a data bug instead of a mock
+  // out-of-date bug. The ::int casts are load-bearing (see pgTextChunks
+  // in imap.ts), so any drift needs a matching mock update.
+  if (/SUBSTRING/i.test(sql)) {
+    throw new Error(
+      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks SQL. ` +
+      `Expected /SUBSTRING\\((text|html)\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
+    );
+  }
   return { rows: [], rowCount: 0 };
 });
 

--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -24,7 +24,7 @@ const columnStore = new Map<string, string>();
 const mockQuery = mock(async (sql: string, values: unknown[]) => {
   // Route SUBSTRING(text FROM ... FOR ...) / SUBSTRING(html FROM ... FOR ...)
   // through the columnStore. Every non-SUBSTRING query returns empty rows.
-  const substringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3\s+FOR\s+\$4\)/);
+  const substringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/);
   if (substringMatch) {
     const column = substringMatch[1] as "text" | "html";
     const [mail_id, , offset, take] = values as [string, string, number, number];

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -54,9 +54,22 @@ export async function* pgTextChunks(
   // Postgres SUBSTRING(text FROM start FOR len): `start` is 1-indexed. We
   // step by `chunkChars` chars each round-trip; a chunk shorter than
   // `chunkChars` OR empty means we've drained the column.
+  //
+  // The `$3::int FOR $4::int` casts are LOAD-BEARING. `pg` sends JS
+  // number params as text with no OID hint, so Postgres has to infer
+  // types from the SUBSTRING call site. Three overloads share the
+  // shape:
+  //   substring(text, int, int)       — numeric offsets (what we want)
+  //   substring(text, text, text)     — SIMILAR TO pattern + escape char
+  //   substring(text, text)           — regex pattern
+  // Postgres picks (2) for two-text params, then reads $4 (`"12000"`)
+  // as the ESCAPE CHARACTER — which must be exactly one character —
+  // and throws `invalid escape string`. Every lazy-body BODY[] stream
+  // fails on the first chunk with no client-side surface (the response
+  // never assembles). Explicit `::int` casts pin the intended overload.
   let offset = 1;
   for (;;) {
-    const sql = `SELECT SUBSTRING(${sourceColumn} FROM $3 FOR $4) AS chunk
+    const sql = `SELECT SUBSTRING(${sourceColumn} FROM $3::int FOR $4::int) AS chunk
                  FROM mails WHERE mail_id = $1 AND user_id = $2`;
     const result = await pool.query(sql, [mail_id, user_id, offset, chunkChars]);
     const chunk = (result.rows[0]?.chunk ?? "") as string;


### PR DESCRIPTION
## Summary

`pgTextChunks` (the chunked BODY[] streaming reader introduced in #739) has been running broken SQL against Postgres since #739 shipped:

```sql
SELECT SUBSTRING(text FROM $3 FOR $4) AS chunk FROM mails WHERE ...
```

`pg` sends JS number params as text with no OID hint. Postgres has to infer types from the SUBSTRING call site. Three overloads share this shape:

| overload | signature | what we get |
|---|---|---|
| 1 | `substring(text, int, int)` | numeric offsets ← intended |
| 2 | `substring(text, text, text)` | SIMILAR TO pattern + escape char |
| 3 | `substring(text, text)` | regex pattern |

Two-text params make Postgres pick overload 2. `$4` (`"12000"`) becomes the ESCAPE CHARACTER, which must be exactly one character. Postgres throws:

```
error: invalid escape string
```

Every lazy-body BODY[] stream fails on the first chunk. The response never assembles; the client sees the fetch error out.

## How it slipped past CI

The unit tests for `pgTextChunks` mock `pg`'s Pool with a `FakePool` whose `query` method matches the SQL text via regex and returns synthetic rows. It doesn't run the SQL against Postgres, so the overload-resolution error never surfaced in the test env. Confirmed by dropping into a real Postgres from claoie's laptop against the prod DB.

## Fix

Explicit `$3::int FOR $4::int` casts pin overload 1. Verified against prod DB (`postgres.hoie.kim:5432/inbox` via `moltboie` read-only role):

```
❌ SUBSTRING(html FROM $3 FOR $4)             — invalid escape string
❌ SUBSTRING(text FROM $3 FOR $4)             — invalid escape string
✅ SUBSTRING(html FROM $3::int FOR $4::int)   — chunk returned as expected
```

## Broader context

This means every lazy-body streaming BODY[] fetch (`BODY[]` FULL, non-partial, via `addBodyFields` in `fetch-helpers.ts:270-279`) has been erroring silently in prod since #739 merged. `_processFetchMessages` catches the throw and logs `Error processing message` per message. The FETCH command still tags OK for the whole batch, so the client sees no explicit failure — it retries.

That reframes the OOM class Hoie and I have been chasing (#757): the streaming path fixes (#737 emitBase64, #738 slicing, #739 lazy path, #754 line counts, #755 mutex) all assumed the streaming path was live in prod. It wasn't. iOS's actual fetches must be taking a different path (partial fetches → materialized) — which is where the ~1.5 MB per-command RSS allocation is happening.

Follow-up work stays in #757: attribute what path iOS actually uses and mitigate the materialized-path RSS climb.

## Test plan

- [x] `bun test src/server/lib/imap` → 771 pass / 0 fail (mocks updated to match new SQL shape)
- [x] `bun test src/server/lib/postgres` → 108 pass / 0 fail
- [x] `tsc --noEmit` clean
- [x] Executed the failing SQL variants against prod DB from claoie's laptop via `moltboie` role — confirmed pre-fix throws, post-fix succeeds
- [ ] Sandbox: reproducer script (20× BODY.PEEK[] on 1.9 MB mail) fails 20/20 pre-fix, succeeds 20/20 post-fix — will run after sandbox spin

Refs: #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)