### PR TITLE
fix(imap): FETCH ENVELOPE emits NIL, not "", for an absent addr-name (#684)

### DIFF
--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -88,7 +88,7 @@ describe("IMAP util", () => {
 
     it("should emit NIL as addr-name for an absent name", () => {
       const addresses: MailAddressValueType[] = [
-        { address: "john@example.com" } as MailAddressValueType
+        { address: "john@example.com" }
       ];
       expect(formatAddressList(addresses)).toBe(
         '(NIL NIL "john" "example.com")'

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -77,11 +77,41 @@ describe("IMAP util", () => {
       );
     });
 
-    it("should handle address with empty name", () => {
+    it("should emit NIL as addr-name for an empty name", () => {
       const addresses: MailAddressValueType[] = [
         { name: "", address: "john@example.com" }
       ];
-      expect(formatAddressList(addresses)).toBe('("" NIL "john" "example.com")');
+      expect(formatAddressList(addresses)).toBe(
+        '(NIL NIL "john" "example.com")'
+      );
+    });
+
+    it("should emit NIL as addr-name for an absent name", () => {
+      const addresses: MailAddressValueType[] = [
+        { address: "john@example.com" } as MailAddressValueType
+      ];
+      expect(formatAddressList(addresses)).toBe(
+        '(NIL NIL "john" "example.com")'
+      );
+    });
+
+    it("should not quote a whitespace-only name away — it is a present name", () => {
+      const addresses: MailAddressValueType[] = [
+        { name: " ", address: "john@example.com" }
+      ];
+      expect(formatAddressList(addresses)).toBe(
+        '(" " NIL "john" "example.com")'
+      );
+    });
+
+    it("should mix NIL and quoted addr-names within one list", () => {
+      const addresses: MailAddressValueType[] = [
+        { name: "", address: "john@example.com" },
+        { name: "Jane Smith", address: "jane@example.com" }
+      ];
+      expect(formatAddressList(addresses)).toBe(
+        '(NIL NIL "john" "example.com") ("Jane Smith" NIL "jane" "example.com")'
+      );
     });
 
     it("should escape quotes in name", () => {
@@ -315,6 +345,26 @@ describe("IMAP util", () => {
       expect(result).toContain('(("Jane" NIL "jane" "example.com"))');
       // ...and the absent reply-to/cc/bcc are bare NIL, not (NIL).
       expect(result).not.toContain("(NIL)");
+    });
+
+    it("emits a no-display-name address as NIL addr-name inside a present address", () => {
+      // A bare `From: sender@example.com` / `To: recipient@example.com`. The
+      // address structure is present, so it stays parenthesized, but each
+      // addr-name is the bare atom NIL.
+      const mail: Partial<MailType> = {
+        from: {
+          text: "sender@example.com",
+          value: [{ name: "", address: "sender@example.com" }]
+        },
+        to: {
+          text: "recipient@example.com",
+          value: [{ name: "", address: "recipient@example.com" }]
+        }
+      };
+      const result = formatEnvelope(mail);
+      expect(result).toContain('((NIL NIL "sender" "example.com"))');
+      expect(result).toContain('((NIL NIL "recipient" "example.com"))');
+      expect(result).not.toContain('""');
     });
   });
 

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -58,10 +58,9 @@ export const formatAddressList = (value?: MailAddressValueType[]): string => {
       const [local, domain] = address.split("@");
       if (!local || !domain) return null;
 
-      // RFC 3501 §9: `addr-name = nstring`. An address whose header carried no
-      // display name has no personal name at all, which is the bare atom NIL —
-      // not `""`, which a client reads as a present-but-empty name and renders
-      // as a blank From/To instead of falling back to the address.
+      // RFC 3501 §9: `addr-name = nstring`. A header that carried no display
+      // name has no personal name at all — the bare atom NIL, not `""`, which
+      // clients read as a present-but-empty name.
       const addrName = name ? `"${name.replace(/"/g, '\\"')}"` : "NIL";
 
       return `(${addrName} NIL "${local}" "${domain}")`;

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -58,10 +58,13 @@ export const formatAddressList = (value?: MailAddressValueType[]): string => {
       const [local, domain] = address.split("@");
       if (!local || !domain) return null;
 
-      // Escape quotes in name
-      const escapedName = name.replace(/"/g, '\\"');
+      // RFC 3501 §9: `addr-name = nstring`. An address whose header carried no
+      // display name has no personal name at all, which is the bare atom NIL —
+      // not `""`, which a client reads as a present-but-empty name and renders
+      // as a blank From/To instead of falling back to the address.
+      const addrName = name ? `"${name.replace(/"/g, '\\"')}"` : "NIL";
 
-      return `("${escapedName}" NIL "${local}" "${domain}")`;
+      return `(${addrName} NIL "${local}" "${domain}")`;
     })
     .filter((item) => item !== null)
     .join(" ");


### PR DESCRIPTION
Closes #684

## Problem

`formatAddressList` (`src/server/lib/imap/util.ts`) wrapped the personal name in quotes unconditionally:

```ts
const escapedName = name.replace(/"/g, '\\"');
return `("${escapedName}" NIL "${local}" "${domain}")`;
```

`name` defaults to `""`, so an address parsed from a header with **no display name** — a bare `From: sender@example.com` — serialized as:

```
(("" NIL "sender" "example.com"))
```

RFC 3501 §9 defines `addr-name = nstring`: an address carrying no phrase must render its name as the bare atom `NIL`. Dovecot returns `(NIL NIL "local" "host")` for the same input. A client that distinguishes `NIL` from `""` (typical in strongly-typed IMAP libraries where `null !== ""`) reads the empty string as a *present-but-empty* personal name and renders a blank From/To instead of falling back to the email address.

Same conformance class as the already-fixed #636 / #648, but at the `addr-name` granularity **inside** a present address structure rather than the whole address list.

## Change

One expression in `formatAddressList`:

```ts
const addrName = name ? `"${name.replace(/"/g, '\\"')}"` : "NIL";
return `(${addrName} NIL "${local}" "${domain}")`;
```

All six envelope address slots (From, Sender, Reply-To, To, Cc, Bcc) route through `formatAddressList`, so they are covered uniformly by the one change. No call-site changes, no schema change, no migration.

The existing `should handle address with empty name` case in `util.test.ts` pinned the buggy output and is flipped here.

## Test plan

`src/server/lib/imap/util.test.ts` — 1 flipped, 4 added:

- `should emit NIL as addr-name for an empty name` — `{ name: "", … }` → `(NIL NIL "john" "example.com")` (was `("" NIL …)`)
- `should emit NIL as addr-name for an absent name` — `name` key omitted entirely, same result
- `should not quote a whitespace-only name away — it is a present name` — `{ name: " " }` still renders `(" " NIL …)`, so the guard is truthiness on the raw value, not a trim
- `should mix NIL and quoted addr-names within one list` — one named + one unnamed address in the same list render independently
- `emits a no-display-name address as NIL addr-name inside a present address` — envelope level, mirroring the issue's reproduction: `((NIL NIL "sender" "example.com"))` for From/Sender and `((NIL NIL "recipient" "example.com"))` for To, with no `""` anywhere in the envelope. The address structures stay parenthesized (the §7.4.2 `(NIL)`-vs-`NIL` rule from #636 is unaffected).

**Mutation-verified** — reverting the one expression to the unconditional-quote form fails exactly those 4 new/changed assertions and nothing else.

**CI-level** — `bun run typecheck` clean, `bun run lint` 0 errors (17 pre-existing warnings, none in touched files), `bun test src/server` 1457 pass / 0 fail.

**E2E** — live IMAP socket sweep, full results below.

---

## E2E — live IMAP socket, sandbox `inbox-pr-761`

Driven over a **real IMAP socket** (port 31761, from the sandbox's own `IMAP_PORT`), against the per-PR clone `inbox_sandbox_10761`. Not a unit-test re-run, not a curl of source.

**Targets are real clone data, not fabricated.** 843 mails in the clone carry `from_address->0->>'name' = ''`; 12151 carry a real display name. Three were chosen to cover five of the six envelope slots:

| UID | covers |
|---|---|
| 23 | `from`, `sender`, `reply-to` all empty-name; `to` **mixed** (1 empty-name + 3 named); `cc`/`bcc` absent |
| 1 | `from` named, `to` empty-name |
| 16 | `from`/`to` named, `cc` empty-name |

### Pre-fix reproduction — the bug was reproduced before asserting the fix

A scratch worktree at `upstream/main` `7028692` was built and run on a separate port against the **same** DB, after confirming its `formatAddressList` still had the unconditional-quote form:

```
* 23 FETCH (UID 23 ENVELOPE ("Sun, 19 Sep 2021 18:43:16 GMT" "<subject>"
    (("" NIL "<local-a>" "<domain-ext>"))
    (("" NIL "<local-a>" "<domain-ext>"))
    (("" NIL "<local-a>" "<domain-ext>"))
    (("" NIL "<local-b>" "<domain-own>") ("<display-name>" NIL "<local-c>" "<domain-own>") …)
    NIL NIL NIL "<message-id>"))
```

`("" NIL …)` reproduced in `from`, `sender`, `reply-to`, `to` and `cc`. Scratch build torn down afterwards; `git worktree list` clean.

### Post-fix

```
* 23 FETCH (UID 23 ENVELOPE ("Sun, 19 Sep 2021 18:43:16 GMT" "<subject>"
    ((NIL NIL "<local-a>" "<domain-ext>"))
    ((NIL NIL "<local-a>" "<domain-ext>"))
    ((NIL NIL "<local-a>" "<domain-ext>"))
    ((NIL NIL "<local-b>" "<domain-own>") ("<display-name>" NIL "<local-c>" "<domain-own>") …)
    NIL NIL NIL "<message-id>"))
a004 OK FETCH completed
```

- bare atom `NIL` at `addr-name`, unquoted.
- the address structure stays parenthesized — `((NIL NIL …))` — so the `(NIL)`-vs-bare-`NIL` rule from #636 is intact: absent `cc`/`bcc` still render as bare `NIL`, never `(NIL)`.
- the mixed case works inside one slot: `to` renders `(NIL NIL …)` beside three `("<display-name>" NIL …)` entries.

### Byte-level proof nothing else moved

ENVELOPE fetched for UIDs 1–200 on both builds and diffed line-by-line after applying only the claimed substitution `("" NIL ` → `(NIL NIL `:

```
{ "total": 200, "identicalAfterNorm": 200, "unexpectedDiffs": 0 }
```

| over those 200 mails | pre-fix | post-fix |
|---|---|---|
| addr structs emitting `("" NIL` | 223 | **0** |
| addr structs emitting `(NIL NIL` | 0 | **223** |
| addr structs with a quoted name | 470 | **470** (unchanged) |
| illegal `(NIL)` slots | 0 | 0 |

### Quote-escaping non-regression

No display name in the clone contains a `"` (0 of 37046 address entries), so this was driven by temporarily setting one row's name to a quote-bearing value, fetching on **both** builds, then restoring. Both emit the identical escaped form:

```
(("Doe, \"JD\" Jr" NIL "<local-a>" "<domain-ext>"))
```

Restore verified by md5 (before == after), row count and the 843 empty-name count unchanged. Disposable per-PR clone, not the local dev DB.

### Session-level smoke — all tagged `OK`, all well-formed

`NOOP` · `LOGIN` · `LIST "" "*"` (3914 untagged) · `SELECT INBOX` · `EXAMINE INBOX [READ-ONLY]` · `STATUS INBOX (MESSAGES UIDNEXT UIDVALIDITY)` · `UID SEARCH` · `UID FETCH 1:12 (FLAGS)` · `UID FETCH 23 (BODYSTRUCTURE)` · `UID FETCH 23 (BODY.PEEK[HEADER.FIELDS …])` · `UID FETCH 20:24 (ENVELOPE)` · `LOGOUT`.

`SELECT`'s untagged set is identical on both builds (`12391 EXISTS`, `UIDVALIDITY 1785302146`, `UIDNEXT 12436`, `HIGHESTMODSEQ 134`). BODYSTRUCTURE unchanged. ENVELOPE also renders correctly inside a multi-item `UID FETCH (UID FLAGS INTERNALDATE RFC822.SIZE ENVELOPE)`.

**Real client library:** `imapflow@1.6.5` connects, authenticates, selects and parses all three envelopes without error on both builds — evidence of **no parse regression**, but *not* evidence of the fix: imapflow normalizes `NIL` and `""` to the same JS `""`, so the difference is invisible at its API. The fix is observable only at the wire level, which is precisely the strict-client class #684 describes.

### Not verified — stated rather than glossed

- **`bcc` with a populated address.** Every `bcc_address` in the clone is null/empty, so `bcc` was only observed in its absent (bare `NIL`) form. It routes through the same `formatAddressList` call, but it was not driven live.
- **A client that actually distinguishes `NIL` from `""`.** imapflow is not one, and none was available. The user-visible payoff (falling back to the address instead of rendering a blank sender) is asserted at the wire level only.
- **No screenshots** — this is a wire-protocol change with no render surface; the evidence is raw socket text.

### Latent crash also closed by the guard

`{ name = "" }` destructuring defaults only fire on `undefined`, so a JSONB-stored `{"name": null}` reached `name.replace(…)` and threw `TypeError`, taking down the entire `UID FETCH (ENVELOPE)`. Under the new truthiness predicate that row renders `NIL`. Not reachable from today's receive path, so no test pins it — noted here so the guard is not later "simplified" to a `.trim()` or a `?? ""`.

### Commit currency

The socket sweep ran against `9aac192`. `8a081fb` (the reviewoie low fixes) changes only a code comment and a redundant test cast — `git diff 9aac192..HEAD` is 4 insertions / 5 deletions across those two lines, no change to any emitted byte. The wire evidence above stands for the head commit.

### Follow-ups filed, not folded in

- #762 — IMAP quoted strings do not escape backslash (`addr-name`, `subject`, `messageId`, BODYSTRUCTURE filename). Pre-existing across four sites in two formatters; wants one shared `nstring()` helper.
- #763 — the plain IMAP port advertises `STARTTLS` in CAPABILITY even with no cert configured. Reproduced on **both** builds, so not caused by this PR.
