### PR TITLE
fix(server): read NODE_ENV at runtime so production branches survive bundling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 EMAIL_DOMAIN=inbox.app
 APP_HOSTNAME=inbox.app
 
+# Opt in to the production posture: JSON logs, HSTS, secure cookies, trust
+# proxy, and generic 500 bodies instead of error messages. Read at runtime by
+# src/server/lib/env.ts, so it belongs in the deployment's environment — the
+# image does not set it. Unset means development posture.
+# NODE_ENV=production
+
 # Optional: Discord webhook URL for server error alarms (unhandled exceptions, 5xx errors, client JS errors)
 # DISCORD_ALARM_WEBHOOK=https://discord.com/api/webhooks/...
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,6 @@ FROM node:22-slim
 
 WORKDIR /app
 
-# Read at runtime by src/server/lib/env.ts. Set on the image so a plain
-# `docker run` of this artifact gets the production posture (JSON logs, HSTS,
-# secure cookies, trust proxy); a deployment can still override it.
-ENV NODE_ENV=production
-
 COPY --from=builder /app/build ./build
 COPY healthcheck.js ./healthcheck.js
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ FROM node:22-slim
 
 WORKDIR /app
 
+# Read at runtime by src/server/lib/env.ts. Set on the image so a plain
+# `docker run` of this artifact gets the production posture (JSON logs, HSTS,
+# secure cookies, trust proxy); a deployment can still override it.
+ENV NODE_ENV=production
+
 COPY --from=builder /app/build ./build
 COPY healthcheck.js ./healthcheck.js
 

--- a/src/server/lib/env.test.ts
+++ b/src/server/lib/env.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, afterEach, afterAll } from "bun:test";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+import { isProduction, nodeEnv } from "./env";
+
+const originalNodeEnv = process.env.NODE_ENV;
+
+const restoreNodeEnv = () => {
+  if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
+  else delete process.env.NODE_ENV;
+};
+
+describe("nodeEnv", () => {
+  afterEach(restoreNodeEnv);
+
+  it("reads NODE_ENV on every call, not once at import", () => {
+    process.env.NODE_ENV = "production";
+    expect(nodeEnv()).toBe("production");
+    process.env.NODE_ENV = "development";
+    expect(nodeEnv()).toBe("development");
+  });
+
+  it("returns undefined when NODE_ENV is unset", () => {
+    delete process.env.NODE_ENV;
+    expect(nodeEnv()).toBeUndefined();
+  });
+});
+
+describe("isProduction", () => {
+  afterEach(restoreNodeEnv);
+
+  it("is true for exactly 'production'", () => {
+    process.env.NODE_ENV = "production";
+    expect(isProduction()).toBe(true);
+  });
+
+  it("is false for any other value", () => {
+    for (const value of ["development", "test", "prod", "Production", ""]) {
+      process.env.NODE_ENV = value;
+      expect(isProduction()).toBe(false);
+    }
+  });
+
+  it("is false when NODE_ENV is unset", () => {
+    delete process.env.NODE_ENV;
+    expect(isProduction()).toBe(false);
+  });
+});
+
+describe("bundled env module", () => {
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-env-bundle-"));
+
+  afterEach(restoreNodeEnv);
+  afterAll(() => fs.rmSync(outdir, { recursive: true, force: true }));
+
+  // The server ships as a Bun bundle, so the checks above passing against the
+  // source proves nothing about the artifact: Bun constant-folds
+  // `process.env.NODE_ENV` at build time. Build this module the way `pack.ts`
+  // does and assert the result still answers to the environment it runs in.
+  it("still reads NODE_ENV at runtime after bundling", async () => {
+    const result = await Bun.build({
+      entrypoints: [path.resolve(import.meta.dir, "env.ts")],
+      target: "node",
+      outdir
+    });
+    expect(result.success).toBe(true);
+
+    const bundled = await import(result.outputs[0]!.path);
+
+    process.env.NODE_ENV = "production";
+    expect(bundled.nodeEnv()).toBe("production");
+    expect(bundled.isProduction()).toBe(true);
+
+    process.env.NODE_ENV = "development";
+    expect(bundled.nodeEnv()).toBe("development");
+    expect(bundled.isProduction()).toBe(false);
+  });
+});

