### PR TITLE
fix(imap): LSUB returns only subscribed mailboxes (#688)

### DIFF
--- a/src/server/lib/imap/mailbox-lsub-subscription.test.ts
+++ b/src/server/lib/imap/mailbox-lsub-subscription.test.ts
@@ -118,14 +118,14 @@ describe("LSUB honours the subscribed flag (#688)", () => {
       expect(names).toContain("Projects");
     });
 
-    it("marks that parent \\Noselect \\HasChildren, not selectable", async () => {
-      const lines = await emit(listSubscribedMailboxes, "", "Projects", HIER);
-      expect(lines).toContainEqual('* LSUB (\\Noselect \\HasChildren) "/" "Projects"\r\n');
+    it("marks that parent \\HasChildren \\Noselect, not selectable", async () => {
+      const lines = await emit(listSubscribedMailboxes, "", "%", HIER);
+      expect(lines).toContainEqual('* LSUB (\\HasChildren \\Noselect) "/" "Projects"\r\n');
     });
 
     it("drops the parent once no descendant is subscribed", async () => {
       const names = namesOf(
-        await emit(listSubscribedMailboxes, "", "Projects*", [
+        await emit(listSubscribedMailboxes, "", "%", [
           { name: "Projects", subscribed: false },
           { name: "Projects/Work", subscribed: false },
         ])
@@ -134,26 +134,71 @@ describe("LSUB honours the subscribed flag (#688)", () => {
     });
 
     it("promotes a grandparent too — every ancestor of a subscribed leaf", async () => {
-      const names = namesOf(
-        await emit(listSubscribedMailboxes, "", "*", [
-          { name: "Projects", subscribed: false },
-          { name: "Projects/Work", subscribed: false },
-          { name: "Projects/Work/Q3", subscribed: true },
-        ])
-      );
-      expect(names.sort()).toEqual(["Projects", "Projects/Work", "Projects/Work/Q3"]);
+      // The actual "%" walk: one level per command, each step reachable only
+      // because the level above was promoted.
+      const DEEP: MailboxEntry[] = [
+        { name: "Projects", subscribed: false },
+        { name: "Projects/Work", subscribed: false },
+        { name: "Projects/Work/Q3", subscribed: true },
+      ];
+      expect(namesOf(await emit(listSubscribedMailboxes, "", "%", DEEP))).toEqual([
+        "Projects",
+      ]);
+      expect(namesOf(await emit(listSubscribedMailboxes, "", "Projects/%", DEEP))).toEqual([
+        "Projects/Work",
+      ]);
+      expect(
+        namesOf(await emit(listSubscribedMailboxes, "", "Projects/Work/%", DEEP))
+      ).toEqual(["Projects/Work/Q3"]);
     });
 
     it("does not promote a name that is only a string prefix, not a path ancestor", async () => {
       // "Project" is a prefix of "Projects/Work" as a string but not an
       // ancestor path, so it must stay hidden.
       const names = namesOf(
-        await emit(listSubscribedMailboxes, "", "*", [
+        await emit(listSubscribedMailboxes, "", "%", [
           { name: "Project", subscribed: false },
           { name: "Projects/Work", subscribed: true },
         ])
       );
-      expect(names).toEqual(["Projects/Work"]);
+      expect(names).toEqual(["Projects"]);
+      expect(names).not.toContain("Project");
+    });
+
+    it("promotes an ancestor that has no mailboxes row of its own", async () => {
+      // CREATE inserts only the name it is given and never the superior ones
+      // (RFC 3501 §6.3.3 says SHOULD, this server does not), so `Projects` can
+      // be missing from the listable set entirely while `Projects/Work` is
+      // subscribed. Without synthesis a "%"-walker sees INBOX and nothing else.
+      const lines = await emit(listSubscribedMailboxes, "", "%", [
+        { name: "INBOX", subscribed: true },
+        { name: "Projects/Work", subscribed: true },
+      ]);
+      expect(namesOf(lines).sort()).toEqual(["INBOX", "Projects"]);
+      expect(lines).toContainEqual('* LSUB (\\HasChildren \\Noselect) "/" "Projects"\r\n');
+    });
+
+    it("reports a SUBSCRIBED parent \\HasChildren too, not \\HasNoChildren", async () => {
+      // getMailboxAttributes returns \HasNoChildren for a user-created box
+      // (#778). Left uncorrected on LSUB that inverts the ancestor rule: a
+      // "%"-walker honouring \HasNoChildren would descend into the
+      // unsubscribed `Projects` above but not into a subscribed one, making
+      // the subscribed subtree the unreachable half.
+      const lines = await emit(listSubscribedMailboxes, "", "%", [
+        { name: "Projects", subscribed: true },
+        { name: "Projects/Work", subscribed: true },
+      ]);
+      expect(lines).toContainEqual('* LSUB (\\HasChildren) "/" "Projects"\r\n');
+    });
+
+    it('does not promote under "*" — the walker already gets the descendant', async () => {
+      // The RFC states the rule for "%", where the name would otherwise
+      // vanish. Firing it for "*" would leave an UNSUBSCRIBEd folder in the
+      // client's list permanently, merely non-openable — #688 unfixed for the
+      // common client that sends LSUB "" "*".
+      const names = namesOf(await emit(listSubscribedMailboxes, "", "*", HIER));
+      expect(names.sort()).toEqual(["INBOX", "Projects/Work"]);
+      expect(names).not.toContain("Projects");
     });
   });
 
@@ -163,12 +208,32 @@ describe("LSUB honours the subscribed flag (#688)", () => {
     expect(lines.filter((line) => line.startsWith("* LSUB")).length).toBe(1);
   });
 
-  it("applies the reference + pattern on top of the subscription filter", async () => {
+  it("applies the pattern on top of the subscription filter", async () => {
     expect(namesOf(await emit(listSubscribedMailboxes, "", "%"))).toEqual(
       expect.arrayContaining(["INBOX", "Sent Messages", "ZzSubYes"])
     );
     expect(namesOf(await emit(listSubscribedMailboxes, "", "%"))).not.toContain(
       "INBOX/accounts"
     );
+  });
+
+  it("concatenates a non-empty reference with the pattern (RFC 3501 §6.3.8)", async () => {
+    // `LSUB "INBOX/" "%"` must behave as the pattern `INBOX/%` — one level
+    // below INBOX, not the root level.
+    const names = namesOf(await emit(listSubscribedMailboxes, "INBOX/", "%"));
+    expect(names).toEqual(["INBOX/accounts"]);
+  });
+
+  it("promotes an ancestor under a non-empty reference", async () => {
+    // The one shape where the reference concatenation and the ancestor set
+    // interact: the promoted name is matched against reference + pattern, so
+    // it has to be the full path, not the segment.
+    const lines = await emit(listSubscribedMailboxes, "Projects/", "%", [
+      { name: "Projects", subscribed: true },
+      { name: "Projects/Work", subscribed: false },
+      { name: "Projects/Work/Q3", subscribed: true },
+    ]);
+    expect(namesOf(lines)).toEqual(["Projects/Work"]);
+    expect(lines).toContainEqual('* LSUB (\\HasChildren \\Noselect) "/" "Projects/Work"\r\n');
   });
 });

--- a/src/server/lib/imap/mailbox-lsub-subscription.test.ts
+++ b/src/server/lib/imap/mailbox-lsub-subscription.test.ts
@@ -88,15 +88,73 @@ describe("LSUB honours the subscribed flag (#688)", () => {
     expect(names).toEqual([]);
   });
 
-  it("computes \\HasChildren against the full set, not the subscribed subset", async () => {
-    // The per-account child is unsubscribed; "Sent Messages" must still report
-    // \HasChildren, otherwise a client prunes a branch it can still SELECT.
+  it("takes 'Sent Messages' attributes from the full set even when its children are filtered out", async () => {
+    // getMailboxAttributes derives \HasChildren for "Sent Messages" by looking
+    // for a "Sent Messages/accounts/" entry. That lookup must see the full
+    // listable set, not the subscribed subset — otherwise dropping the
+    // unsubscribed children would flip the parent to \HasNoChildren and a
+    // client would prune a branch it can still SELECT.
     const lines = await emit(listSubscribedMailboxes, "", "Sent Messages", [
       { name: "Sent Messages", subscribed: true },
       { name: "Sent Messages/accounts", subscribed: false },
       { name: "Sent Messages/accounts/work", subscribed: false },
     ]);
     expect(lines.some((line) => line.includes("(\\HasChildren)"))).toBe(true);
+  });
+
+  // RFC 3501 §6.3.9. CREATE accepts a "/" in the name (verified against a live
+  // server), so a hierarchical user mailbox is reachable — and without this
+  // rule, unsubscribing the parent hides the subscribed child from any client
+  // that walks the tree with "%".
+  describe("an unsubscribed parent of a subscribed child stays visible as \\Noselect", () => {
+    const HIER: MailboxEntry[] = [
+      { name: "INBOX", subscribed: true },
+      { name: "Projects", subscribed: false },
+      { name: "Projects/Work", subscribed: true },
+    ];
+
+    it('LSUB "" "%" still returns the parent so the subtree is reachable', async () => {
+      const names = namesOf(await emit(listSubscribedMailboxes, "", "%", HIER));
+      expect(names).toContain("Projects");
+    });
+
+    it("marks that parent \\Noselect \\HasChildren, not selectable", async () => {
+      const lines = await emit(listSubscribedMailboxes, "", "Projects", HIER);
+      expect(lines).toContainEqual('* LSUB (\\Noselect \\HasChildren) "/" "Projects"\r\n');
+    });
+
+    it("drops the parent once no descendant is subscribed", async () => {
+      const names = namesOf(
+        await emit(listSubscribedMailboxes, "", "Projects*", [
+          { name: "Projects", subscribed: false },
+          { name: "Projects/Work", subscribed: false },
+        ])
+      );
+      expect(names).toEqual([]);
+    });
+
+    it("promotes a grandparent too — every ancestor of a subscribed leaf", async () => {
+      const names = namesOf(
+        await emit(listSubscribedMailboxes, "", "*", [
+          { name: "Projects", subscribed: false },
+          { name: "Projects/Work", subscribed: false },
+          { name: "Projects/Work/Q3", subscribed: true },
+        ])
+      );
+      expect(names.sort()).toEqual(["Projects", "Projects/Work", "Projects/Work/Q3"]);
+    });
+
+    it("does not promote a name that is only a string prefix, not a path ancestor", async () => {
+      // "Project" is a prefix of "Projects/Work" as a string but not an
+      // ancestor path, so it must stay hidden.
+      const names = namesOf(
+        await emit(listSubscribedMailboxes, "", "*", [
+          { name: "Project", subscribed: false },
+          { name: "Projects/Work", subscribed: true },
+        ])
+      );
+      expect(names).toEqual(["Projects/Work"]);
+    });
   });
 
   it("an empty pattern still returns the hierarchy delimiter, no mailboxes", async () => {

--- a/src/server/lib/imap/mailbox-lsub-subscription.test.ts
+++ b/src/server/lib/imap/mailbox-lsub-subscription.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Tests for LSUB's subscription filter (RFC 3501 §6.3.9, #688).
+ *
+ * Before the fix, listSubscribedMailboxes read the same `store.listMailboxes()`
+ * set LIST reads and filtered only by the pattern, so LSUB output was
+ * byte-identical to LIST and UNSUBSCRIBE was a persistent no-op. These cases
+ * pin that an unsubscribed user-created mailbox drops out of LSUB, that the
+ * derived system mailboxes stay in regardless, and that hierarchy attributes
+ * are still computed against the full listable set.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { listSubscribedMailboxes, listMailboxes } from "./mailbox-ops";
+import type { MailboxEntry, Store } from "./store";
+
+const TREE: MailboxEntry[] = [
+  { name: "INBOX", subscribed: true },
+  { name: "Sent Messages", subscribed: true },
+  { name: "Sent Messages/accounts", subscribed: true },
+  { name: "Sent Messages/accounts/work", subscribed: true },
+  { name: "INBOX/accounts", subscribed: true },
+  { name: "INBOX/accounts/work", subscribed: true },
+  { name: "ZzSubYes", subscribed: true },
+  { name: "ZzSubNo", subscribed: false },
+];
+
+const fakeStore = (entries: MailboxEntry[]): Store =>
+  ({
+    listMailboxEntries: async () => entries,
+    listMailboxes: async () => entries.map((entry) => entry.name),
+  }) as unknown as Store;
+
+const emit = async (
+  command: typeof listSubscribedMailboxes,
+  reference: string,
+  pattern: string,
+  entries: MailboxEntry[] = TREE
+): Promise<string[]> => {
+  const lines: string[] = [];
+  await command("A1", reference, pattern, fakeStore(entries), (data: string) => {
+    lines.push(data);
+    return true;
+  });
+  return lines;
+};
+
+const namesOf = (lines: string[]): string[] =>
+  lines
+    .filter((line) => line.startsWith("* LSUB"))
+    .map((line) => line.replace(/.*"\/" "(.*)"\r\n$/, "$1"));
+
+describe("LSUB honours the subscribed flag (#688)", () => {
+  it("omits an unsubscribed user-created mailbox", async () => {
+    const names = namesOf(await emit(listSubscribedMailboxes, "", "ZzSub*"));
+    expect(names).toEqual(["ZzSubYes"]);
+    expect(names).not.toContain("ZzSubNo");
+  });
+
+  it("still returns the subscribed sibling that LIST returns", async () => {
+    const lines: string[] = [];
+    await listMailboxes("A1", "", "ZzSub*", fakeStore(TREE), (data: string) => {
+      lines.push(data);
+      return true;
+    });
+    const listNames = lines
+      .filter((line) => line.startsWith("* LIST"))
+      .map((line) => line.replace(/.*"\/" "(.*)"\r\n$/, "$1"));
+
+    // LIST is unchanged — it reports both. The two commands must now differ.
+    expect(listNames.sort()).toEqual(["ZzSubNo", "ZzSubYes"]);
+  });
+
+  it("keeps INBOX in LSUB — it has no mailboxes row to unsubscribe from", async () => {
+    const names = namesOf(await emit(listSubscribedMailboxes, "", "*"));
+    expect(names).toContain("INBOX");
+    expect(names).toContain("Sent Messages");
+    expect(names).toContain("INBOX/accounts");
+    expect(names).not.toContain("ZzSubNo");
+  });
+
+  it("returns nothing when every user mailbox is unsubscribed except the derived set", async () => {
+    const names = namesOf(
+      await emit(listSubscribedMailboxes, "", "Zz*", [
+        { name: "INBOX", subscribed: true },
+        { name: "ZzSubNo", subscribed: false },
+      ])
+    );
+    expect(names).toEqual([]);
+  });
+
+  it("computes \\HasChildren against the full set, not the subscribed subset", async () => {
+    // The per-account child is unsubscribed; "Sent Messages" must still report
+    // \HasChildren, otherwise a client prunes a branch it can still SELECT.
+    const lines = await emit(listSubscribedMailboxes, "", "Sent Messages", [
+      { name: "Sent Messages", subscribed: true },
+      { name: "Sent Messages/accounts", subscribed: false },
+      { name: "Sent Messages/accounts/work", subscribed: false },
+    ]);
+    expect(lines.some((line) => line.includes("(\\HasChildren)"))).toBe(true);
+  });
+
+  it("an empty pattern still returns the hierarchy delimiter, no mailboxes", async () => {
+    const lines = await emit(listSubscribedMailboxes, "", "");
+    expect(lines.some((line) => line.includes('(\\Noselect) "/" ""'))).toBe(true);
+    expect(lines.filter((line) => line.startsWith("* LSUB")).length).toBe(1);
+  });
+
+  it("applies the reference + pattern on top of the subscription filter", async () => {
+    expect(namesOf(await emit(listSubscribedMailboxes, "", "%"))).toEqual(
+      expect.arrayContaining(["INBOX", "Sent Messages", "ZzSubYes"])
+    );
+    expect(namesOf(await emit(listSubscribedMailboxes, "", "%"))).not.toContain(
+      "INBOX/accounts"
+    );
+  });
+});

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -24,7 +24,7 @@ import {
   SENT_MESSAGES_ACCOUNTS_FOLDER,
   SENT_MESSAGES_FOLDER,
 } from "./util";
-import { Store } from "./store";
+import { MailboxEntry, Store } from "./store";
 import { StatusItem } from "./types";
 import {
   buildSequenceMapping,
@@ -385,6 +385,25 @@ export async function listMailboxes(
   }
 }
 
+/**
+ * Every proper ancestor path of a subscribed mailbox — `Projects/Work/Q3`
+ * contributes `Projects` and `Projects/Work`. Built in one pass over the
+ * entries (O(names × depth)) rather than re-scanning the set per candidate,
+ * which would be quadratic on an account with thousands of per-address boxes.
+ */
+const collectAncestors = (entries: MailboxEntry[]): Set<string> => {
+  const ancestors = new Set<string>();
+  entries
+    .filter((entry) => entry.subscribed)
+    .forEach((entry) => {
+      const parts = entry.name.split("/");
+      for (let i = 1; i < parts.length; i++) {
+        ancestors.add(parts.slice(0, i).join("/"));
+      }
+    });
+  return ancestors;
+};
+
 export async function listSubscribedMailboxes(
   tag: string,
   reference: string,
@@ -399,20 +418,27 @@ export async function listSubscribedMailboxes(
       return;
     }
     const entries = await store.listMailboxEntries();
-    // Attributes are computed against the full listable set, not the
-    // subscribed subset, so \HasChildren stays correct when a parent is
-    // subscribed and its children are not.
+    // Attributes come from the full listable set, not the subscribed subset,
+    // so filtering a child out of the response cannot change what its parent
+    // reports.
     const allBoxes = entries.map((entry) => entry.name);
+    const ancestorsOfSubscribed = collectAncestors(entries);
     entries
-      .filter((entry) => entry.subscribed)
+      .filter((entry) => entry.subscribed || ancestorsOfSubscribed.has(entry.name))
       .filter((entry) => matchesListPattern(reference, pattern, entry.name))
       .forEach((entry) => {
-        const attrs = getMailboxAttributes(entry.name, allBoxes);
+        // RFC 3501 §6.3.9: an unsubscribed name that has subscribed
+        // descendants is still returned, marked \Noselect, so a client
+        // walking the hierarchy with "%" can still reach the child. It is in
+        // this list only because it has one, hence \HasChildren.
+        const attrs = entry.subscribed
+          ? getMailboxAttributes(entry.name, allBoxes)
+          : "\\Noselect \\HasChildren";
         write(`* LSUB (${attrs}) "/" "${entry.name}"\r\n`);
       });
     write(`${tag} OK LSUB completed\r\n`);
   } catch (error) {
-    logger.error("Error listing subscribed mailboxes", { component: "imap" }, error);
+    logger.error("Error listing subscribed mailboxes", { component: "imap.lsub" }, error);
     write(`${tag} NO LSUB failed\r\n`);
   }
 }

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -398,12 +398,17 @@ export async function listSubscribedMailboxes(
       write(`${tag} OK LSUB completed\r\n`);
       return;
     }
-    const boxes = await store.listMailboxes();
-    boxes
-      .filter((box) => matchesListPattern(reference, pattern, box))
-      .forEach((box) => {
-        const attrs = getMailboxAttributes(box, boxes);
-        write(`* LSUB (${attrs}) "/" "${box}"\r\n`);
+    const entries = await store.listMailboxEntries();
+    // Attributes are computed against the full listable set, not the
+    // subscribed subset, so \HasChildren stays correct when a parent is
+    // subscribed and its children are not.
+    const allBoxes = entries.map((entry) => entry.name);
+    entries
+      .filter((entry) => entry.subscribed)
+      .filter((entry) => matchesListPattern(reference, pattern, entry.name))
+      .forEach((entry) => {
+        const attrs = getMailboxAttributes(entry.name, allBoxes);
+        write(`* LSUB (${attrs}) "/" "${entry.name}"\r\n`);
       });
     write(`${tag} OK LSUB completed\r\n`);
   } catch (error) {

--- a/src/server/lib/imap/mailbox-ops.ts
+++ b/src/server/lib/imap/mailbox-ops.ts
@@ -386,23 +386,36 @@ export async function listMailboxes(
 }
 
 /**
- * Every proper ancestor path of a subscribed mailbox — `Projects/Work/Q3`
- * contributes `Projects` and `Projects/Work`. Built in one pass over the
- * entries (O(names × depth)) rather than re-scanning the set per candidate,
- * which would be quadratic on an account with thousands of per-address boxes.
+ * Every proper ancestor path of the given names — `Projects/Work/Q3`
+ * contributes `Projects` and `Projects/Work`. Built in one pass
+ * (O(names × depth)) rather than re-scanning the set per candidate, which
+ * would be quadratic on an account with thousands of per-address boxes, and
+ * keyed on path segments so a `Project` that is merely a string prefix of
+ * `Projects/Work` is not treated as its parent.
  */
-const collectAncestors = (entries: MailboxEntry[]): Set<string> => {
+const collectAncestors = (names: string[]): Set<string> => {
   const ancestors = new Set<string>();
-  entries
-    .filter((entry) => entry.subscribed)
-    .forEach((entry) => {
-      const parts = entry.name.split("/");
-      for (let i = 1; i < parts.length; i++) {
-        ancestors.add(parts.slice(0, i).join("/"));
-      }
-    });
+  names.forEach((name) => {
+    const parts = name.split("/");
+    for (let i = 1; i < parts.length; i++) {
+      ancestors.add(parts.slice(0, i).join("/"));
+    }
+  });
   return ancestors;
 };
+
+/**
+ * `getMailboxAttributes` derives \HasChildren only for the `accounts/` parents
+ * and the unified Sent folder, so a user-created `Projects` reports
+ * \HasNoChildren even with `Projects/Work` present (#778 — the same gap hits
+ * LIST). LSUB cannot carry it: the ancestor rule below returns an
+ * *unsubscribed* parent as \HasChildren, so leaving the subscribed one at
+ * \HasNoChildren would tell a "%"-walking client to descend into the hidden
+ * branch and prune the visible one. Corrected on this response only; LIST
+ * keeps its current bytes until #778 lands.
+ */
+const withHierarchyAttribute = (attrs: string, hasChildren: boolean): string =>
+  hasChildren ? attrs.replace("\\HasNoChildren", "\\HasChildren") : attrs;
 
 export async function listSubscribedMailboxes(
   tag: string,
@@ -418,22 +431,46 @@ export async function listSubscribedMailboxes(
       return;
     }
     const entries = await store.listMailboxEntries();
-    // Attributes come from the full listable set, not the subscribed subset,
-    // so filtering a child out of the response cannot change what its parent
-    // reports.
+    // Hierarchy is a property of the full listable set, not of the subscribed
+    // subset, so filtering a child out of the response cannot change what its
+    // parent reports.
     const allBoxes = entries.map((entry) => entry.name);
-    const ancestorsOfSubscribed = collectAncestors(entries);
-    entries
+    const parentPaths = collectAncestors(allBoxes);
+
+    // RFC 3501 §6.3.9: an unsubscribed name sitting between the root and a
+    // subscribed descendant is still returned, marked \Noselect, or a client
+    // walking one level at a time never reaches the child. That loss is
+    // specific to "%": a "*" walker is handed the descendant itself, so
+    // promoting there would only keep an unsubscribed folder in the client's
+    // subscription list forever — the #688 complaint this PR is fixing.
+    const promoteAncestors = (reference + pattern).includes("%");
+    const ancestorsOfSubscribed = promoteAncestors
+      ? collectAncestors(entries.filter((entry) => entry.subscribed).map((e) => e.name))
+      : new Set<string>();
+
+    // An ancestor need not exist as a mailbox of its own. Nothing here creates
+    // the superior names on CREATE (RFC 3501 §6.3.3 only says SHOULD), so
+    // `Projects/Work` can be subscribed with no `Projects` row at all — and
+    // §6.3.9's own example is precisely such a name, which is why the rule
+    // marks it \Noselect rather than assuming it is selectable.
+    const listed = new Set(allBoxes);
+    const synthesized: MailboxEntry[] = [...ancestorsOfSubscribed]
+      .filter((name) => !listed.has(name))
+      .sort()
+      .map((name) => ({ name, subscribed: false }));
+
+    [...entries, ...synthesized]
       .filter((entry) => entry.subscribed || ancestorsOfSubscribed.has(entry.name))
       .filter((entry) => matchesListPattern(reference, pattern, entry.name))
       .forEach((entry) => {
-        // RFC 3501 §6.3.9: an unsubscribed name that has subscribed
-        // descendants is still returned, marked \Noselect, so a client
-        // walking the hierarchy with "%" can still reach the child. It is in
-        // this list only because it has one, hence \HasChildren.
+        // An unsubscribed name is in this response only because it has a
+        // subscribed descendant, hence \HasChildren unconditionally.
         const attrs = entry.subscribed
-          ? getMailboxAttributes(entry.name, allBoxes)
-          : "\\Noselect \\HasChildren";
+          ? withHierarchyAttribute(
+              getMailboxAttributes(entry.name, allBoxes),
+              parentPaths.has(entry.name)
+            )
+          : "\\HasChildren \\Noselect";
         write(`* LSUB (${attrs}) "/" "${entry.name}"\r\n`);
       });
     write(`${tag} OK LSUB completed\r\n`);

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -145,7 +145,7 @@ describe("Store.storeMail — what the destination box decides (#725)", () => {
       { name: "Archive", special_use: null, address: null, subscribed: false },
     ] as never);
     const store = new Store(makeUser());
-    expect(await store.listMailboxes()).toEqual(["INBOX", "Archive"]);
+    expect(await store.listMailboxes()).toEqual(["INBOX", "Drafts", "Junk", "Archive"]);
   });
 });
 

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -145,7 +145,14 @@ describe("Store.storeMail — what the destination box decides (#725)", () => {
       { name: "Archive", special_use: null, address: null, subscribed: false },
     ] as never);
     const store = new Store(makeUser());
-    expect(await store.listMailboxes()).toEqual(["INBOX", "Drafts", "Junk", "Archive"]);
+    expect(await store.listMailboxes()).toEqual([
+      "INBOX",
+      "Drafts",
+      "Junk",
+      "Starred",
+      "Trash",
+      "Archive",
+    ]);
   });
 });
 

--- a/src/server/lib/imap/store.test.ts
+++ b/src/server/lib/imap/store.test.ts
@@ -139,6 +139,53 @@ describe("Store.storeMail — what the destination box decides (#725)", () => {
     await new Store(makeUser()).storeMail(makeMail(), "Sent Messages");
     expect(savedInput().mailbox).toBeUndefined();
   });
+
+  it("lists an unsubscribed user mailbox — LIST is not subscription-filtered", async () => {
+    mockGetMailboxesByUser.mockResolvedValue([
+      { name: "Archive", special_use: null, address: null, subscribed: false },
+    ] as never);
+    const store = new Store(makeUser());
+    expect(await store.listMailboxes()).toEqual(["INBOX", "Archive"]);
+  });
+});
+
+describe("Store.listMailboxEntries — subscription state for LSUB (#688)", () => {
+  beforeEach(() => {
+    mockGetAccountStats.mockClear();
+    mockGetMailboxesByUser.mockClear();
+    mockGetAccountStats.mockResolvedValue([]);
+    mockGetMailboxesByUser.mockResolvedValue([]);
+  });
+
+  it("carries each user mailbox's subscribed column through", async () => {
+    mockGetMailboxesByUser.mockResolvedValue([
+      { name: "ZzSubYes", special_use: null, address: null, subscribed: true },
+      { name: "ZzSubNo", special_use: null, address: null, subscribed: false },
+    ] as never);
+
+    const store = new Store(makeUser());
+    const entries = await store.listMailboxEntries();
+
+    expect(entries).toContainEqual({ name: "ZzSubYes", subscribed: true });
+    expect(entries).toContainEqual({ name: "ZzSubNo", subscribed: false });
+  });
+
+  it("marks the derived mailboxes subscribed — they have no row to unsubscribe from", async () => {
+    mockGetAccountStats.mockResolvedValue([{ address: "work@alice.example.com" }] as never);
+
+    const store = new Store(makeUser());
+    const entries = await store.listMailboxEntries();
+
+    expect(entries.length).toBeGreaterThan(1);
+    expect(entries.every((entry) => entry.subscribed)).toBe(true);
+    expect(entries.map((entry) => entry.name)).toContain("INBOX");
+  });
+
+  it("falls back to a subscribed INBOX when the backend throws", async () => {
+    mockGetMailboxesByUser.mockRejectedValue(new Error("db down"));
+    const store = new Store(makeUser());
+    expect(await store.listMailboxEntries()).toEqual([{ name: "INBOX", subscribed: true }]);
+  });
 });
 
 describe("simplifyCriterion — NOT/OR operand normalisation (regression for #551)", () => {

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -355,7 +355,11 @@ export class Store {
     try {
       return await this.listMailboxEntriesOrThrow();
     } catch (error) {
-      logger.error("Error listing mailboxes", { component: "imap.store" }, error);
+      logger.error(
+        "Error listing mailboxes with subscription state",
+        { component: "imap.store" },
+        error
+      );
       return [{ name: "INBOX", subscribed: true }];
     }
   };

--- a/src/server/lib/imap/store.ts
+++ b/src/server/lib/imap/store.ts
@@ -63,6 +63,19 @@ export type StoreFetchedMail = Partial<Mail> & {
 };
 
 /**
+ * One name from the listable mailbox set, with the subscription state LSUB
+ * filters on. Only user-created mailboxes have a `mailboxes` row to
+ * unsubscribe from; the derived ones (INBOX, the unified Sent folder, the
+ * `accounts/` parents and the per-account boxes) are implicitly subscribed and
+ * must stay in LSUB regardless — a client that loses INBOX from LSUB has no
+ * folder set left to render (#688).
+ */
+export interface MailboxEntry {
+  name: string;
+  subscribed: boolean;
+}
+
+/**
  * Normalises a parsed SearchCriterion into the flat `{ type, value }` shape that
  * searchMailsByUid consumes. NOT/OR recurse so their operands are normalised too —
  * otherwise the SQL builder would read the wrong field off the raw parser shape
@@ -240,7 +253,7 @@ export class Store {
    * conflating the two turns a transient DB hiccup into a permanent-sounding
    * `NO Mailbox does not exist` for the SELECT/STATUS/EXAMINE caller (#601).
    */
-  private listMailboxesOrThrow = async (): Promise<string[]> => {
+  private listMailboxEntriesOrThrow = async (): Promise<MailboxEntry[]> => {
     // Match HTTP /api/mails/accounts: filter by user's domain so we only
     // expose addresses that belong to this server, not every external
     // CC/BCC/recipient address found on stored mails.
@@ -256,11 +269,11 @@ export class Store {
       const trimmed = name.trim();
       if (!seen.has(trimmed)) {
         seen.add(trimmed);
-        mailboxes.push(trimmed);
+        mailboxes.push({ name: trimmed, subscribed: true });
       }
     };
 
-    const mailboxes: string[] = [];
+    const mailboxes: MailboxEntry[] = [];
     addMailbox("INBOX");
 
     // Utility folders are listed unconditionally: a client needs `Drafts` to
@@ -300,16 +313,21 @@ export class Store {
     });
 
     // Add user-created mailboxes (those without a special_use and no address tie-in)
-    const systemNames = new Set(mailboxes.map((m) => m.toLowerCase()));
+    const systemNames = new Set(mailboxes.map((m) => m.name.toLowerCase()));
     userMailboxes
       .filter((mb) => mb.special_use === null && mb.address === null)
       .forEach((mb) => {
         if (!systemNames.has(mb.name.toLowerCase())) {
-          mailboxes.push(mb.name);
+          mailboxes.push({ name: mb.name, subscribed: mb.subscribed });
         }
       });
 
     return mailboxes;
+  };
+
+  private listMailboxesOrThrow = async (): Promise<string[]> => {
+    const entries = await this.listMailboxEntriesOrThrow();
+    return entries.map((entry) => entry.name);
   };
 
   /**
@@ -324,6 +342,21 @@ export class Store {
     } catch (error) {
       logger.error("Error listing mailboxes", { component: "imap.store" }, error);
       return ["INBOX"];
+    }
+  };
+
+  /**
+   * LSUB-facing version: the same listable set as `listMailboxes`, carrying
+   * each name's subscription state so the LSUB handler can drop the
+   * unsubscribed ones while still computing hierarchy attributes against the
+   * full set (#688). Same `["INBOX"]` fallback rationale as `listMailboxes`.
+   */
+  listMailboxEntries = async (): Promise<MailboxEntry[]> => {
+    try {
+      return await this.listMailboxEntriesOrThrow();
+    } catch (error) {
+      logger.error("Error listing mailboxes", { component: "imap.store" }, error);
+      return [{ name: "INBOX", subscribed: true }];
     }
   };
 


### PR DESCRIPTION
`LSUB` returned the full listable mailbox set — byte-for-byte identical to
`LIST` — regardless of each mailbox's `subscribed` flag. `SUBSCRIBE` /
`UNSUBSCRIBE` persisted the column correctly, but nothing read it, so
`UNSUBSCRIBE` was a permanent no-op from the client's point of view: the folder
the user hid reappeared on the next `LSUB`.

RFC 3501 §6.3.9: *"The LSUB command returns a subset of names from the set of
names that the user has declared as being 'active' or 'subscribed'."*

Closes #688

## Why it is not a one-line filter

Only user-created rows live in the `mailboxes` table. The derived mailboxes —
`INBOX`, the `Drafts` / `Junk` utility folders, the unified `Sent Messages`, the
`accounts/` parents and every per-account box — are server-defined or computed
from `getAccountStats` and have no row to unsubscribe from. Filtering
`listMailboxes()` by `subscribed` wholesale would have dropped `INBOX` out of
`LSUB` and left a client with no folder set to render.

## What changed

- **`store.ts`** — the builder now yields `MailboxEntry` (`{ name, subscribed }`)
  instead of a bare name. Derived names are emitted as implicitly subscribed;
  a user-created name carries its own column. `listMailboxesOrThrow` maps the
  names off it, so `LIST` and the `mailboxExists` gate are untouched — including
  the `["INBOX"]` transient-error fallback they rely on (#601).
- **`listMailboxEntries()`** — the LSUB-facing accessor, with the same fallback
  shape as `listMailboxes` (`[{ name: "INBOX", subscribed: true }]`).
- **`mailbox-ops.ts`** — the LSUB handler emits the subscribed subset, plus the
  `\Noselect` ancestors described below.

Newly created mailboxes are unaffected: `createMailbox` already defaults
`subscribed` to true (`input.subscribed !== false`), so a `CREATE` still shows
up in `LSUB` without an explicit `SUBSCRIBE`.

## The `\Noselect` ancestor rule (RFC 3501 §6.3.9)

> *"Consider what happens if `foo/bar` is subscribed but `foo` is not. A `%`
> wildcard to LSUB must return `foo`, not `foo/bar`, in the LSUB response, and
> it MUST be flagged with the `\Noselect` attribute."*

The first draft of this PR deferred that rule on the claim that no user mailbox
is hierarchical. **That claim was wrong** — reviewoie caught it and a live
server confirmed: nothing validates the hierarchy delimiter on `CREATE`, so
`CREATE Projects/Work` succeeds and `matchesListPattern` already treats `/` as
the delimiter. Without the rule, `UNSUBSCRIBE Projects` made `LSUB "" "%"`
return nothing at all — a `%`-walking client lost a subtree it could still
reach before this PR.

So every proper ancestor of a subscribed mailbox is returned marked
`\HasChildren \Noselect`. Ancestors are collected in one pass keyed on path
segments (O(names × depth)); re-scanning the entry set per candidate would be
quadratic on an account with thousands of per-address boxes, and a naive
`startsWith` would also promote `Project` for a subscribed `Projects/Work`.

Three details of the rule, all settled by reviewoie R2:

- **It fires only for patterns containing `%`.** The RFC states it for `%`
  because that is where the name would otherwise vanish; a `*` walker is
  handed the descendant itself. Promoting under `*` would mean
  `UNSUBSCRIBE Projects` never removes the folder from the client's list at
  all — it just becomes non-openable while still holding mail and still
  answering `SELECT`. That is issue 688 unfixed for the common client that
  sends `LSUB "" "*"`.
- **An ancestor does not have to exist as a mailbox.** `createMailbox`
  inserts only the name it is given, and nothing rejects `CREATE
  Projects/Work` without a prior `CREATE Projects` (RFC 3501 §6.3.3 says the
  server SHOULD create the superior names; this one does not). So the
  promoted set is synthesized from the subscribed paths, not filtered out of
  the existing rows — RFC 3501 §6.3.9's own example is precisely a `foo`
  that is not itself a mailbox, which is why the rule marks it `\Noselect`.
- **A *subscribed* parent reports `\HasChildren` on LSUB too.** See below.

## Deliberate LIST / LSUB divergence

`getMailboxAttributes` derives `\HasChildren` only for the `accounts/` parents
and the unified `Sent` folder, and returns `\HasNoChildren` for everything else
— so `LIST "" "Projects*"` reports `Projects` as `\HasNoChildren` even with
`Projects/Work` present. That gap is **pre-existing and hits `LIST` identically**,
so widening it into this PR would mean changing `LIST` output for every client
(`INBOX` itself would start reporting `\HasChildren`). Filed separately as #778.

LSUB cannot wait for it, though: the ancestor rule above returns an
*unsubscribed* parent as `\HasChildren`, so leaving the subscribed one at
`\HasNoChildren` inverts the hierarchy signal — a `%`-walking client that
honours `\HasNoChildren` would descend into the hidden branch and prune the
visible one, making the *subscribed* subtree the unreachable half. So the
`\HasChildren` correction is applied on the LSUB response only, computed from
the same one-pass ancestor set over the full listable rows. `LIST` bytes are
unchanged until #778 lands.

## Test plan

- **Unit, pre-fix reproduction first.** The new cases in
  `mailbox-lsub-subscription.test.ts` were run against the pre-fix handler:
  3 fail (unsubscribed box present in `LSUB "" "ZzSub*"`, present in
  `LSUB "" "*"`, and the all-unsubscribed case returning a name instead of
  nothing). All pass after. **17 cases total.** The 6 added or rewritten for
  the R2 round were mutation-tested the same way — reverting
  `mailbox-ops.ts` to the previous handler with the new tests in place fails
  exactly those 6 and nothing else:
  - a row-less ancestor is promoted (`Projects/Work` subscribed, no
    `Projects` row) — pre-fix returns `INBOX` and nothing else
  - a *subscribed* parent reports `\HasChildren`, not `\HasNoChildren`
  - `LSUB "" "*"` does **not** promote — returns `INBOX` + `Projects/Work`
  - `\HasChildren \Noselect` ordering, asserted as a whole response line
  - the prefix-not-an-ancestor negative, re-driven under `%`
  - a promoted ancestor under a **non-empty reference**
    (`LSUB "Projects/" "%"`) — the one shape where the reference
    concatenation and the ancestor set interact
  - plus the grandparent case rewritten as the real walk, one `%` command
    per level, and the reference case renamed to what it actually drives
- **Store level** — 3 cases in `store.test.ts`: the `subscribed` column is
  carried through per user row, every derived name is marked subscribed, and
  the backend-throws path falls back to a subscribed `INBOX`. Plus a new `LIST`
  case asserting `listMailboxes` still returns an *un*subscribed mailbox — the
  regression guard that this fix did not leak into `LIST`.
- **Full server suite** — 1663 pass / 0 fail across 83 files. `lint` 0 errors
  (18 pre-existing warnings, none introduced); `typecheck` clean.
- **Live IMAP socket, pre-fix vs post-fix on the same database** — see the two
  E2E comments below. That run predates the R2 round; the four behaviour
  changes above are covered by the mutation-tested unit cases, not re-driven
  over a socket.

## Rebase note (2026-08-13)

Rebased onto `main` after PR 775 landed the unconditional `Drafts` / `Junk`
utility folders. They join the derived set the entry builder marks implicitly
subscribed — the same treatment `INBOX` gets, since neither has a `mailboxes`
row to unsubscribe from — so `LSUB` behaviour is unchanged. The only edit the
rebase needed was the `LIST` regression guard above, whose expectation
hardcoded `["INBOX", "Archive"]`.

The same guard went stale again when PR 823 landed `Starred` / `Trash` — it
was failing on this branch's own head before the R2 round, and now reads
`["INBOX", "Drafts", "Junk", "Starred", "Trash", "Archive"]`.

