### PR TITLE
perf(imap): stream partial BODY[] fetches via segment-walk

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1643,16 +1643,21 @@ describe("buildFetchResponsePart partial BODY[]<start.length> streams through se
     }
   });
 
-  it("emits EXACTLY `part.length` bytes on iOS's chunked <off.N> sequence (wire-trailer parity)", async () => {
+  it("emits EXACTLY `part.length` bytes on chunked <off.N> partial sequence (wire-trailer parity)", async () => {
     // Reviewoie #769 R1 caught: partial FULL was using `sumSegmentBytes`
     // (trailer-inclusive) as the total-bytes ceiling, but
     // `streamPartialFromSegments` never emits the trailer — so any
     // partial reaching end-of-body advertised `{N}` two bytes larger
-    // than what actually landed on the wire. iOS's chunked sync sends
-    // `<0.65536>`, `<65536.65536>`, ..., `<last.65536>` — the last
+    // than what actually landed on the wire. iOS's real chunked sync
+    // uses `<0.65536>`, `<65536.65536>`, ..., `<last.65536>` — the last
     // chunk always hits this, corrupting every subsequent tagged
-    // response. This test drains each stream and cross-checks the
-    // count instead of asserting only on `part.length`.
+    // response. This test walks the same *pattern* at a much smaller
+    // chunk (250 B) against a small in-memory mail, so at least three
+    // iterations fire and the last one lands < chunkSize with the
+    // clamp active. Drains each stream and cross-checks the count
+    // instead of asserting only on `part.length` — the parity test in
+    // session-utils compared against `streamFromSegments` (which also
+    // excludes the trailer, so its parity held) and missed this class.
     const chunkSize = 250;
     let start = 0;
     for (let i = 0; i < 10; i += 1) {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1643,6 +1643,45 @@ describe("buildFetchResponsePart partial BODY[]<start.length> streams through se
     }
   });
 
+  it("emits EXACTLY `part.length` bytes on iOS's chunked <off.N> sequence (wire-trailer parity)", async () => {
+    // Reviewoie #769 R1 caught: partial FULL was using `sumSegmentBytes`
+    // (trailer-inclusive) as the total-bytes ceiling, but
+    // `streamPartialFromSegments` never emits the trailer — so any
+    // partial reaching end-of-body advertised `{N}` two bytes larger
+    // than what actually landed on the wire. iOS's chunked sync sends
+    // `<0.65536>`, `<65536.65536>`, ..., `<last.65536>` — the last
+    // chunk always hits this, corrupting every subsequent tagged
+    // response. This test drains each stream and cross-checks the
+    // count instead of asserting only on `part.length`.
+    const chunkSize = 250;
+    let start = 0;
+    for (let i = 0; i < 10; i += 1) {
+      const part = await buildFetchResponsePart(
+        mail,
+        {
+          type: "BODY",
+          peek: false,
+          section: { type: "FULL" },
+          partial: { start, length: chunkSize },
+        },
+        `doc-partial-chunked-${i}`,
+        "INBOX"
+      );
+      if (!part) break;
+      if (part.type === "simple") break; // NIL at end
+      expect(part.type).toBe("stream");
+      if (part.type !== "stream") break;
+      let emitted = 0;
+      for await (const chunk of part.stream) emitted += chunk.byteLength;
+      expect(
+        emitted,
+        `wire desync at chunk ${i} <${start}.${chunkSize}>: advertised ${part.length}, emitted ${emitted}`
+      ).toBe(part.length);
+      if (part.length < chunkSize) break; // reached end
+      start += chunkSize;
+    }
+  });
+
   it("clamps length to available bytes when start+length exceeds total", async () => {
     // For this small mail, requesting 100_000_000 bytes at offset 0
     // must return a stream advertising the actual full body length,

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1597,14 +1597,16 @@ describe("buildBodyResponsePart cached-path shape preservation", () => {
   });
 });
 
-describe("buildFetchResponsePart partial BODY[]<start.length> materializes text+html", () => {
-  // iOS Mail's chunked large-body
-  // pull uses `BODY[]<0.65536>`, then `BODY[]<65536.65536>`, etc. The lazy
-  // shape (`text_octets` + `html_octets` instead of the strings) cannot
-  // drive the sync materializer in buildFullMessage — partial FULL falls
-  // through to `getBodyContent → buildFullMessage`, which throws on lazy
-  // segments. addBodyFields must project `text` + `html` when `partial` is
-  // set so buildFullMessage has real strings to slice.
+describe("buildFetchResponsePart partial BODY[]<start.length> streams through segments", () => {
+  // iOS Mail's chunked large-body pull uses `BODY[]<0.65536>`, then
+  // `BODY[]<65536.65536>`, etc. Under the segment-walk streamer, partial
+  // fetches take the SAME shape as non-partial full fetches — they
+  // project the LAZY synthetics (`text_octets` / `html_octets` +
+  // `mail_id` / `user_id`) and stream through `streamPartialFromSegments`,
+  // slicing in-flight to the requested [start, start+length) window.
+  // Peak stays O(chunk) regardless of body size, which is the whole
+  // point of #757's kill-materialized-fallback direction — cache is
+  // not needed when the stream itself is byte-range-aware.
 
   const mail: Partial<MailType> = {
     uid: { account: 1, domain: 1 } as MailType["uid"],
@@ -1618,7 +1620,7 @@ describe("buildFetchResponsePart partial BODY[]<start.length> materializes text+
     attachments: [] as unknown as MailType["attachments"],
   };
 
-  it("returns a simple part (not a stream) for BODY[]<0.100>", async () => {
+  it("returns a stream part for BODY[]<0.100>", async () => {
     const part = await buildFetchResponsePart(
       mail,
       {
@@ -1631,14 +1633,59 @@ describe("buildFetchResponsePart partial BODY[]<start.length> materializes text+
       "INBOX"
     );
     expect(part).not.toBeNull();
-    // Partial goes through the materializing path — `simple` (or `literal`,
-    // depending on section-key shape); the important invariant is "does not
-    // throw" AND "is not a stream".
-    expect(part!.type).not.toBe("stream");
+    expect(part!.type).toBe("stream");
+    // Header carries the origin-octet form (`<start>`), no length echo
+    // per RFC 3501 §7.4.2 msg-att-static.
+    if (part!.type === "stream") {
+      expect(part!.header).toBe("BODY[]<0>");
+      expect(part!.length).toBeLessThanOrEqual(100);
+      expect(part!.length).toBeGreaterThan(0);
+    }
   });
 
-  it("addBodyFields for BODY[FULL] with partial projects text + html (materialized), not the lazy synthetics", () => {
-    const fields = new Set<FetchRequestedField>();
+  it("clamps length to available bytes when start+length exceeds total", async () => {
+    // For this small mail, requesting 100_000_000 bytes at offset 0
+    // must return a stream advertising the actual full body length,
+    // not 100_000_000 (which would desync the {N} literal).
+    const part = await buildFetchResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: false,
+        section: { type: "FULL" },
+        partial: { start: 0, length: 100_000_000 },
+      },
+      "doc-partial-clamp",
+      "INBOX"
+    );
+    expect(part!.type).toBe("stream");
+    if (part!.type === "stream") {
+      // Real body is a few hundred bytes; sanity-check the length was clamped.
+      expect(part!.length).toBeLessThan(100_000_000);
+      expect(part!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns NIL when start is past end-of-body", async () => {
+    const part = await buildFetchResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: false,
+        section: { type: "FULL" },
+        partial: { start: 100_000_000, length: 100 },
+      },
+      "doc-partial-past-end",
+      "INBOX"
+    );
+    expect(part!.type).toBe("simple");
+    if (part!.type === "simple") {
+      expect(part!.content).toContain("NIL");
+    }
+  });
+
+  it("addBodyFields for BODY[FULL] with partial projects the same LAZY synthetics as non-partial", () => {
+    const partialFields = new Set<FetchRequestedField>();
     addBodyFields(
       {
         type: "BODY",
@@ -1646,23 +1693,22 @@ describe("buildFetchResponsePart partial BODY[]<start.length> materializes text+
         section: { type: "FULL" },
         partial: { start: 0, length: 100 },
       },
-      fields
+      partialFields
     );
-    expect(fields.has("text")).toBe(true);
-    expect(fields.has("html")).toBe(true);
-    expect(fields.has("text_octets" as FetchRequestedField)).toBe(false);
-    expect(fields.has("html_octets" as FetchRequestedField)).toBe(false);
-  });
-
-  it("addBodyFields for non-partial BODY[FULL] still projects the lazy synthetics", () => {
-    const fields = new Set<FetchRequestedField>();
+    const fullFields = new Set<FetchRequestedField>();
     addBodyFields(
       { type: "BODY", peek: false, section: { type: "FULL" } },
-      fields
+      fullFields
     );
-    expect(fields.has("text_octets" as FetchRequestedField)).toBe(true);
-    expect(fields.has("html_octets" as FetchRequestedField)).toBe(true);
-    expect(fields.has("text")).toBe(false);
-    expect(fields.has("html")).toBe(false);
+    // Both variants project the lazy synthetics — the field set is
+    // identical because both take the segment-walk streaming path.
+    for (const f of ["text_octets", "html_octets", "mail_id", "user_id"] as const) {
+      expect(partialFields.has(f as FetchRequestedField)).toBe(true);
+      expect(fullFields.has(f as FetchRequestedField)).toBe(true);
+    }
+    for (const f of ["text", "html"] as const) {
+      expect(partialFields.has(f as FetchRequestedField)).toBe(false);
+      expect(fullFields.has(f as FetchRequestedField)).toBe(false);
+    }
   });
 });

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -23,6 +23,7 @@ import {
   streamFromSegments,
   streamPartialFromSegments,
   sumSegmentBytes,
+  WIRE_TRAILER,
   getBodyPart,
   getBodyPartHeaders,
   getBodySectionKey,
@@ -447,7 +448,17 @@ export async function buildBodyResponsePart(
     // which `sumSegmentBytes` counts (via WIRE_TRAILER), so the stream
     // must emit it too.
     const segments = buildMessageSegments(mail, docId);
+    // `sumSegmentBytes` includes the 2-byte wire trailer (`\r\n`) that the
+    // non-partial FULL branch appends after streaming the segments. RFC
+    // 3501 §6.4.5 partial fetches address bytes of the RFC 2822
+    // serialization only — the wire trailer is IMAP framing, not part of
+    // the message. Using the trailer-inclusive total for the partial
+    // range would let `<0.total>` (or any range that reaches the end)
+    // advertise 2 more bytes than `streamPartialFromSegments` actually
+    // emits — a wire desync where the next tagged response's leading
+    // bytes get consumed as body.
     const totalBodyLength = sumSegmentBytes(segments);
+    const partialAddressableBytes = totalBodyLength - WIRE_TRAILER;
     // Acquire the per-key mutex OUTSIDE the byte-budget so a queued
     // same-key waiter doesn't pin a byte-slot while it waits. When it
     // owns the key, it then acquires the byte budget for its stream.
@@ -455,16 +466,16 @@ export async function buildBodyResponsePart(
     if (partial) {
       // RFC 3501 §6.4.5: `BODY[]<start.length>` returns bytes
       // [start, start+length) of the RFC 2822 serialization. When
-      // `start >= totalBodyLength` return NIL — the octet range is
+      // `start >= partialAddressableBytes` return NIL — the octet range is
       // vacuous. Otherwise clamp `length` to what's actually available
       // so the `{N}` literal advertises the true emitted count.
       const { start, length: requestedLength } = partial;
-      if (start >= totalBodyLength) {
+      if (start >= partialAddressableBytes) {
         return { type: "simple", content: `${sectionKey} NIL` };
       }
       const emittedLength = Math.min(
         requestedLength,
-        totalBodyLength - start
+        partialAddressableBytes - start
       );
       const partialStream = withStreamMutex(streamKey, () =>
         withBodyBudgetStream(async function* () {

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -21,6 +21,7 @@ import {
   buildMessageSegments,
   computeFullMessageSize,
   streamFromSegments,
+  streamPartialFromSegments,
   sumSegmentBytes,
   getBodyPart,
   getBodyPartHeaders,
@@ -264,20 +265,16 @@ export function addBodyFields(
 ): void {
   switch (bodyFetch.section.type) {
     case "FULL":
-      // Partial fetch (`BODY[]<start.length>`) falls through to
-      // `buildFullMessage`, a synchronous materializer that can't drive
-      // the async pg reader — it needs the whole `text` / `html`
-      // strings loaded, not the octet counts. Full-body pulls skip
-      // the strings and stream via `pgTextChunks`.
-      if (bodyFetch.partial) {
-        fields.add("text");
-        fields.add("html");
-      } else {
-        fields.add("text_octets");
-        fields.add("html_octets");
-        fields.add("mail_id");
-        fields.add("user_id");
-      }
+      // Both full and partial FULL BODY[] fetches route through the
+      // segment-walk streamer (`streamFromSegments` / `streamPartialFromSegments`).
+      // The lazy synthetics (`text_octets` / `html_octets` / `mail_id` /
+      // `user_id`) let the emitter pull the text/html columns via
+      // chunked pg SUBSTRING at emit time instead of materializing the
+      // strings up front — peak stays O(chunk) for both variants.
+      fields.add("text_octets");
+      fields.add("html_octets");
+      fields.add("mail_id");
+      fields.add("user_id");
       fields.add("subject");
       fields.add("from");
       fields.add("to");
@@ -421,7 +418,11 @@ export async function buildBodyResponsePart(
   // keeps per-fetch peak sub-MB, so caching the resolved Buffer would
   // add an O(body) materialization cost — the very cost the streaming
   // rewrite was written to eliminate. The cache is retained for
-  // TEXT / HEADER / partial where materialization is unavoidable anyway.
+  // non-partial TEXT / MIME_PART body, where materialization is
+  // unavoidable via `getBodyContent`. Partial BODY[] now streams too
+  // (via `streamPartialFromSegments`), so the cache is no longer on
+  // that path either — the segment walker slices in-flight to the
+  // requested byte range without pulling more upstream than needed.
   //
   // Instead, `withStreamMutex(key, ...)` serializes SAME-KEY streams:
   // one iOS-pipelined `UID FETCH X (UID BODY)` on the same UID runs to
@@ -433,7 +434,7 @@ export async function buildBodyResponsePart(
   // it uncapped would let K concurrent sockets each stream a distinct large
   // body while the budget covered only the cheaper paths. The slot is held for
   // the stream's whole lifetime and released even if the consumer abandons it.
-  if (!partial && !isHeaderLikeSection(section) && section.type === "FULL") {
+  if (!isHeaderLikeSection(section) && section.type === "FULL") {
     // Build the segment list ONCE — reproducing it inside the stream
     // would `stat` attachment files a second time, and a file whose size
     // changed between calls (upload-in-progress, mid-write race, etc.)
@@ -446,11 +447,40 @@ export async function buildBodyResponsePart(
     // which `sumSegmentBytes` counts (via WIRE_TRAILER), so the stream
     // must emit it too.
     const segments = buildMessageSegments(mail, docId);
-    const length = sumSegmentBytes(segments);
+    const totalBodyLength = sumSegmentBytes(segments);
     // Acquire the per-key mutex OUTSIDE the byte-budget so a queued
     // same-key waiter doesn't pin a byte-slot while it waits. When it
     // owns the key, it then acquires the byte budget for its stream.
     const streamKey = bodyBufferKey(docId, sectionKey);
+    if (partial) {
+      // RFC 3501 §6.4.5: `BODY[]<start.length>` returns bytes
+      // [start, start+length) of the RFC 2822 serialization. When
+      // `start >= totalBodyLength` return NIL — the octet range is
+      // vacuous. Otherwise clamp `length` to what's actually available
+      // so the `{N}` literal advertises the true emitted count.
+      const { start, length: requestedLength } = partial;
+      if (start >= totalBodyLength) {
+        return { type: "simple", content: `${sectionKey} NIL` };
+      }
+      const emittedLength = Math.min(
+        requestedLength,
+        totalBodyLength - start
+      );
+      const partialStream = withStreamMutex(streamKey, () =>
+        withBodyBudgetStream(async function* () {
+          yield* streamPartialFromSegments(segments, start, emittedLength);
+        })
+      );
+      // The origin-octet header form is `BODY[<section>]<start>` per
+      // §7.4.2 msg-att-static — no length echo; the `{N}` literal
+      // already carries the count.
+      return {
+        type: "stream",
+        stream: partialStream,
+        header: `${sectionKey}<${start}>`,
+        length: emittedLength,
+      };
+    }
     const stream = withStreamMutex(streamKey, () =>
       withBodyBudgetStream(async function* () {
         yield* streamFromSegments(segments);
@@ -461,7 +491,7 @@ export async function buildBodyResponsePart(
       type: "stream",
       stream,
       header: sectionKey,
-      length,
+      length: totalBodyLength,
     };
   }
 

--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -67,7 +67,9 @@ mock.module("pg", pgMock);
 const {
   buildMessageSegments,
   streamFromSegments,
+  streamPartialFromSegments,
   computeFullMessageSize,
+  sumSegmentBytes,
 } = await import("./session-utils");
 const { resetPool } = await import("../postgres/client");
 const { pgTextChunks, PG_TEXT_CHUNK_CHARS } = await import(
@@ -462,5 +464,170 @@ describe("buildMessageSegments — lazy mode wire parity", () => {
     expect(substringCalls.length).toBeGreaterThanOrEqual(
       Math.floor(html.length / PG_TEXT_CHUNK_CHARS)
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// streamPartialFromSegments — RFC 3501 §6.4.5 BODY[]<start.length> path
+// ---------------------------------------------------------------------------
+
+describe("streamPartialFromSegments — byte-range slice", () => {
+  const drainToBuffer = async (
+    stream: AsyncIterable<Buffer>
+  ): Promise<Buffer> => {
+    const chunks: Buffer[] = [];
+    for await (const c of stream) chunks.push(c);
+    return Buffer.concat(chunks as unknown as Uint8Array[]);
+  };
+
+  const baseHeaders = {
+    subject: "partial-range",
+    messageId: "<partial-range@test>",
+    date: "2026-08-01T00:00:00Z",
+    from: { text: "a@example.com", value: [{ address: "a@example.com", name: "" }] },
+    to: { text: "b@example.com", value: [{ address: "b@example.com", name: "" }] },
+    envelopeTo: [{ address: "b@example.com", name: "" }],
+  } as const;
+
+  // The parity invariant: streamPartialFromSegments(segs, start, length) is
+  // byte-identical to the substring of the full concatenation. Sweeps a
+  // grid of offsets across a body large enough to exercise multiple
+  // pg SUBSTRING pulls per segment, both crossing and staying inside
+  // individual segments.
+  it("emits exactly the [start, start+length) slice of the full segment concat", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    // ~50 KB text + ~200 KB html — small enough for the full concat to
+    // fit in a test buffer, big enough that the html segment alone
+    // spans multiple PG_TEXT_CHUNK_CHARS pulls.
+    const text = "plain-body ".repeat(4500);
+    const html = "<p>rich body</p>".repeat(12000);
+    columnStore.set("mail-partial:text", text);
+    columnStore.set("mail-partial:html", html);
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: Buffer.byteLength(text, "utf8"),
+        html_octets: Buffer.byteLength(html, "utf8"),
+        mail_id: "mail-partial",
+        user_id: "user-1",
+      } as never,
+      "docId-partial"
+    );
+    const full = await drainToBuffer(streamFromSegments(segments));
+    const total = full.byteLength;
+
+    // Grid of (start, length) pairs designed to hit: (a) start-of-message,
+    // (b) mid-segment cuts, (c) segment-boundary crossings, (d) end-of-body,
+    // (e) length exceeding remaining bytes.
+    const cases: Array<[number, number]> = [
+      [0, 100],
+      [0, total],
+      [1, 1000],
+      [Math.floor(total / 3), Math.floor(total / 3)],
+      [total - 10, 10],
+      [total - 100, 100_000], // over-request → clamp
+    ];
+    for (const [start, length] of cases) {
+      const slice = await drainToBuffer(
+        streamPartialFromSegments(segments, start, length)
+      );
+      const expected = full.subarray(start, Math.min(total, start + length));
+      expect(
+        slice.equals(expected as unknown as Uint8Array),
+        `mismatch at start=${start} length=${length}: got ${slice.byteLength}B, expected ${expected.byteLength}B`
+      ).toBe(true);
+    }
+  });
+
+  it("returns an empty stream when start is at or past total", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    columnStore.set("mail-empty-slice:text", "hello");
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: 5,
+        html_octets: 0,
+        mail_id: "mail-empty-slice",
+        user_id: "user-1",
+      } as never,
+      "docId-empty-slice"
+    );
+    const total = sumSegmentBytes(segments) - 2; // exclude WIRE_TRAILER; partial has no trailer
+    const past = await drainToBuffer(
+      streamPartialFromSegments(segments, total + 100, 500)
+    );
+    expect(past.byteLength).toBe(0);
+    const zeroLen = await drainToBuffer(
+      streamPartialFromSegments(segments, 0, 0)
+    );
+    expect(zeroLen.byteLength).toBe(0);
+  });
+
+  it("peak chunk stays O(chunk) on a large lazy body — never materializes the whole slice", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    // 800 KB html body — a whole-message materialize would be ~1.1 MB.
+    const html = "z".repeat(800_000);
+    columnStore.set("mail-partial-big:html", html);
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: 0,
+        html_octets: Buffer.byteLength(html, "utf8"),
+        mail_id: "mail-partial-big",
+        user_id: "user-1",
+      } as never,
+      "docId-partial-big"
+    );
+    // Request a 400 KB slice from the middle of the message.
+    const totalMsg = sumSegmentBytes(segments) - 2;
+    const start = Math.floor(totalMsg / 3);
+    const length = Math.min(400_000, totalMsg - start);
+    let maxChunk = 0;
+    let emitted = 0;
+    for await (const chunk of streamPartialFromSegments(segments, start, length)) {
+      emitted += chunk.byteLength;
+      if (chunk.byteLength > maxChunk) maxChunk = chunk.byteLength;
+    }
+    expect(emitted).toBe(length);
+    // Peak transient chunk is ~64 KiB (base64 of SLICE_RAW_BYTES). The
+    // 400 KB slice never appears as a single Buffer.
+    expect(maxChunk).toBeLessThan(80 * 1024);
+    // Each SUBSTRING pull is still bounded by PG_TEXT_CHUNK_CHARS.
+    for (const call of substringCalls) {
+      expect(call.take).toBe(PG_TEXT_CHUNK_CHARS);
+    }
+  });
+
+  it("stops pulling upstream once the slice is satisfied — early-return releases the pg cursor", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    const html = "y".repeat(500_000);
+    columnStore.set("mail-early-return:html", html);
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: 0,
+        html_octets: Buffer.byteLength(html, "utf8"),
+        mail_id: "mail-early-return",
+        user_id: "user-1",
+      } as never,
+      "docId-early-return"
+    );
+
+    // Request only the first 2000 bytes — reader should stop within the
+    // first couple of SUBSTRING pulls, not drain the whole column.
+    for await (const _ of streamPartialFromSegments(segments, 0, 2000)) {
+      // consume
+    }
+    // A drain of the full column would need ~500_000 / PG_TEXT_CHUNK_CHARS
+    // = ~42 pulls. Early-return should keep it to a small constant.
+    expect(substringCalls.length).toBeLessThan(5);
   });
 });

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -647,27 +647,127 @@ export async function* streamFromSegments(
   segments: MessageSegment[]
 ): AsyncGenerator<Buffer, void, unknown> {
   for (const segment of segments) {
-    switch (segment.kind) {
-      case "literal":
-        yield* emitLiteral(segment.value);
-        break;
-      case "base64":
-        yield* emitBase64(segment.source);
-        break;
-      case "attachment":
-        yield* emitAttachment(segment);
-        break;
-      case "lazy-text":
-        // Stream the mails.<source> column via chunked SUBSTRING reads.
-        // Both the char-carry (surrogate at chunk boundary) and byte-carry
-        // (3-byte alignment) inside emitBase64 survive across upstream
-        // pgTextChunks pulls, so the encoded output equals what a whole-
-        // string encode of the same column would produce.
-        yield* emitBase64(
-          pgTextChunks(segment.mail_id, segment.user_id, segment.source)
-        );
-        break;
+    yield* streamOneSegment(segment);
+  }
+}
+
+/**
+ * Consume `source` from the byte offset `skip`, emit at most `take` bytes,
+ * then stop. Sub-chunk trimming happens at the intersection of `source`'s
+ * chunk boundaries and the [skip, skip+take) window — so a large chunk that
+ * straddles the window gets sliced to only its overlap, and the tail of
+ * `source` past `skip+take` is never pulled.
+ *
+ * Peak transient stays chunk-bounded by construction: at any moment we hold
+ * one `Buffer` view (a `subarray` of the upstream chunk) or nothing. The
+ * upstream generator is closed on early return via for-await semantics
+ * (`.return()` on the iterator), so if the underlying source holds resources
+ * (pgTextChunks cursor, fs descriptor) they release the moment the take is
+ * satisfied. That's the mechanism that makes a partial-fetch BODY[] pull
+ * exactly its `<start.length>` window and stop, instead of driving the
+ * segment through to completion.
+ */
+async function* sliceStream(
+  source: AsyncIterable<Buffer>,
+  skip: number,
+  take: number
+): AsyncGenerator<Buffer, void, unknown> {
+  if (take <= 0) return;
+  let skipped = 0;
+  let taken = 0;
+  for await (const chunk of source) {
+    if (taken >= take) return;
+    let start = 0;
+    if (skipped < skip) {
+      const skipHere = Math.min(chunk.byteLength, skip - skipped);
+      skipped += skipHere;
+      start = skipHere;
     }
+    if (start >= chunk.byteLength) continue;
+    const remaining = take - taken;
+    const end = Math.min(chunk.byteLength, start + remaining);
+    // subarray is a view; copy out so early-return releases the upstream
+    // chunk's backing ArrayBuffer instead of pinning it.
+    const view = chunk.subarray(start, end);
+    const emit =
+      view.byteLength === chunk.byteLength
+        ? chunk
+        : Buffer.from(view as unknown as Uint8Array);
+    taken += emit.byteLength;
+    yield emit;
+    if (taken >= take) return;
+  }
+}
+
+/**
+ * Emit exactly the bytes `[start, start+length)` of the segment
+ * concatenation. Same output as `Buffer.concat(...streamFromSegments(segs))
+ * .subarray(start, start + length)`, but never materializes the whole
+ * concatenation and stops pulling the moment `take` is satisfied.
+ *
+ * Byte-offset walk: for each segment we know its exact wire byte count
+ * (`segmentByteLength`), so we skip segments entirely before the window,
+ * stop on the first segment entirely after it, and slice-in-flight through
+ * `sliceStream` on the ones that overlap.
+ *
+ * This is the streaming path for `BODY[]<start.length>` — the RFC 3501
+ * §6.4.5 partial-fetch form. iOS Mail uses it for essentially every
+ * body fetch (verified via #758 attribution: 25/25 partial vs 0/25 full
+ * stream in the sample window). Before this fn, partial fell to
+ * `buildFullMessage` which materialized the whole RFC 2822 serialization
+ * then sliced; peak allocation was O(message). With this: O(chunk).
+ *
+ * Load-bearing invariant (same as `streamFromSegments`): the caller MUST
+ * share ONE segment list with `sumSegmentBytes` for the range-clamp math —
+ * a second `buildMessageSegments` call would `stat` attachment files a
+ * second time and can race the measurement, producing a wire-length
+ * disagreement.
+ */
+export async function* streamPartialFromSegments(
+  segments: MessageSegment[],
+  start: number,
+  length: number
+): AsyncGenerator<Buffer, void, unknown> {
+  if (length <= 0) return;
+  const end = start + length;
+  let cumulative = 0;
+  for (const segment of segments) {
+    if (cumulative >= end) return;
+    const segBytes = segmentByteLength(segment);
+    const segStart = cumulative;
+    const segEnd = cumulative + segBytes;
+    cumulative = segEnd;
+    if (segEnd <= start) continue;
+    const skipInSeg = Math.max(0, start - segStart);
+    const takeInSeg = Math.min(segBytes, end - segStart) - skipInSeg;
+    if (takeInSeg <= 0) continue;
+    // Emit this segment through its own generator, then trim via
+    // sliceStream. Peak allocation matches `streamFromSegments` for the
+    // same segment kind — chunk-bounded, no per-segment materialization
+    // beyond what the emitter itself already holds transiently.
+    yield* sliceStream(streamOneSegment(segment), skipInSeg, takeInSeg);
+  }
+}
+
+/** Stream exactly one segment as `streamFromSegments` would for that kind. */
+async function* streamOneSegment(
+  segment: MessageSegment
+): AsyncGenerator<Buffer, void, unknown> {
+  switch (segment.kind) {
+    case "literal":
+      yield* emitLiteral(segment.value);
+      break;
+    case "base64":
+      yield* emitBase64(segment.source);
+      break;
+    case "attachment":
+      yield* emitAttachment(segment);
+      break;
+    case "lazy-text":
+      yield* emitBase64(
+        pgTextChunks(segment.mail_id, segment.user_id, segment.source)
+      );
+      break;
   }
 }
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -346,8 +346,11 @@ const segmentByteLength = (segment: MessageSegment): number => {
 /**
  * Trailing `\r\n` the wire response appends after the body serialization.
  * `RFC822.SIZE` includes it so `SIZE == {N}` holds for `BODY[]`.
+ * Exported so the partial-fetch code path in `buildBodyResponsePart` can
+ * subtract it from `sumSegmentBytes(segments)` — partial fetches address
+ * RFC 2822 bytes only and don't include the IMAP wire trailer.
  */
-const WIRE_TRAILER = 2;
+export const WIRE_TRAILER = 2;
 
 /**
  * Sum the exact WIRE byte count for an already-built segment list. Used by


### PR DESCRIPTION
## Summary

Kills the last O(body) materialization path in the FETCH pipeline. Before this PR, `BODY[]<start.length>` partial fetches took `buildFullMessage` + `applyPartialFetch` — sync whole-body materialize then substring, peak = O(full message). Per #758 attribution, iOS Mail uses this shape essentially 100% of the time; its retry-storm pipeline of same-UID partial fetches was the OOM class driver in #757.

After: partial BODY[] on FULL section streams through the same segment-walker as non-partial FULL. Peak drops from O(message) to O(chunk = ~48 KiB raw / ~64 KiB base64), regardless of body size or partial window length. Cache is no longer on this path — the segment walker slices in-flight without pulling more upstream than needed. Answers the design question from Discord: "if we stream everything properly we don't need caching do we?" — right, and now we don't.

## How

New helper `streamPartialFromSegments(segments, start, length)`:
- Walks the pre-built segment list, accumulating each segment's cumulative byte offset via `segmentByteLength`.
- Skips segments entirely before the window, stops on the first segment entirely after it.
- For overlapping segments, delegates per-segment slicing to a thin `sliceStream(source, skip, take)` transformer on the same emitters `streamFromSegments` uses (`emitLiteral`, `emitBase64`, `emitAttachment`, `pgTextChunks`-driven `emitBase64`).

New `sliceStream(source, skip, take)`:
- Consumes an `AsyncIterable<Buffer>`, skips `skip` bytes lazily, emits at most `take`, then stops.
- Chunk-bounded peak (view of upstream chunk, copied out so early-return releases upstream backing).
- Early-return on the `for await` propagates `.return()` upstream — pg cursors and file descriptors close the moment the take is satisfied.

Wired at `fetch-helpers.ts:buildBodyResponsePart`:
- Partial FULL takes the same segments + mutex + budget shape as non-partial FULL.
- Response `type: "stream"`, `header: BODY[]<start>` (origin-octet form per §7.4.2), `length` clamped to what's actually emitted.
- `start >= totalBodyLength` returns `NIL`.

`addBodyFields` unified — both partial and full FULL project the same lazy synthetics. Materialized-text fallback for partial is gone.

## Tests

New in `session-utils-lazy-text.test.ts`:
- Byte-parity across 6 (start, length) grid points on a ~250 KB lazy-body message — output byte-identical to full concat's `.subarray(start, start+length)` on every point, including over-request clamp.
- Empty slice when `start >= total` and when `length === 0`.
- Peak chunk < 80 KiB when slicing 400 KB from an 800 KB body.
- Early-return stops SUBSTRING pulls at ~4 (vs ~42 for full drain).

Rewritten in `fetch-helpers.test.ts`:
- Partial BODY[] returns a stream part (was: not-a-stream).
- Correct header shape `BODY[]<0>`, clamped length.
- NIL when `start` past end.
- addBodyFields projects the same lazy synthetics for partial as for full (was: partial projected `text`+`html`).

Full server suite: 1458 pass / 0 fail. `tsc --noEmit` clean.

## Risk

Partial fetches are on a hot path (iOS's primary shape). Byte-parity tests pin the exact output shape. The remaining variables:
- Base64 chunk boundary correctness inside `emitBase64` — already covered by #737/#738 surrogate + slice-alignment tests, unchanged here.
- Attachment fs.read at offset — `emitAttachment` already reads via `readSync` at position, still starts at 0 for full segments; the slice trim happens post-encoding in `sliceStream`, so the file read is not offset-aware (it's still whole-attachment). Optimization opportunity but not a correctness risk.
- Mutex + body-budget still wrap partial (same as full) — no regression in throttle behavior.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `bun test src/server` — 1458 pass / 0 fail
- [ ] Sandbox: burst 20× `BODY[]<0.65536>` on the same UID and verify RSS stays chunk-bounded (was ~10-50 MB per fetch on the materialized path)
- [ ] Prod (after merge + deploy): iOS burst on the crash-shape mailbox — RSS ceiling should stay well below 256 MiB

Refs: #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)