### PR TITLE
fix(imap): page mail bodies by code point, not UTF-16 code unit (#765)

### DIFF
--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -32,8 +32,11 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const column = substringMatch[1] as "text" | "html";
     const [mail_id, , offset, take] = values as [string, string, number, number];
     const stored = columnStore.get(`${mail_id}:${column}`) ?? "";
+    // Code points, not code units — Postgres offsets a text column by
+    // characters. See the same note in session-utils-lazy-text.test.ts (#765).
+    const codePoints = [...stored];
     const start = Math.max(0, offset - 1);
-    const chunk = stored.slice(start, start + take);
+    const chunk = codePoints.slice(start, start + take).join("");
     substringCalls.push({ column, take, returnedChars: chunk.length });
     return { rows: [{ chunk }], rowCount: 1 };
   }

--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -30,9 +30,17 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const [mail_id, , offset, take] = values as [string, string, number, number];
     substringCalls.push({ column, offset, take });
     const stored = columnStore.get(`${mail_id}:${column}`) ?? "";
-    // Pg SUBSTRING FROM is 1-indexed. Clamp for offsets past end.
+    // Pg SUBSTRING FROM is 1-indexed and counts CHARACTERS (code points),
+    // NOT UTF-16 code units. `String.slice` counts code units, so a mock
+    // built on it disagrees with Postgres for any body containing an
+    // astral character — and, because the reader used to advance its
+    // offset in code units too, the two errors cancelled and the emoji
+    // round-trip test below passed against a stream that silently dropped
+    // characters in prod (#765). Spreading to an array gives code points,
+    // which is the unit Postgres actually uses.
+    const codePoints = [...stored];
     const start = Math.max(0, offset - 1);
