### PR TITLE
cleanup(imap): drop the dead RFC822 partial check in the FETCH body-shape counter

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -576,9 +576,9 @@ export class ImapRequestHandler {
             if (item.partial) bodyFullPartial += 1;
             else bodyFullStream += 1;
           } else if (item.type === "RFC822") {
-            // RFC822 aliases BODY[] — same code path split.
-            if ("partial" in item && (item as { partial?: unknown }).partial) bodyFullPartial += 1;
-            else bodyFullStream += 1;
+            // RFC822 aliases BODY[] but has no partial-range form (RFC 3501
+            // §6.4.5), so it is always the streaming path.
+            bodyFullStream += 1;
           }
         }
       };

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -558,14 +558,14 @@ export class ImapRequestHandler {
       const arrayBuffersDeltaKB = Math.round(
         (memAfter.arrayBuffers - memBefore.arrayBuffers) / 1024
       );
-      // Attribution of which BODY[] variant a FETCH command uses. `partial`
-      // = the client sent `BODY[]<start.length>` (partial fetch) → routes
-      // to the materialized `buildFullMessage` path (loads text+html
-      // strings into V8 heap). Absence of `.partial` on a FULL BODY[]
-      // request → routes to the lazy-body streaming path (`pgTextChunks`
-      // + `emitBase64`, sub-MB peak). Under an iOS retry storm, this
-      // integer tells us which path is actually driving the RSS climb
-      // #757 is chasing. Non-FETCH commands set both to 0.
+      // Attribution of which BODY[] variant a FETCH command uses.
+      // `bodyFullPartial` = the client sent `BODY[]<start.length>`, which
+      // routes to `streamPartialFromSegments`; `bodyFullStream` = a full
+      // `BODY[]` or `RFC822`, which routes to `streamFromSegments`. Both
+      // walk the segment list rather than materializing text+html into the
+      // V8 heap, so under an iOS retry storm this pair attributes RSS by
+      // request shape, not by materialized-vs-streamed. Non-FETCH commands
+      // set both to 0.
       let bodyFullPartial = 0;
       let bodyFullStream = 0;
       const collectBodyShapes = (r: ImapRequest): void => {
@@ -576,8 +576,8 @@ export class ImapRequestHandler {
             if (item.partial) bodyFullPartial += 1;
             else bodyFullStream += 1;
           } else if (item.type === "RFC822") {
-            // RFC822 aliases BODY[] but has no partial-range form (RFC 3501
-            // §6.4.5), so it is always the streaming path.
+            // RFC822 aliases BODY[] and has no partial-range form (RFC 3501
+            // §6.4.5), so it always counts as a full fetch.
             bodyFullStream += 1;
           }
         }


### PR DESCRIPTION
## What

`collectBodyShapes` in `src/server/lib/imap/handler.ts` attributes each FETCH to
the partial vs streaming body path for the `IMAP command completed` log payload.
The `RFC822` arm carried a `"partial" in item` guard that can never be true:

- `Rfc822Fetch` (`src/server/lib/imap/types.ts:156-158`) is `{ type: "RFC822" }` —
  no `partial` field.
- `parseFetchDataItem` (`src/server/lib/imap/parsers/fetch-parsers.ts:211-212`)
  returns that bare literal; the `<start.length>` scanner runs only on the `BODY`
  arm.

So the guard is dead and the arm always increments `bodyFullStream`. Collapsed to
that, plus a one-line note on why RFC822 has no partial form. Single file, no
behavior change.

## Scope note — the logger half was dropped from this PR

This PR previously also carried a `logger.ts` change (emit `error.stack`
unconditionally in the pretty formatter) and the matching per-callsite cleanup in
`message-ops.ts`. reviewoie's HIGH on 2026-08-01 was correct and took that half's
premise with it: prod does **not** reach `formatJson` today, because Bun folds
`process.env.NODE_ENV` at bundle time and the built artifact ships
`isProduction() { return false; }` — so emitting the stack unconditionally in
pretty would have started writing full stacks to prod stdout from ~92
`logger.error`/`logger.warn` callsites, including the per-message catch inside the
FETCH loop.

That folding bug is #766, fixed in PR #789. The logger change is a follow-up on
top of #789, not a dependency of this one — so this PR is now only the half that
never depended on it, and it is reviewable on its own.

## Test plan

Server-side IMAP change with no client surface, so the drive is a real IMAP
client rather than a browser: raw socket via `bun`, LOGIN → SELECT INBOX → FETCH
variants against the branch server on a local `inbox` DB, reading
`bodyFullPartial` / `bodyFullStream` back out of the emitted
`IMAP command completed` log payload.

- `FETCH 1 RFC822` → partial 0, stream 1
- `UID FETCH 1:* RFC822` → partial 0, stream 1 (UID recursion still reaches the arm)
- `FETCH 1:5 BODY[]` → partial 0, stream 1
- `FETCH 1:50 BODY[]<0.100>` → partial 1, stream 0 (partial detection on the BODY
  arm is untouched)
- `FETCH 1:5 (RFC822 BODY[]<0.10>)` → partial 1, stream 1 — both arms in one
  command, discriminated correctly

The last case is the one that matters: RFC822 and a partial BODY[] in the same
FETCH still land in different counters after the guard is removed.

Also run against the branch:

- `bun test src/server` — 1552 pass, 0 fail, 75 files
- `bun run typecheck` — clean
- `bun run lint` — 0 errors (18 pre-existing warnings, none in the touched file)

## reviewoie round 2 (on `1ce81bd`)

Core claim verified independently by the reviewer at both the parse layer and
the execution layer; counter output byte-identical before/after. Two findings on
the surrounding comment block, both folded in as `e3a765b`:

- **MED — the block comment describing the counters is stale.** It claimed a
  partial `BODY[]` routes to the materialized `buildFullMessage` path. It does
  not: `fetch-helpers.ts` gates on `section.type === "FULL"` and returns from
  inside that block for both shapes (`streamPartialFromSegments` for the partial
  branch, `streamFromSegments` for the full branch); the `buildFullMessage`
  fall-through is unreachable for FULL sections. I confirmed this by reading
  `fetch-helpers.ts:478-545` rather than taking the finding's word. Left as-is,
  an RSS triage reading `bodyFullPartial > 0` would conclude text+html
  materialization was driving the heap climb when both counters now measure
  streaming paths. My new RFC822 line leaned on the same false contrast
  ("always the streaming path"), so it is reworded to describe the counter
  ("always counts as a full fetch") instead of the execution path.
- **LOW — issue-narrative in committed source.** The same sentence carried
  "the RSS climb #757 is chasing", which the comment-hygiene rule forbids;
  it went out with the rewrite.

Both are inside the eight-line comment that defines the two counters this PR
edits, so they are folded in here rather than deferred. Re-verified after the
fix commit: `bun test src/server` 1552 pass / 0 fail, `bun run typecheck` clean.