--- a/src/server/lib/env.test.ts
+++ b/src/server/lib/env.test.ts
@@ -49,6 +49,30 @@ describe("isProduction", () => {
   });
 });
 
+describe("server source", () => {
+  const walk = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return /\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name) ? [full] : [];
+    });
+
+  // The bundling guard below only covers env.ts. A dot-access read written
+  // anywhere else folds to a literal in the artifact while every test that
+  // exercises the source still passes, which is how these branches went
+  // unnoticed. config.ts destructures, so it does not match.
+  it("reads NODE_ENV only through env.ts", () => {
+    const serverDir = path.resolve(import.meta.dir, "..");
+    const envModule = path.resolve(import.meta.dir, "env.ts");
+    const offenders = walk(serverDir)
+      .filter((file) => file !== envModule)
+      .filter((file) => /process\.env\.NODE_ENV/.test(fs.readFileSync(file, "utf8")))
+      .map((file) => path.relative(serverDir, file));
+
+    expect(offenders).toEqual([]);
+  });
+});
+
 describe("bundled env module", () => {
   const outdir = fs.mkdtempSync(path.join(os.tmpdir(), "inbox-env-bundle-"));
 

--- a/src/server/lib/env.ts
+++ b/src/server/lib/env.ts
@@ -1,0 +1,13 @@
+/**
+ * Runtime environment access.
+ *
+ * Bun's bundler constant-folds the exact member expression `process.env.NODE_ENV`
+ * into a literal at build time, and the server ships as a bundle. Written that
+ * way, a NODE_ENV check is decided by whatever the *build* saw and the
+ * container's environment can no longer change it. Bracket access is left alone,
+ * so every NODE_ENV read goes through here.
+ */
+
+export const nodeEnv = (): string | undefined => process.env["NODE_ENV"];
+
+export const isProduction = (): boolean => nodeEnv() === "production";

--- a/src/server/lib/http/app.test.ts
+++ b/src/server/lib/http/app.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { json } from "express";
+import type { Server } from "http";
+import path from "path";
+
+import { createExpressApp } from "./app";
+
+const originalNodeEnv = process.env.NODE_ENV;
+const restoreNodeEnv = () => {
+  if (originalNodeEnv !== undefined) process.env.NODE_ENV = originalNodeEnv;
+  else delete process.env.NODE_ENV;
+};
+
+describe("createExpressApp", () => {
+  afterEach(restoreNodeEnv);
+
+  it("resolves both runtime settings from the environment it is called in", () => {
+    process.env.NODE_ENV = "production";
+    const prod = createExpressApp();
+    process.env.NODE_ENV = "development";
+    const dev = createExpressApp();
+
+    // `false` is express's own default for trust proxy — asserted rather than
+    // omitted so a stray unconditional `app.set("trust proxy", 1)` fails here.
+    expect([
+      prod.get("env"),
+      prod.get("trust proxy"),
+      dev.get("env"),
+      dev.get("trust proxy")
+    ]).toEqual(["production", 1, "development", false]);
+  });
+
+  // The consequence the `env` setting exists for, driven over a real socket
+  // rather than asserted on the setting alone: finalhandler decides from
+  // `app.get("env")` whether an unhandled error's stack goes into the response
+  // body. A malformed-JSON POST reaches it with no authentication.
+  it("does not disclose a stack trace on a malformed body in production", async () => {
+    process.env.NODE_ENV = "production";
+    const app = createExpressApp();
+    app.use(json());
+    app.post("/probe", (_req, res) => res.send("ok"));
+
+    let server: Server | undefined;
+    try {
+      server = await new Promise<Server>((resolve) => {
+        const s = app.listen(0, () => resolve(s));
+      });
+      const { port } = server.address() as { port: number };
+      const res = await fetch(`http://127.0.0.1:${port}/probe`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{ not json"
+      });
+      const body = await res.text();
+
+      expect(res.status).toBe(400);
+      expect([
+        body.includes("SyntaxError"),
+        body.includes("at "),
+        body.includes(".js:")
+      ]).toEqual([false, false, false]);
+    } finally {
+      server?.close();
+    }
+  });
+});
+
+describe("bundled createExpressApp", () => {
+  afterEach(restoreNodeEnv);
+
+  // The two cases above cannot fail for the bug this guards. Unbundled, express
+  // seeds `env` correctly from its own `process.env.NODE_ENV` read, so deleting
+  // our explicit set changes nothing — the fold only happens at build time.
+  // Building the module the way `pack.ts` does is the only place the defect is
+  // observable, which is why the source-level suite missed it originally.
+  it("still answers to the runtime NODE_ENV after bundling", async () => {
+    const result = await Bun.build({
+      entrypoints: [path.resolve(import.meta.dir, "app.ts")],
+      target: "node"
+    });
+    expect(result.success).toBe(true);
+
+    // Written through Bun.write rather than node:fs — a module-scoped
+    // fs/os call is resolved against whatever another suite's process-global
+    // mock.module left in place, which silently skipped this whole describe
+    // in a full-directory run.
+    const outfile = path.join(
+      "/tmp",
+      `inbox-http-app-${process.pid}`,
+      "app.js"
+    );
+    await Bun.write(outfile, result.outputs[0]!);
+    const bundled = await import(outfile);
+
+    process.env.NODE_ENV = "production";
+    const prod = bundled.createExpressApp();
+    process.env.NODE_ENV = "development";
+    const dev = bundled.createExpressApp();
+
+    expect([prod.get("env"), dev.get("env")]).toEqual([
+      "production",
+      "development"
+    ]);
+  });
+});

--- a/src/server/lib/http/app.ts
+++ b/src/server/lib/http/app.ts
@@ -1,0 +1,32 @@
+import express from "express";
+
+import { isProduction } from "../env";
+
+/**
+ * Constructs the express app with every setting that has to be resolved from
+ * the *runtime* environment.
+ *
+ * Express seeds `env` itself from the member expression Bun constant-folds, so
+ * in the shipped bundle it is frozen at whatever the build saw and no container
+ * environment can move it. finalhandler reads `env` to decide whether an
+ * unhandled error's stack goes into the response body — with it stuck at
+ * "development", an unauthenticated malformed-JSON POST answers with a full
+ * stack trace and absolute bundle paths.
+ *
+ * The app is built here rather than settings being applied to a caller's app so
+ * the two cannot drift: there is no express() in this codebase that skipped
+ * them.
+ */
+export const createExpressApp = (): express.Application => {
+  const app = express();
+
+  app.set("env", isProduction() ? "production" : "development");
+
+  // Trust first proxy for secure cookie detection behind reverse proxy.
+  // (Rate limiting reads X-Real-IP directly and does not rely on req.ip.)
+  if (isProduction()) {
+    app.set("trust proxy", 1);
+  }
+
+  return app;
+};

--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -11,6 +11,13 @@ import { logger } from "../logger";
 export const initializeHttp = async () => {
   const app = express();
 
+  // Express seeds this setting from the environment through the same member
+  // expression the bundler folds, so in the shipped bundle it is frozen at
+  // "development" and no container environment can move it. finalhandler reads
+  // it to decide whether an unhandled error's stack goes into the response
+  // body, so it has to be set explicitly here. See lib/env.ts.
+  app.set("env", isProduction() ? "production" : "development");
+
   // Trust first proxy for secure cookie detection behind reverse proxy.
   // (Rate limiting reads X-Real-IP directly and does not rely on req.ip.)
   if (isProduction()) {

--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -4,25 +4,13 @@ import session from "express-session";
 import path from "path";
 
 import { getDomain, isProduction, PostgresSessionStore } from "server";
+import { createExpressApp } from "./app";
 import apiRouter from "./routes";
 import { startCleanupScheduler } from "./rate-limit";
 import { logger } from "../logger";
 
 export const initializeHttp = async () => {
-  const app = express();
-
-  // Express seeds this setting from the environment through the same member
-  // expression the bundler folds, so in the shipped bundle it is frozen at
-  // "development" and no container environment can move it. finalhandler reads
-  // it to decide whether an unhandled error's stack goes into the response
-  // body, so it has to be set explicitly here. See lib/env.ts.
-  app.set("env", isProduction() ? "production" : "development");
-
-  // Trust first proxy for secure cookie detection behind reverse proxy.
-  // (Rate limiting reads X-Real-IP directly and does not rely on req.ip.)
-  if (isProduction()) {
-    app.set("trust proxy", 1);
-  }
+  const app = createExpressApp();
 
   // Security headers
   app.use((_req, res, next) => {

--- a/src/server/lib/http/index.ts
+++ b/src/server/lib/http/index.ts
@@ -3,7 +3,7 @@ import fileupload from "express-fileupload";
 import session from "express-session";
 import path from "path";
 
-import { getDomain, PostgresSessionStore } from "server";
+import { getDomain, isProduction, PostgresSessionStore } from "server";
 import apiRouter from "./routes";
 import { startCleanupScheduler } from "./rate-limit";
 import { logger } from "../logger";
@@ -13,7 +13,7 @@ export const initializeHttp = async () => {
 
   // Trust first proxy for secure cookie detection behind reverse proxy.
   // (Rate limiting reads X-Real-IP directly and does not rely on req.ip.)
-  if (process.env.NODE_ENV === "production") {
+  if (isProduction()) {
     app.set("trust proxy", 1);
   }
 
@@ -22,7 +22,7 @@ export const initializeHttp = async () => {
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("X-Frame-Options", "DENY");
     res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
-    if (process.env.NODE_ENV === "production") {
+    if (isProduction()) {
       res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
     }
     next();
@@ -44,7 +44,7 @@ export const initializeHttp = async () => {
       saveUninitialized: false,
       rolling: true,
       cookie: {
-        secure: process.env.NODE_ENV === "production",
+        secure: isProduction(),
         sameSite: "strict",
         maxAge: 1000 * 60 * 60 * 24 * 7
       },

--- a/src/server/lib/http/routes/route.ts
+++ b/src/server/lib/http/routes/route.ts
@@ -1,5 +1,6 @@
 import { Router, RequestHandler, Request, Response, NextFunction } from "express";
 import { logger } from "../../logger";
+import { isProduction } from "../../env";
 import { sendAlarm } from "../../alarm";
 
 export type Method = "GET" | "POST" | "DELETE";
@@ -62,12 +63,11 @@ export class Route<T> {
         `Route Error: ${this.method} ${this.path}`,
         `**Error:** ${error instanceof Error ? error.message : String(error)}`
       ).catch(() => undefined);
-      const message =
-        process.env.NODE_ENV === "production"
-          ? "Internal server error"
-          : error instanceof Error
-            ? error.message
-            : String(error);
+      const message = isProduction()
+        ? "Internal server error"
+        : error instanceof Error
+          ? error.message
+          : String(error);
       res.status(500).json({ status: "error", message });
     }
   };

--- a/src/server/lib/index.ts
+++ b/src/server/lib/index.ts
@@ -1,3 +1,6 @@
+// Environment access (standalone, no dependencies)
+export * from "./env";
+
 // Logging (standalone, no dependencies)
 export { logger } from "./logger";
 

--- a/src/server/lib/logger.ts
+++ b/src/server/lib/logger.ts
@@ -6,6 +6,8 @@
  * - Test: Silent by default (LOG_LEVEL=debug to enable)
  */
 
+import { isProduction, nodeEnv } from "./env";
+
 type LogLevel = "debug" | "info" | "warn" | "error";
 
 interface LogContext {
@@ -44,12 +46,8 @@ function getLogLevel(): LogLevel {
   const env = process.env.LOG_LEVEL?.toLowerCase();
   if (env && env in LOG_LEVELS) return env as LogLevel;
   // Default: silent in test, info otherwise
-  if (process.env.NODE_ENV === "test") return "error";
+  if (nodeEnv() === "test") return "error";
   return "info";
-}
-
-function isProduction(): boolean {
-  return process.env.NODE_ENV === "production";
 }
 
 function shouldLog(level: LogLevel): boolean {


### PR DESCRIPTION
Closes #766.

## The defect

Bun's bundler constant-folds the exact member expression `process.env.NODE_ENV` at build time. `Dockerfile:17` runs `bun run build` with `NODE_ENV` unset, so in the shipped bundle every `process.env.NODE_ENV === "production"` became the literal `false` — and because the branch is gone, setting `NODE_ENV=production` in the container could not bring it back.

`#766` filed this against the logger. Grepping the rest of the tree found the same fold had silently killed **six** production branches, four of them security-relevant. All verified by running the built artifact, not by reading source:

| | branch | shipped bundle before | consequence |
|---|---|---|---|
| 1 | `logger` output format | `function isProduction() { return false }` | prod emitted `formatPretty`, never `formatJson` |
| 2 | `app.set("trust proxy", 1)` | `if (false) {}` | never ran, so `req.protocol` ignored the reverse proxy |
| 3 | `Strict-Transport-Security` header | `if (false) {}` | HSTS never sent |
| 4 | session `cookie.secure` | `secure: false` | session cookie issued without `Secure` |
| 5 | 500 response body | `error instanceof Error ? error.message : String(error)` | raw internal error strings returned to clients |
| 6 | express's own `env` setting | `var env = "development"` | finalhandler put unhandled-error stacks in the response body |

Note that `route.test.ts` already had a passing `hides error message in production` test. It tests the source, which was always correct; the artifact was not. That gap is the thing worth fixing, not just the call sites.

## The fix

`src/server/lib/env.ts` holds one NODE_ENV read written so the bundler leaves it alone, and every call site goes through its `isProduction()`. Only the dot-access member expression is folded — bracket access, destructuring and every other env var survive, which is confirmed in the test plan below. `config.ts` already destructured `NODE_ENV`, so it was never affected and is unchanged.

`env.test.ts` builds the module the way `pack.ts` does and asserts the built output still answers to the environment it runs in. Reverting the helper to dot-access fails that test (checked: the bundle froze `"test"` and the assertion caught it), so this cannot silently regress.

**The image does not set `NODE_ENV`** — the production posture is opt-in, per Hoie's review. The deployment turns it on by putting `NODE_ENV=production` in its own environment; on this compose that is `.env.local`, loaded via `env_file`, and `.env.example` documents it. The Dockerfile is unchanged by this PR. So this diff restores the six branches; the deployment's environment decides whether they run, and until that variable is set in prod the posture stays exactly where it is today.

**Branch 6 is the one worth reading twice.** `pack.ts` bundles `node_modules`, so express's own read folded too, and unlike the other five no container environment could reach it — the artifact ships `var env = "development"` and `app.get("env")` is permanently that. finalhandler consults it to decide whether to put an error's stack in the response body. So on `upstream/main` today:

```
POST /api/mails/mark   Content-Type: application/json   body: {bad
-> 400 text/html   <pre>SyntaxError: Expected property name or '}' ...
                     at parse2 (file:///app/build/server/bundle.js:40249:21) ...
```

Full stack, absolute server paths, bundle offsets — and **unauthenticated**, because `json()` is mounted app-level ahead of the session gate. The parse error never enters the api router (a Router has arity 3, so express skips past it hunting for an error handler), so neither `Route`'s try/catch nor the router's own error handler ever sees it. Reproduced against both the baseline and the patched artifact, then fixed by setting `env` explicitly at app construction and re-verified: the same request now returns `<pre>Bad Request</pre>` with no stack. Credit to reviewoie for catching this — my first pass audited `src/` only, which by construction cannot see it.

**Where branch 6 lives now, and why it is guarded differently.** The two runtime-resolved settings (`env` and `trust proxy`) moved out of `http/index.ts` into `createExpressApp` in `src/server/lib/http/app.ts`, so there is no `express()` in the codebase that can skip them. That relocation exists because branch 6 was the only one of the six with no regression guard: deleting `app.set("env", …)` left tests, typecheck and lint green while the unauthenticated stack disclosure returned in the next image. The repo-wide source scan cannot reach it — express reads NODE_ENV inside `node_modules`, so no `src/` file matches. `http/app.test.ts` closes that hole: it `Bun.build`s the module the way `pack.ts` does, imports the bundle and calls `createExpressApp()` under two `NODE_ENV` values. Confirmed load-bearing — deleting the set fails it, while the two source-level cases in the same file stay green, because unbundled express seeds `env` correctly on its own.

**What the runtime variable reaches, precisely.** The bundle now contains exactly three live NODE_ENV reads: `env.ts`, and the two in `config.ts` that pick the `.env.<NODE_ENV>` file. Everything else — every remaining dependency's copy — was folded at build time and stays folded. So this PR restores the branches the repo wrote itself plus express's, and does not put the rest of the dependency tree into production mode. Doing that means building with `NODE_ENV=production`, which changes behavior across every dependency at once and deserves its own diff and verification; filed as #792.

**Two side effects worth naming.** Setting `NODE_ENV=production` also flips `config.ts`'s `extraEnv` from `""` to `".env.production"`, so dotenv attempts that file each boot — no impact on the shipped image, which COPYs no `.env*` and where dotenv does not override already-set vars. And branch 1 is not a pure format change: `formatJson` serializes `entry.error` including `stack`, whereas `formatPretty` printed stacks only under `LOG_LEVEL=debug`. Every prod `logger.error` now carries a full stack into journald, whose retention is host-owned. That is the point of structured logging, but it is a log-volume change, so it should be a decision rather than a surprise.

## 🔴 Before merging

Two prerequisites, both in the deployment rather than in this diff.

**1. `NODE_ENV=production` has to be set in prod's environment**, or this PR changes nothing there — every branch stays on its development side, same as today. Since the image no longer sets it, that is a deliberate step on the deploy host's `.env.local`. Nothing breaks if it is left unset; the stack-trace disclosure and the missing `Secure` cookie simply persist.

**2.** Branches 2 and 4 are load-bearing together, and they only work if the reverse proxy in front of the app sends `X-Forwarded-Proto: https`. That is exactly what the dead `trust proxy` branch existed to consume, but it has never actually run in prod, so it has never been exercised.

I verified both sides of this (details in the test plan):

- **With** the header: login succeeds, cookie is stored with `Secure`, session survives reload.
- **Without** the header: `express-session` refuses to set a `Secure` cookie over a connection it believes is plain http, so **no cookie is issued and login silently fails** — the app bounces straight back to the login screen.

It fails **quietly**, which is the part that makes it worth checking rather than discovering. Existing sessions do not drop: `PostgresSessionStore.get` restores `secure` from the stored row and express-session reuses that stored cookie, so sessions minted before the deploy keep `secure:false` and keep being re-issued under `rolling: true`. Only *new* logins stop working. So a missing `X-Forwarded-Proto` produces no visible outage on deploy — just logins that silently fail while everyone already signed in bleeds out over the 7-day `maxAge`.

Prod terminates TLS somewhere ahead of the container, and I can't inspect that config from here. If the proxy already forwards the scheme, this merges clean. If it doesn't, it needs to before this lands. Worth a look either way — the app has been serving cookies without `Secure` this whole time.

<@394466005918941184>

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bunx eslint src` — 0 errors (18 pre-existing warnings, none in changed files)
- [x] `bun test src/server` — **1510 pass / 0 fail** (+7 new `env.test.ts` cases). Re-run after the branch-6 fix commit: same, no regression.
- [x] **CI green on the current head** (93c61f1, after rebase onto `upstream/main` da2b242) — **1804 pass / 0 fail** across the full suite, including the 3 new `http/app.test.ts` cases.
- [x] **Regression guard proven to bite** — rewrote `env.ts` to dot-access; the bundling test failed with `Expected: "production" / Received: "test"`, i.e. the constant had been frozen into the build. Restored.
- [x] **Bundler behaviour pinned directly** — built a probe module with five read forms. Only `process.env.NODE_ENV` folds (to `false` unset, `true` under `NODE_ENV=production`); `process.env["NODE_ENV"]`, destructured `NODE_ENV`, aliased `env.NODE_ENV` and other vars such as `LOG_FORMAT` all survive verbatim.
- [x] **Artifact diff, all six branches** — rebuilt `build/server/bundle.js` and re-grepped: `isProduction()` is now a live call at each site instead of a folded literal, and `app.set("env", ...)` is evaluated at startup rather than pinned.
- [x] **Repo-wide guard added** — a source scan over `src/server` (excluding tests and `env.ts`) asserts the folded member expression appears nowhere else. Checked that it bites: injecting a dot-access read into `lib/util.ts` fails the test naming that file. This is the check that would have caught the five branches written in this repo — branch 6 is vendored and out of its reach, which is what `http/app.test.ts`'s bundled case covers instead.
- [x] **Branch-6 guard proven to bite** — deleted `app.set("env", …)` from `createExpressApp`: the bundled `http/app.test.ts` case fails (`"development"` where `"production"` is expected) while the two source-level cases and the rest of the suite stay green. Restored.
- [x] **Branch 6, before and after, unauthenticated** — `POST /api/mails/mark` with `Content-Type: application/json` and body `{bad`, no session. Baseline and pre-fix patched: `400 text/html` whose body is the full `SyntaxError` stack including absolute `bundle.js` paths and line offsets. After the fix: `<pre>Bad Request</pre>`, and a grep for `SyntaxError`/`bundle.js` in the response body returns **0**.

**Live artifact E2E — baseline vs patched, both `node build/server/bundle.js` under `NODE_ENV=production`**, real local dev DB, patched on a separate port, baseline detached at `upstream/main` (5906df8):

- [x] **Log format** — parsed every emitted startup line as JSON. Baseline: **0 structured lines / 11 non-JSON** (ANSI-coloured pretty output). Patched: **11 structured lines / 0 non-JSON**. This is the reported bug, reproduced and fixed on the artifact.
- [x] **`POST /api/users/login` response headers, four-way:**
  - baseline + `X-Forwarded-Proto: https` → no HSTS; `Set-Cookie: connect.sid=…; HttpOnly; SameSite=Strict` — **no `Secure`**
  - patched + `X-Forwarded-Proto: https` → **HSTS present**; cookie carries **`Secure`**
  - baseline, no forwarded proto → no HSTS, cookie still without `Secure`
  - patched, no forwarded proto → HSTS present, **no `Set-Cookie` at all** (the failure mode flagged above)
  - Patched issuing the cookie only when the scheme is forwarded also proves branch 2 is live: `express` only honours `X-Forwarded-Proto` once `trust proxy` is set.
- [x] **UI E2E, real clicks at 390×844, through a reverse proxy that forwards the scheme** (stands in for the prod topology) against the production-mode bundle:
  - `/` → login screen renders (`@hoie.kim`), typed into the username/password fields and clicked **Login** — no `page.goto` of an authed URL.
  - Landed on the mail list: header row `18038424692-vj9-24e`, message *"Undelivered Mail Returned to Sender"* from Mail Delivery System, category tabs New/All/Saved/Sent/Spam and the account list all render.
  - Browser cookie store: `connect.sid` present, `secure=true httpOnly=true sameSite=Strict`.
  - `GET /api/users/login` → `hasUser: true`, `username: admin`. Reload → still `hasUser: true`, same list re-renders.
  - `page.on("pageerror")` + console-error watch: **none**.
  - Screenshots eye-checked: `/tmp/pr-766-proxy-{1-login,3-after-login,4-after-reload}.png`.
  - **Re-run in full after the branch-6 fix commit** — identical on every assertion, still zero page errors, no regression.
- [x] **Same UI run without the forwarded scheme** — cookie not stored (`connect.sid` absent), `hasUser: false`, reload returns to the login screen, console shows the expected 401. Screenshot `/tmp/pr-766-noproxy-4-after-reload.png` eye-checked. Documents the prerequisite above.

Not covered: I could not trigger a live thrown 500 through the public routes to demo branch 5 end to end — the mails routes I probed all return handled `failed` responses rather than throwing. Branch 5 rests on the artifact grep plus the existing `route.test.ts` production case. (Branch 6's leak is a *different* path — it never reaches `Route`'s catch at all, which is exactly why it was invisible.)

Probing for that throw did surface a separate, unrelated data-integrity bug in `POST /api/mails/mark`, filed as #790 rather than folded in here.