-    const chunk = stored.slice(start, start + take);
+    const chunk = codePoints.slice(start, start + take).join("");
     return { rows: [{ chunk }], rowCount: 1 };
   }
   // Fail loud if a SUBSTRING call arrives in a shape the mock doesn't

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -68,18 +68,71 @@ export async function* pgTextChunks(
   // and throws `invalid escape string`. Every lazy-body BODY[] stream
   // fails on the first chunk with no client-side surface (the response
   // never assembles). Explicit `::int` casts pin the intended overload.
-  let offset = 1;
-  for (;;) {
+  yield* pageByCodePoints(async (offset, take) => {
     const sql = `SELECT SUBSTRING(${sourceColumn} FROM $3::int FOR $4::int) AS chunk
                  FROM mails WHERE mail_id = $1 AND user_id = $2`;
-    const result = await pool.query(sql, [mail_id, user_id, offset, chunkChars]);
-    const chunk = (result.rows[0]?.chunk ?? "") as string;
+    const result = await pool.query(sql, [mail_id, user_id, offset, take]);
+    return (result.rows[0]?.chunk ?? "") as string;
+  }, chunkChars);
+}
+
+/**
+ * The paging loop behind `pgTextChunks`, over any 1-indexed
+ * character-addressed source. Split out from the SQL so the offset
+ * arithmetic — the part that was wrong in #765 — is testable without a
+ * process-global `pg` double; the server suite has a dozen files
+ * installing their own pool mock and the first importer of `client.ts`
+ * binds it for the whole run, so a mock-based test here is not reliable.
+ *
+ * `readChunk(offset, take)` must have Postgres `SUBSTRING` semantics:
+ * 1-indexed, counting CHARACTERS, returning "" once `offset` is past the
+ * end (the terminator).
+ */
+export async function* pageByCodePoints(
+  readChunk: (offset: number, take: number) => Promise<string>,
+  chunkChars: number
+): AsyncGenerator<string, void, unknown> {
+  let offset = 1;
+  for (;;) {
+    const chunk = await readChunk(offset, chunkChars);
     if (chunk.length === 0) return;
     yield chunk;
-    if (chunk.length < chunkChars) return;
-    offset += chunk.length;
+    // `offset` is a Postgres SUBSTRING offset, so it counts CHARACTERS —
+    // one per code point. `chunk.length` counts UTF-16 code units, which
+    // is two for every non-BMP character (emoji, rarer CJK). Advancing by
+    // the code-unit count overshoots by exactly the number of astral
+    // characters in the chunk, silently SKIPPING that many characters at
+    // every chunk boundary. The stream then emits fewer octets than
+    // `octet_length()` measured, which is the value `segmentByteLength`
+    // already advertised in the `{N}` literal — so a strict client reads
+    // the response trailer as body and the connection desynchronizes
+    // (#765). The same count decides termination: a final chunk of
+    // 11_999 characters that includes one astral char has `.length`
+    // 12_000 and would not look short.
+    const codePoints = countCodePoints(chunk);
+    if (codePoints < chunkChars) return;
+    offset += codePoints;
   }
 }
+
+/**
+ * Code points in a UTF-16 string — `[...s].length` without allocating an
+ * array per chunk. Postgres hands back well-formed UTF-8, so every high
+ * surrogate here is followed by its low half; the pair check is still
+ * explicit so a lone surrogate counts as one rather than swallowing the
+ * next character.
+ */
+const countCodePoints = (s: string): number => {
+  let count = 0;
+  for (let i = 0; i < s.length; i++, count++) {
+    const code = s.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff && i + 1 < s.length) {
+      const next = s.charCodeAt(i + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) i++;
+    }
+  }
+  return count;
+};
 
 /**
  * Callers pass `mailbox` as the raw IMAP box path (e.g. `INBOX/accounts/amazon`,

--- a/src/server/lib/postgres/repositories/mails/pg-text-chunks.test.ts
+++ b/src/server/lib/postgres/repositories/mails/pg-text-chunks.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Offset-arithmetic tests for the mail-body pager behind `pgTextChunks`
+ * (inbox #765).
+ *
+ * The reader pages a mail body with `SUBSTRING(<col> FROM $off FOR $take)`.
+ * Postgres offsets a `text` column by CHARACTERS — one per code point —
+ * while `String.prototype.length` counts UTF-16 code units, two for every
+ * non-BMP character. Advancing the offset by the code-unit count overshoots
+ * by exactly the number of astral characters in the chunk, dropping that
+ * many characters at each boundary. Because `segmentByteLength` advertises
+ * `octet_length()` in the `{N}` literal, the loss also shortens the literal
+ * and desynchronizes strict IMAP clients.
+ *
+ * `pageByCodePoints` takes the reader as an argument, so these tests drive
+ * the real loop against a Postgres-accurate fake WITHOUT `mock.module("pg")`.
+ * That matters: `mock.module` is process-global in Bun
+ * (reference_bun_mock_module_global_hoisting.md) and a dozen files in this
+ * suite install their own pool double — the first importer of `client.ts`
+ * binds it for the whole run, so a mock-based test here passes alone and
+ * fails in `bun test src/server`.
+ *
+ * The fake below slices by CODE POINT, which is what Postgres does. The pool
+ * mocks in the IMAP suites used `String.slice` (code units); that error
+ * cancelled the reader's identical error, which is why their emoji
+ * round-trip test passed against a stream that dropped characters in prod.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { pageByCodePoints, PG_TEXT_CHUNK_CHARS } from "./imap";
+
+/**
+ * `SUBSTRING(col FROM offset FOR take)` over a JS string: 1-indexed,
+ * counting code points, "" once offset is past the end.
+ */
+const postgresLikeReader = (stored: string, calls: number[]) =>
+  async (offset: number, take: number): Promise<string> => {
+    calls.push(offset);
+    const codePoints = [...stored];
+    const start = Math.max(0, offset - 1);
+    return codePoints.slice(start, start + take).join("");
+  };
+
+const drain = async (stored: string, chunkChars: number) => {
+  const offsets: number[] = [];
+  const parts: string[] = [];
+  for await (const chunk of pageByCodePoints(postgresLikeReader(stored, offsets), chunkChars)) {
+    parts.push(chunk);
+  }
+  return { out: parts.join(""), offsets };
+};
+
+describe("pageByCodePoints reassembles the column exactly (#765)", () => {
+  it("round-trips a pure-ASCII column (control — passes with either offset unit)", async () => {
+    const body = "abcdefghij".repeat(50); // 500 chars, no astral
+    const { out, offsets } = await drain(body, 100);
+    expect(out).toBe(body);
+    expect(offsets.slice(0, 5)).toEqual([1, 101, 201, 301, 401]);
+  });
+
+  it("round-trips a column whose chunks contain astral characters", async () => {
+    // Each 🙂 is ONE Postgres character but TWO UTF-16 code units. With 4
+    // per 12-code-point group, a 100-character chunk overshoots by ~33 code
+    // units under the old arithmetic — that many characters silently
+    // skipped at every boundary.
+    const body = "ab🙂cd🙂ef🙂gh🙂".repeat(60); // 720 code points
+    const { out, offsets } = await drain(body, 100);
+
+    expect(out).toBe(body);
+    // The literal-length invariant: what the stream emits must equal the
+    // octet count `octet_length()` reports, which is what `{N}` advertises.
+    expect(Buffer.byteLength(out, "utf8")).toBe(Buffer.byteLength(body, "utf8"));
+    // Offsets must advance by CODE POINTS (100), not code units (which
+    // would be 100 + astralCount and would leave gaps).
+    expect(offsets.slice(0, 5)).toEqual([1, 101, 201, 301, 401]);
+  });
+
+  it("does not drop the character sitting exactly on a chunk boundary", async () => {
+    const body = "x".repeat(9) + "🙂" + "y".repeat(9) + "🙂" + "z".repeat(9);
+    const { out } = await drain(body, 10);
+    expect(out).toBe(body);
+    expect([...out].length).toBe([...body].length);
+  });
+
+  it("terminates on a final chunk that is short in CODE POINTS", async () => {
+    // 12 code points / 16 code units at chunkChars = 16: the old check
+    // (`chunk.length < chunkChars`) sees 16 and keeps paging; the
+    // code-point check sees 12 and stops.
+    const body = "ab🙂cd🙂ef🙂gh🙂";
+    const { out, offsets } = await drain(body, 16);
+    expect(out).toBe(body);
+    expect(offsets.length).toBe(1);
+  });
+
+  it("handles a column that is entirely astral characters", async () => {
+    const body = "🙂".repeat(250); // 250 code points, 500 code units
+    const { out, offsets } = await drain(body, 100);
+    expect(out).toBe(body);
+    expect(Buffer.byteLength(out, "utf8")).toBe(1000); // 4 bytes each
+    expect(offsets.slice(0, 3)).toEqual([1, 101, 201]);
+  });
+
+  it("mixes multi-byte BMP and astral characters without drift", async () => {
+    // café (BMP accents, 2 bytes) + ☕/日本語 (3 bytes) + 😀 (astral, 4
+    // bytes). Only the astral char costs two code units — the BMP
+    // multi-byte characters are a control showing byte-length alone is not
+    // the confusion.
+    const body = "café ☕ 日本語 😀 ".repeat(500);
+    const { out } = await drain(body, PG_TEXT_CHUNK_CHARS);
+    expect(out).toBe(body);
+    expect(Buffer.byteLength(out, "utf8")).toBe(Buffer.byteLength(body, "utf8"));
+  });
+
+  it("returns nothing for an absent column without paging forever", async () => {
+    const { out, offsets } = await drain("", 100);
+    expect(out).toBe("");
+    expect(offsets.length).toBe(1);
+  });
+
+  it("stops after one read when the column is exactly one short chunk", async () => {
+    const body = "abc";
+    const { out, offsets } = await drain(body, 100);
+    expect(out).toBe(body);
+    expect(offsets).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary

`pgTextChunks` pages a mail body with `SUBSTRING(<col> FROM $off FOR $take)` and advanced `$off` by `chunk.length`. That counts **UTF-16 code units**; a Postgres `text` offset counts **characters**. Every non-BMP character (emoji, rarer CJK) makes the two disagree by one, so the reader skipped one character per astral character at each chunk boundary.

Two consequences, both live in prod:

- **Silent data loss** — characters dropped from the body delivered to the client.
- **Short literal** — the stream emits fewer octets than `octet_length()` measured, and that measurement is what `segmentByteLength` already put in the `{N}` literal. A strict client reads the `)\r\n<tag> OK FETCH completed\r\n` trailer as body and the connection desynchronizes for every later command. That is the symptom reported in the issue.

## The issue's guess was wrong — measurement instead

The issue proposed `emitAttachment` as the source. It is not: that function already pads to `advertised` on every exit path (`session-utils.ts` lines 680-688 on `upstream/main`). The correlation with attachment count was coincidental — those mails also carry emoji.

Replaying both offset arithmetics against the local dev DB for uid 10154, the mail in the issue's table:

| column | `octet_length()` | streamed, offset by code UNITS | streamed, offset by code POINTS |
|---|---|---|---|
| `text` | 12877 | 12837 (−40) | 12877 — exact |
| `html` | 3156561 | 3156521 (−40) | 3156561 — exact |

## What changes

- `pgTextChunks` advances by `countCodePoints(chunk)`. The same count decides termination: a final chunk of 11999 characters containing one astral char has `.length` 12000 and would not look short.
- `countCodePoints` is an explicit surrogate-pair walk rather than `[...s].length`, so it does not allocate an array per chunk on the hot body-stream path.
- The paging loop is split out as `pageByCodePoints(readChunk, chunkChars)`. Rationale in "Testing note" below.
- The pool mocks in `session-utils-lazy-text.test.ts` and `fetch-helpers-lazy-body.test.ts` now slice by code point, matching Postgres.

## Testing note — why the existing emoji test did not catch this

`session-utils-lazy-text.test.ts` already has a test named *"stream produces byte-identical output to base64(mail.html) even split into ~12k chunks"* whose body is `"café ☕ 日本語 😀 ".repeat(2000)` with the comment *"6-byte-per-char emoji is the worst case."* It passed — because its mock sliced with `String.slice` (code units) and that error exactly cancelled the reader's identical error. Correcting the mock makes that existing test fail on `upstream/main` and pass here.

Two wrong units cancelling is also why a pg-mock-based test for the new behaviour is fragile: `mock.module` is process-global in Bun and a dozen files in this suite install their own pool double, so the first importer of `client.ts` binds it for the whole run. A mock-based version of these tests passed alone and failed under `bun test src/server`. `pageByCodePoints` takes its reader as an argument, so the arithmetic is tested against a Postgres-accurate fake with no module double at all.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — no new warnings on touched files.
- [x] `bun test src/server` — **1511 pass / 0 fail** (was 1503 tests; +8 new).
- [x] New `pg-text-chunks.test.ts`: ASCII control, astral round-trip, character on the boundary, short-final-chunk termination, all-astral column, mixed BMP-multibyte + astral, empty column, single-short-chunk.
- [x] **Red without the fix**: reverting the one arithmetic line turns 4 of the 8 red; the ASCII/empty controls stay green, confirming they discriminate.
- [x] Corrected mock makes the pre-existing emoji round-trip test a real assertion.

### E2E — live IMAP against the local dev DB

Started the server and drove a real IMAP session (`LOGIN` → `SELECT INBOX` → `UID FETCH <uid> BODY.PEEK[]`), reading raw socket bytes and comparing the octets after `{N}\r\n` against the declared `N`. All three mails from the issue's reproduction table:

| uid | attachments | declared `{N}` | before: octets available | after: octets available | trailer seen after literal |
|---|---|---|---|---|---|
| 10154 | 11 | 4229056 | 4228974 — **short** | 4229082 — **exact** | `)\r\na3 OK FETCH completed\r\n` |
| 9802 | 7 | 4226786 | short | **exact** | `)\r\na3 OK FETCH completed\r\n` |
| 279 | 0 | 17939 | exact (control) | **exact** | `)\r\na3 OK FETCH completed\r\n` |

Before the fix the check reported `emittedEqualsDeclared: false` and no trailer — the desync in the issue. After, every mail emits at least its declared count and the tagged completion lands where the client expects it. The attachment-free control is unchanged.

Closes #765
