### PR TITLE
feat(imap): Drafts and Junk utility mailboxes (#725)

### DIFF
--- a/src/server/lib/imap/capabilities.test.ts
+++ b/src/server/lib/imap/capabilities.test.ts
@@ -14,6 +14,13 @@ describe("IMAP capabilities", () => {
   it("defaults to plain (advertises STARTTLS) when called with no args", () => {
     expect(getCapabilities().split(" ")).toContain("STARTTLS");
   });
+
+  it("advertises SPECIAL-USE on both ports", () => {
+    // The utility folders carry RFC 6154 attributes in LIST; a client only
+    // reads them for role discovery once the extension is advertised.
+    expect(getCapabilities(false).split(" ")).toContain("SPECIAL-USE");
+    expect(getCapabilities(true).split(" ")).toContain("SPECIAL-USE");
+  });
 });
 
 describe("getImapPort", () => {

--- a/src/server/lib/imap/capabilities.test.ts
+++ b/src/server/lib/imap/capabilities.test.ts
@@ -15,11 +15,13 @@ describe("IMAP capabilities", () => {
     expect(getCapabilities().split(" ")).toContain("STARTTLS");
   });
 
-  it("advertises SPECIAL-USE on both ports", () => {
-    // The utility folders carry RFC 6154 attributes in LIST; a client only
-    // reads them for role discovery once the extension is advertised.
-    expect(getCapabilities(false).split(" ")).toContain("SPECIAL-USE");
-    expect(getCapabilities(true).split(" ")).toContain("SPECIAL-USE");
+  it("does not advertise SPECIAL-USE", () => {
+    // RFC 6154 §2: the LIST attributes need no capability. The capability
+    // string denotes the LIST-EXTENDED selection/return options, and
+    // `parseList` rejects `LIST (SPECIAL-USE) "" "*"` outright — advertising
+    // it would turn a capability-driven client's discovery into a BAD.
+    expect(getCapabilities(false).split(" ")).not.toContain("SPECIAL-USE");
+    expect(getCapabilities(true).split(" ")).not.toContain("SPECIAL-USE");
   });
 });
 

--- a/src/server/lib/imap/capabilities.ts
+++ b/src/server/lib/imap/capabilities.ts
@@ -9,6 +9,10 @@ export const getCapabilities = (isTls = false) => {
     "IDLE",
     "MOVE",
     "CONDSTORE",
+    // RFC 6154 §2: LIST reports \Drafts / \Junk on the utility folders, but a
+    // client only reads those attributes for role discovery once the server
+    // advertises the extension — otherwise it keeps guessing at folder names.
+    "SPECIAL-USE",
     "AUTH=PLAIN"
   ];
 

--- a/src/server/lib/imap/capabilities.ts
+++ b/src/server/lib/imap/capabilities.ts
@@ -9,10 +9,11 @@ export const getCapabilities = (isTls = false) => {
     "IDLE",
     "MOVE",
     "CONDSTORE",
-    // RFC 6154 §2: LIST reports \Drafts / \Junk on the utility folders, but a
-    // client only reads those attributes for role discovery once the server
-    // advertises the extension — otherwise it keeps guessing at folder names.
-    "SPECIAL-USE",
+    // No SPECIAL-USE here on purpose. RFC 6154 §2 is explicit that the
+    // attributes `getMailboxAttributes` emits need no capability on a plain
+    // LIST; the capability string denotes the LIST-EXTENDED selection/return
+    // options (RFC 5258), which this server's parser rejects. Advertising it
+    // would make a client send `LIST (SPECIAL-USE) "" "*"` and get BAD.
     "AUTH=PLAIN"
   ];
 

--- a/src/server/lib/imap/copy.test.ts
+++ b/src/server/lib/imap/copy.test.ts
@@ -518,8 +518,10 @@ describe("COPY address routing into a utility folder (#725)", () => {
   });
 
   it("keeps the source recipient for Drafts too, case-insensitively", async () => {
+    // The client names the box in lowercase; `canonicalMailbox` resolves it to
+    // the listed spelling before the existence gate, so the copy still lands.
     const mails = [sourceMail({ domain: 5, account: 50 })];
-    const { store, stored } = makeCopyStore(["drafts"], mails);
+    const { store, stored } = makeCopyStore(["Drafts"], mails);
     await runCopy(
       copyReq("drafts", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
       true,

--- a/src/server/lib/imap/copy.test.ts
+++ b/src/server/lib/imap/copy.test.ts
@@ -36,6 +36,7 @@ import {
 import { restoreLeaves } from "test-helpers";
 import type { MailType, SignedUser } from "common";
 import { Store } from "./store";
+import { boxToAccount } from "./util";
 import type { CopyRequest } from "./types";
 import type { SequenceState } from "./sequence-resolver";
 
@@ -500,5 +501,44 @@ describe("COPY dispatch — sequence vs UID semantics (#520)", () => {
       emptySeqState()
     );
     expect(getMessagesCalled).toBe(false);
+  });
+});
+
+describe("COPY address routing into a utility folder (#725)", () => {
+  it("keeps the source recipient — a utility folder selects on the flag, not the address", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeCopyStore(["Junk"], mails);
+    await runCopy(
+      copyReq("Junk", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+  });
+
+  it("keeps the source recipient for Drafts too, case-insensitively", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeCopyStore(["drafts"], mails);
+    await runCopy(
+      copyReq("drafts", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+  });
+
+  it("still re-anchors to the destination account for an address-filtered box", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeCopyStore(["Archive"], mails);
+    await runCopy(
+      copyReq("Archive", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      { store, storeMailCalls: stored }
+    );
+    const destAddress = boxToAccount(VALID_USER.username, "Archive");
+    expect(stored[0].to?.value).toEqual([{ address: destAddress, name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: destAddress, name: "" }]);
   });
 });

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -18,8 +18,10 @@ import {
   isAccountsFolder,
   isInbox,
   isSentMessagesAccountsFolder,
+  isUtilityFolder,
   SENT_MESSAGES_ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
+  UTILITY_FOLDERS,
 } from "./util";
 import { Store } from "./store";
 import { StatusItem } from "./types";
@@ -49,7 +51,7 @@ export async function createMailbox(
   // Without this guard, the DB would accept the INSERT (no row named
   // "inbox" exists) and leave a phantom user-mailbox row that's de-duped
   // out of LIST but lingers in the table.
-  if (isInbox(cleanName)) {
+  if (isInbox(cleanName) || isUtilityFolder(cleanName)) {
     write(`${tag} NO [ALREADYEXISTS] Mailbox already exists\r\n`);
     return;
   }
@@ -89,6 +91,13 @@ export async function deleteMailbox(
   // get a misleading "does not exist" instead of the correct refusal.
   if (isInbox(cleanName)) {
     write(`${tag} NO [CANNOT] Cannot delete INBOX\r\n`);
+    return;
+  }
+  // Same reason INBOX is refused: a utility folder is a server-defined view
+  // with no row behind it, so `deleteMailboxByName` would report "does not
+  // exist" for a box the client can see in LIST.
+  if (isUtilityFolder(cleanName)) {
+    write(`${tag} NO [CANNOT] Cannot delete system mailbox\r\n`);
     return;
   }
   try {
@@ -137,8 +146,12 @@ export async function renameMailbox(
     write(`${tag} NO [CANNOT] RENAME INBOX is not supported\r\n`);
     return;
   }
-  // Target must not collide with the synthetic INBOX either.
-  if (isInbox(cleanNew)) {
+  if (isUtilityFolder(cleanOld)) {
+    write(`${tag} NO [CANNOT] Cannot rename system mailbox\r\n`);
+    return;
+  }
+  // Target must not collide with a synthetic mailbox either.
+  if (isInbox(cleanNew) || isUtilityFolder(cleanNew)) {
     write(`${tag} NO [ALREADYEXISTS] Target mailbox already exists\r\n`);
     return;
   }
@@ -282,6 +295,13 @@ export async function statusMailbox(
 // ---------------------------------------------------------------------------
 
 export function getMailboxAttributes(box: string, allBoxes: string[]): string {
+  // RFC 6154 §2: the special-use attribute travels alongside the ordinary ones
+  // in a plain LIST response, which is how a client maps a role to a box name
+  // without guessing at the name.
+  const utility = UTILITY_FOLDERS.find((folder) => folder.name === box);
+  if (utility) {
+    return `${utility.specialUse} \\HasNoChildren`;
+  }
   if (isAccountsFolder(box)) {
     return "\\HasChildren \\Noselect";
   }

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -19,9 +19,9 @@ import {
   isInbox,
   isSentMessagesAccountsFolder,
   isUtilityFolder,
+  utilityFolder,
   SENT_MESSAGES_ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
-  UTILITY_FOLDERS,
 } from "./util";
 import { Store } from "./store";
 import { StatusItem } from "./types";
@@ -298,9 +298,13 @@ export function getMailboxAttributes(box: string, allBoxes: string[]): string {
   // RFC 6154 §2: the special-use attribute travels alongside the ordinary ones
   // in a plain LIST response, which is how a client maps a role to a box name
   // without guessing at the name.
-  const utility = UTILITY_FOLDERS.find((folder) => folder.name === box);
+  const utility = utilityFolder(box);
   if (utility) {
-    return `${utility.specialUse} \\HasNoChildren`;
+    // The CREATE guard only refuses the utility name itself, so `Drafts/sub`
+    // is a legal user box — scan for children like every other branch rather
+    // than asserting \HasNoChildren and contradicting the same LIST response.
+    const hasChildren = allBoxes.some((b) => b.startsWith(`${box}/`));
+    return `${utility.specialUse} ${hasChildren ? "\\HasChildren" : "\\HasNoChildren"}`;
   }
   if (isAccountsFolder(box)) {
     return "\\HasChildren \\Noselect";

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -20,6 +20,7 @@ import {
   isSentMessagesAccountsFolder,
   isUtilityFolder,
   utilityFolder,
+  canonicalMailbox,
   SENT_MESSAGES_ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
 } from "./util";
@@ -230,7 +231,7 @@ export async function statusMailbox(
   // RFC 3501 §5.1: INBOX is case-insensitive. Canonicalize so downstream
   // responses (* STATUS "INBOX" ...) echo the canonical name regardless of
   // the casing the client used.
-  const mailbox = isInbox(mailboxArg) ? "INBOX" : mailboxArg;
+  const mailbox = canonicalMailbox(mailboxArg);
   try {
     if (!(await store.mailboxExists(mailbox))) {
       write(`${tag} NO Mailbox does not exist\r\n`);
@@ -441,7 +442,7 @@ export async function selectMailbox(
   // mailbox stored on the session and every downstream response (`* OK
   // [READ-WRITE]`, EXISTS/RECENT, FETCH responses) reflect "INBOX" rather
   // than whatever casing the client sent.
-  const cleanName = isInbox(unquoted) ? "INBOX" : unquoted;
+  const cleanName = canonicalMailbox(unquoted);
 
   if (isAccountsFolder(cleanName)) {
     write(`${tag} NO [CANNOT] ${ACCOUNTS_FOLDER} is not selectable\r\n`);

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -12,7 +12,14 @@ import {
 import { logger } from "server";
 import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
-import { boxToAccount, deriveCopyMessageId, isDomainScoped, isInbox, isSentBox } from "./util";
+import {
+  boxToAccount,
+  deriveCopyMessageId,
+  isDomainScoped,
+  isInbox,
+  isSentBox,
+  isUtilityFolder,
+} from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
   FetchRequest,
@@ -643,6 +650,7 @@ export async function copyMessageTyped(
     // filter); `destIsDomainScoped` drives the destination UID space for the
     // COPYUID response (INBOX and the unified Sent folder both use uid.domain).
     const destIsInbox = isInbox(destMailbox);
+    const destIsUtility = isUtilityFolder(destMailbox);
     const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
 
@@ -729,7 +737,13 @@ export async function copyMessageTyped(
       // every received mail in the user's domain). `to_text` is
       // preserved so the client's FETCH BODY[HEADER] still shows the
       // original recipient header — the override only affects routing.
-      if (destIsInbox) {
+      //
+      // A utility folder has no address filter either — it selects on the
+      // placement flag alone — so it takes the same branch. Addressing the
+      // copy to `boxToAccount` there would name the folder itself
+      // (`Junk@<domain>`), which overwrites the real recipient and makes
+      // `getAccountStats` report a per-account mailbox by that name.
+      if (destIsInbox || destIsUtility) {
         newMail.to = sourceMail.to;
         newMail.envelopeTo = sourceMail.envelopeTo ?? [];
       } else {
@@ -932,6 +946,7 @@ export async function moveMessageTyped(
     // `*IsDomainScoped` drives the UID space (INBOX and the unified Sent folder
     // both use uid.domain).
     const destIsInbox = isInbox(destMailbox);
+    const destIsUtility = isUtilityFolder(destMailbox);
     const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
     const sourceIsInbox = isInbox(selectedMailbox);
@@ -988,9 +1003,11 @@ export async function moveMessageTyped(
         answered: sourceMail.answered,
       });
 
-      if (destIsInbox) {
-        // INBOX has no address filter; the new copy surfaces in INBOX
-        // regardless of `to_address` / `envelope_to` content. But if the
+      if (destIsInbox || destIsUtility) {
+        // Neither INBOX nor a utility folder has an address filter; the new
+        // copy surfaces there regardless of `to_address` / `envelope_to`
+        // content, so addressing it to `boxToAccount` would name the folder
+        // itself (`Junk@<domain>`) and overwrite the real recipient. But if the
         // source view IS address-filtered (accounts/foo, Sent Messages/
         // accounts/foo), preserving the source's address fields would
         // re-anchor the new copy in the source mailbox even AFTER we

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -14,12 +14,10 @@ import { Store } from "./store";
 import { StoreOperationType } from "../postgres/repositories/mails";
 import {
   boxToAccount,
+  canonicalMailbox,
   deriveCopyMessageId,
   isDomainScoped,
-  isInbox,
   isSentBox,
-  isUtilityFolder,
-  canonicalMailbox,
 } from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
@@ -647,11 +645,10 @@ export async function copyMessageTyped(
     // synthetic address that drives the destination-mailbox query
     // (e.g. "Archive@<domain>").
     const destAccount = boxToAccount(user.username, destMailbox);
-    // `destIsInbox` drives address routing below (INBOX has no address
-    // filter); `destIsDomainScoped` drives the destination UID space for the
-    // COPYUID response (INBOX and the unified Sent folder both use uid.domain).
-    const destIsInbox = isInbox(destMailbox);
-    const destIsUtility = isUtilityFolder(destMailbox);
+    // `destIsDomainScoped` drives both address routing below (a domain-scoped
+    // box has no address filter) and the destination UID space for the COPYUID
+    // response (INBOX, the unified Sent folder and the utility folders all use
+    // uid.domain).
     const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
 
@@ -733,18 +730,17 @@ export async function copyMessageTyped(
       // destinations the copy must address ALL of these to the
       // destination account so it surfaces in the destination AND does
       // not stay surfaced in the source (the source's envelope_to / cc
-      // / bcc would re-anchor it). For INBOX targets the existing
-      // header fields are fine — INBOX has no address filter (it shows
-      // every received mail in the user's domain). `to_text` is
-      // preserved so the client's FETCH BODY[HEADER] still shows the
-      // original recipient header — the override only affects routing.
+      // / bcc would re-anchor it). `to_text` is preserved so the client's
+      // FETCH BODY[HEADER] still shows the original recipient header — the
+      // override only affects routing.
       //
-      // A utility folder has no address filter either — it selects on the
-      // placement flag alone — so it takes the same branch. Addressing the
-      // copy to `boxToAccount` there would name the folder itself
-      // (`Junk@<domain>`), which overwrites the real recipient and makes
+      // A domain-scoped destination (INBOX, the unified Sent folder, a utility
+      // folder) selects rows without an address term, so the copy surfaces
+      // there on its own and the real recipient is kept. `boxToAccount` would
+      // otherwise name the folder itself (`Junk@<domain>`,
+      // `Sent Messages@<domain>`) — that overwrites the recipient and makes
       // `getAccountStats` report a per-account mailbox by that name.
-      if (destIsInbox || destIsUtility) {
+      if (destIsDomainScoped) {
         newMail.to = sourceMail.to;
         newMail.envelopeTo = sourceMail.envelopeTo ?? [];
       } else {
@@ -944,13 +940,11 @@ export async function moveMessageTyped(
     const user = store.getUser();
     const destAccount = boxToAccount(user.username, destMailbox);
     // `*IsInbox` drives address routing below (INBOX has no address filter);
-    // `*IsDomainScoped` drives the UID space (INBOX and the unified Sent folder
-    // both use uid.domain).
-    const destIsInbox = isInbox(destMailbox);
-    const destIsUtility = isUtilityFolder(destMailbox);
+    // `*IsDomainScoped` drives both the UID space (INBOX, the unified Sent
+    // folder and the utility folders all use uid.domain) and, for the
+    // destination, address routing below.
     const destIsDomainScoped = isDomainScoped(destMailbox);
     const destIsSent = isSentBox(destMailbox);
-    const sourceIsInbox = isInbox(selectedMailbox);
     const sourceIsDomainScoped = isDomainScoped(selectedMailbox);
     const srcUidOf = (mail: Partial<MailType>): number =>
       sourceIsDomainScoped ? mail.uid!.domain : mail.uid!.account;
@@ -1004,33 +998,15 @@ export async function moveMessageTyped(
         answered: sourceMail.answered,
       });
 
-      if (destIsInbox || destIsUtility) {
-        // Neither INBOX nor a utility folder has an address filter; the new
-        // copy surfaces there regardless of `to_address` / `envelope_to`
-        // content, so addressing it to `boxToAccount` would name the folder
-        // itself (`Junk@<domain>`) and overwrite the real recipient. But if the
-        // source view IS address-filtered (accounts/foo, Sent Messages/
-        // accounts/foo), preserving the source's address fields would
-        // re-anchor the new copy in the source mailbox even AFTER we
-        // expunge the original — the message would re-appear in the
-        // source view under a new UID. To prevent that, clear the
-        // routing JSONB to empty when the source is non-INBOX. INBOX→
-        // INBOX is a no-op address-wise so it's safe to preserve.
-        if (sourceIsInbox) {
-          newMail.to = sourceMail.to;
-          newMail.envelopeTo = sourceMail.envelopeTo ?? [];
-        } else {
-          newMail.to = sourceMail.to
-            ? { value: [], text: sourceMail.to.text }
-            : undefined;
-          newMail.envelopeTo = [];
-          newMail.cc = sourceMail.cc
-            ? { value: [], text: sourceMail.cc.text }
-            : undefined;
-          newMail.bcc = sourceMail.bcc
-            ? { value: [], text: sourceMail.bcc.text }
-            : undefined;
-        }
+      if (destIsDomainScoped) {
+        // Same rule as COPY — a domain-scoped destination selects rows without
+        // an address term, so keep the real recipient. There is nothing to
+        // re-anchor: no mapping row is written for such a destination, and
+        // every other box reads through an INNER JOIN on `mail_mailbox_uid`
+        // (`repositories/mails/imap.ts`), so the clone cannot surface in the
+        // source view no matter what its address fields say.
+        newMail.to = sourceMail.to;
+        newMail.envelopeTo = sourceMail.envelopeTo ?? [];
       } else {
         const destAddr = { address: destAccount, name: "" };
         newMail.to = {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -774,14 +774,10 @@ export async function copyMessageTyped(
       newMail.uid.domain = newDomainUid;
       newMail.uid.account = newAccountUid;
 
-      // Dual-write toward #702 PR-2b: mirror the account UID into the
-      // `mail_mailbox_uid` map when the destination is account-scoped.
-      // Domain-scoped destinations (INBOX, unified Sent Messages) skip —
-      // the mapping only tracks account UID spaces.
-      const ok = await store.storeMail(
-        newMail,
-        destIsDomainScoped ? undefined : destMailbox,
-      );
+      // storeMail derives the rest from the destination: the
+      // `mail_mailbox_uid` mapping for a mapped box (#702 PR-2b), and the
+      // membership flag for a utility folder.
+      const ok = await store.storeMail(newMail, destMailbox);
       if (!ok) {
         write(`${tag} NO [SERVERBUG] COPY partially failed\r\n`);
         return;
@@ -1044,13 +1040,8 @@ export async function moveMessageTyped(
       newMail.uid.domain = newDomainUid;
       newMail.uid.account = newAccountUid;
 
-      // Dual-write toward #702 PR-2b: mirror the account UID into the
-      // `mail_mailbox_uid` map when the destination is account-scoped.
-      // Domain-scoped destinations skip — see COPY for full rationale.
-      const ok = await store.storeMail(
-        newMail,
-        destIsDomainScoped ? undefined : destMailbox,
-      );
+      // Same destination handling as COPY — see there.
+      const ok = await store.storeMail(newMail, destMailbox);
       if (!ok) {
         // Pre-deletion failure: copies already stored in the destination
         // linger; the source is untouched. Client can re-issue MOVE.
@@ -1176,12 +1167,9 @@ export async function appendMessage(
     mail.uid.domain = domainUid;
     mail.uid.account = accountUid;
 
-    // Dual-write toward #702 PR-2b: mirror the account UID into the
-    // `mail_mailbox_uid` map when the APPEND target is account-scoped.
-    const result = await store.storeMail(
-      mail,
-      isDomainScoped(targetMailbox) ? undefined : targetMailbox,
-    );
+    // storeMail derives the mapping row and the utility-folder placement
+    // flag from the target box.
+    const result = await store.storeMail(mail, targetMailbox);
 
     const uid = isDomainScoped(targetMailbox) ? mail.uid.domain : mail.uid.account;
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -19,6 +19,7 @@ import {
   isInbox,
   isSentBox,
   isUtilityFolder,
+  canonicalMailbox,
 } from "./util";
 import { shouldMarkAsRead } from "./session-utils";
 import {
@@ -559,7 +560,7 @@ export async function copyMessageTyped(
 ): Promise<void> {
   try {
     // Canonicalize destination per RFC 3501 §5.1 (INBOX case-insensitive).
-    const destMailbox = isInbox(copyRequest.mailbox) ? "INBOX" : copyRequest.mailbox;
+    const destMailbox = canonicalMailbox(copyRequest.mailbox);
 
     // RFC 4315 §2.1: destination must exist; otherwise NO [TRYCREATE].
     if (!(await store.mailboxExists(destMailbox))) {
@@ -869,7 +870,7 @@ export async function moveMessageTyped(
   }
 
   try {
-    const destMailbox = isInbox(moveRequest.mailbox) ? "INBOX" : moveRequest.mailbox;
+    const destMailbox = canonicalMailbox(moveRequest.mailbox);
 
     // RFC 6851 §3.4-§3.5: MOVE to the currently-selected mailbox is a
     // no-op (the messages are already where they'd land). Skip the
@@ -1175,9 +1176,7 @@ export async function appendMessage(
     // (false), skipping onAppended (the sequence-mapping rebuild) and
     // leaving the next seq-numbered FETCH for the appended message
     // returning wrong/missing data.
-    const targetMailbox = isInbox(appendRequest.mailbox)
-      ? "INBOX"
-      : appendRequest.mailbox;
+    const targetMailbox = canonicalMailbox(appendRequest.mailbox);
     const account = boxToAccount(user.username, targetMailbox);
     const domainUid = await getDomainUidNext(user.id);
     const accountUid = await getAccountUidNext(user.id, account);

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -423,12 +423,17 @@ describe("MOVE overlapping ranges — dedupe by source UID (#626, RFC 4315 §3 v
   });
 });
 
-describe("MOVE happy path — non-INBOX source → INBOX dest (#453, address-clear invariant)", () => {
-  it("clears to/envelopeTo/cc/bcc routing so the moved copy does not re-surface in the source account view", async () => {
-    // Source is a per-account mailbox (Archive). The source row carries
-    // src@hoie.kim in to/envelope_to; if the INBOX clone preserved those,
-    // the jsonb account filter would re-match it in Archive after the
-    // original is expunged (reviewoie HIGH 3). The clone must clear them.
+describe("MOVE happy path — non-INBOX source → INBOX dest (#453)", () => {
+  it("keeps the routing addresses, and still targets the expunge and the dest UID space", async () => {
+    // Source is a mapped mailbox (Archive). The clone used to have its
+    // routing JSONB cleared here, on the theory that a jsonb address filter
+    // would otherwise re-match it in Archive after the original is expunged.
+    // That filter (`buildHeaderAddressCondition`) belongs to the WEB reads in
+    // `repositories/mails/http.ts`; every IMAP box outside the domain-scoped
+    // set reads through an INNER JOIN on `mail_mailbox_uid` instead, and the
+    // clone gets no mapping row for a domain-scoped destination — so it
+    // cannot re-surface in Archive either way. Clearing only stripped the
+    // recipient the web views group by.
     const mails = [sourceMail({ domain: 9, account: 90 })];
     const { store, stored, getExpungeArg } = makeMoveStore(["Archive"], mails);
     const seqState: SequenceState = {
@@ -446,12 +451,11 @@ describe("MOVE happy path — non-INBOX source → INBOX dest (#453, address-cle
     );
 
     expect(stored.length).toBe(1);
-    // Routing value arrays cleared; only header text survives.
-    expect(stored[0].to?.value).toEqual([]);
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
     expect(stored[0].to?.text).toBe("src@hoie.kim");
-    expect(stored[0].envelopeTo).toEqual([]);
-    expect(stored[0].cc?.value).toEqual([]);
-    expect(stored[0].bcc?.value).toEqual([]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].cc?.value).toEqual([{ address: "ccd@x.com", name: "" }]);
+    expect(stored[0].bcc?.value).toEqual([{ address: "bccd@x.com", name: "" }]);
 
     // Non-INBOX source → expunge keys on the ACCOUNT UID, not domain.
     expect(getExpungeArg()).toEqual([90]);
@@ -544,19 +548,57 @@ describe("MOVE address routing into a utility folder (#725)", () => {
     expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
   });
 
-  it("clears rather than re-anchors when the source view is address-filtered", async () => {
+  it("keeps the source recipient from a mapped box too — mark-as-junk", async () => {
+    // The canonical gesture: SELECT a per-account box, MOVE the message to
+    // Junk. Every non-domain-scoped box reads through an INNER JOIN on
+    // `mail_mailbox_uid` and the clone gets no mapping row, so it cannot
+    // re-surface in the source no matter what its address fields say —
+    // clearing them would only drop the message out of the per-account Spam
+    // tab and every web view, which read by recipient address.
     const mails = [sourceMail({ domain: 5, account: 50 })];
-    const { store, stored } = makeMoveStore(["Junk", "Archive"], mails);
+    const { store, stored } = makeMoveStore(
+      ["Junk", "INBOX/accounts/src"],
+      mails
+    );
     await runMove(
       moveReq("Junk", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
       true,
       store,
       false,
-      "Archive"
+      "INBOX/accounts/src"
     );
-    expect(stored[0].to?.value).toEqual([]);
-    expect(stored[0].envelopeTo).toEqual([]);
-    expect(stored[0].to?.text).toBe("src@hoie.kim");
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+  });
+
+  it("keeps the source recipient on the not-junk gesture, Junk -> INBOX", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeMoveStore(["Junk"], mails);
+    await runMove(
+      moveReq("INBOX", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store,
+      false,
+      "Junk"
+    );
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+  });
+
+  it("keeps the source recipient for the unified Sent folder", async () => {
+    // `boxToAccount(user, "Sent Messages")` matches neither accounts prefix, so
+    // it would hand back the folder name as a local part — the same shape as
+    // `Junk@<domain>`, and `getAccountStats` has no `sent` term to filter it
+    // back out, so it would surface as a phantom per-account box in LIST.
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeMoveStore(["Sent Messages"], mails);
+    await runMove(
+      moveReq("Sent Messages", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store
+    );
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
   });
 
   it("still re-anchors to the destination account for an address-filtered dest", async () => {

--- a/src/server/lib/imap/move.test.ts
+++ b/src/server/lib/imap/move.test.ts
@@ -41,6 +41,7 @@ import {
 import { restoreLeaves } from "test-helpers";
 import type { MailType, SignedUser } from "common";
 import { Store } from "./store";
+import { boxToAccount } from "./util";
 import type { MoveRequest } from "./types";
 import type { SequenceState } from "./sequence-resolver";
 
@@ -527,5 +528,46 @@ describe("MOVE COPYUID positional pairing — out-of-order set (#624, RFC 4315 �
     // And the smaller source UID must own the smaller dest UID (ascending
     // assignment) — the assertion that fails on the pre-#624 code.
     expect(actualDestOf(3)).toBeLessThan(actualDestOf(5));
+  });
+});
+
+describe("MOVE address routing into a utility folder (#725)", () => {
+  it("keeps the source recipient from INBOX — the flag places it, not the address", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeMoveStore(["Junk"], mails);
+    await runMove(
+      moveReq("Junk", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store
+    );
+    expect(stored[0].to?.value).toEqual([{ address: "src@hoie.kim", name: "" }]);
+    expect(stored[0].envelopeTo).toEqual([{ address: "src@hoie.kim", name: "" }]);
+  });
+
+  it("clears rather than re-anchors when the source view is address-filtered", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeMoveStore(["Junk", "Archive"], mails);
+    await runMove(
+      moveReq("Junk", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store,
+      false,
+      "Archive"
+    );
+    expect(stored[0].to?.value).toEqual([]);
+    expect(stored[0].envelopeTo).toEqual([]);
+    expect(stored[0].to?.text).toBe("src@hoie.kim");
+  });
+
+  it("still re-anchors to the destination account for an address-filtered dest", async () => {
+    const mails = [sourceMail({ domain: 5, account: 50 })];
+    const { store, stored } = makeMoveStore(["Archive"], mails);
+    await runMove(
+      moveReq("Archive", { type: "uid", ranges: [{ start: 1, end: 100 }] }),
+      true,
+      store
+    );
+    const destAddress = boxToAccount(VALID_USER.username, "Archive");
+    expect(stored[0].to?.value).toEqual([{ address: destAddress, name: "" }]);
   });
 });

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -114,7 +114,7 @@ describe("Store.storeMail — what the destination box decides (#725)", () => {
     // "this is a draft". Without the flag the row is written and shows up in no
     // mailbox the client asked for.
     await new Store(makeUser()).storeMail(makeMail(), "Drafts");
-    expect(savedInput().draft).toBe(true);
+    expect(savedInput().placement).toEqual({ draft: true });
   });
 
   it("records no mapping row for a utility destination", async () => {
@@ -122,14 +122,13 @@ describe("Store.storeMail — what the destination box decides (#725)", () => {
     // per-box UID nothing reads and burn a counter value.
     await new Store(makeUser()).storeMail(makeMail(), "Junk");
     expect(savedInput().mailbox).toBeUndefined();
-    expect(savedInput().is_spam).toBe(true);
+    expect(savedInput().placement).toEqual({ is_spam: true });
   });
 
   it("records the mapping row for a mapped destination and touches no flag", async () => {
     await new Store(makeUser()).storeMail(makeMail(), "INBOX/accounts/alice");
     expect(savedInput().mailbox).toBe("INBOX/accounts/alice");
-    expect(savedInput().draft).toBe(false);
-    expect(savedInput().is_spam).toBeUndefined();
+    expect(savedInput().placement).toBeUndefined();
   });
 
   it("records no mapping row for INBOX or the unified Sent view", async () => {

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -82,10 +82,62 @@ describe("Store.listMailboxes", () => {
     expect(mockGetAccountStats).toHaveBeenCalledWith("admin-1", true, "example.com");
   });
 
-  it("returns ['INBOX'] when no accounts and no user mailboxes exist", async () => {
+  it("returns only the server-defined boxes when no accounts and no user mailboxes exist", async () => {
+    // The utility folders are unconditional (#725): a client has to see
+    // `Drafts` before it has a draft to put there, and RFC 6154 role discovery
+    // reads them off LIST. The account folders stay conditional.
     const store = new Store(makeUser());
     const result = await store.listMailboxes();
-    expect(result).toEqual(["INBOX"]);
+    expect(result).toEqual(["INBOX", "Drafts", "Junk"]);
+  });
+});
+
+describe("Store.storeMail — what the destination box decides (#725)", () => {
+  const makeMail = () =>
+    ({
+      messageId: "m-1",
+      subject: "s",
+      draft: false,
+      uid: { domain: 7, account: 3 },
+    }) as never;
+
+  const savedInput = () =>
+    mockSaveMail.mock.calls[0][0] as unknown as Record<string, unknown>;
+
+  beforeEach(() => {
+    mockSaveMail.mockClear();
+    mockSaveMail.mockResolvedValue({ _id: "x" } as never);
+  });
+
+  it("sets the membership flag for a utility destination", async () => {
+    // A client that APPENDs to `Drafts` without sending `\Draft` still means
+    // "this is a draft". Without the flag the row is written and shows up in no
+    // mailbox the client asked for.
+    await new Store(makeUser()).storeMail(makeMail(), "Drafts");
+    expect(savedInput().draft).toBe(true);
+  });
+
+  it("records no mapping row for a utility destination", async () => {
+    // Utility views enumerate uid_domain; a mapping row would give the mail a
+    // per-box UID nothing reads and burn a counter value.
+    await new Store(makeUser()).storeMail(makeMail(), "Junk");
+    expect(savedInput().mailbox).toBeUndefined();
+    expect(savedInput().is_spam).toBe(true);
+  });
+
+  it("records the mapping row for a mapped destination and touches no flag", async () => {
+    await new Store(makeUser()).storeMail(makeMail(), "INBOX/accounts/alice");
+    expect(savedInput().mailbox).toBe("INBOX/accounts/alice");
+    expect(savedInput().draft).toBe(false);
+    expect(savedInput().is_spam).toBeUndefined();
+  });
+
+  it("records no mapping row for INBOX or the unified Sent view", async () => {
+    await new Store(makeUser()).storeMail(makeMail(), "INBOX");
+    expect(savedInput().mailbox).toBeUndefined();
+    mockSaveMail.mockClear();
+    await new Store(makeUser()).storeMail(makeMail(), "Sent Messages");
+    expect(savedInput().mailbox).toBeUndefined();
   });
 });
 

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -32,6 +32,8 @@ import {
   isSentBox,
   isAccountsFolder,
   isSentMessagesAccountsFolder,
+  utilityPlacement,
+  UTILITY_FOLDERS,
   ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
   SENT_MESSAGES_ACCOUNTS_FOLDER,
@@ -219,12 +221,14 @@ export class Store {
    * searchMailsByUid/expungeDeletedMails/expungeMailsByUid). `mailboxArg` is
    * the raw box path — the same string the write side stores in
    * `mail_mailbox_uid.mailbox` — for account-scoped, sent-account-scoped, AND
-   * user-created mailboxes (`Archive`, etc.). `null` for the two domain-scoped
-   * views (`INBOX`, unified `Sent Messages`), which stay on `mails.uid_domain`.
+   * user-created mailboxes (`Archive`, etc.), and the lookup key for a utility
+   * folder's membership predicate. `null` only for `INBOX` and the unified
+   * `Sent Messages`, the two views that select their rows by scope alone and so
+   * have nothing for the repository to key on.
    */
   private resolveMappedBox(box: string): { mailboxArg: string | null; isSent: boolean } {
     const isSent = isSentBox(box);
-    const mailboxArg = isDomainScoped(box) ? null : box;
+    const mailboxArg = isInbox(box) || box === SENT_MESSAGES_FOLDER ? null : box;
     return { mailboxArg, isSent };
   }
 
@@ -258,6 +262,13 @@ export class Store {
 
     const mailboxes: string[] = [];
     addMailbox("INBOX");
+
+    // Utility folders are listed unconditionally: a client needs `Drafts` to
+    // exist before it has a draft to APPEND into it, and RFC 6154 role
+    // discovery only works if the box is in LIST. They are added ahead of the
+    // user-created boxes below so a same-named user box de-dupes into the
+    // server-defined view rather than shadowing it.
+    UTILITY_FOLDERS.forEach(({ name }) => addMailbox(name));
 
     // Add Sent Messages (unified across all accounts) if any sent mail exists
     if (sentStats.length > 0) {
@@ -628,15 +639,22 @@ export class Store {
   };
 
   /**
-   * Store a new mail message. `mailbox` is the destination path
-   * (`COPY dest`, `MOVE dest`, `APPEND target`) — passed through to
-   * `pgSaveMail` for the account-scoped `mail_mailbox_uid` mapping.
-   * Caller passes `undefined` for domain-scoped destinations (INBOX,
-   * unified `Sent Messages`) so the mapping only records account-space
-   * UIDs. Undefined here + `pgSaveMail`'s guard skips the mapping write.
+   * Store a new mail message. `destination` is the box the write names
+   * (`COPY dest`, `MOVE dest`, `APPEND target`); it decides two things:
+   *
+   * - **Mapping.** Only a mapped destination gets a `mail_mailbox_uid` row.
+   *   Domain-scoped destinations (INBOX, unified `Sent Messages`, the utility
+   *   folders) enumerate by `uid_domain` and record no mapping.
+   * - **Placement.** A utility folder selects its rows by flag, so a write that
+   *   names one sets that flag here rather than relying on the client to have
+   *   sent it — an APPEND to `Drafts` without `\Draft` would otherwise land
+   *   somewhere the client did not ask for.
    */
-  storeMail = async (mail: Mail, mailbox?: string): Promise<boolean> => {
+  storeMail = async (mail: Mail, destination?: string): Promise<boolean> => {
     try {
+      const placement = destination ? utilityPlacement(destination) : undefined;
+      const mailbox =
+        destination && !isDomainScoped(destination) ? destination : undefined;
       const input: SaveMailInput = {
         user_id: this.user.id,
         message_id: mail.messageId,
@@ -667,6 +685,7 @@ export class Store {
         uid_domain: mail.uid?.domain,
         uid_mailbox: mail.uid?.account,
         mailbox,
+        ...placement,
       };
 
       const result = await pgSaveMail(input);

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -685,7 +685,7 @@ export class Store {
         uid_domain: mail.uid?.domain,
         uid_mailbox: mail.uid?.account,
         mailbox,
-        ...placement,
+        placement,
       };
 
       const result = await pgSaveMail(input);

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -387,15 +387,24 @@ export const UTILITY_FOLDERS: {
   { name: "Junk", specialUse: "\\Junk", placement: { is_spam: true } },
 ];
 
+/**
+ * The utility folder `box` names, or `undefined` for any other box.
+ *
+ * Case-insensitive, like `isInbox` and unlike an exact-match lookup: LIST
+ * de-dups user boxes against these names case-insensitively, so an exact-match
+ * guard would let `CREATE "drafts"` through into a row that LIST then hides and
+ * SELECT then rejects — the phantom `createMailbox`'s guard exists to prevent.
+ */
+export const utilityFolder = (box: string) =>
+  UTILITY_FOLDERS.find((folder) => folder.name.toLowerCase() === box.toLowerCase());
+
 /** Returns true for a server-defined utility mailbox (`Drafts`, `Junk`). */
-export const isUtilityFolder = (box: string): boolean =>
-  UTILITY_FOLDERS.some((folder) => folder.name === box);
+export const isUtilityFolder = (box: string): boolean => !!utilityFolder(box);
 
 /** The flags a mail must carry to land in `box`, or `undefined` for any other box. */
 export const utilityPlacement = (
   box: string
-): { draft?: boolean; is_spam?: boolean } | undefined =>
-  UTILITY_FOLDERS.find((folder) => folder.name === box)?.placement;
+): { draft?: boolean; is_spam?: boolean } | undefined => utilityFolder(box)?.placement;
 
 /** Maps an email address to its received-mail virtual mailbox name. */
 export const accountToBox = (accountName: string): string => {

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -406,6 +406,18 @@ export const utilityPlacement = (
   box: string
 ): { draft?: boolean; is_spam?: boolean } | undefined => utilityFolder(box)?.placement;
 
+/**
+ * The canonical spelling of a server-defined mailbox name, unchanged for any
+ * other box. Every entry point that takes a mailbox name off the wire (SELECT,
+ * STATUS, COPY, MOVE, APPEND) has to run it through here: `isInbox` and
+ * `utilityFolder` both match case-insensitively, but `mailboxExists` compares
+ * against the LIST names exactly, so an un-canonicalized `drafts` is refused by
+ * CREATE as already existing and by SELECT as not existing — leaving the client
+ * with no legal next command.
+ */
+export const canonicalMailbox = (box: string): string =>
+  isInbox(box) ? "INBOX" : (utilityFolder(box)?.name ?? box);
+
 /** Maps an email address to its received-mail virtual mailbox name. */
 export const accountToBox = (accountName: string): string => {
   const localPart = accountName.split("@")[0];

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -362,6 +362,41 @@ export const ACCOUNTS_FOLDER = "INBOX/accounts";
 export const SENT_MESSAGES_FOLDER = "Sent Messages";
 export const SENT_MESSAGES_ACCOUNTS_FOLDER = `${SENT_MESSAGES_FOLDER}/accounts`;
 
+/**
+ * Server-defined utility mailboxes: flag-derived views of the user's mail that
+ * exist whether or not anything currently matches, the way `Drafts` and `Junk`
+ * do on Gmail and Outlook.
+ *
+ * - `specialUse` is the RFC 6154 attribute LIST reports, so a client can find
+ *   each box by role instead of by name.
+ * - `placement` is what a write into the box has to set for the row to actually
+ *   be in it. These views select by flag, so a COPY / MOVE / APPEND that names
+ *   one and does not set the flag would report success and leave the message
+ *   nowhere the client can see it.
+ *
+ * The matching read-side predicate lives in `repositories/mails/views.ts`,
+ * which this module cannot import (the repository is re-exported by the
+ * `server` barrel this file pulls from). `views.test.ts` pins the two together.
+ */
+export const UTILITY_FOLDERS: {
+  name: string;
+  specialUse: string;
+  placement: { draft?: boolean; is_spam?: boolean };
+}[] = [
+  { name: "Drafts", specialUse: "\\Drafts", placement: { draft: true } },
+  { name: "Junk", specialUse: "\\Junk", placement: { is_spam: true } },
+];
+
+/** Returns true for a server-defined utility mailbox (`Drafts`, `Junk`). */
+export const isUtilityFolder = (box: string): boolean =>
+  UTILITY_FOLDERS.some((folder) => folder.name === box);
+
+/** The flags a mail must carry to land in `box`, or `undefined` for any other box. */
+export const utilityPlacement = (
+  box: string
+): { draft?: boolean; is_spam?: boolean } | undefined =>
+  UTILITY_FOLDERS.find((folder) => folder.name === box)?.placement;
+
 /** Maps an email address to its received-mail virtual mailbox name. */
 export const accountToBox = (accountName: string): string => {
   const localPart = accountName.split("@")[0];
@@ -395,19 +430,21 @@ export const isInbox = (box: string): boolean => {
 };
 
 /**
- * Returns true for the domain-scoped mailboxes — INBOX and the unified
- * "Sent Messages" folder — whose UID space is `uid_domain` rather than
- * the per-mailbox UID (`mail_mailbox_uid.uid`). This mirrors both
- * `Store.resolveBox` and `resolveMappedBox` — the former returns
- * `accountName === null`, the latter returns `mailboxArg === null` for
- * exactly these two paths. FETCH / COPY / MOVE / APPEND must gate on this
- * predicate (not `isInbox` alone): the unified Sent folder is domain-scoped
- * too, so keying its emitted UID off the per-mailbox UID makes
- * `uidToSeqNumber` miss (messages silently dropped from FETCH, wrong
- * COPYUID source UIDs). See #702.
+ * Returns true for the mailboxes whose UID space is `uid_domain` rather than
+ * the per-mailbox UID (`mail_mailbox_uid.uid`): INBOX, the unified
+ * "Sent Messages" folder, and the utility folders. None of them hold mapping
+ * rows. FETCH / COPY / MOVE / APPEND must gate on this predicate (not `isInbox`
+ * alone): the unified Sent folder is domain-scoped too, so keying its emitted
+ * UID off the per-mailbox UID makes `uidToSeqNumber` miss (messages silently
+ * dropped from FETCH, wrong COPYUID source UIDs). See #702.
+ *
+ * Not the same question as "does the repository take `null` for this box":
+ * a utility folder is domain-scoped but still passes its name, because that is
+ * what its membership predicate is keyed on. `Store.resolveMappedBox` draws
+ * that second line.
  */
 export const isDomainScoped = (box: string): boolean => {
-  return isInbox(box) || box === SENT_MESSAGES_FOLDER;
+  return isInbox(box) || box === SENT_MESSAGES_FOLDER || isUtilityFolder(box);
 };
 
 /** Returns true for the accounts/ parent folder itself (non-selectable). */

--- a/src/server/lib/imap/utility-mailboxes.test.ts
+++ b/src/server/lib/imap/utility-mailboxes.test.ts
@@ -1,0 +1,119 @@
+/**
+ * The IMAP surface of the utility mailboxes (#725).
+ *
+ * `Drafts` and `Junk` are server-defined views, not rows in `mailboxes`. That
+ * makes them behave like INBOX for every command that manipulates the mailbox
+ * itself: they always exist, so CREATE is a conflict, and there is nothing
+ * behind them to DELETE or RENAME. Without the guards the DB layer answers each
+ * of those with `[NONEXISTENT] Mailbox does not exist` — for a box the client
+ * can see in its own LIST output.
+ *
+ * The row-level half of the feature (which mails each view holds) lives in
+ * `repositories/mails/views.test.ts`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  isDomainScoped,
+  isUtilityFolder,
+  utilityPlacement,
+  UTILITY_FOLDERS,
+} from "./util";
+import {
+  createMailbox,
+  deleteMailbox,
+  renameMailbox,
+  getMailboxAttributes,
+} from "./mailbox-ops";
+import { Store } from "./store";
+import type { SignedUser } from "common";
+
+const NAMES = UTILITY_FOLDERS.map((folder) => folder.name);
+
+const makeStore = (): Store =>
+  new Store({ id: "u1", username: "admin" } as SignedUser);
+
+const run = async (
+  op: (write: (data: string) => boolean) => Promise<void>
+): Promise<string[]> => {
+  const lines: string[] = [];
+  await op((data: string) => {
+    lines.push(data);
+    return true;
+  });
+  return lines;
+};
+
+describe("isUtilityFolder", () => {
+  it("matches the defined names exactly", () => {
+    expect(isUtilityFolder("Drafts")).toBe(true);
+    expect(isUtilityFolder("Junk")).toBe(true);
+  });
+
+  it("is case-sensitive and not a prefix match", () => {
+    // RFC 3501 §5.1 makes INBOX the only case-insensitive name; every other
+    // mailbox name is compared literally, so `drafts` stays a name the user
+    // could legitimately create.
+    expect(isUtilityFolder("drafts")).toBe(false);
+    expect(isUtilityFolder("Drafts2")).toBe(false);
+    expect(isUtilityFolder("INBOX/Drafts")).toBe(false);
+    expect(isUtilityFolder("")).toBe(false);
+  });
+
+  it("puts every utility folder in the domain UID space", () => {
+    for (const name of NAMES) expect(isDomainScoped(name)).toBe(true);
+  });
+});
+
+describe("LIST attributes", () => {
+  it("reports the RFC 6154 special-use attribute", () => {
+    expect(getMailboxAttributes("Drafts", NAMES)).toBe("\\Drafts \\HasNoChildren");
+    expect(getMailboxAttributes("Junk", NAMES)).toBe("\\Junk \\HasNoChildren");
+  });
+
+  it("leaves every other box's attributes alone", () => {
+    expect(getMailboxAttributes("Archive", ["Archive"])).toBe("\\HasNoChildren");
+    expect(getMailboxAttributes("INBOX/accounts", ["INBOX/accounts"])).toBe(
+      "\\HasChildren \\Noselect"
+    );
+  });
+});
+
+describe("CREATE / DELETE / RENAME against a utility folder", () => {
+  it("CREATE reports the conflict, not a DB insert", async () => {
+    for (const name of NAMES) {
+      const lines = await run((write) => createMailbox("A1", name, makeStore(), write));
+      expect(lines).toEqual(["A1 NO [ALREADYEXISTS] Mailbox already exists\r\n"]);
+    }
+  });
+
+  it("DELETE refuses instead of reporting a missing mailbox", async () => {
+    for (const name of NAMES) {
+      const lines = await run((write) => deleteMailbox("A1", name, makeStore(), write));
+      expect(lines).toEqual(["A1 NO [CANNOT] Cannot delete system mailbox\r\n"]);
+    }
+  });
+
+  it("RENAME refuses as source and as target", async () => {
+    for (const name of NAMES) {
+      expect(
+        await run((write) => renameMailbox("A1", name, "Elsewhere", makeStore(), write))
+      ).toEqual(["A1 NO [CANNOT] Cannot rename system mailbox\r\n"]);
+      expect(
+        await run((write) => renameMailbox("A1", "Archive", name, makeStore(), write))
+      ).toEqual(["A1 NO [ALREADYEXISTS] Target mailbox already exists\r\n"]);
+    }
+  });
+});
+
+describe("utilityPlacement", () => {
+  it("returns the flag a write into the box must set", () => {
+    expect(utilityPlacement("Drafts")).toEqual({ draft: true });
+    expect(utilityPlacement("Junk")).toEqual({ is_spam: true });
+  });
+
+  it("returns nothing for any other box", () => {
+    expect(utilityPlacement("Archive")).toBeUndefined();
+    expect(utilityPlacement("INBOX")).toBeUndefined();
+  });
+});

--- a/src/server/lib/imap/utility-mailboxes.test.ts
+++ b/src/server/lib/imap/utility-mailboxes.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect } from "bun:test";
 import {
+  canonicalMailbox,
   isDomainScoped,
   isUtilityFolder,
   utilityPlacement,
@@ -71,6 +72,23 @@ describe("isUtilityFolder", () => {
 
   it("puts every utility folder in the domain UID space", () => {
     for (const name of NAMES) expect(isDomainScoped(name)).toBe(true);
+  });
+});
+
+describe("canonicalMailbox", () => {
+  it("resolves a utility name to its listed spelling", () => {
+    // The guards match case-insensitively but `mailboxExists` compares against
+    // the LIST names exactly, so without this every entry point would refuse
+    // `drafts` as both already-existing (CREATE) and non-existent (SELECT).
+    expect(canonicalMailbox("drafts")).toBe("Drafts");
+    expect(canonicalMailbox("JUNK")).toBe("Junk");
+  });
+
+  it("still canonicalizes INBOX and leaves every other name alone", () => {
+    expect(canonicalMailbox("inbox")).toBe("INBOX");
+    expect(canonicalMailbox("Archive")).toBe("Archive");
+    expect(canonicalMailbox("Drafts/sub")).toBe("Drafts/sub");
+    expect(canonicalMailbox("INBOX/accounts/junk")).toBe("INBOX/accounts/junk");
   });
 });
 

--- a/src/server/lib/imap/utility-mailboxes.test.ts
+++ b/src/server/lib/imap/utility-mailboxes.test.ts
@@ -50,13 +50,22 @@ describe("isUtilityFolder", () => {
     expect(isUtilityFolder("Junk")).toBe(true);
   });
 
-  it("is case-sensitive and not a prefix match", () => {
-    // RFC 3501 §5.1 makes INBOX the only case-insensitive name; every other
-    // mailbox name is compared literally, so `drafts` stays a name the user
-    // could legitimately create.
-    expect(isUtilityFolder("drafts")).toBe(false);
+  it("is case-insensitive, matching the LIST de-dup", () => {
+    // `Store.listMailboxesOrThrow` de-dups user boxes against these names
+    // case-insensitively, so `drafts` names no listable box. An exact-case
+    // guard would let `CREATE "drafts"` write a row that LIST then hides and
+    // SELECT then rejects — the phantom the CREATE guard exists to prevent.
+    expect(isUtilityFolder("drafts")).toBe(true);
+    expect(isUtilityFolder("JUNK")).toBe(true);
+  });
+
+  it("matches the whole name — not a prefix, suffix, or substring", () => {
+    // `INBOX/accounts/junk` is a real per-account box in prod (a user whose
+    // local-part is `junk`). A substring match would swallow it.
+    expect(isUtilityFolder("INBOX/accounts/junk")).toBe(false);
     expect(isUtilityFolder("Drafts2")).toBe(false);
     expect(isUtilityFolder("INBOX/Drafts")).toBe(false);
+    expect(isUtilityFolder("Drafts/sub")).toBe(false);
     expect(isUtilityFolder("")).toBe(false);
   });
 

--- a/src/server/lib/postgres/models/common.ts
+++ b/src/server/lib/postgres/models/common.ts
@@ -59,7 +59,7 @@ export const UID_DOMAIN = "uid_domain";
 // within a mailbox. Bumped by the IMAP write paths — new-message insert
 // (saveMail, incl. APPEND/COPY), STORE (setMailFlags), and EXPUNGE/MOVE.
 // markMailSpam bumps it too: the flip moves the mail in or out of IMAP's INBOX
-// (see `quarantinesSpam`), which is a membership change a CONDSTORE client must
+// (see `isInboxTree`), which is a membership change a CONDSTORE client must
 // be able to detect. The remaining web-REST mutators (markMailRead /
 // markMailSaved) still do not bump it in phase 1 — they change no membership,
 // and no client can observe modseq until phase 3 (FETCH CHANGEDSINCE) lands.

--- a/src/server/lib/postgres/models/mail.ts
+++ b/src/server/lib/postgres/models/mail.ts
@@ -413,6 +413,7 @@ export const mailsTable = createTable<MailJSON, MailSchema, MailModel>({
     { column: UID_DOMAIN },
     { column: MODSEQ },
     { column: IS_SPAM },
+    { column: DRAFT },
     { column: EXPUNGED },
     // Address containment (@>) filters for the per-account reads —
     // buildHeaderAddressCondition in repositories/mails/http.ts. jsonb_path_ops

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -9,6 +9,7 @@ import {
   MAIL_ID,
   USER_ID,
   ENVELOPE_TO,
+  MODSEQ,
   DB_NOW,
   RFC822_SIZE,
   TEXT_LINE_COUNT,
@@ -61,6 +62,14 @@ export interface SaveMailInput {
   spam_score?: number;
   spam_reasons?: string[] | null;
   is_spam?: boolean;
+  /**
+   * Flags the destination box selects on, when it is a flag-derived utility
+   * view (`Drafts`, `Junk`). Applied on both the INSERT and the 23505 merge
+   * branch: membership there is the flag, so a merge that skipped it would
+   * answer `OK [APPENDUID …]` for a message that landed in no box the client
+   * named. `utilityPlacement` in `imap/util.ts` produces it.
+   */
+  placement?: { draft?: boolean; is_spam?: boolean };
   /**
    * Destination mailbox path (per-account like `INBOX/accounts/claude` /
    * `Sent Messages/accounts/claude`, or user-created like `Archive`). When
@@ -168,6 +177,7 @@ export const saveMail = async (
       spam_score: input.spam_score ?? 0,
       spam_reasons: input.spam_reasons ? JSON.stringify(input.spam_reasons) : null,
       is_spam: input.is_spam ?? false,
+      ...input.placement,
     };
 
     const row = await mailsTable.insert(data, [MAIL_ID]);
@@ -237,6 +247,22 @@ export const saveMail = async (
       // `ON CONFLICT (user_id, mailbox, mail_id) DO NOTHING`, so the
       // loser's counter tick and mapping-insert round-trip are wasted
       // (rare, sub-ms, off the SMTP reply path) — the winner's row wins.
+      // A mapped destination gets its membership from the mapping row below; a
+      // utility destination gets it from the flag, and `existing` predates this
+      // write, so the flag has to be set here too. Without it the APPEND is
+      // acknowledged and the message is in no box the client named. The flip is
+      // a membership change, so it advances the mod-sequence like markMailSpam.
+      if (input.placement) {
+        await mailsTable.updateWhere(
+          { user_id: input.user_id, message_id: input.message_id },
+          {
+            ...input.placement,
+            [MODSEQ]: await getNextModseq(input.user_id),
+            updated: DB_NOW,
+          }
+        );
+      }
+
       let persistedUid: number | undefined;
       if (input.mailbox && (input.uid_mailbox ?? 0) > 0) {
         persistedUid = await writeMailboxUid(
@@ -443,7 +469,7 @@ export const deleteMail = async (
  * Distinguishing "no change" from "not found" lets the caller skip classifier
  * training on idempotent re-marks while still surfacing real auth failures.
  *
- * The flip moves the mail in or out of IMAP's INBOX (see `quarantinesSpam`), so
+ * The flip moves the mail in or out of IMAP's INBOX (see `isInboxTree`), so
  * it advances the mod-sequence the way every other membership change does. That
  * keeps HIGHESTMODSEQ honest — without it a CONDSTORE client (RFC 7162 §3.1.2)
  * reads an unchanged value and concludes the mailbox never changed. It is not

--- a/src/server/lib/postgres/repositories/mails/counters.ts
+++ b/src/server/lib/postgres/repositories/mails/counters.ts
@@ -15,6 +15,7 @@ import {
   MAIL_ID,
   UID,
 } from "../../models";
+import { usesDomainUidSpace } from "./views";
 
 /**
  * Build the atomic UID-reservation upsert.
@@ -255,6 +256,13 @@ export const getNextModseq = async (user_id: string): Promise<number> => {
  * (QRESYNC, later phases) detects the removal. Returns 1 for an empty mailbox
  * (the DEFAULT-1 floor), never 0 — a 0 HIGHESTMODSEQ signals "no persistent
  * mod-sequences", which this store does support.
+ *
+ * Membership is deliberately NOT applied: the value only has to be an upper
+ * bound the client can compare against, and a bound that ignores the filter
+ * still moves whenever a message enters or leaves the box (both are stamped
+ * writes). Filtering it would let the value fall — a mail leaving `Drafts`
+ * would take the maximum with it — and a HIGHESTMODSEQ that decreases makes a
+ * CONDSTORE client conclude nothing changed.
  */
 export const getHighestModseq = async (
   user_id: string,
@@ -264,7 +272,7 @@ export const getHighestModseq = async (
   try {
     let sql: string;
     let values: ParamValue[];
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       sql = `
         SELECT COALESCE(MAX(${MODSEQ}), 1) AS highest FROM mails
         WHERE ${USER_ID} = $1 AND ${SENT} = $2

--- a/src/server/lib/postgres/repositories/mails/imap.test.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.test.ts
@@ -1088,65 +1088,8 @@ describe("buildCriterionClause — combinators don't orphan bound params (#672)"
   });
 });
 
-describe("INBOX quarantines spam (#605)", () => {
-  const load = async () => await import(".");
-
-  describe("quarantinesSpam", () => {
-    it("covers INBOX itself", async () => {
-      const { quarantinesSpam } = await load();
-      expect(quarantinesSpam(null, false)).toBe(true);
-    });
-
-    it("covers INBOX's per-account sub-views", async () => {
-      const { quarantinesSpam } = await load();
-      expect(quarantinesSpam("INBOX/accounts/alice", false)).toBe(true);
-    });
-
-    it("leaves the unified Sent view alone — sent mail is never classified", async () => {
-      const { quarantinesSpam } = await load();
-      expect(quarantinesSpam(null, true)).toBe(false);
-      expect(quarantinesSpam("Sent Messages/accounts/alice", true)).toBe(false);
-    });
-
-    it("leaves user-created mailboxes alone — an explicit COPY stays visible", async () => {
-      const { quarantinesSpam } = await load();
-      expect(quarantinesSpam("Archive", false)).toBe(false);
-      // A user-created box whose name merely starts with the folder's letters
-      // is not an accounts sub-view; only the full `INBOX/accounts/` path is.
-      expect(quarantinesSpam("INBOX/accountsish", false)).toBe(false);
-      expect(quarantinesSpam("INBOX/accounts", false)).toBe(false);
-    });
-  });
-
-  describe("SQL emitters", () => {
-    it("emit the is_spam predicate for a quarantining box", async () => {
-      const { membershipExpression, membershipCondition } = await load();
-      expect(membershipExpression(null, false)).toBe("is_spam = FALSE");
-      expect(membershipCondition(null, false)).toBe(" AND is_spam = FALSE");
-    });
-
-    it("qualify the column with the caller's alias", async () => {
-      const { membershipExpression, membershipCondition } = await load();
-      expect(membershipExpression("INBOX/accounts/alice", false, "m.")).toBe(
-        "m.is_spam = FALSE"
-      );
-      expect(membershipCondition("INBOX/accounts/alice", false, "m.")).toBe(
-        " AND m.is_spam = FALSE"
-      );
-    });
-
-    it("degrade to a no-op every non-quarantining box can interpolate", async () => {
-      const { membershipExpression, membershipCondition } = await load();
-      // `TRUE` keeps `COUNT(*) FILTER (WHERE …)` well-formed; "" appends
-      // cleanly to an existing WHERE. Neither needs a caller-side branch.
-      expect(membershipExpression("Archive", false)).toBe("TRUE");
-      expect(membershipCondition("Archive", false)).toBe("");
-      expect(membershipExpression(null, true)).toBe("TRUE");
-      expect(membershipCondition(null, true)).toBe("");
-    });
-  });
-
-  describe("every mailbox-scoped site applies the rule (source regression)", () => {
+describe("every mailbox applies its membership rule (#605, #725)", () => {
+  describe("every mailbox-scoped site applies it (source regression)", () => {
     // One missed site desynchronises INBOX's membership: e.g. a filtered
     // `getAllUids` (the seq→UID map) against an unfiltered `countMessages`
     // makes EXISTS exceed the addressable sequence range.
@@ -1184,20 +1127,26 @@ describe("INBOX quarantines spam (#605)", () => {
     // branch is the other: `UID STORE 1:* +FLAGS (\Deleted)` on INBOX followed
     // by EXPUNGE destroys quarantined spam the client was never shown.
     const applications: Record<string, number> = {
-      countMessages: 7,
-      getMailsByRangeUncoalesced: 5,
-      setMailFlags: 6,
-      searchMailsByUid: 1,
-      getAllUids: 2,
+      countMessages: 4, // total + unread FILTER, in each of the two branches
+      getMailsByRangeUncoalesced: 4, // UID and sequence range, in each branch
+      setMailFlags: 4, // two domain WHERE clauses, plus the mapping branch's pair
+      searchMailsByUid: 1, // one conditions list serves both branches
+      getAllUids: 2, // one per branch
       getFirstUnseenUid: 2,
-      expungeDeletedMails: 3,
+      expungeDeletedMails: 2, // domain filter bag + mapping SELECT
       expungeMailsByUid: 2,
     };
 
     const HELPERS =
-      "(?:membershipCondition|membershipExpression|quarantinesSpam)";
+      "(?:membershipCondition|membershipExpression|membershipFilter|filtersMembership)";
 
-    const applicationSites = (body: string) => {
+    const applicationSites = (rawBody: string) => {
+      // Comments mention the rule by name constantly; counting them would let a
+      // real application be deleted as long as the prose survived.
+      const body = rawBody
+        .split("\n")
+        .map((line) => line.replace(/\/\/.*$/, ""))
+        .join("\n");
       const locals = new Set(
         [...body.matchAll(new RegExp(`const\\s+(\\w+)\\s*=\\s*${HELPERS}\\(`, "g"))].map(
           (m) => m[1]
@@ -1243,18 +1192,6 @@ describe("INBOX quarantines spam (#605)", () => {
       // One per branch: domain-scoped (uid_domain) and per-mailbox (x.uid).
       expect(maxUidLines).toHaveLength(2);
       for (const line of maxUidLines) expect(line).not.toContain("FILTER");
-    });
-
-    it("does not exclude \\Deleted mail from INBOX", async () => {
-      // `mails.deleted` is the IMAP \Deleted flag; RFC 3501 §6.4.3 keeps those
-      // messages in the mailbox until EXPUNGE. Assert on what the rule actually
-      // emits — `is_spam` and nothing else — rather than on the absence of a
-      // string, which would pass just as well on a file that never had one.
-      const { membershipExpression, membershipCondition } = await import(".");
-      for (const box of [null, "INBOX/accounts/alice"]) {
-        expect(membershipExpression(box, false)).toBe("is_spam = FALSE");
-        expect(membershipCondition(box, false)).toBe(" AND is_spam = FALSE");
-      }
     });
 
     it("stamps a mod-sequence when a spam flip moves a mail out of INBOX", async () => {

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -15,10 +15,16 @@ import {
   MAIL_MAILBOX_UID,
   MAILBOX,
   UID,
-  IS_SPAM,
 } from "../../models";
 import { getNextModseq } from "./counters";
 import { singleFlight } from "./inflight";
+import {
+  filtersMembership,
+  membershipCondition,
+  membershipExpression,
+  membershipFilter,
+  usesDomainUidSpace,
+} from "./views";
 
 /**
  * Character-length chunk size for the SUBSTRING body-streaming reader. Chosen
@@ -208,66 +214,15 @@ const countCodePoints = (s: string): number => {
 
 /**
  * Callers pass `mailbox` as the raw IMAP box path (e.g. `INBOX/accounts/amazon`,
- * `Sent Messages/accounts/claoie`, or a user-created box like `Archive`) — the
- * exact string the write side stores in `mail_mailbox_uid.mailbox`. `null` is
- * reserved for domain-scoped views (`INBOX`, unified `Sent Messages`), which
- * stay on `mails.uid_domain` and don't participate in the per-mailbox mapping.
- */
-
-/**
- * Prefix of the per-account received boxes (`INBOX/accounts/<local-part>`).
- * Mirrors `ACCOUNTS_FOLDER` in `imap/util.ts`, which cannot be imported here:
- * that module pulls from the `server` barrel, which re-exports this repository.
- */
-const INBOX_ACCOUNTS_PREFIX = "INBOX/accounts/";
-
-/**
- * Whether a mailbox quarantines spam-classified mail — true for the INBOX tree
- * only.
+ * `Sent Messages/accounts/claoie`, a user-created box like `Archive`, or a
+ * utility view like `Drafts`). For a mapped box that is the exact string the
+ * write side stores in `mail_mailbox_uid.mailbox`; for a utility view it is the
+ * key its membership rule is looked up under. `null` is reserved for the two
+ * views with no name of their own, `INBOX` and the unified `Sent Messages`.
  *
- * INBOX (`mailbox === null`, `sent = false`) has no address condition at all,
- * and its per-account sub-views match purely on delivery address, so a
- * spam-classified mail lands in both simply by having been received, showing up
- * intermixed with ham and counting toward EXISTS/UNSEEN. The web client routes
- * those rows to a dedicated Spam view; this is the IMAP side of the same
- * quarantine. Until a `Junk` mailbox exists, quarantined mail is reachable over
- * the web client only.
- *
- * Deliberately narrow on two axes:
- * - **Sent is never classified.** `is_spam` is only ever written on received
- *   mail, so the unified `Sent Messages` view and its sub-boxes are untouched.
- * - **User-created mailboxes keep their contents.** A mail the user COPYed into
- *   `Archive` is an explicit placement; the classifier does not get to hide it.
- *
- * Note this is not extended to `deleted`: `mails.deleted` is the IMAP
- * `\Deleted` flag, and RFC 3501 §6.4.3 requires `\Deleted` messages to stay in
- * the mailbox until EXPUNGE removes them. Soft-deleted mail leaving INBOX is a
- * `Trash` mailbox question (#725), not an INBOX predicate.
+ * Which branch a box takes is `usesDomainUidSpace`, not `mailbox === null` —
+ * see `views.ts`.
  */
-export const quarantinesSpam = (mailbox: string | null, sent: boolean): boolean =>
-  !sent && (mailbox === null || mailbox.startsWith(INBOX_ACCOUNTS_PREFIX));
-
-/**
- * Boolean expression selecting the rows a mailbox actually contains. `TRUE` for
- * every box that shows spam, so callers can interpolate it unconditionally.
- * `prefix` qualifies the column for queries that alias `mails` (e.g. `"m."`).
- */
-export const membershipExpression = (
-  mailbox: string | null,
-  sent: boolean,
-  prefix: string = ""
-): string => (quarantinesSpam(mailbox, sent) ? `${prefix}${IS_SPAM} = FALSE` : "TRUE");
-
-/**
- * The same rule as a suffix for an existing `WHERE`, empty when the box shows
- * spam so it appends cleanly to any clause.
- */
-export const membershipCondition = (
-  mailbox: string | null,
-  sent: boolean,
-  prefix: string = ""
-): string =>
-  quarantinesSpam(mailbox, sent) ? ` AND ${prefix}${IS_SPAM} = FALSE` : "";
 
 export const countMessages = async (
   user_id: string,
@@ -292,7 +247,7 @@ export const countMessages = async (
     // instead. Tracked in #743.
     const membership = membershipExpression(mailbox, sent);
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       // Domain-wide count (INBOX / unified Sent Messages) — still keyed on
       // uid_domain, unchanged by #702's per-mailbox mapping migration.
       sql = `
@@ -456,7 +411,7 @@ const getMailsByRangeUncoalesced = async (
     const modseqMailboxClause =
       changedSince !== undefined ? ` AND m.${MODSEQ} > $6` : "";
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       // Domain-wide query (INBOX / unified Sent Messages) — still on
       // uid_domain, unchanged by the per-mailbox mapping migration.
       const projection = mailsColumns.length > 0 ? mailsColumns.join(", ") : "*";
@@ -644,7 +599,7 @@ export const setMailFlags = async (
     // following EXPUNGE would destroy it.
     const membership = membershipCondition(mailbox, sent);
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       const returningCols = `${UID_DOMAIN} as uid, read, saved, deleted, draft, answered, ${MODSEQ} as modseq`;
       if (useUid) {
         const whereClause = `user_id = $1 AND sent = $2 AND ${UID_DOMAIN} >= $3 AND ${UID_DOMAIN} <= $4${membership}`;
@@ -698,7 +653,7 @@ export const setMailFlags = async (
         // counts messages the seq map does not and shifts every position after
         // them. The join is emitted only for a box that filters; every other
         // box keeps the mapping-only scan it had.
-        const membershipJoin = quarantinesSpam(mailbox, sent)
+        const membershipJoin = filtersMembership(mailbox, sent)
           ? `JOIN mails z ON z.${USER_ID} = y.${USER_ID} AND z.${MAIL_ID} = y.${MAIL_ID}
              AND z.${SENT} = $2 AND z.${EXPUNGED} = FALSE
              AND ${membershipExpression(mailbox, sent, "z.")}`
@@ -999,7 +954,7 @@ export const searchMailsByUid = async (
     // uses the plain column on `mails`; per-mailbox uses the
     // JOIN-aliased mapping. `buildCriterionClause` emits fragments like
     // `${uidField} >= $N`, so the alias needs to be qualified.
-    const uidField = mailbox === null ? UID_DOMAIN : `x.${UID}`;
+    const uidField = usesDomainUidSpace(mailbox) ? UID_DOMAIN : `x.${UID}`;
 
     // Always exclude expunged messages from search, and anything the mailbox
     // doesn't show — SEARCH must not return UIDs the client can't FETCH.
@@ -1013,7 +968,7 @@ export const searchMailsByUid = async (
 
     // Base table + optional mailbox join
     let fromClause: string;
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       fromClause = "mails m";
     } else {
       // JOIN mapping — the mailbox condition IS the membership predicate.
@@ -1065,7 +1020,7 @@ export const getAllUids = async (
     let sql: string;
     let values: ParamValue[];
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE${membershipCondition(mailbox, sent)}
@@ -1108,7 +1063,7 @@ export const getFirstUnseenUid = async (
     let sql: string;
     let values: ParamValue[];
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       sql = `
         SELECT ${UID_DOMAIN} as uid FROM mails
         WHERE user_id = $1 AND sent = $2 AND expunged = FALSE AND read = FALSE${membershipCondition(mailbox, sent)}
@@ -1151,11 +1106,11 @@ export const expungeDeletedMails = async (
 ): Promise<number[]> => {
   try {
     // EXPUNGE removes `\Deleted` messages *from the selected mailbox*, so a
-    // quarantined mail is out of reach here too — otherwise an INBOX EXPUNGE
-    // would collect spam the client never saw and could not have flagged.
-    const quarantined = quarantinesSpam(mailbox, sent);
+    // mail the box does not show is out of reach here too — otherwise an INBOX
+    // EXPUNGE would collect spam the client never saw and could not have flagged.
+    const membership = membershipFilter(mailbox, sent);
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       // Domain-wide expunge — still on uid_domain, unchanged.
       const rows = await mailsTable.updateWhere(
         {
@@ -1163,7 +1118,7 @@ export const expungeDeletedMails = async (
           [SENT]: sent,
           [DELETED]: true,
           [EXPUNGED]: false,
-          ...(quarantined ? { [IS_SPAM]: false } : {}),
+          ...membership,
         },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.
@@ -1236,9 +1191,9 @@ export const expungeMailsByUid = async (
   try {
     // Same membership rule as EXPUNGE: MOVE's source-side removal only ever
     // addresses UIDs the selected mailbox actually holds.
-    const quarantined = quarantinesSpam(mailbox, sent);
+    const membership = membershipFilter(mailbox, sent);
 
-    if (mailbox === null) {
+    if (usesDomainUidSpace(mailbox)) {
       // Domain-wide: simple equality on user_id+sent + IN(uids).
       const rows = await mailsTable.updateWhere(
         {
@@ -1246,7 +1201,7 @@ export const expungeMailsByUid = async (
           [SENT]: sent,
           [EXPUNGED]: false,
           [UID_DOMAIN]: { op: "IN", value: uids },
-          ...(quarantined ? { [IS_SPAM]: false } : {}),
+          ...membership,
         },
         // Bump modseq so the expunge advances HIGHESTMODSEQ (RFC 7162) — a
         // resyncing CONDSTORE/QRESYNC client detects the removal.

--- a/src/server/lib/postgres/repositories/mails/index.ts
+++ b/src/server/lib/postgres/repositories/mails/index.ts
@@ -6,7 +6,10 @@
 //     stats, unread notifications).
 //   - imap: IMAP protocol operations (count, range FETCH, STORE flags, SEARCH,
 //     UID enumeration, EXPUNGE).
+//   - views: which rows each mailbox contains and which UID space it
+//     enumerates, shared by counters and imap.
 export * from "./core";
 export * from "./counters";
 export * from "./http";
 export * from "./imap";
+export * from "./views";

--- a/src/server/lib/postgres/repositories/mails/placement.test.ts
+++ b/src/server/lib/postgres/repositories/mails/placement.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `saveMail`'s utility-folder placement, on BOTH branches.
+ *
+ * The INSERT branch is observable from the caller's input object, so
+ * `imap/store.test.ts` can pin it. The 23505 merge branch is not: it rewrites a
+ * row that already exists, and a caller-side assertion passes whether or not
+ * that write happens. This file runs the REAL `saveMail` so the merge branch's
+ * SQL is what gets asserted.
+ *
+ * Why it matters: a utility view selects its rows by flag. An APPEND into
+ * `Drafts` for a Message-ID the account already has takes the merge branch, and
+ * a merge that skipped the flag would answer `OK [APPENDUID …]` for a message
+ * that landed in no box the client named.
+ *
+ * Two module-registry hazards have to be cleared to get here, both process-wide
+ * and neither undoable from this file:
+ *
+ *  - `imap/store.test.ts` mock.modules the `repositories/mails` barrel with a
+ *    stub `saveMail`, and `mock.module` replaces the export binding graph-wide
+ *    — a plain `import "./core"` resolves to that stub even though it never
+ *    names the barrel. Bun keys the registry by the full specifier string, so a
+ *    cache-busting query suffix is a different key and reaches the real module.
+ *  - The pg FakePool seam then does not bind (first importer of `client.ts`
+ *    wins), so the pool is mocked at the leaf `client` module instead, and
+ *    restored in `afterAll` so nothing bleeds onward.
+ */
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
+
+type Call = { sql: string; values: unknown[] };
+let calls: Call[] = [];
+
+/** Set per test: what the INSERT does. */
+let insertBehavior: "ok" | "conflict" = "ok";
+
+const EXISTING_MAIL_ID = "existing-mail-id";
+
+/**
+ * The row the merge branch re-reads. `MailModel` validates every column, so
+ * this has to be complete — the flags are the part the assertions care about,
+ * and they start in the state the placement is supposed to change.
+ */
+const existingRow = () => ({
+  mail_id: EXISTING_MAIL_ID,
+  user_id: "user-1",
+  message_id: "<msg@example.com>",
+  subject: "s",
+  date: new Date().toISOString(),
+  html: "",
+  text: "",
+  from_address: null,
+  from_text: null,
+  to_address: null,
+  to_text: null,
+  cc_address: null,
+  cc_text: null,
+  bcc_address: null,
+  bcc_text: null,
+  reply_to_address: null,
+  reply_to_text: null,
+  envelope_from: null,
+  envelope_to: null,
+  attachments: null,
+  read: false,
+  saved: false,
+  sent: false,
+  deleted: false,
+  draft: false,
+  answered: false,
+  expunged: false,
+  insight: null,
+  uid_domain: 7,
+  modseq: 1,
+  spam_score: 0,
+  spam_reasons: null,
+  is_spam: false,
+  rfc822_size: 0,
+  text_line_count: 1,
+  html_line_count: 1,
+  updated: new Date().toISOString(),
+  search_vector: null,
+});
+
+const fakeQuery = async (sql: string, values?: unknown[]) => {
+  calls.push({ sql, values: values ?? [] });
+  const text = sql.trim().toUpperCase();
+
+  // Order matters: the `mails` INSERT also ends in RETURNING and contains
+  // VALUES, so match the table name before any generic shape.
+  if (text.startsWith("INSERT INTO MAILS ")) {
+    if (insertBehavior === "conflict") {
+      throw Object.assign(new Error("duplicate key"), { code: "23505" });
+    }
+    return { rows: [{ mail_id: "new-mail-id" }], rowCount: 1 };
+  }
+  // getNextModseq reserves through `mail_uid_counters`.
+  if (text.includes("MAIL_UID_COUNTERS")) {
+    return { rows: [{ last_uid: 42 }], rowCount: 1 };
+  }
+  // The merge branch's re-read of the existing row.
+  if (text.startsWith("SELECT") && text.includes("FROM MAILS")) {
+    return { rows: [existingRow()], rowCount: 1 };
+  }
+  return { rows: [], rowCount: 0 };
+};
+
+const realClient = await import("../../client");
+mock.module("../../client", () => ({ ...realClient, pool: { query: fakeQuery } }));
+
+const { saveMail } = await import(`${import.meta.dir}/core.ts?real=725`);
+
+afterAll(() => {
+  mock.module("../../client", () => realClient);
+});
+
+beforeEach(() => {
+  calls = [];
+  insertBehavior = "ok";
+});
+
+const input = (placement?: { draft?: boolean; is_spam?: boolean }) => ({
+  user_id: "user-1",
+  message_id: "<msg@example.com>",
+  subject: "s",
+  placement,
+});
+
+/** Every UPDATE issued against `mails`, lowercased for substring matching. */
+const mailUpdates = () =>
+  calls.map((c) => c.sql.trim().toLowerCase()).filter((s) => s.startsWith("update mails"));
+
+describe("saveMail — utility placement on the INSERT branch", () => {
+  it("writes the flag as part of the inserted row", async () => {
+    await saveMail(input({ draft: true }));
+    const insert = calls.find((c) => c.sql.trim().toLowerCase().startsWith("insert into mails"));
+    expect(insert).toBeDefined();
+    expect(insert!.sql.toLowerCase()).toContain("draft");
+    // The row carries `draft = TRUE`, not the SaveMailInput default of FALSE.
+    expect(insert!.values).toContain(true);
+  });
+});
+
+describe("saveMail — utility placement on the 23505 merge branch", () => {
+  it("sets the flag on the existing row so the message is in the box the client named", async () => {
+    insertBehavior = "conflict";
+    const result = await saveMail(input({ draft: true }));
+
+    // The merge branch must still resolve to the pre-existing row.
+    expect(result?._id).toBe(EXISTING_MAIL_ID);
+
+    expect(mailUpdates().some((s) => s.includes("draft"))).toBe(true);
+  });
+
+  it("advances the mod-sequence, because placement is a membership change", async () => {
+    insertBehavior = "conflict";
+    await saveMail(input({ is_spam: true }));
+
+    const placementUpdate = mailUpdates().find((s) => s.includes("is_spam"));
+    expect(placementUpdate).toBeDefined();
+    expect(placementUpdate).toContain("modseq");
+  });
+
+  it("issues no placement UPDATE when the destination is not a utility folder", async () => {
+    insertBehavior = "conflict";
+    await saveMail(input(undefined));
+
+    expect(mailUpdates().some((s) => s.includes("draft") || s.includes("is_spam"))).toBe(false);
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/views.test.ts
+++ b/src/server/lib/postgres/repositories/mails/views.test.ts
@@ -55,11 +55,25 @@ describe("utility views", () => {
   });
 
   it("do not inherit a prototype key as a view name", () => {
-    // The lookup is a plain object index, so a name like `constructor` must not
-    // resolve to a predicate and silently take the domain branch.
+    // Mailbox names are user input and `"toString" in {}` is true, so the
+    // lookup is a Map — a box called `constructor` must not resolve to a
+    // predicate and silently take the domain branch.
     expect(isUtilityView("constructor")).toBe(false);
     expect(isUtilityView("toString")).toBe(false);
     expect(membershipExpression("constructor", false)).toBe("TRUE");
+  });
+
+  it("match case-insensitively, like the IMAP-side folder lookup", () => {
+    // `Store.listMailboxesOrThrow` de-dups user boxes against these names
+    // case-insensitively and `utilityFolder` matches the same way. If the
+    // read side ever stops lowercasing, `APPEND drafts` still stamps
+    // draft = TRUE while `SELECT drafts` routes to the mapping join instead
+    // of the flag view — the message lands somewhere the client can't read.
+    expect(isUtilityView("drafts")).toBe(true);
+    expect(isUtilityView("JUNK")).toBe(true);
+    expect(usesDomainUidSpace("drafts")).toBe(true);
+    expect(membershipExpression("drafts", false)).toBe("draft = TRUE");
+    expect(membershipExpression("JUNK", false)).toBe("is_spam = TRUE");
   });
 });
 
@@ -71,6 +85,15 @@ describe("INBOX", () => {
     expect(membershipExpression("INBOX/accounts/alice", false, "m.")).toBe(
       "m.is_spam = FALSE AND m.draft = FALSE"
     );
+  });
+
+  it("stops at the accounts prefix boundary", () => {
+    // The rule keys on `INBOX/accounts/` with the trailing slash. Dropping it
+    // would pull the non-selectable parent and any similarly-named user box
+    // into the INBOX tree, so they would start hiding spam with nothing else
+    // in the suite noticing.
+    expect(membershipExpression("INBOX/accounts", false)).toBe("TRUE");
+    expect(membershipExpression("INBOX/accountsish", false)).toBe("TRUE");
   });
 
   it("does not exclude \\Deleted mail", () => {

--- a/src/server/lib/postgres/repositories/mails/views.test.ts
+++ b/src/server/lib/postgres/repositories/mails/views.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Which rows each mailbox contains (#725).
+ *
+ * The utility views are defined twice by necessity — once here in the
+ * repository (the predicate) and once in `imap/util.ts` (the LIST attribute and
+ * the write-side placement flag), because the IMAP module pulls from the
+ * `server` barrel that re-exports this repository. The last describe block is
+ * the guard that keeps the two copies saying the same thing.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  DRAFTS_VIEW,
+  JUNK_VIEW,
+  filtersMembership,
+  isUtilityView,
+  membershipCondition,
+  membershipExpression,
+  membershipFilter,
+  usesDomainUidSpace,
+} from "./views";
+
+describe("utility views", () => {
+  it("select their rows by flag", () => {
+    expect(membershipExpression(DRAFTS_VIEW, false)).toBe("draft = TRUE");
+    expect(membershipExpression(JUNK_VIEW, false)).toBe("is_spam = TRUE");
+    expect(membershipCondition(DRAFTS_VIEW, false)).toBe(" AND draft = TRUE");
+    expect(membershipCondition(JUNK_VIEW, false)).toBe(" AND is_spam = TRUE");
+  });
+
+  it("qualify the column with the caller's alias", () => {
+    expect(membershipExpression(DRAFTS_VIEW, false, "m.")).toBe("m.draft = TRUE");
+    expect(membershipCondition(JUNK_VIEW, false, "m.")).toBe(" AND m.is_spam = TRUE");
+  });
+
+  it("read the domain UID space — they hold no mapping rows to join", () => {
+    // The whole point of naming them: a utility view reaches the repository as a
+    // string (so its predicate can be looked up) but must still take the
+    // `uid_domain` branch. Routing it to the JOIN would match zero mapping rows
+    // and report a permanently empty mailbox.
+    expect(usesDomainUidSpace(DRAFTS_VIEW)).toBe(true);
+    expect(usesDomainUidSpace(JUNK_VIEW)).toBe(true);
+    expect(usesDomainUidSpace(null)).toBe(true);
+    expect(usesDomainUidSpace("INBOX/accounts/alice")).toBe(false);
+    expect(usesDomainUidSpace("Archive")).toBe(false);
+  });
+
+  it("are matched exactly, not by prefix", () => {
+    // A user-created `Drafts2` is an ordinary mapped box; treating it as a view
+    // would hand it INBOX's UID space and hide every mail it actually holds.
+    expect(isUtilityView("Drafts2")).toBe(false);
+    expect(isUtilityView("INBOX/Drafts")).toBe(false);
+    expect(isUtilityView(null)).toBe(false);
+    expect(usesDomainUidSpace("Drafts2")).toBe(false);
+  });
+
+  it("do not inherit a prototype key as a view name", () => {
+    // The lookup is a plain object index, so a name like `constructor` must not
+    // resolve to a predicate and silently take the domain branch.
+    expect(isUtilityView("constructor")).toBe(false);
+    expect(isUtilityView("toString")).toBe(false);
+    expect(membershipExpression("constructor", false)).toBe("TRUE");
+  });
+});
+
+describe("INBOX", () => {
+  it("hides spam and drafts — each has a view of its own", () => {
+    expect(membershipExpression(null, false)).toBe(
+      "is_spam = FALSE AND draft = FALSE"
+    );
+    expect(membershipExpression("INBOX/accounts/alice", false, "m.")).toBe(
+      "m.is_spam = FALSE AND m.draft = FALSE"
+    );
+  });
+
+  it("does not exclude \\Deleted mail", () => {
+    // `mails.deleted` is the IMAP \Deleted flag; RFC 3501 §6.4.3 keeps those
+    // messages in the mailbox until EXPUNGE. Assert on what the rule emits
+    // rather than on the absence of a string, which would pass just as well on
+    // a rule that never had one.
+    expect(Object.keys(membershipFilter(null, false))).toEqual([
+      "is_spam",
+      "draft",
+    ]);
+  });
+
+  it("leaves sent mail and user-created boxes unfiltered", () => {
+    expect(membershipExpression(null, true)).toBe("TRUE");
+    expect(membershipExpression("Sent Messages/accounts/alice", true)).toBe("TRUE");
+    expect(membershipExpression("Archive", false)).toBe("TRUE");
+    expect(membershipCondition("Archive", false)).toBe("");
+    expect(filtersMembership("Archive", false)).toBe(false);
+    expect(filtersMembership(null, false)).toBe(true);
+    expect(filtersMembership(DRAFTS_VIEW, false)).toBe(true);
+  });
+});
+
+describe("the IMAP-side folder table agrees with the predicate", () => {
+  it("names the same boxes", async () => {
+    const { UTILITY_FOLDERS } = await import("../../../imap/util");
+    expect(UTILITY_FOLDERS.map((folder) => folder.name).sort()).toEqual(
+      [DRAFTS_VIEW, JUNK_VIEW].sort()
+    );
+  });
+
+  it("writes exactly the flags the view reads", async () => {
+    // A COPY / MOVE / APPEND into a utility folder sets `placement`; the view
+    // selects on `membershipFilter`. If they ever disagree, the write reports
+    // success and the message is invisible in the box the client named.
+    const { UTILITY_FOLDERS } = await import("../../../imap/util");
+    for (const { name, placement } of UTILITY_FOLDERS) {
+      expect(placement, `no placement for ${name}`).toEqual(
+        membershipFilter(name, false)
+      );
+    }
+  });
+
+  it("is listed as domain-scoped on the IMAP side too", async () => {
+    // `isDomainScoped` drives which UID the wire reports (COPYUID / APPENDUID /
+    // FETCH); it has to agree with `usesDomainUidSpace`, which drives which UID
+    // the query selects. Disagreement emits a UID that addresses nothing.
+    const { isDomainScoped } = await import("../../../imap/util");
+    for (const view of [DRAFTS_VIEW, JUNK_VIEW]) {
+      expect(isDomainScoped(view)).toBe(usesDomainUidSpace(view));
+    }
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/views.ts
+++ b/src/server/lib/postgres/repositories/mails/views.ts
@@ -1,0 +1,139 @@
+import { IS_SPAM, DRAFT } from "../../models";
+
+/**
+ * Which rows each IMAP mailbox contains, and which UID space it enumerates.
+ *
+ * Two kinds of mailbox reach this repository:
+ *
+ *  - **Mapped boxes** — the per-account views (`INBOX/accounts/<local-part>`,
+ *    `Sent Messages/accounts/<local-part>`) and user-created boxes. Membership
+ *    is a row in `mail_mailbox_uid`, which also carries the per-box UID.
+ *  - **Domain views** — `INBOX`, the unified `Sent Messages`, and the utility
+ *    views below. They hold no mapping rows: membership is a predicate over
+ *    `mails`, and UIDs come from `mails.uid_domain`.
+ *
+ * The rules live here rather than in `imap.ts` so `counters.ts` can apply the
+ * same branch without importing the module that imports it.
+ *
+ * The box names are duplicated from `imap/util.ts`, which cannot be imported
+ * here: that module pulls from the `server` barrel, which re-exports this
+ * repository. `views.test.ts` pins the two copies together.
+ */
+
+/** Prefix of the per-account received boxes (`INBOX/accounts/<local-part>`). */
+const INBOX_ACCOUNTS_PREFIX = "INBOX/accounts/";
+
+/**
+ * Flag-derived views over the user's whole domain, mirroring folders the web
+ * client already has. Each is one predicate over `mails` — no mapping rows, no
+ * backfill — which is also why membership tracks the flag: a mail leaves
+ * `Drafts` the moment `\Draft` is cleared, with nothing to keep in sync.
+ */
+export const DRAFTS_VIEW = "Drafts";
+export const JUNK_VIEW = "Junk";
+
+/**
+ * A mailbox's membership rule as `column → required value`. One definition
+ * renders both ways it is consumed: a SQL fragment for the hand-built IMAP
+ * queries, and a filter bag for the `Table` call sites — so the two can't drift.
+ */
+export type MembershipFilter = Record<string, boolean>;
+
+// A Map, not an object literal: mailbox names are user input, and `"toString"
+// in {}` is true — an object lookup would hand a user-created box called
+// `constructor` the domain UID space and show it the whole account.
+const UTILITY_VIEW_MEMBERSHIP = new Map<string, MembershipFilter>([
+  [DRAFTS_VIEW, { [DRAFT]: true }],
+  [JUNK_VIEW, { [IS_SPAM]: true }],
+]);
+
+/** Whether `mailbox` names one of the flag-derived utility views. */
+export const isUtilityView = (mailbox: string | null): boolean =>
+  mailbox !== null && UTILITY_VIEW_MEMBERSHIP.has(mailbox);
+
+/**
+ * Whether a mailbox enumerates `mails.uid_domain` rather than joining
+ * `mail_mailbox_uid`. True for the two unnamed domain views (`mailbox === null`)
+ * and for the utility views, which carry a name only so their membership rule
+ * can be looked up — they hold no mapping rows to join.
+ */
+export const usesDomainUidSpace = (mailbox: string | null): boolean =>
+  mailbox === null || isUtilityView(mailbox);
+
+/**
+ * Whether a mailbox hides spam-classified and draft mail — true for the INBOX
+ * tree only.
+ *
+ * INBOX (`mailbox === null`, `sent = false`) has no address condition at all,
+ * and its per-account sub-views match purely on delivery address, so a
+ * spam-classified or half-written mail lands in both simply by existing, showing
+ * up intermixed with real mail and counting toward EXISTS/UNSEEN. Each now has a
+ * view of its own (`Junk`, `Drafts`) — this is the other half of giving them
+ * one home, and it matches where the web client already routes the same rows.
+ *
+ * Deliberately narrow on two axes:
+ * - **Sent is never classified.** `is_spam` is only ever written on received
+ *   mail, so the unified `Sent Messages` view and its sub-boxes are untouched.
+ * - **User-created mailboxes keep their contents.** A mail the user COPYed into
+ *   `Archive` is an explicit placement; the classifier does not get to hide it.
+ *
+ * Note this is not extended to `deleted`: `mails.deleted` is the IMAP
+ * `\Deleted` flag, and RFC 3501 §6.4.3 requires `\Deleted` messages to stay in
+ * the mailbox until EXPUNGE removes them. Soft-deleted mail leaving INBOX is a
+ * `Trash` mailbox question (#725), not an INBOX predicate.
+ */
+export const quarantinesSpam = (mailbox: string | null, sent: boolean): boolean =>
+  !sent && (mailbox === null || mailbox.startsWith(INBOX_ACCOUNTS_PREFIX));
+
+/**
+ * The rows a mailbox contains, on top of the scope (user, `sent`, `expunged`,
+ * mapping join) its caller already applies. Empty for a box that filters
+ * nothing.
+ *
+ * The utility views need no `sent` term of their own: `Drafts` and `Junk` both
+ * resolve to `sent = false` through `isSentBox`, and every caller binds that.
+ * A view spanning both directions (`Starred`, `Trash`) would need the `sent`
+ * condition to move in here — see #725.
+ */
+export const membershipFilter = (
+  mailbox: string | null,
+  sent: boolean
+): MembershipFilter => {
+  const utility = mailbox !== null ? UTILITY_VIEW_MEMBERSHIP.get(mailbox) : undefined;
+  if (utility) return utility;
+  if (quarantinesSpam(mailbox, sent)) return { [IS_SPAM]: false, [DRAFT]: false };
+  return {};
+};
+
+/**
+ * The membership rule as a boolean expression. `TRUE` for a box that filters
+ * nothing, so callers can interpolate it unconditionally. `prefix` qualifies the
+ * columns for queries that alias `mails` (e.g. `"m."`).
+ */
+export const membershipExpression = (
+  mailbox: string | null,
+  sent: boolean,
+  prefix: string = ""
+): string => {
+  const terms = Object.entries(membershipFilter(mailbox, sent)).map(
+    ([column, value]) => `${prefix}${column} = ${value ? "TRUE" : "FALSE"}`
+  );
+  return terms.length > 0 ? terms.join(" AND ") : "TRUE";
+};
+
+/**
+ * The same rule as a suffix for an existing `WHERE`, empty when the box filters
+ * nothing so it appends cleanly to any clause.
+ */
+export const membershipCondition = (
+  mailbox: string | null,
+  sent: boolean,
+  prefix: string = ""
+): string => {
+  const expression = membershipExpression(mailbox, sent, prefix);
+  return expression === "TRUE" ? "" : ` AND ${expression}`;
+};
+
+/** Whether the box shows a strict subset of the rows its scope selects. */
+export const filtersMembership = (mailbox: string | null, sent: boolean): boolean =>
+  Object.keys(membershipFilter(mailbox, sent)).length > 0;

--- a/src/server/lib/postgres/repositories/mails/views.ts
+++ b/src/server/lib/postgres/repositories/mails/views.ts
@@ -42,14 +42,21 @@ export type MembershipFilter = Record<string, boolean>;
 // A Map, not an object literal: mailbox names are user input, and `"toString"
 // in {}` is true — an object lookup would hand a user-created box called
 // `constructor` the domain UID space and show it the whole account.
+//
+// Keyed lowercase and looked up lowercase, because the LIST de-dup in
+// `Store.listMailboxesOrThrow` is case-insensitive: `drafts` resolves to no
+// listable box, so it must not resolve to a different UID space either.
 const UTILITY_VIEW_MEMBERSHIP = new Map<string, MembershipFilter>([
-  [DRAFTS_VIEW, { [DRAFT]: true }],
-  [JUNK_VIEW, { [IS_SPAM]: true }],
+  [DRAFTS_VIEW.toLowerCase(), { [DRAFT]: true }],
+  [JUNK_VIEW.toLowerCase(), { [IS_SPAM]: true }],
 ]);
+
+const utilityMembership = (mailbox: string | null): MembershipFilter | undefined =>
+  mailbox === null ? undefined : UTILITY_VIEW_MEMBERSHIP.get(mailbox.toLowerCase());
 
 /** Whether `mailbox` names one of the flag-derived utility views. */
 export const isUtilityView = (mailbox: string | null): boolean =>
-  mailbox !== null && UTILITY_VIEW_MEMBERSHIP.has(mailbox);
+  utilityMembership(mailbox) !== undefined;
 
 /**
  * Whether a mailbox enumerates `mails.uid_domain` rather than joining
@@ -61,8 +68,9 @@ export const usesDomainUidSpace = (mailbox: string | null): boolean =>
   mailbox === null || isUtilityView(mailbox);
 
 /**
- * Whether a mailbox hides spam-classified and draft mail — true for the INBOX
- * tree only.
+ * Whether a mailbox is in the INBOX tree — INBOX itself or one of its
+ * per-account sub-views. Those are the boxes that hide spam-classified and
+ * half-written mail.
  *
  * INBOX (`mailbox === null`, `sent = false`) has no address condition at all,
  * and its per-account sub-views match purely on delivery address, so a
@@ -82,7 +90,7 @@ export const usesDomainUidSpace = (mailbox: string | null): boolean =>
  * the mailbox until EXPUNGE removes them. Soft-deleted mail leaving INBOX is a
  * `Trash` mailbox question (#725), not an INBOX predicate.
  */
-export const quarantinesSpam = (mailbox: string | null, sent: boolean): boolean =>
+export const isInboxTree = (mailbox: string | null, sent: boolean): boolean =>
   !sent && (mailbox === null || mailbox.startsWith(INBOX_ACCOUNTS_PREFIX));
 
 /**
@@ -99,9 +107,11 @@ export const membershipFilter = (
   mailbox: string | null,
   sent: boolean
 ): MembershipFilter => {
-  const utility = mailbox !== null ? UTILITY_VIEW_MEMBERSHIP.get(mailbox) : undefined;
-  if (utility) return utility;
-  if (quarantinesSpam(mailbox, sent)) return { [IS_SPAM]: false, [DRAFT]: false };
+  const utility = utilityMembership(mailbox);
+  // Copied, not returned by reference: this module is public through the
+  // `server` barrel, and the entries are the view definitions themselves.
+  if (utility) return { ...utility };
+  if (isInboxTree(mailbox, sent)) return { [IS_SPAM]: false, [DRAFT]: false };
   return {};
 };
 


### PR DESCRIPTION
Adds the first two of the four mailboxes from #725 — `Drafts` and `Junk`.

**Stacks on #740.** That PR introduced the per-mailbox membership predicate this
one generalises; branching off `main` instead would have conflicted with it in
every query in `repositories/mails/imap.ts`. Only the last commit is mine — once
#740 merges, this collapses to that commit alone.

## What each mailbox is

A flag-derived view over the user's whole domain: `Drafts` is `draft = TRUE`,
`Junk` is `is_spam = TRUE`. Both are already expressible from existing columns —
no new table, no backfill.

That shape is deliberate over the `mail_mailbox_uid` mapping the account folders
use. Membership here flips whenever the user marks a mail spam or clears a draft;
keeping mapping rows in step with flag flips would be a second sync problem, and
the flag is already the source of truth. The cost is that UIDs stay in the domain
space (option (a) from my scoping comment — no reply on the fork, and it is what
INBOX and the unified Sent view already do, so this is the consistent default
rather than a new precedent). Say the word if you want per-mailbox UIDs instead
and I will move them.

## What changed

- **`repositories/mails/views.ts` (new)** — one `column -> value` definition per
  mailbox, rendered two ways: a SQL fragment for the hand-built IMAP queries and
  a filter bag for the `Table.updateWhere` call sites. #740 had those two
  renderings written separately; folding them into one definition is what keeps
  a view's read predicate and its expunge filter from drifting apart. Living in
  its own module also lets `counters.ts` take the same branch — `getHighestModseq`
  on a named view used to join the mapping table and report the `1` floor forever.
- **`usesDomainUidSpace` replaces `mailbox === null`** as the branch test. A
  utility view reaches the repository as a string, so its predicate can be looked
  up, but still reads `uid_domain`.
- **INBOX now hides drafts as well as spam.** Each has a mailbox of its own; a
  mail listed in both counts twice toward EXISTS/UNSEEN. `\Deleted` is
  deliberately still *not* excluded — RFC 3501 §6.4.3 keeps those in the mailbox
  until EXPUNGE.
- **Writes place the mail.** COPY / MOVE / APPEND into a utility folder set the
  flag the view selects on. Without it the write reports success and the message
  is in no mailbox the client asked for. `storeMail` now takes the destination box
  and derives both the mapping row and the placement from it, instead of each of
  the three call sites re-deriving the mapping rule.
- **CREATE / DELETE / RENAME refuse the names** the way they already refuse
  INBOX — otherwise the DB layer answers `[NONEXISTENT]` for a box the client can
  see in its own LIST output.
- **LIST reports `\Drafts` / `\Junk`** (RFC 6154 §2). The SPECIAL-USE capability
  is *not* advertised: it promises the `(SPECIAL-USE)` LIST selection and return
  options, which are not implemented. (`USE=` on CREATE is a *separate*
  capability, `CREATE-SPECIAL-USE`, RFC 6154 §3 — an earlier revision of this
  section wrongly folded it in.) Clients read the attributes off a plain LIST
  regardless; the tradeoff is that a client gating role discovery on the
  capability will not look for them.

## Not in this PR

- **Flag propagation on COPY/MOVE** — `cloneFields` carries `"flags"`, which is
  not in `PartialMailModel.validFields`, so it is dropped and the clone is
  written `draft = FALSE`. MOVE out of `Drafts` therefore works today for the
  wrong reason, and a legitimate fix to flag propagation would make the message
  reappear in `Drafts`. Filed as #785 with the coupling recorded.
`Starred` and `Trash`. Both span sent *and* received mail (the web client's Saved
view spans both by design, per #568), and every query here binds `sent` as a
parameter the caller supplies. Making a view span both means moving the `sent`
condition into the membership rule — mechanical, but it renumbers the bound
parameters in every one of these queries, and it is not worth burying inside this
diff. `views.ts` is where it lands.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (18 pre-existing warnings, none in touched files)
- [x] `bun test src/server` — **1539 pass / 0 fail** (+25: `views.test.ts`,
      `utility-mailboxes.test.ts`, `Store.storeMail` destination cases)
- [x] The membership-application source guard from #740 kept, and made honest:
      it was counting the rule's name where it appeared in *comments*, so two of
      its floors were higher than the number of real application sites. It now
      strips comments and the floors are the true per-branch counts.
- [x] A test pins the two copies of the folder table together (the repository
      cannot import `imap/util.ts` — the `server` barrel re-exports the
      repository), asserting the names, the read predicate against the write-side
      placement, and `isDomainScoped` against `usesDomainUidSpace`.
- [x] **Live IMAP E2E**, same local dev DB, two servers on non-default ports:
      a baseline at this PR's parent (#740 head) and the patched branch.

| | baseline | patched |
|---|---|---|
| `LIST "" "%"` | `INBOX`, `Sent Messages` | `+ (\Drafts \HasNoChildren) "Drafts"`, `+ (\Junk \HasNoChildren) "Junk"` |
| `SELECT "Junk"` | `NO Mailbox does not exist` | `41 EXISTS` — matches the row count for `is_spam AND NOT sent` |
| `SELECT "Drafts"` | `NO Mailbox does not exist` | `0 EXISTS` (none in this DB yet) |
| `SELECT "INBOX"` | `11284 EXISTS` | `11283 EXISTS` — the draft below is gone from INBOX |
| `STATUS "Junk" (MESSAGES UNSEEN)` | — | `MESSAGES 41 UNSEEN 0` |

  Then, on the patched server:
  - `APPEND "Drafts" {179}` **with no `\Draft` flag** → `OK [APPENDUID …]`;
    `SELECT "Drafts"` → `1 EXISTS`; `UID FETCH 1:* (FLAGS ENVELOPE)` →
    `FLAGS (\Draft)` with the envelope intact. The placement rule is what makes
    that mail land where the client named.
  - Re-`SELECT "INBOX"` → still `11283 EXISTS` (the new draft is in `Drafts`
    only, not both).
  - `CREATE "Drafts"` → `NO [ALREADYEXISTS]`; `DELETE "Junk"` → `NO [CANNOT]`;
    `RENAME "Drafts" "MyDrafts"` → `NO [CANNOT]`; `RENAME "Archive" "Junk"` →
    `NO [ALREADYEXISTS]`.
  - `SELECT "Drafts2"` → `NO Mailbox does not exist` — the guard is an exact
    name match, so an ordinary user box with a similar name is untouched.
  - `SEARCH ALL` inside `Junk` returned 41 UIDs, two of them repeated. That is
    the pre-existing legacy duplicate-`uid_domain` data tracked in #620 (two
    pairs of spam rows share a UID in this DB), not something this diff
    introduces — the baseline server reads the same rows.
- [x] The appended test mail was deleted afterwards; the dev DB is back to
      as-found (0 draft rows).

Part of #725. Leak gate run on the commit message, the staged diff and this body.




---

## Post-review commits (2026-08-05)

Rebased onto current `upstream/main` (the branch was stacked on the unsquashed
#740 commits, now squash-merged as `040c9a3` — replayed with `--onto`), then two
fix commits off the reviewoie round:

- **`4e0e8b1`** — a `COPY`/`MOVE` into a utility folder was taking the
  destination re-anchoring branch, rewriting `to_address` / `envelope_to` to the
  folder's own name (`Junk@<domain>`). That overwrote the real recipient and made
  the per-account stats invent a mailbox by that name, visible as a phantom
  `INBOX/accounts/Junk` in LIST. A utility folder has no address filter — the
  placement flag alone puts the copy there — so it now takes the same branch as
  INBOX. Five tests across `copy.test.ts` / `move.test.ts`, including the
  unchanged re-anchoring case for an address-filtered destination.
- **`efd1061`** — the utility-name guards match case-insensitively but
  `mailboxExists` compares against the LIST names exactly, so a client naming the
  box in lowercase was refused by `CREATE` as already existing and by `SELECT` as
  non-existent. All five wire entry points (SELECT, STATUS, COPY, MOVE, APPEND)
  now route through one `canonicalMailbox` helper. Same commit advertises
  `SPECIAL-USE` in CAPABILITY, without which a client never reads the RFC 6154
  attributes LIST already emits.

Both verified against a running server on a throwaway database, before and after,
with the row-level `to_address` read back out of Postgres — see the review reply
comment for the captured output. Suite after both: 1585 pass / 0 fail across 78
files; typecheck clean; lint 0 errors; CI green.
