### PR TITLE
perf(imap): stream BODY[TEXT] and BODY[<part>] lazily, partial included (#757)

### DIFF
--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -97,6 +97,13 @@ const release = (): void => {
  * even if `fn` throws. When the caller is inside a
  * `runInBodyBudgetContext` scope, the wait time (0 if the acquire was
  * immediate) is added to that scope's ledger.
+ *
+ * **No production caller as of #757** — every fetch path that used to
+ * materialize a body now streams, so `withBodyBudgetStream` holds the slot
+ * instead. Kept as the promise-shaped entry point to the SAME semaphore
+ * (`acquire` / `release` / `waitQueue` / the ledger), which is what
+ * `body-budget.test.ts` exercises directly; a materializing caller added
+ * later must go through the budget rather than around it.
  */
 export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
   await acquire();

--- a/src/server/lib/imap/body-budget.ts
+++ b/src/server/lib/imap/body-budget.ts
@@ -103,7 +103,8 @@ const release = (): void => {
  * instead. Kept as the promise-shaped entry point to the SAME semaphore
  * (`acquire` / `release` / `waitQueue` / the ledger), which is what
  * `body-budget.test.ts` exercises directly; a materializing caller added
- * later must go through the budget rather than around it.
+ * later must go through the budget rather than around it. Deletion — and
+ * the test port it requires — tracked in #834.
  */
 export const withBodyBudget = async <T>(fn: () => Promise<T>): Promise<T> => {
   await acquire();

--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -23,7 +23,12 @@ import { describe, it, expect, mock, beforeAll, afterAll } from "bun:test";
 import { restoreLeaves } from "test-helpers";
 import type { MailType } from "common";
 
-const substringCalls: Array<{ column: "text" | "html"; take: number; returnedChars: number }> = [];
+const substringCalls: Array<{
+  column: "text" | "html";
+  unit: "chars" | "bytes";
+  take: number;
+  returned: number;
+}> = [];
 const columnStore = new Map<string, string>();
 
 const mockQuery = mock(async (sql: string, values: unknown[]) => {
@@ -37,7 +42,28 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const codePoints = [...stored];
     const start = Math.max(0, offset - 1);
     const chunk = codePoints.slice(start, start + take).join("");
-    substringCalls.push({ column, take, returnedChars: chunk.length });
+    substringCalls.push({ column, unit: "chars", take, returned: chunk.length });
+    return { rows: [{ chunk }], rowCount: 1 };
+  }
+  // pgByteChunks' shape — the partial BODY[TEXT] / BODY[<part>] windows
+  // seek by BYTE offset so they can start mid-column instead of draining
+  // from code point 1. `convert_to(col, 'UTF8')` on a UTF8 server encoding
+  // returns the column's raw bytes verbatim, so the mock encodes the
+  // stored text and returns the byte range. Splitting a multi-byte
+  // sequence at a boundary is intentional: the consumer base64-encodes
+  // the bytes, it never decodes them. Same branch as the one in
+  // session-utils-lazy-text.test.ts.
+  const byteSubstringMatch = sql.match(
+    /SUBSTRING\(convert_to\((text|html),\s*'UTF8'\)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/
+  );
+  if (byteSubstringMatch) {
+    const column = byteSubstringMatch[1] as "text" | "html";
+    const [mail_id, , offset, take] = values as [string, string, number, number];
+    const stored = columnStore.get(`${mail_id}:${column}`) ?? "";
+    const bytes = Buffer.from(stored, "utf8");
+    const start = Math.max(0, offset - 1);
+    const chunk = bytes.subarray(start, start + take);
+    substringCalls.push({ column, unit: "bytes", take, returned: chunk.byteLength });
     return { rows: [{ chunk }], rowCount: 1 };
   }
   // Fail loud on unrecognized SUBSTRING — mirrors the guard in
@@ -46,8 +72,9 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
   // regex is stale."
   if (/SUBSTRING/i.test(sql)) {
     throw new Error(
-      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks SQL. ` +
-      `Expected /SUBSTRING\\((text|html)\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
+      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks / pgByteChunks SQL. ` +
+      `Expected pgTextChunks /SUBSTRING\\((text|html) FROM \\$3::int FOR \\$4::int\\)/ or ` +
+      `pgByteChunks /SUBSTRING\\(convert_to\\((text|html), 'UTF8'\\) FROM \\$3::int FOR \\$4::int\\)/, got: ${sql}`
     );
   }
   // Any other query (e.g. rfc822_size persist) just no-ops with an empty
@@ -72,7 +99,7 @@ mock.module("pg", pgMock);
 
 const { buildFetchResponsePart } = await import("./fetch-helpers");
 const { resetPool } = await import("../postgres/client");
-const { PG_TEXT_CHUNK_CHARS } = await import(
+const { PG_TEXT_CHUNK_CHARS, PG_TEXT_CHUNK_BYTES } = await import(
   "../postgres/repositories/mails/imap"
 );
 
@@ -143,9 +170,14 @@ describe("BODY[] peak-transient bound: 500 KB lazy body streams in chunks, not o
     // the SUBSTRING and re-added `SELECT text, html FROM mails ...`, this
     // would see one giant pull (or zero, if the SUBSTRING never fired).
     expect(substringCalls.length).toBeGreaterThan(0);
+    expect(substringCalls.map((c) => c.unit)).toEqual(
+      substringCalls.map(() => "chars")
+    );
+    expect(substringCalls.map((c) => c.take)).toEqual(
+      substringCalls.map(() => PG_TEXT_CHUNK_CHARS)
+    );
     for (const call of substringCalls) {
-      expect(call.take).toBe(PG_TEXT_CHUNK_CHARS);
-      expect(call.returnedChars).toBeLessThanOrEqual(PG_TEXT_CHUNK_CHARS);
+      expect(call.returned).toBeLessThanOrEqual(PG_TEXT_CHUNK_CHARS);
     }
 
     // Chunk count MUST scale with body size. A single giant pull (the
@@ -269,9 +301,9 @@ describe("BODY[] peak-transient bound: 500 KB lazy body streams in chunks, not o
       expect(substringCalls.length).toBeGreaterThanOrEqual(
         Math.floor(html.length / PG_TEXT_CHUNK_CHARS)
       );
-      for (const call of substringCalls) {
-        expect(call.take).toBe(PG_TEXT_CHUNK_CHARS);
-      }
+      expect(substringCalls.map((c) => c.take)).toEqual(
+        substringCalls.map(() => PG_TEXT_CHUNK_CHARS)
+      );
     });
   }
 
@@ -315,8 +347,18 @@ describe("BODY[] peak-transient bound: 500 KB lazy body streams in chunks, not o
     // column per window would make the pipeline O(n²) in round-trips and
     // put the whole body back in flight. `sliceStream` closes the upstream
     // generator via for-await `.return()` the moment `take` is satisfied.
-    const fullBodyPulls = Math.floor(html.length / PG_TEXT_CHUNK_CHARS);
-    expect(substringCalls.length).toBeGreaterThan(0);
-    expect(substringCalls.length).toBeLessThan(fullBodyPulls);
+    //
+    // The partial path seeks by BYTE (pgByteChunks), so the pull count is
+    // bounded by the window, not by the column: exactly enough 48 KiB byte
+    // pulls to cover 64 KiB. Pinning the exact count rather than "less than
+    // a full drain" is what makes this bite — a regression that dropped the
+    // early `.return()` would still land under a full-drain bound while
+    // reading far more than the window needs.
+    expect(substringCalls.map((c) => c.unit)).toEqual(
+      substringCalls.map(() => "bytes")
+    );
+    expect(substringCalls.length).toBe(
+      Math.ceil((64 * 1024) / PG_TEXT_CHUNK_BYTES)
+    );
   });
 });

--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -361,4 +361,111 @@ describe("BODY[] peak-transient bound: 500 KB lazy body streams in chunks, not o
       Math.ceil((64 * 1024) / PG_TEXT_CHUNK_BYTES)
     );
   });
+
+  // The test above only exercises `start: 0`, where "reads only its own
+  // slice" is trivially true — there is nothing before the window to skip,
+  // so a reader that drained from position 1 and discarded would pass it
+  // unchanged. The property that actually matters is that the cost of
+  // window k does NOT grow with k. This sweep drives the whole body as
+  // consecutive 64 KiB windows — the shape iOS Mail issues for a large
+  // message — and pins both the per-window bound and the total.
+  //
+  // Under a from-position-1-and-discard reader the per-window counts climb
+  // linearly (5, 9, 13, ... ) and the total is P·(W+1)/2 — ~33x a single
+  // full pass on a 4 MB body, i.e. minutes per body at the measured
+  // per-pass latency. `streamLazyTextPartial` seeks pgByteChunks to the
+  // 3-byte-aligned raw offset for the window instead, so each window costs
+  // O(len) and the total is O(body), not O(body²/window).
+  it("consecutive partial BODY[TEXT] windows cost O(window) each, not O(offset)", async () => {
+    columnStore.clear();
+    const html = "<p>" + "v".repeat(500 * 1024 - 8) + "</p>";
+    columnStore.set("mail-window-walk:html", html);
+
+    const mail = {
+      ...baseHeaders,
+      text_octets: 0,
+      html_octets: Buffer.byteLength(html, "utf8"),
+      mail_id: "mail-window-walk",
+      user_id: "user-1",
+    } as never;
+
+    const windowLength = 64 * 1024;
+    const readSection = async (
+      partial?: { start: number; length: number }
+    ): Promise<{ body: Buffer; pulls: number; declared: number }> => {
+      substringCalls.length = 0;
+      const part = await buildFetchResponsePart(
+        mail,
+        { type: "BODY", peek: true, section: { type: "TEXT" }, ...(partial ? { partial } : {}) },
+        "mail-window-walk",
+        "INBOX"
+      );
+      if (part === null || part.type !== "stream") throw new Error("expected stream");
+      const chunks: Buffer[] = [];
+      for await (const chunk of part.stream) chunks.push(chunk);
+      return {
+        body: Buffer.concat(chunks as unknown as Uint8Array[]),
+        pulls: substringCalls.length,
+        declared: part.length,
+      };
+    };
+
+    // Baseline: one unwindowed pass over the same section. Its trailing
+    // CRLF is IMAP framing appended after the section, not part of the
+    // octets a `<start.length>` range addresses — so compare against the
+    // body minus that trailer.
+    const full = await readSection();
+    const fullBody = full.body.subarray(0, full.body.byteLength - 2);
+    const fullPassPulls = full.pulls;
+    expect(fullPassPulls).toBeGreaterThan(0);
+
+    const windowCount = Math.ceil(fullBody.byteLength / windowLength);
+    // A 500 KB body at 64 KiB per window — enough windows that a linear
+    // per-window climb is unmistakable against a flat one.
+    expect(windowCount).toBeGreaterThanOrEqual(8);
+
+    const perWindowPulls: number[] = [];
+    const collected: Buffer[] = [];
+    for (let k = 0; k < windowCount; k++) {
+      const start = k * windowLength;
+      const { body, pulls, declared } = await readSection({ start, length: windowLength });
+      // Every window reads by BYTE offset — a regression to the
+      // code-point reader (`unit: "chars"`) would re-introduce #765's
+      // over-advance on astral characters as well as the cost climb.
+      expect(substringCalls.map((c) => c.unit)).toEqual(
+        substringCalls.map(() => "bytes")
+      );
+      expect(body.byteLength).toBe(declared);
+      expect(declared).toBe(Math.min(windowLength, fullBody.byteLength - start));
+      perWindowPulls.push(pulls);
+      collected.push(body);
+    }
+
+    // 1. Correctness first: the windows must reassemble into exactly the
+    //    unwindowed section. Byte-seeking past a base64 boundary is the
+    //    way this fix could be fast and WRONG, so cost assertions below
+    //    only mean anything with this one holding.
+    expect(Buffer.concat(collected as unknown as Uint8Array[]).equals(fullBody as unknown as Uint8Array)).toBe(true);
+
+    // 2. Per-window cost is bounded by the WINDOW, not the offset. The
+    //    `+ 1` is the at-most-one extra pull from aligning the seek down
+    //    to the 3-raw-byte / 4-base64-char grid; it is a constant, not a
+    //    function of k.
+    const windowBound = Math.ceil(windowLength / PG_TEXT_CHUNK_BYTES) + 1;
+    for (const pulls of perWindowPulls) {
+      expect(pulls).toBeLessThanOrEqual(windowBound);
+    }
+
+    // 3. The anti-quadratic assertion. The last window sits ~450 KB into
+    //    the column; if it cost anything like its offset it would dwarf
+    //    the first. Compare the tail window against the first — flat, not
+    //    climbing.
+    expect(perWindowPulls[windowCount - 1]).toBeLessThanOrEqual(perWindowPulls[0] + 1);
+
+    // 4. And in aggregate: walking the whole body in windows stays within
+    //    a small constant of a single full pass. The discard reader would
+    //    land at ~(windowCount+1)/2 times it.
+    const totalPulls = perWindowPulls.reduce((a, b) => a + b, 0);
+    expect(totalPulls).toBeLessThanOrEqual(fullPassPulls + windowCount + 1);
+  });
 });

--- a/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
+++ b/src/server/lib/imap/fetch-helpers-lazy-body.test.ts
@@ -202,4 +202,121 @@ describe("BODY[] peak-transient bound: 500 KB lazy body streams in chunks, not o
     // never touches the pg reader.
     expect(substringCalls.length).toBe(0);
   });
+
+  // #757: BODY[] was the only section on the lazy path. TEXT and
+  // MIME_PART projected the materialized `text`/`html` columns, so each
+  // command held O(sizeof(text) + sizeof(html)) in V8's heap for its
+  // whole duration — invisible to the concurrency and bytes-in-flight
+  // budgets (#727 / #753), which bound CONCURRENT builds and a
+  // same-socket pipeline is serial by construction
+  // (`handler.ts` awaits each `handleRequest`). 14 of these back to back
+  // is the 144 → 272 MB climb the issue recorded. These tests pin every
+  // body-bearing section onto the chunked reader.
+  const sectionCases: Array<{
+    label: string;
+    fetch: Parameters<typeof buildFetchResponsePart>[1];
+  }> = [
+    { label: "BODY[TEXT]", fetch: { type: "BODY", peek: true, section: { type: "TEXT" } } },
+    {
+      label: "BODY[1]",
+      fetch: { type: "BODY", peek: true, section: { type: "MIME_PART", partNumber: "1" } },
+    },
+    {
+      label: "BODY[1.TEXT]",
+      fetch: {
+        type: "BODY",
+        peek: true,
+        section: { type: "MIME_PART", partNumber: "1", subSection: "TEXT" },
+      },
+    },
+    { label: "RFC822.TEXT", fetch: { type: "RFC822.TEXT" } },
+  ];
+
+  for (const { label, fetch } of sectionCases) {
+    it(`${label} streams a 500 KB lazy body through chunked SUBSTRING, never one allocation`, async () => {
+      substringCalls.length = 0;
+      columnStore.clear();
+      const html = "<p>" + "z".repeat(500 * 1024 - 8) + "</p>";
+      columnStore.set(`mail-${label}:html`, html);
+
+      const mail = {
+        ...baseHeaders,
+        text_octets: 0,
+        html_octets: Buffer.byteLength(html, "utf8"),
+        mail_id: `mail-${label}`,
+        user_id: "user-1",
+      } as never;
+
+      const part = await buildFetchResponsePart(mail, fetch, `mail-${label}`, "INBOX");
+
+      expect(part).not.toBeNull();
+      expect(part!.type).toBe("stream");
+      if (part!.type !== "stream") throw new Error("expected stream");
+
+      let emitted = 0;
+      let maxChunk = 0;
+      for await (const chunk of part.stream) {
+        emitted += chunk.byteLength;
+        if (chunk.byteLength > maxChunk) maxChunk = chunk.byteLength;
+      }
+
+      expect(emitted).toBe(part.length);
+      expect(maxChunk).toBeLessThan(80 * 1024);
+      // The whole point: the column arrived in bounded pulls. A regression
+      // that re-added `text`/`html` to the projection would make
+      // `wantsLazyBodies` false, emit `base64` segments off the
+      // materialized string, and fire ZERO SUBSTRING calls.
+      expect(substringCalls.length).toBeGreaterThanOrEqual(
+        Math.floor(html.length / PG_TEXT_CHUNK_CHARS)
+      );
+      for (const call of substringCalls) {
+        expect(call.take).toBe(PG_TEXT_CHUNK_CHARS);
+      }
+    });
+  }
+
+  it("a partial BODY[TEXT] window stops pulling once its range is satisfied", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    const html = "<p>" + "w".repeat(500 * 1024 - 8) + "</p>";
+    columnStore.set("mail-partial-text:html", html);
+
+    const mail = {
+      ...baseHeaders,
+      text_octets: 0,
+      html_octets: Buffer.byteLength(html, "utf8"),
+      mail_id: "mail-partial-text",
+      user_id: "user-1",
+    } as never;
+
+    const part = await buildFetchResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "TEXT" },
+        partial: { start: 0, length: 64 * 1024 },
+      },
+      "mail-partial-text",
+      "INBOX"
+    );
+
+    expect(part).not.toBeNull();
+    expect(part!.type).toBe("stream");
+    if (part!.type !== "stream") throw new Error("expected stream");
+
+    let emitted = 0;
+    for await (const chunk of part.stream) emitted += chunk.byteLength;
+    expect(emitted).toBe(part.length);
+    expect(part.length).toBe(64 * 1024);
+
+    // iOS Mail pulls a large body as a sequence of 64 KiB partial windows.
+    // Each window must read only its own slice — driving the full 500 KB
+    // column per window would make the pipeline O(n²) in round-trips and
+    // put the whole body back in flight. `sliceStream` closes the upstream
+    // generator via for-await `.return()` the moment `take` is satisfied.
+    const fullBodyPulls = Math.floor(html.length / PG_TEXT_CHUNK_CHARS);
+    expect(substringCalls.length).toBeGreaterThan(0);
+    expect(substringCalls.length).toBeLessThan(fullBodyPulls);
+  });
 });

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -248,19 +248,28 @@ describe("getRequestedFields", () => {
       });
     }
 
-    // `getBodyPartHeaders` decides part existence off `mail.text.trim()`
-    // and has no streaming counterpart, so these two keep the strings.
+    // `getBodyPartHeaders` needs only "does a text/html part exist",
+    // which `resolveBodyPresence` answers from the octet counts. Pulling
+    // the strings would make `UID FETCH 1:* (BODY.PEEK[1.MIME])` project
+    // every row's full body — #757's allocation shape — to compute two
+    // booleans.
     for (const sub of ["MIME", "HEADER"] as const) {
-      it(`BODY[1.${sub}] still projects text/html — getBodyPartHeaders needs them`, () => {
+      it(`BODY[1.${sub}] projects the octet counts, NOT text/html`, () => {
         const fields = bodyFetch({ type: "MIME_PART", partNumber: "1", subSection: sub });
-        expect(fields.has("text")).toBe(true);
-        expect(fields.has("html")).toBe(true);
+        expect(fields.has("text")).toBe(false);
+        expect(fields.has("html")).toBe(false);
+        for (const f of ["text_octets", "html_octets", "mail_id", "user_id"] as const) {
+          expect(fields.has(f as FetchRequestedField)).toBe(true);
+        }
       });
     }
 
-    // Union semantics: one FETCH asking for both shapes must still get
-    // the materialized columns, or the .MIME half silently drops.
-    it("BODY[TEXT] + BODY[1.MIME] in one FETCH projects text/html for the .MIME half", () => {
+    // Union semantics: the projection is a per-command union, so a single
+    // FETCH pairing the two shapes must stay lazy end to end. If `.MIME`
+    // re-added the strings, `wantsLazyBodies` would go false and the
+    // BODY[TEXT] half would materialize the whole body — giving back the
+    // entire win for that command.
+    it("BODY[TEXT] + BODY[1.MIME] in one FETCH stays lazy — no text/html in the union", () => {
       const fields = getRequestedFields([
         { type: "BODY", peek: true, section: { type: "TEXT" } },
         {
@@ -269,8 +278,11 @@ describe("getRequestedFields", () => {
           section: { type: "MIME_PART", partNumber: "1", subSection: "MIME" },
         },
       ]);
-      expect(fields.has("text")).toBe(true);
-      expect(fields.has("html")).toBe(true);
+      expect(fields.has("text")).toBe(false);
+      expect(fields.has("html")).toBe(false);
+      for (const f of ["text_octets", "html_octets", "mail_id", "user_id"] as const) {
+        expect(fields.has(f as FetchRequestedField)).toBe(true);
+      }
     });
   });
 
@@ -1817,20 +1829,19 @@ describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 
   // FETCH tuple with no diagnostic). Both now take the segment walker
   // and stream correctly — that is the fix, asserted positively below.
   //
-  // `.MIME` / `.HEADER` is the one sub-section with no streaming
-  // counterpart, so it still depends on the projection keeping
-  // `text`/`html`; its null-return on a lazy-only mail stays pinned as
-  // the guard for that dependency.
-  it("BODY[1.MIME] on lazy-only mail (text/html undefined) — silent null-return via short-circuit", async () => {
+  // `.MIME` / `.HEADER` has no streaming counterpart — it returns a few
+  // hundred bytes of static MIME header — but it no longer needs the
+  // materialized strings either: `getBodyPartHeaders` reads part
+  // existence through `resolveBodyPresence`, which prefers the octet
+  // counts. Previously this shape hit
+  // `mail.text && mail.text.trim().length > 0` with `text` undefined,
+  // short-circuited to falsy, and fired the early
+  // `!hasAttachments && !hasText && !hasHtml → return null` — a SILENT
+  // null-return that dropped the response part from the FETCH tuple with
+  // no diagnostic. Pinned positively now: the part is emitted, and it
+  // names the same part `BODY[1]` streams.
+  it("BODY[1.MIME] on lazy-only mail (text/html undefined) returns the part's MIME header", async () => {
     const mail = prodShapeMail({ text: undefined as unknown as string, html: undefined as unknown as string });
-    // `getBodyPartHeaders`'s predicate is
-    // `mail.text && mail.text.trim().length > 0` — undefined
-    // short-circuits before `.trim()`, `hasText`/`hasHtml` degrade to
-    // falsy, and the early `!hasAttachments && !hasText && !hasHtml
-    // → return null` fires. Silent null-return (NOT a throw) — the
-    // response part is dropped from the FETCH tuple with no
-    // diagnostic. That's the class of wrong-shape bug the projection
-    // guards against.
     const part = await buildBodyResponsePart(
       mail,
       {
@@ -1841,7 +1852,53 @@ describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 
       "doc-prod-mime-lazy",
       "INBOX"
     );
-    expect(part).toBeNull();
+    expect(part).not.toBeNull();
+    expect(part!.type).toBe("literal");
+    if (part!.type !== "literal") throw new Error("expected literal");
+    // text_octets > 0 AND html_octets > 0 → multipart/alternative, so
+    // part 1 is the text/plain half. Same numbering `buildMessageSegments`
+    // assigns, which is the invariant `resolveBodyPresence` exists to hold.
+    expect(part.content).toContain("Content-Type: text/plain; charset=utf-8");
+  });
+
+  // The whitespace-only divergence `resolveBodyPresence` documents, made
+  // explicit: on the materialized path a `"   "` body is NOT a part; on
+  // the lazy path a non-zero octet count says it is. Both callers read
+  // the same helper, so `BODY[1.MIME]` and `BODY[1]` agree either way —
+  // which is the property that actually matters on the wire.
+  it("BODY[1.MIME] and BODY[1] agree on part numbering for a text-only lazy mail", async () => {
+    const mail = prodShapeMail({
+      text: undefined as unknown as string,
+      html: undefined as unknown as string,
+      html_octets: 0,
+    });
+    const mimePart = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "MIME_PART", partNumber: "1", subSection: "MIME" },
+      },
+      "doc-prod-mime-text-only",
+      "INBOX"
+    );
+    expect(mimePart).not.toBeNull();
+    if (mimePart!.type !== "literal") throw new Error("expected literal");
+    // html_octets === 0 → single text/plain part at 1, not multipart.
+    expect(mimePart.content).toContain("Content-Type: text/plain; charset=utf-8");
+
+    // And part 2 does not exist in that structure.
+    const absent = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "MIME_PART", partNumber: "2", subSection: "MIME" },
+      },
+      "doc-prod-mime-text-only",
+      "INBOX"
+    );
+    expect(absent).toBeNull();
   });
 
   it("BODY[TEXT]<0.100> on lazy-only mail streams — no buildFullMessage, no throw", async () => {

--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -57,7 +57,7 @@ import {
   FetchMailInput,
 } from "./fetch-helpers";
 import { formatEnvelope } from "./util";
-import { BodyFetch, SequenceSet } from "./types";
+import { BodyFetch, BodySection, SequenceSet } from "./types";
 import {
   withBodyBudget,
   bodyBudgetCapacity,
@@ -200,22 +200,77 @@ describe("getRequestedFields", () => {
         { type: "BODY", peek: false, section: { type: "TEXT" } }
       ]);
       expect([...rfc].sort()).toEqual([...body].sort());
-      // Post-cache-deletion: TEXT projects BOTH materialized (text/html)
-      // AND lazy synthetics. The materialized shape is needed by the
-      // partial-fetch fall-through path (`getBodyContent → buildFullMessage`)
-      // and by `getBodyPartHeaders` for `.MIME` / `.HEADER` sub-sections;
-      // the lazy synthetics carry the segment metadata for the streaming
-      // branches. `wantsLazyBodies` reads text-undefined so the streaming
-      // path emits `base64` segments (materialized source, chunk-bounded
-      // output) rather than `lazy-text` (pgTextChunks) — this trades the
-      // lazy-segment memory win for correctness across all fall-through
-      // paths.
-      expect(rfc.has("text")).toBe(true);
-      expect(rfc.has("html")).toBe(true);
+      // #757: TEXT projects ONLY the lazy synthetics, exactly like
+      // BODY[]. Both the partial and non-partial TEXT branches stream
+      // through the segment walker now, so nothing under TEXT needs the
+      // materialized strings — and projecting them would flip
+      // `wantsLazyBodies` to false, putting O(sizeof(text)+sizeof(html))
+      // back on the V8 heap for every command.
+      expect(rfc.has("text")).toBe(false);
+      expect(rfc.has("html")).toBe(false);
       expect(rfc.has("text_octets" as FetchRequestedField)).toBe(true);
       expect(rfc.has("html_octets" as FetchRequestedField)).toBe(true);
       expect(rfc.has("mail_id" as FetchRequestedField)).toBe(true);
       expect(rfc.has("user_id" as FetchRequestedField)).toBe(true);
+    });
+  });
+
+  // #757: the per-command allocation that survived a same-socket
+  // pipelined burst. `getRequestedFields` drives the SQL projection, so
+  // a shape that adds `text`/`html` pulls the multi-MB columns into V8's
+  // heap for the whole command — 14 of those back-to-back is the
+  // 144 → 272 MB RSS climb the issue recorded. Only the two sub-sections
+  // that genuinely cannot stream may ask for them.
+  describe("body-column projection is lazy-only except for .MIME / .HEADER (#757)", () => {
+    const bodyFetch = (section: BodySection, partial?: { start: number; length: number }) =>
+      getRequestedFields([
+        { type: "BODY", peek: true, section, ...(partial ? { partial } : {}) },
+      ]);
+
+    const lazyOnlyCases: [string, BodySection, { start: number; length: number }?][] = [
+      ["BODY[]", { type: "FULL" }, undefined],
+      ["BODY[]<0.100>", { type: "FULL" }, { start: 0, length: 100 }],
+      ["BODY[TEXT]", { type: "TEXT" }, undefined],
+      ["BODY[TEXT]<0.100>", { type: "TEXT" }, { start: 0, length: 100 }],
+      ["BODY[1]", { type: "MIME_PART", partNumber: "1" }, undefined],
+      ["BODY[1]<0.100>", { type: "MIME_PART", partNumber: "1" }, { start: 0, length: 100 }],
+      ["BODY[1.TEXT]", { type: "MIME_PART", partNumber: "1", subSection: "TEXT" }, undefined],
+    ];
+
+    for (const [label, section, partial] of lazyOnlyCases) {
+      it(`${label} projects the lazy synthetics and NOT text/html`, () => {
+        const fields = bodyFetch(section, partial);
+        expect(fields.has("text")).toBe(false);
+        expect(fields.has("html")).toBe(false);
+        for (const f of ["text_octets", "html_octets", "mail_id", "user_id"] as const) {
+          expect(fields.has(f as FetchRequestedField)).toBe(true);
+        }
+      });
+    }
+
+    // `getBodyPartHeaders` decides part existence off `mail.text.trim()`
+    // and has no streaming counterpart, so these two keep the strings.
+    for (const sub of ["MIME", "HEADER"] as const) {
+      it(`BODY[1.${sub}] still projects text/html — getBodyPartHeaders needs them`, () => {
+        const fields = bodyFetch({ type: "MIME_PART", partNumber: "1", subSection: sub });
+        expect(fields.has("text")).toBe(true);
+        expect(fields.has("html")).toBe(true);
+      });
+    }
+
+    // Union semantics: one FETCH asking for both shapes must still get
+    // the materialized columns, or the .MIME half silently drops.
+    it("BODY[TEXT] + BODY[1.MIME] in one FETCH projects text/html for the .MIME half", () => {
+      const fields = getRequestedFields([
+        { type: "BODY", peek: true, section: { type: "TEXT" } },
+        {
+          type: "BODY",
+          peek: true,
+          section: { type: "MIME_PART", partNumber: "1", subSection: "MIME" },
+        },
+      ]);
+      expect(fields.has("text")).toBe(true);
+      expect(fields.has("html")).toBe(true);
     });
   });
 
@@ -1348,12 +1403,15 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     const part = await buildBodyResponsePart(mail, fetch, "doc-1", "INBOX");
 
     expect(part).not.toBeNull();
-    expect(part!.type).toBe("literal");
-    if (part!.type !== "literal") throw new Error("expected literal part");
+    // #757: partial TEXT streams through the segment walker now instead
+    // of materializing via `buildFullMessage` + slicing. The literal-length
+    // invariant below is unchanged — only the carrier is.
+    expect(part!.type).toBe("stream");
+    const emitted = await contentAsStringAny(part!);
     // The {N} literal header must match the bytes that follow it on the wire;
     // before the fix the partial branch appended an uncounted CRLF, advertising
     // {10} while emitting 12 octets and desyncing the client's parse.
-    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    expect(Buffer.byteLength(emitted, "utf8")).toBe(part!.length);
     // A <0.10> partial returns exactly 10 octets — no trailing CRLF.
     expect(part!.length).toBe(10);
     // inbox #640: the response partial marker is the single origin octet only
@@ -1362,7 +1420,79 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     expect(part!.header).toContain("<0>");
     expect(part!.header).not.toContain("<0.10>");
     expect(part!.header).not.toMatch(/<\d+\.\d+>/);
-    expect(part!.content.endsWith("\r\n")).toBe(false);
+    expect(emitted.endsWith("\r\n")).toBe(false);
+  });
+
+  it("slices the SAME octets the non-partial BODY[TEXT] stream emits", async () => {
+    // The load-bearing equivalence: `<start.length>` addresses a window of
+    // the section's own wire bytes. Walking a different subset than
+    // `sumBodyBytes` measured would desync the literal — this pins the two
+    // together by construction rather than by arithmetic.
+    const full = await buildBodyResponsePart(
+      mail,
+      { type: "BODY", peek: false, section: { type: "TEXT" } },
+      "doc-1",
+      "INBOX"
+    );
+    const fullBody = await contentAsStringAny(full!);
+    // Non-partial appends the IMAP wire trailer; the partial range does not
+    // address it (RFC 3501 §6.4.5).
+    const addressable = fullBody.slice(0, -2);
+
+    for (const [start, length] of [[0, 10], [5, 8], [3, 1]] as const) {
+      const part = await buildBodyResponsePart(
+        mail,
+        { type: "BODY", peek: false, section: { type: "TEXT" }, partial: { start, length } },
+        "doc-1",
+        "INBOX"
+      );
+      expect(await contentAsStringAny(part!)).toBe(
+        addressable.slice(start, start + length)
+      );
+    }
+  });
+
+  it("clamps a range that overruns the section and NILs one that starts past it", async () => {
+    const full = await buildBodyResponsePart(
+      mail,
+      { type: "BODY", peek: false, section: { type: "TEXT" } },
+      "doc-1",
+      "INBOX"
+    );
+    const addressable = (await contentAsStringAny(full!)).slice(0, -2);
+
+    // Overrun: `{N}` must advertise what is actually available, not what
+    // was asked for — otherwise the client waits for octets never sent.
+    const overrun = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: false,
+        section: { type: "TEXT" },
+        partial: { start: 4, length: 1_000_000 },
+      },
+      "doc-1",
+      "INBOX"
+    );
+    expect(overrun!.type).toBe("stream");
+    expect(overrun!.length).toBe(addressable.length - 4);
+    expect(Buffer.byteLength(await contentAsStringAny(overrun!), "utf8")).toBe(
+      overrun!.length
+    );
+
+    // Vacuous: start at or past the end emits NIL, not a zero-octet literal.
+    const vacuous = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: false,
+        section: { type: "TEXT" },
+        partial: { start: addressable.length, length: 10 },
+      },
+      "doc-1",
+      "INBOX"
+    );
+    expect(vacuous).toEqual({ type: "simple", content: "BODY[TEXT] NIL" });
   });
 
   it("matches literal length to emitted octets at a non-zero offset too", async () => {
@@ -1376,8 +1506,9 @@ describe("buildBodyResponsePart — partial fetch literal length (inbox #581)", 
     const part = await buildBodyResponsePart(mail, fetch, "doc-1", "INBOX");
 
     expect(part).not.toBeNull();
-    if (part!.type !== "literal") throw new Error("expected literal part");
-    expect(Buffer.byteLength(part!.content, "utf8")).toBe(part!.length);
+    expect(part!.type).toBe("stream");
+    const emitted = await contentAsStringAny(part!);
+    expect(Buffer.byteLength(emitted, "utf8")).toBe(part!.length);
     expect(part!.length).toBe(8);
     // inbox #640: single origin octet only — not the request's `<start.length>`.
     expect(part!.header).toContain("<5>");
@@ -1653,16 +1784,6 @@ describe("buildBodyResponsePart cached-path shape preservation", () => {
 // prod-shape mail (lazy fields only, text/html undefined) to guard
 // against the field-projection regressing again.
 describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 R1)", () => {
-  const contentAsString = (part: FetchResponsePart): string => {
-    if (part.type === "literal") {
-      return Buffer.isBuffer(part.content)
-        ? part.content.toString("utf8")
-        : part.content;
-    }
-    if (part.type === "simple") return part.content;
-    throw new Error(`unexpected type ${part.type}`);
-  };
-
   // Prod-shape: mail row projected by getMailsByRange as it appears
   // for a real FETCH — no `text` / `html` strings, just octet counts +
   // synthetic id fields.
@@ -1684,29 +1805,22 @@ describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 
     ...overrides,
   }) as Partial<MailType>;
 
-  // These 3 tests EXPLICITLY set `text: undefined` so they exercise the
-  // failure mode reviewoie R1 caught: if `addBodyFields` were to drop
-  // `text`/`html` from the projection again, `getMailsByRange` would
-  // return this exact shape (lazy fields only), and the fall-through
-  // paths (`.MIME`/`.HEADER` → `getBodyPartHeaders`, partial TEXT →
-  // `buildFullMessage`, partial MIME_PART bare → `getBodyPart`) would
-  // all fail. The specific failure mode differs per path:
-  //   - `getBodyPartHeaders` / `getBodyPart`: predicates
-  //     `mail.text && mail.text.trim().length > 0` short-circuit on
-  //     undefined → hasText/hasHtml degrade to false → silent
-  //     null-return (response part dropped from the FETCH tuple with
-  //     no diagnostic).
-  //   - `buildFullMessage`: throws
-  //     "buildFullMessage: cannot materialize a lazy-text segment"
-  //     when segments are lazy.
-  // Under the CURRENT code these paths ALSO fail — that's the point:
-  // a regression that reintroduced the projection defect wouldn't be
-  // caught by these tests (they'd match the failing-shape from BOTH
-  // directions). The load-bearing regression guard is the
-  // `getRequestedFields` describe at :214-215 asserting `text`/`html`
-  // ARE projected. These tests document the fall-through paths that
-  // depend on that projection — a paired documentation of the
-  // failure surface.
+  // These tests EXPLICITLY set `text: undefined` so the mail arrives in
+  // the shape `getMailsByRange` now returns for every body-bearing
+  // section: lazy fields only, no materialized strings.
+  //
+  // Before #757, partial TEXT fell through to `buildFullMessage` (which
+  // THROWS "cannot materialize a lazy-text segment" on this shape) and
+  // partial bare MIME_PART fell through to `getBodyPart` (whose
+  // `mail.text && mail.text.trim().length > 0` predicate short-circuits
+  // on undefined → silent null-return, response part dropped from the
+  // FETCH tuple with no diagnostic). Both now take the segment walker
+  // and stream correctly — that is the fix, asserted positively below.
+  //
+  // `.MIME` / `.HEADER` is the one sub-section with no streaming
+  // counterpart, so it still depends on the projection keeping
+  // `text`/`html`; its null-return on a lazy-only mail stays pinned as
+  // the guard for that dependency.
   it("BODY[1.MIME] on lazy-only mail (text/html undefined) — silent null-return via short-circuit", async () => {
     const mail = prodShapeMail({ text: undefined as unknown as string, html: undefined as unknown as string });
     // `getBodyPartHeaders`'s predicate is
@@ -1730,43 +1844,29 @@ describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 
     expect(part).toBeNull();
   });
 
-  it("BODY[TEXT]<0.100> on lazy-only mail — buildFullMessage throws on lazy segments", async () => {
+  it("BODY[TEXT]<0.100> on lazy-only mail streams — no buildFullMessage, no throw", async () => {
     const mail = prodShapeMail({ text: undefined as unknown as string, html: undefined as unknown as string });
-    // getBodyContent → buildFullMessage throws
-    // "buildFullMessage: cannot materialize a lazy-text segment" when
-    // segments are lazy — same failure mode reviewoie R1 caught.
-    // Under buildBodyResponsePart the throw is caught upstream and
-    // logged as `Error processing message`; the tag itself completes
-    // OK from the client's perspective but the response part is dropped.
-    let threw = false;
-    let result: FetchResponsePart | null = null;
-    try {
-      result = await buildBodyResponsePart(
-        mail,
-        {
-          type: "BODY",
-          peek: true,
-          section: { type: "TEXT" },
-          partial: { start: 0, length: 100 },
-        },
-        "doc-prod-partial-text-lazy",
-        "INBOX"
-      );
-    } catch (e) {
-      threw = true;
-      expect(String(e)).toContain("lazy-text segment");
-    }
-    // Documents the failure — throw or null-return, both bad shapes
-    // for the client. Projection MUST populate `text`/`html` on
-    // getMailsByRange output for this path to be safe.
-    expect(threw || result === null).toBe(true);
+    const part = await buildBodyResponsePart(
+      mail,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "TEXT" },
+        partial: { start: 0, length: 100 },
+      },
+      "doc-prod-partial-text-lazy",
+      "INBOX"
+    );
+    expect(part).not.toBeNull();
+    expect(part!.type).toBe("stream");
+    expect(part!.header).toBe("BODY[TEXT]<0>");
+    // 100 text octets + 100 html octets base64-encode well past 100 wire
+    // bytes, so the request's length is served in full.
+    expect(part!.length).toBe(100);
   });
 
-  it("BODY[1]<0.100> on lazy-only mail — getBodyPart returns null (drops the fetch item)", async () => {
+  it("BODY[1]<0.100> on lazy-only mail streams the part instead of dropping it", async () => {
     const mail = prodShapeMail({ text: undefined as unknown as string, html: undefined as unknown as string });
-    // getBodyPart: `mail.text && mail.text.trim().length > 0` — undefined
-    // short-circuits to false. hasHtml also false (same reason). No
-    // part matches → returns null → response part dropped.
     const part = await buildBodyResponsePart(
       mail,
       {
@@ -1778,7 +1878,12 @@ describe("buildBodyResponsePart on prod-shape (lazy-projected) mail (inbox #770 
       "doc-prod-partial-part-lazy",
       "INBOX"
     );
-    expect(part).toBeNull();
+    expect(part).not.toBeNull();
+    expect(part!.type).toBe("stream");
+    expect(part!.header).toBe("BODY[1]<0>");
+    // text_octets is 100 → base64 is ceil(100/3)*4 = 136 wire bytes for
+    // part 1, so a <0.100> window is fully served.
+    expect(part!.length).toBe(100);
   });
 });
 

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -24,9 +24,12 @@ import {
   streamPartialFromSegments,
   streamBodyFromSegments,
   streamPartBodyFromSegments,
+  selectBodySegments,
+  selectPartBodySegments,
   sumSegmentBytes,
   sumBodyBytes,
   sumPartBodyBytes,
+  MessageSegment,
   WIRE_TRAILER,
   getBodyPart,
   getBodyPartHeaders,
@@ -37,7 +40,7 @@ import {
   BodySection,
   FetchDataItem,
 } from "./types";
-import { withBodyBudget, withBodyBudgetStream } from "./body-budget";
+import { withBodyBudgetStream } from "./body-budget";
 import { withStreamMutex } from "./stream-mutex";
 import {
   updateRfc822Size,
@@ -45,21 +48,20 @@ import {
   getMailBody,
   countLines,
 } from "../postgres/repositories/mails/core";
-// `withBodyBudget` gates the small remaining set of paths that still
-// materialize before emitting: partial fetches on non-FULL non-header
-// sections (BODY[TEXT]<...>, BODY[<part>]<...>), which fall through to
-// `getBodyContent` + `applyPartialFetch`. Same RSS scaling concern the
-// budget existed to protect against, so same gate.
+// Only the stream form of the budget is used now: every body-bearing
+// section streams, and the sections that still materialize (header-like)
+// are a few KiB each — gating those would queue them behind multi-MB
+// streams for no memory benefit.
 
 // ---------------------------------------------------------------------------
 // FetchResponsePart types (local to the fetch subsystem)
 // ---------------------------------------------------------------------------
 
 // `content` is a string for small parts (headers, simple attributes) and a
-// Buffer for the small residual materialized paths (header-like sections,
-// partial fetches on non-FULL sections). All large-body paths (FULL,
-// TEXT, MIME_PART) emit via `type: "stream"` — see stream-mutex.ts +
-// #755 for the per-key mutex that serializes concurrent same-key streams.
+// Buffer for the residual materialized paths (header-like sections only).
+// All body-bearing paths (FULL, TEXT, MIME_PART — partial included) emit
+// via `type: "stream"` — see stream-mutex.ts + #755 for the per-key mutex
+// that serializes concurrent same-key streams.
 //
 // **stream** variant: BODY[] / RFC822 for a fetch that streams its bytes
 // directly to the socket via `streamFromSegments`, never materializing
@@ -290,19 +292,15 @@ export function addBodyFields(
       break;
 
     case "TEXT":
-      // BODY[TEXT]: non-partial streams via `streamBodyFromSegments`
-      // (segments minus the top-level header literal). Partial TEXT
-      // falls through to `getBodyContent → buildFullMessage`, which
-      // requires materialized `text` / `html` strings — projecting them
-      // keeps partial correct AND makes `.MIME` / `.HEADER` sub-section
-      // handling (`getBodyPartHeaders`, which reads `mail.text.trim()`)
-      // work. Cost: `wantsLazyBodies` returns false when the strings
-      // are present, so `buildMessageSegments` emits `base64` segments
-      // instead of `lazy-text` — the non-partial TEXT stream is still
-      // chunk-bounded on the output side but `mail.text` / `mail.html`
-      // sit in memory for the fetch's duration.
-      fields.add("text");
-      fields.add("html");
+      // BODY[TEXT] — partial AND non-partial now take the segment-walk
+      // streaming path (`streamBodyFromSegments` / `streamPartialSubset`
+      // over `selectBodySegments`), so neither needs the materialized
+      // strings. Projecting only the lazy synthetics keeps
+      // `wantsLazyBodies` true, which makes `buildMessageSegments` emit
+      // `lazy-text` segments — the text/html columns are read in chunked
+      // pg SUBSTRING at emit time instead of being pulled into V8's heap
+      // for the fetch's duration. Peak per TEXT fetch drops from
+      // O(sizeof(text) + sizeof(html)) to O(chunk), matching FULL.
       fields.add("text_octets");
       fields.add("html_octets");
       fields.add("mail_id");
@@ -363,16 +361,24 @@ export function addBodyFields(
     }
 
     case "MIME_PART":
-      // BODY[<part>]: non-partial bare/.TEXT streams via
-      // `streamPartBodyFromSegments` (segment filter by partPath).
-      // Partial fetches AND `.MIME` / `.HEADER` sub-sections fall
-      // through to `getBodyPart` / `getBodyPartHeaders`, both of
-      // which use `mail.text.trim()` to decide part existence.
-      // Projecting materialized `text` / `html` keeps those correct.
-      // Same trade-off as TEXT: non-partial bare/.TEXT still streams
-      // chunk-bounded on output but the source strings sit in memory.
-      fields.add("text");
-      fields.add("html");
+      // BODY[<part>]: bare / `.TEXT` stream via
+      // `streamPartBodyFromSegments` / `streamPartialSubset` over
+      // `selectPartBodySegments` — lazy synthetics only, same O(chunk)
+      // bound as TEXT and FULL.
+      //
+      // `.MIME` / `.HEADER` still fall through to `getBodyPartHeaders`,
+      // which decides part existence off `mail.text.trim()` and cannot
+      // drive the SUBSTRING reader, so those two keep the materialized
+      // strings. They return a part's MIME header block — a few hundred
+      // bytes — so the projection cost is bounded by the mail's body size
+      // only for a request shape no bulk client issues in a loop.
+      if (
+        bodyFetch.section.subSection === "HEADER" ||
+        bodyFetch.section.subSection === "MIME"
+      ) {
+        fields.add("text");
+        fields.add("html");
+      }
       fields.add("text_octets");
       fields.add("html_octets");
       fields.add("mail_id");
@@ -424,6 +430,49 @@ function isHeaderLikeSection(section: BodySection): boolean {
   );
 }
 
+/**
+ * `BODY[<section>]<start.length>` over an already-selected segment subset.
+ *
+ * The FULL branch has its own copy of this clamp because it subtracts
+ * `WIRE_TRAILER` from a trailer-inclusive total; TEXT and MIME_PART measure
+ * their subsets with `sumBodyBytes` / `sumPartBodyBytes`, which are already
+ * trailer-free, so `addressableBytes` arrives correct and both share this.
+ *
+ * RFC 3501 §6.4.5: `start` past the end is a vacuous range — emit NIL rather
+ * than a zero-octet literal. Otherwise clamp `length` to what is actually
+ * available so the `{N}` literal advertises the true emitted count.
+ *
+ * Load-bearing: `segments` must be the SAME subset `addressableBytes` was
+ * summed over. `streamPartialFromSegments` walks cumulative byte offsets, so
+ * clamping against a different subset than the walk would desync the wire.
+ */
+function streamPartialSubset(
+  segments: MessageSegment[],
+  addressableBytes: number,
+  partial: { start: number; length: number },
+  sectionKey: string,
+  streamKey: string
+): FetchResponsePart {
+  const { start, length: requestedLength } = partial;
+  if (start >= addressableBytes) {
+    return { type: "simple", content: `${sectionKey} NIL` };
+  }
+  const emittedLength = Math.min(requestedLength, addressableBytes - start);
+  const stream = withStreamMutex(streamKey, () =>
+    withBodyBudgetStream(async function* () {
+      yield* streamPartialFromSegments(segments, start, emittedLength);
+    })
+  );
+  // Origin-octet header form is `BODY[<section>]<start>` per §7.4.2
+  // msg-att-static — no length echo; the `{N}` literal carries the count.
+  return {
+    type: "stream",
+    stream,
+    header: `${sectionKey}<${start}>`,
+    length: emittedLength,
+  };
+}
+
 export async function buildBodyResponsePart(
   mail: Partial<MailType>,
   bodyFetch: BodyFetch,
@@ -438,21 +487,24 @@ export async function buildBodyResponsePart(
   // label the response part with the item the client requested.
   const sectionKey = keyOverride ?? getBodySectionKey(section);
 
-  // Non-header-like body sections (FULL, TEXT, bare/`.TEXT` MIME_PART —
-  // and partial FULL) take the segment-walk streaming path:
-  // `buildMessageSegments` builds the ordered segment list once,
-  // `sumSegmentBytes` / `sumBodyBytes` / `sumPartBodyBytes` measure the
-  // exact wire byte count (one `stat` per attachment, no reads) so
-  // `{N}` is pinned before the first chunk yields, and the appropriate
-  // `stream*Segments` generator yields chunk-bounded Buffers to the
-  // socket. Peak transient on the output side is O(chunk) for all
-  // section variants; for FULL the SOURCE is also chunk-bounded (lazy
-  // text/html + attachment reads); for TEXT / MIME_PART the source
-  // strings sit in memory for the fetch's duration because the
-  // fall-through paths (`.MIME` / `.HEADER`, partial variants) need
-  // materialized `mail.text` / `mail.html` for correctness. Completing
-  // the lazy migration for those paths is tracked as a follow-up
-  // under #757.
+  // EVERY non-header-like body section (FULL, TEXT, bare/`.TEXT`
+  // MIME_PART — partial and non-partial alike) takes the segment-walk
+  // streaming path: `buildMessageSegments` builds the ordered segment
+  // list once, `sumSegmentBytes` / `sumBodyBytes` / `sumPartBodyBytes`
+  // measure the exact wire byte count (one `stat` per attachment, no
+  // reads) so `{N}` is pinned before the first chunk yields, and the
+  // appropriate `stream*Segments` generator yields chunk-bounded Buffers
+  // to the socket.
+  //
+  // Both the SOURCE and the output side are now O(chunk) for all of
+  // them: `getRequestedFields` projects only the lazy synthetics for
+  // these shapes, so `buildMessageSegments` emits `lazy-text` segments
+  // that pull the column in chunked pg SUBSTRING reads at emit time.
+  // Before this, TEXT and MIME_PART projected the materialized
+  // `mail.text` / `mail.html`, so each command held
+  // O(sizeof(text) + sizeof(html)) in V8's heap for its duration — the
+  // per-command allocation that survived a same-socket pipelined burst
+  // long enough to stack up under GC lag (#757).
   //
   // Cache is deleted (was `body-buffer.ts`): streaming makes it
   // unnecessary. Retention shapes the pre-cache-deletion code returned:
@@ -546,24 +598,36 @@ export async function buildBodyResponsePart(
     };
   }
 
-  if (!partial && !isHeaderLikeSection(section) && section.type === "TEXT") {
+  if (!isHeaderLikeSection(section) && section.type === "TEXT") {
     // BODY[TEXT] — RFC 3501 §6.4.5 "text body of the message, omitting
     // the header." Streamed by walking the segments and skipping the
     // top-level header literal, then appending the same one-CRLF wire
-    // trailer the pre-cache-deletion path did (`raw + "\r\n"`). Output
-    // stays chunk-bounded via `emitBase64`; the SOURCE is
-    // `mail.text` / `mail.html` held in memory (`addBodyFields` projects
-    // both materialized + lazy, and `wantsLazyBodies` returns false
-    // when strings are present, so segments are `base64`-kind not
-    // `lazy-text`). FULL still uses lazy synthetics — peak per FULL
-    // fetch is O(chunk), TEXT is O(sizeof(mail.text) + sizeof(mail.html))
-    // + O(chunk).
+    // trailer the pre-cache-deletion path did (`raw + "\r\n"`). Both
+    // sides are chunk-bounded: `emitBase64` on output, `lazy-text`
+    // segments on input (`addBodyFields` projects the synthetics only,
+    // so `wantsLazyBodies` holds). Peak per TEXT fetch is O(chunk),
+    // same as FULL.
+    //
+    // `<start.length>` addresses the TEXT section's own octets, which is
+    // exactly `bodyBytes` — the one-CRLF wire trailer below is IMAP
+    // framing appended after the section, not part of it, so the partial
+    // range must NOT include it (same reasoning as the FULL branch's
+    // `totalBodyLength - WIRE_TRAILER`).
     const segments = buildMessageSegments(mail, docId);
     const bodyBytes = sumBodyBytes(segments);
     if (bodyBytes === 0) {
       return { type: "simple", content: `${sectionKey} NIL` };
     }
     const streamKey = `${docId}::${sectionKey}`;
+    if (partial) {
+      return streamPartialSubset(
+        selectBodySegments(segments),
+        bodyBytes,
+        partial,
+        sectionKey,
+        streamKey
+      );
+    }
     const stream = withStreamMutex(streamKey, () =>
       withBodyBudgetStream(async function* () {
         yield* streamBodyFromSegments(segments);
@@ -578,7 +642,7 @@ export async function buildBodyResponsePart(
     };
   }
 
-  if (!partial && !isHeaderLikeSection(section) && section.type === "MIME_PART") {
+  if (!isHeaderLikeSection(section) && section.type === "MIME_PART") {
     // BODY[<part>] — RFC 3501 §6.4.5. `.HEADER` / `.MIME` return the
     // part's MIME header block (materialized, cheap — see the
     // header-like fallthrough below via `getBodyContent`). Bare number
@@ -604,6 +668,15 @@ export async function buildBodyResponsePart(
         return null;
       }
       const streamKey = `${docId}::${sectionKey}`;
+      if (partial) {
+        return streamPartialSubset(
+          selectPartBodySegments(segments, partPath),
+          partBytes,
+          partial,
+          sectionKey,
+          streamKey
+        );
+      }
       const stream = withStreamMutex(streamKey, () =>
         withBodyBudgetStream(async function* () {
           yield* streamPartBodyFromSegments(segments, partPath);
@@ -619,17 +692,14 @@ export async function buildBodyResponsePart(
     }
   }
 
-  // Partial fetch (`BODY[]<start.length>`) and header-like sections
-  // (`BODY[HEADER.FIELDS ...]`) fall through here. Partial STILL
-  // materializes the full body via `buildFullMessage` before slicing
-  // in `applyPartialFetch`, so the RSS scaling concern is the same as
-  // the shared-body path — gate through the budget. Header-like
-  // sections are cheap (≤ a few KiB) and don't need gating; hop over
-  // them with an immediate acquire/release by only gating when the
-  // request is a partial.
-  const content = partial
-    ? await withBodyBudget(() => Promise.resolve(getBodyContent(mail, section, docId)))
-    : getBodyContent(mail, section, docId);
+  // Only header-like sections reach here now: `BODY[HEADER]`,
+  // `BODY[HEADER.FIELDS ...]`, and a MIME part's `.HEADER` / `.MIME`.
+  // Every body-bearing section (FULL, TEXT, bare/`.TEXT` MIME_PART) is
+  // handled above, partial included, so no path below materializes a
+  // body and the body budget no longer has anything to protect here —
+  // gating a header block behind it would just queue a few-KiB response
+  // behind multi-MB streams.
+  const content = getBodyContent(mail, section, docId);
   if (content === null) {
     return null;
   }

--- a/src/server/lib/imap/fetch-helpers.ts
+++ b/src/server/lib/imap/fetch-helpers.ts
@@ -17,7 +17,6 @@ import {
 } from "./util";
 import {
   applyPartialFetch,
-  buildFullMessage,
   buildMessageSegments,
   computeFullMessageSize,
   streamFromSegments,
@@ -31,7 +30,6 @@ import {
   sumPartBodyBytes,
   MessageSegment,
   WIRE_TRAILER,
-  getBodyPart,
   getBodyPartHeaders,
   getBodySectionKey,
 } from "./session-utils";
@@ -84,24 +82,27 @@ export type FetchResponsePart =
 // Body content extraction
 // ---------------------------------------------------------------------------
 
+/**
+ * The materialized content of a HEADER-LIKE body section — `BODY[HEADER]`,
+ * `BODY[HEADER.FIELDS ...]`, and a MIME part's `.HEADER` / `.MIME`. Each
+ * returns a few hundred bytes of header text and includes its own delimiting
+ * blank line (see `isHeaderLikeSection`).
+ *
+ * Deliberately NOT a general body reader. Every body-bearing section (FULL,
+ * TEXT, bare/`.TEXT` MIME_PART — partial and non-partial alike) is served by
+ * the segment-walk streaming path in `buildBodyResponsePart` and returns
+ * before reaching the call site here, so a body branch on this function
+ * would be dead code that also reintroduces the O(body-length) allocation
+ * this path exists to avoid — and would throw outright on the lazy row shape
+ * `getMailsByRange` now projects, since there is no materialized `text` /
+ * `html` to read.
+ */
 export function getBodyContent(
-  mail: Partial<MailType>,
+  mail: FetchMailInput,
   section: BodySection,
   docId: string
 ): string | null {
   switch (section.type) {
-    case "FULL":
-      return buildFullMessage(mail, docId);
-
-    case "TEXT": {
-      const fullMessage = buildFullMessage(mail, docId);
-      const headerEndIndex = fullMessage.indexOf("\r\n\r\n");
-      if (headerEndIndex !== -1) {
-        return fullMessage.substring(headerEndIndex + 4);
-      }
-      return "";
-    }
-
     case "HEADER":
       // RFC 3501 §6.4.5: a HEADER fetch includes the RFC-2822 delimiting blank
       // line between the header block and the body. `formatHeaders` joins the
@@ -142,20 +143,15 @@ export function getBodyContent(
     }
 
     case "MIME_PART":
-      // RFC 3501 §6.4.5: `.HEADER`/`.MIME` return the part's MIME header fields;
-      // `.TEXT` (and a bare part number) return the part body without them. For
-      // this codebase's synthetic parts `getBodyPart` already yields the body
-      // sans MIME header, so `.TEXT` and no-subsection resolve identically.
-      switch (section.subSection) {
-        case "HEADER":
-        case "MIME": {
-          const headers = getBodyPartHeaders(mail, section.partNumber);
-          return headers === null ? null : headers + "\r\n\r\n";
-        }
-        case "TEXT":
-        default:
-          return getBodyPart(mail, section.partNumber);
+      // RFC 3501 §6.4.5: `.HEADER`/`.MIME` return the part's MIME header
+      // fields. `.TEXT` and a bare part number return the part BODY, which
+      // streams via `selectPartBodySegments` in `buildBodyResponsePart` and
+      // never arrives here.
+      if (section.subSection === "HEADER" || section.subSection === "MIME") {
+        const headers = getBodyPartHeaders(mail, section.partNumber);
+        return headers === null ? null : headers + "\r\n\r\n";
       }
+      return null;
 
     default:
       return null;
@@ -366,19 +362,16 @@ export function addBodyFields(
       // `selectPartBodySegments` — lazy synthetics only, same O(chunk)
       // bound as TEXT and FULL.
       //
-      // `.MIME` / `.HEADER` still fall through to `getBodyPartHeaders`,
-      // which decides part existence off `mail.text.trim()` and cannot
-      // drive the SUBSTRING reader, so those two keep the materialized
-      // strings. They return a part's MIME header block — a few hundred
-      // bytes — so the projection cost is bounded by the mail's body size
-      // only for a request shape no bulk client issues in a loop.
-      if (
-        bodyFetch.section.subSection === "HEADER" ||
-        bodyFetch.section.subSection === "MIME"
-      ) {
-        fields.add("text");
-        fields.add("html");
-      }
+      // `.MIME` / `.HEADER` fall through to `getBodyPartHeaders`, which
+      // needs only "does a text/html part exist" — `resolveBodyPresence`
+      // answers that from `text_octets` / `html_octets`, the same
+      // predicate `buildMessageSegments` uses. So this branch projects
+      // the synthetics only, like the rest: `UID FETCH 1:*
+      // (BODY.PEEK[1.MIME])` no longer pulls every row's body into
+      // `fetchMailsForRange`'s Map (#757's allocation shape), and
+      // `wantsLazyBodies` stays true when a single command pairs `.MIME`
+      // with `BODY[TEXT]` — the projection is a per-command union, so
+      // adding the strings here would have un-lazied that whole command.
       fields.add("text_octets");
       fields.add("html_octets");
       fields.add("mail_id");

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -1060,7 +1060,7 @@ async function* streamOneSegment(
  * `sumSegmentBytes` / `sumBodyBytes` on the same `buildMessageSegments`
  * result), so nothing materializes a whole message any more. Kept with its
  * tests because it is still the reference semantics the streamers are
- * asserted against; deletion is tracked separately since it also touches the
+ * asserted against; deletion is tracked in #834, which also covers the
  * `session.ts` / `models/common.ts` prose that names it. Do NOT reintroduce
  * it on a fetch path — peak allocation is O(message), which is #729/#757.
  */
@@ -1113,8 +1113,7 @@ export const buildFullMessage = (mail: FetchMailInput, docId?: string): string =
  *
  * **No production caller as of #757**, for the same reason as
  * `buildFullMessage`: `BODY[<part>]` (bare and `.TEXT`) streams via
- * `selectPartBodySegments`. Its part-numbering remains the reference the
- * streaming path and `getBodyPartHeaders` are asserted to agree with.
+ * `selectPartBodySegments`. Deletion tracked in #834.
  */
 export const getBodyPart = (
   mail: Partial<MailType>,
@@ -1186,10 +1185,15 @@ export const getBodyPart = (
  * MIME header block for a specific body part (RFC 3501 §6.4.5 `BODY[<part>.MIME]`
  * / `BODY[<part>.HEADER]`). Returns the part's `Content-Type` +
  * `Content-Transfer-Encoding` (+ `Content-Disposition` for attachments) fields
- * with no trailing CRLF — the caller appends the delimiting blank line. Mirrors
- * `buildMessageSegments`' part-numbering exactly (both derive part existence
- * from `resolveBodyPresence`) so `BODY[1.MIME]` names the same part as
- * `BODY[1]` emits.
+ * with no trailing CRLF — the caller appends the delimiting blank line.
+ *
+ * Shares `resolveBodyPresence` with `buildMessageSegments`, so the two agree
+ * on WHETHER a text / html part exists. They still disagree on attachment
+ * numbering when a mail has attachments but no text/html body: this function
+ * reserves slot 1 for body content unconditionally while
+ * `buildMessageSegments` does not, so the attachment stamped `partPath` `"1"`
+ * is described here as part 2. Pre-existing and tracked in #833 — do not
+ * assume the two are interchangeable for attachment parts.
  *
  * Reads the body columns only through `resolveBodyPresence`, which prefers
  * `text_octets` / `html_octets` — every return below is a static

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -946,18 +946,23 @@ async function* streamLazyTextPartial(
 export async function* streamBodyFromSegments(
   segments: MessageSegment[]
 ): AsyncGenerator<Buffer, void, unknown> {
-  for (const segment of segments) {
-    if (segment.kind === "literal" && segment.role === "headers") continue;
-    yield* streamOneSegment(segment);
-  }
+  yield* streamFromSegmentList(selectBodySegments(segments));
 }
+
+/**
+ * The `BODY[TEXT]` subset of a segment list — everything except the header
+ * literal. Single source of truth for the predicate: the byte sum, the full
+ * stream and the partial stream all select through this, so a partial range
+ * can never be clamped against a different subset than the one it walks.
+ */
+export const selectBodySegments = (segments: MessageSegment[]): MessageSegment[] =>
+  segments.filter(
+    (segment) => !(segment.kind === "literal" && segment.role === "headers")
+  );
 
 /** Byte length of the `BODY[TEXT]` payload — everything except the header literal. */
 export const sumBodyBytes = (segments: MessageSegment[]): number =>
-  segments.reduce((acc, segment) => {
-    if (segment.kind === "literal" && segment.role === "headers") return acc;
-    return acc + segmentByteLength(segment);
-  }, 0);
+  sumSegmentListBytes(selectBodySegments(segments));
 
 /**
  * Stream just the body content segment(s) belonging to RFC 3501 part
@@ -973,23 +978,40 @@ export async function* streamPartBodyFromSegments(
   segments: MessageSegment[],
   partPath: string
 ): AsyncGenerator<Buffer, void, unknown> {
-  for (const segment of segments) {
-    if (segment.kind === "literal") continue;
-    if (segment.partPath !== partPath) continue;
-    yield* streamOneSegment(segment);
-  }
+  yield* streamFromSegmentList(selectPartBodySegments(segments, partPath));
 }
+
+/** The `BODY[<partPath>]` subset of a segment list. Counterpart of `selectBodySegments`. */
+export const selectPartBodySegments = (
+  segments: MessageSegment[],
+  partPath: string
+): MessageSegment[] =>
+  segments.filter(
+    (segment) => segment.kind !== "literal" && segment.partPath === partPath
+  );
 
 /** Byte length of the `BODY[<partPath>]` payload — sum of matching body segments. */
 export const sumPartBodyBytes = (
   segments: MessageSegment[],
   partPath: string
-): number =>
-  segments.reduce((acc, segment) => {
-    if (segment.kind === "literal") return acc;
-    if (segment.partPath !== partPath) return acc;
-    return acc + segmentByteLength(segment);
-  }, 0);
+): number => sumSegmentListBytes(selectPartBodySegments(segments, partPath));
+
+/**
+ * Sum a segment list verbatim — no `WIRE_TRAILER`, unlike `sumSegmentBytes`.
+ * The trailer is IMAP framing appended by the non-partial branches, not part
+ * of the RFC 2822 serialization a partial range addresses (RFC 3501 §6.4.5).
+ */
+const sumSegmentListBytes = (segments: MessageSegment[]): number =>
+  segments.reduce((acc, segment) => acc + segmentByteLength(segment), 0);
+
+/** Stream an already-selected segment list in order. */
+async function* streamFromSegmentList(
+  segments: MessageSegment[]
+): AsyncGenerator<Buffer, void, unknown> {
+  for (const segment of segments) {
+    yield* streamOneSegment(segment);
+  }
+}
 
 /** Stream exactly one segment as `streamFromSegments` would for that kind. */
 async function* streamOneSegment(

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -213,6 +213,33 @@ const wantsLazyBodies = (mail: FetchMailInput): boolean =>
   mail.html === undefined;
 
 /**
+ * Does this mail have a text / an html body part?
+ *
+ * Single source of truth for the predicate that decides the synthetic MIME
+ * structure — `buildMessageSegments` (which parts exist on the wire) and
+ * `getBodyPartHeaders` (which part number names which header block) MUST
+ * agree, or `BODY[1.MIME]` describes a different part than `BODY[1]` emits.
+ *
+ * In lazy mode it derives from `octet_length()` so neither caller has to
+ * project the multi-MB `text` / `html` columns just to compute two booleans.
+ * A non-zero octet count is treated as "has content" even if the content is
+ * whitespace-only; the materialized path keeps the stricter `.trim()` check.
+ * Whitespace-only bodies are pathological in real mail, and the two modes
+ * only ever disagree on that case.
+ */
+const resolveBodyPresence = (
+  mail: FetchMailInput
+): { hasText: boolean; hasHtml: boolean } => {
+  if (wantsLazyBodies(mail)) {
+    return { hasText: mail.text_octets! > 0, hasHtml: mail.html_octets! > 0 };
+  }
+  return {
+    hasText: !!mail.text && mail.text.trim().length > 0,
+    hasHtml: !!mail.html && mail.html.trim().length > 0,
+  };
+};
+
+/**
  * The RFC 822 serialization of `mail`, as an ordered segment list.
  *
  * Attachment bodies are referenced by id + resolved size, never read, so
@@ -230,18 +257,7 @@ export const buildMessageSegments = (
 ): MessageSegment[] => {
   const headers = formatHeaders(mail, docId);
   const isLazy = wantsLazyBodies(mail);
-  // In lazy mode, `hasText`/`hasHtml` derive from `octet_length()` — the
-  // materialized `.trim()` check isn't possible without loading the column.
-  // A non-zero octet count is treated as "has content" even if the content
-  // is whitespace-only. Whitespace-only bodies are pathological in real
-  // mail and callers that need the trim-check semantics stay on the
-  // materialized path (pass `mail.text` / `mail.html`).
-  const hasText = isLazy
-    ? mail.text_octets! > 0
-    : !!mail.text && mail.text.trim().length > 0;
-  const hasHtml = isLazy
-    ? mail.html_octets! > 0
-    : !!mail.html && mail.html.trim().length > 0;
+  const { hasText, hasHtml } = resolveBodyPresence(mail);
   const hasAttachments = !!mail.attachments && mail.attachments.length > 0;
 
   const segments: MessageSegment[] = [];
@@ -1038,11 +1054,15 @@ async function* streamOneSegment(
 /**
  * Build the complete RFC 822 message as a single string.
  *
- * Materializing consumer for `getBodyContent`'s TEXT section, which needs
- * `indexOf("\r\n\r\n") + substring` over the whole message. Prefer
- * `streamFromSegments` (paired with `sumSegmentBytes` on the same
- * `buildMessageSegments` result) for BODY[] / RFC822 — this function's
- * peak allocation is O(message), which is what #729 was about.
+ * **No production caller as of #757.** Its last one was `getBodyContent`'s
+ * FULL / TEXT sections; every body-bearing section now takes the segment-walk
+ * streaming path (`streamFromSegments` / `streamBodyFromSegments` paired with
+ * `sumSegmentBytes` / `sumBodyBytes` on the same `buildMessageSegments`
+ * result), so nothing materializes a whole message any more. Kept with its
+ * tests because it is still the reference semantics the streamers are
+ * asserted against; deletion is tracked separately since it also touches the
+ * `session.ts` / `models/common.ts` prose that names it. Do NOT reintroduce
+ * it on a fetch path — peak allocation is O(message), which is #729/#757.
  */
 export const buildFullMessage = (mail: FetchMailInput, docId?: string): string => {
   const parts: string[] = [];
@@ -1089,7 +1109,12 @@ export const buildFullMessage = (mail: FetchMailInput, docId?: string): string =
 };
 
 /**
- * Get specific body part from multipart message
+ * Get specific body part from multipart message.
+ *
+ * **No production caller as of #757**, for the same reason as
+ * `buildFullMessage`: `BODY[<part>]` (bare and `.TEXT`) streams via
+ * `selectPartBodySegments`. Its part-numbering remains the reference the
+ * streaming path and `getBodyPartHeaders` are asserted to agree with.
  */
 export const getBodyPart = (
   mail: Partial<MailType>,
@@ -1162,18 +1187,25 @@ export const getBodyPart = (
  * / `BODY[<part>.HEADER]`). Returns the part's `Content-Type` +
  * `Content-Transfer-Encoding` (+ `Content-Disposition` for attachments) fields
  * with no trailing CRLF — the caller appends the delimiting blank line. Mirrors
- * `getBodyPart`'s part-numbering exactly so `BODY[1.MIME]` names the same part
- * as `BODY[1]`.
+ * `buildMessageSegments`' part-numbering exactly (both derive part existence
+ * from `resolveBodyPresence`) so `BODY[1.MIME]` names the same part as
+ * `BODY[1]` emits.
+ *
+ * Reads the body columns only through `resolveBodyPresence`, which prefers
+ * `text_octets` / `html_octets` — every return below is a static
+ * `Content-Type:` block or an attachment header, so the content itself is
+ * never needed. That is what lets `addBodyFields` keep `text` / `html` out of
+ * the `.MIME` / `.HEADER` projection: `UID FETCH 1:* (BODY.PEEK[1.MIME])`
+ * would otherwise pull every row's full body into `fetchMailsForRange`'s Map.
  */
 export const getBodyPartHeaders = (
-  mail: Partial<MailType>,
+  mail: FetchMailInput,
   partNum: string
 ): string | null => {
   const parts = partNum.split(".");
   const mainPart = parseInt(parts[0], 10);
 
-  const hasText = mail.text && mail.text.trim().length > 0;
-  const hasHtml = mail.html && mail.html.trim().length > 0;
+  const { hasText, hasHtml } = resolveBodyPresence(mail);
   const hasAttachments = mail.attachments && mail.attachments.length > 0;
 
   if (!hasAttachments && !hasText && !hasHtml) {


### PR DESCRIPTION
## Summary

`BODY[]` was the only body section on the lazy path. `BODY[TEXT]` and `BODY[<part>]` projected the materialized `text` / `html` columns, so **every such command held O(sizeof(text) + sizeof(html)) in V8's heap for its whole duration.**

That allocation is invisible to both existing budgets. #727 caps CONCURRENT builds and #753 caps aggregate bytes in flight — but a same-socket pipeline is **serial by construction** (`handler.ts:239` awaits each `handleRequest`), so concurrency is 1 and neither cap ever engages. The per-command allocations stack up behind GC instead. That is the 144 to 272 MB climb over 14 sequential commands the issue recorded, and it is why #755's mutex did not help.

The issue's candidate table listed six unverified hypotheses. This PR answers the one that reproduces: **materialized `text`/`html` on the mail row for TEXT / MIME_PART fetches.** Measurement below.

## What changes

- `getRequestedFields` projects only the lazy synthetics for `TEXT` and for bare / `.TEXT` `MIME_PART`. `wantsLazyBodies` then holds, so `buildMessageSegments` emits `lazy-text` segments and the columns are read in chunked pg `SUBSTRING` at emit time.
- **Partial `BODY[TEXT]<a.b>` and partial `BODY[<part>]<a.b>` now stream too**, through a shared `streamPartialSubset` over `selectBodySegments` / `selectPartBodySegments`. They previously fell through to `buildFullMessage` — O(message), and it throws outright on a lazy segment list. Per the #758 attribution quoted in `session-utils.ts`, partial is the shape iOS Mail actually uses.
- `.MIME` / `.HEADER` project the octet counts too, not the strings. `getBodyPartHeaders` needs only "does a text/html part exist", which `resolveBodyPresence` — shared with `buildMessageSegments`, so the two cannot disagree — answers from `text_octets` / `html_octets`. Every return is a static `Content-Type:` block or an attachment header, so the content itself is never read. This matters twice: `UID FETCH 1:* (BODY.PEEK[1.MIME])` no longer projects every row's body into `fetchMailsForRange`'s Map, and because projection is a per-command union, a single FETCH pairing `.MIME` with `BODY[TEXT]` stays lazy instead of un-lazying the whole command.
- The body budget no longer gates the fall-through. Only header-like sections reach it now, and queuing a few-KiB header block behind multi-MB streams costs latency for no memory benefit.

`selectBodySegments` / `selectPartBodySegments` make the subset a single source of truth: the byte sum, the full stream and the partial stream all select through the same predicate, so a partial range cannot be clamped against a different subset than the one it walks.

## Ordering — resolved, #772 has merged

`BODY[TEXT]` joining the segment path meant it inherited #765 (short literal on bodies containing astral characters) until **#772** landed. #772 merged 2026-08-05 and this branch is rebased on top of it, so the ordering constraint is cleared — no merge gate remains. All numbers below were measured with #772 applied; the E2E section states what each configuration was.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun run lint` — no new warnings on touched files.
- [x] `bun test src/server` — **1661 pass / 0 fail**. Full suite `bun test` — **1762 pass / 0 fail** (CI's exact `bun test --coverage --coverage-reporter=lcov` reproduces this locally).
- [x] Five pre-existing tests pinned the old shape and were rewritten to assert the new one. Two of them — `BODY[TEXT]<0.100>` and `BODY[1]<0.100>` on a lazy-only mail — previously asserted *"buildFullMessage throws"* and *"getBodyPart returns null (drops the fetch item)"*. Those were documentation of this bug; they now assert the section streams.
- [x] New in `fetch-helpers.test.ts`: a projection matrix over every body section asserting lazy-only vs materialized, the union case, and partial-range clamping / vacuous-range NIL / same-octets-as-the-non-partial-stream equivalence.
- [x] New in `fetch-helpers-lazy-body.test.ts`: `BODY[TEXT]`, `BODY[1]`, `BODY[1.TEXT]` and `RFC822.TEXT` each stream a 500 KB lazy body through chunked SUBSTRING with emitted octets equal to the advertised literal; plus a partial-window test asserting the reader **stops pulling** once its range is satisfied rather than driving the whole column per window.

### E2E — live IMAP, pipelined burst on one socket

Started the server against the local dev DB and drove a real IMAP session: `LOGIN` → `SELECT INBOX` → warm-up fetch → then **20 `UID FETCH <uid> (UID BODY[TEXT])` written to the socket before reading any response**, which is the issue's reproduction shape. Target is the largest mail in the box, RFC822.SIZE 4229056 bytes. Server RSS sampled via `ps` on the server pid.

| configuration | burst | response bytes | RSS before | RSS after | **RSS delta** | all 20 tagged OK |
|---|---|---|---|---|---|---|
| `upstream/main` | 20 | 84575890 | 317 MB | 374 MB | **+57 MB** | yes |
| this PR + #772 | 20 | 84575890 | 233 MB | 254 MB | **+21 MB** | yes |

Response bytes are **identical**, so the wire output is unchanged — this is a memory change, not a content change.

Literal-exactness spot check on the same mail (raw socket read, octets after `{N}\r\n` compared against the declared `N`): `BODY[TEXT]` declares 4228721 and the trailer `)\r\na3 OK FETCH completed\r\n` lands where the client expects it.

Control — `BODY[]`, which this PR does not touch — is byte-identical and same-latency on both:

| configuration | burst | response bytes | duration |
|---|---|---|---|
| `upstream/main` | 3 | 12687051 | 11977 ms |
| this PR | 3 | 12687051 | 11857 ms |

### The trade this makes, stated plainly

`BODY[TEXT]` on that 4 MB mail goes from ~0.2 s to ~4.2 s per command. That is not new slowness introduced here — it is exactly what `BODY[]` already costs on the same mail (~4.0 s per command on `upstream/main`, table above), because both now use the same chunked reader. The old TEXT path was fast **because** it was materializing, which is the bug.

The underlying cost is `PG_TEXT_CHUNK_CHARS = 12_000` producing ~350 sequential round-trips for a 4 MB body. That N-round-trip loop is a pre-existing property of the lazy path on every shape, and it deserves its own issue rather than being tuned inside this one — I did not want to bundle a chunk-size change into a memory fix, since the two pull in opposite directions.

Closes #757

---

## Rebase note (2026-08-06, pr-readiness-check)

Rebased onto `upstream/main` after PR 798 merged. 798 moved the partial
BODY[] path onto `pgByteChunks`, which seeks by byte via
`SUBSTRING(convert_to(col, 'UTF8') ...)`. This PR's
`fetch-helpers-lazy-body.test.ts` mock only modelled `pgTextChunks`'
code-point shape, so it tripped its own fail-loud guard and the `test`
job went red on the rebased head.

Fixed in `45b3049` (was `2e66026` before subsequent rebases rewrote it;
identical patch-id) — test-only, no source change:
- Added the byte-substring branch to the mock, mirroring the one already
  in `session-utils-lazy-text.test.ts`.
- Tagged every recorded pull with its `unit` ("chars" | "bytes") so the
  peak-transient assertions can no longer compare a byte-pull count
  against a char-pull denominator.
- Pinned the partial window to the exact byte-pull count
  (`ceil(64 KiB / PG_TEXT_CHUNK_BYTES)` = 2) instead of the previous
  loose "fewer than a full drain" bound. Both new assertions were
  mutation-tested — expecting 3 pulls, and expecting unit "chars", each
  fail the test.

`bun run typecheck` / `bun run lint` clean; `bun test src` 1686 pass / 0 fail.

Re-rebased 2026-08-13 onto `upstream/main` (`dad0bd8`). Branch is 0 behind;
both commits carry the same patch-ids as before the rebase, so nothing above
changed content. CI on the rebased head `45b3049`: build / test / secrets-scan
all pass.



---

## Round 2 (2026-08-14) — reviewoie R1 findings addressed

R1 (2026-08-04, at pre-rebase `aeaaec6`) filed changes-requested with 6 findings. Disposition:

| R1 finding | Disposition |
|---|---|
| **High** — partial fetch at a non-zero offset drives the pg SUBSTRING reader from byte 0 and discards, so a windowed body pull is quadratic in round-trips | **Resolved by the rebase.** `streamLazyTextPartial` + `pgByteChunks(..., startRawByte)` landed on main and `streamPartialFromSegments` routes `lazy-text` through the offset-aware seek, which `streamPartialSubset` inherits for both `BODY[TEXT]` and `BODY[<part>]`. Measured below. |
| **Med** — the test meant to pin that property only exercised `start: 0`, where the assertion is trivially true | **Fixed.** New sweep test, mutation-checked. |
| **Med** — `.MIME` / `.HEADER` projects the multi-MB `text` / `html` columns to compute two booleans | **Fixed** via `resolveBodyPresence`. See the rewritten bullet above. |
| **Med** — merge-order gate on #772 | **Cleared.** #772 merged 2026-08-05; branch is rebased past it and the partial path is byte-indexed, pinned by `unit === "bytes"` assertions. |
| **Low** — `withBodyBudget` has no production caller | Kept, now documented as such; deletion + the test port it needs tracked in #834. |
| **Low** — `getBodyContent`'s FULL / TEXT / `.TEXT` branches unreachable | **Removed**, along with the two now-unused imports. `getBodyContent` is a header-like-section reader now and says so. `buildFullMessage` / `getBodyPart` documented as production-dead; deletion tracked in #834. |

### Measurement — windowed cost is flat, not linear in the offset

Walking a 500 KB lazy body as consecutive 64 KiB `BODY[TEXT]<k*65536.65536>` windows, counting SUBSTRING round-trips per window:

| | per-window pulls | total | vs one full pass |
|---|---|---|---|
| at head | `[2,2,2,2,2,2,2,2,2,2,1]` | **21** | 43 |
| offset seek removed (mutation) | `[2,3,4,5,6,7,8,9,10,11,11]` | 76 | 43 |

The mutation reproduces R1's reported linear climb. Critically, the **old** `start: 0` test still passes under that mutation while the new sweep fails — which is exactly the gap R1 identified.

The sweep also asserts the windows reassemble byte-for-byte into the unwindowed section, so a fast-but-wrong seek past a base64 boundary cannot pass it.

### Also filed from this round

- #833 — `BODY[<n>.MIME]` part numbering is off by one for a mail with attachments but no text/html body. Pre-existing (verified identical on `upstream/main`), surfaced while making `getBodyPartHeaders` share the presence predicate. Out of scope here.
- #834 — remove the three helpers that no longer have a production caller.

### CI

The red `test` check is **issue #827's flake**, not this PR: the same 16 failures (`users.test.ts` + `saveMail — utility placement`, none of which this PR touches) appear on 8 of the 13 PRs rebased onto `c10cc4d` today, including PR 809's byte-identical set, and were already present on this branch at its previous head `369bbdc5`. The full suite is 1762 pass / 0 fail locally under CI's exact command. New this round: `gh run rerun` no longer clears it — recorded on #827.
