### PR TITLE
fix(imap): FETCH returns a partial subset instead of NO [LIMIT]

### DIFF
--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -89,9 +89,11 @@ export async function fetchMessagesTyped(
     const clampedSet = clampSequenceSetToFirst(
       seqState.seqToUid,
       fetchRequest.sequenceSet,
-      limit
+      limit,
+      isUidCommand
     );
-    logger.info("FETCH clamped to server per-command cap", {
+    // debug, not info — iOS full-sync fires ceil(N/limit) clamp events per session.
+    logger.debug("FETCH clamped to server per-command cap", {
       component: "imap",
       tag,
       requestedCount,

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -76,7 +76,8 @@ export async function fetchMessagesTyped(
   );
   const requestedCount = countSequenceSetMessages(
     seqState.seqToUid,
-    fetchRequest.sequenceSet
+    fetchRequest.sequenceSet,
+    isUidCommand
   );
   const limit = isFlagsOnly ? Infinity : isHeaderOnly ? 500 : 50;
   if (requestedCount > limit) {

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -37,6 +37,7 @@ import {
   resolveUidRangeSentinel,
   uidToSeqNumber,
   countSequenceSetMessages,
+  clampSequenceSetToFirst,
   buildSequenceMapping,
   SequenceState,
 } from "./sequence-resolver";
@@ -79,8 +80,25 @@ export async function fetchMessagesTyped(
   );
   const limit = isFlagsOnly ? Infinity : isHeaderOnly ? 500 : 50;
   if (requestedCount > limit) {
-    write(`${tag} NO [LIMIT] FETCH too much data requested\r\n`);
-    return;
+    // Return a subset instead of `NO [LIMIT]`. RFC 3501 §6.4.5 lets the
+    // server return fewer messages than requested; the client observes
+    // the uncovered range and issues a follow-up FETCH for it, walking
+    // the mailbox in cap-sized chunks. iOS Mail specifically treats any
+    // tagged `NO` as fatal (shows "Cannot Get Mail" modal); a
+    // shortened `OK` completes cleanly and iOS keeps syncing.
+    const clampedSet = clampSequenceSetToFirst(
+      seqState.seqToUid,
+      fetchRequest.sequenceSet,
+      limit
+    );
+    logger.info("FETCH clamped to server per-command cap", {
+      component: "imap",
+      tag,
+      requestedCount,
+      limit,
+      clampedRanges: clampedSet.ranges,
+    });
+    fetchRequest = { ...fetchRequest, sequenceSet: clampedSet };
   }
 
   // RFC 4551 §3.3.1: a CHANGEDSINCE fetch implies the MODSEQ data item, so the

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -227,39 +227,120 @@ describe("uidToSeqNumber", () => {
   });
 });
 
-describe("countSequenceSetMessages", () => {
+describe("countSequenceSetMessages — SEQ axis (isUidCommand=false)", () => {
   const uids = [10, 20, 30, 40, 50];
 
   it("counts a single-message range", () => {
     const set: SequenceSet = { ranges: [{ start: 2 }] };
-    expect(countSequenceSetMessages(uids, set)).toBe(1);
+    expect(countSequenceSetMessages(uids, set, false)).toBe(1);
   });
 
   it("counts a start:end range", () => {
     const set: SequenceSet = { ranges: [{ start: 2, end: 4 }] };
-    expect(countSequenceSetMessages(uids, set)).toBe(3);
+    expect(countSequenceSetMessages(uids, set, false)).toBe(3);
   });
 
   it("clamps ranges beyond mailbox size", () => {
     const set: SequenceSet = { ranges: [{ start: 3, end: 100 }] };
-    expect(countSequenceSetMessages(uids, set)).toBe(3);
+    expect(countSequenceSetMessages(uids, set, false)).toBe(3);
   });
 
   it("sums multiple ranges", () => {
     const set: SequenceSet = {
       ranges: [{ start: 1, end: 2 }, { start: 4 }],
     };
-    expect(countSequenceSetMessages(uids, set)).toBe(3);
+    expect(countSequenceSetMessages(uids, set, false)).toBe(3);
   });
 
   it("clamps both start and end to 0 on empty mailbox", () => {
     const set: SequenceSet = { ranges: [{ start: 1, end: 10 }] };
-    expect(countSequenceSetMessages([], set)).toBe(1);
+    expect(countSequenceSetMessages([], set, false)).toBe(1);
   });
 
   it("returns 0 for empty sequence set", () => {
     const set: SequenceSet = { ranges: [] };
-    expect(countSequenceSetMessages(uids, set)).toBe(0);
+    expect(countSequenceSetMessages(uids, set, false)).toBe(0);
+  });
+});
+
+describe("countSequenceSetMessages — UID axis (isUidCommand=true)", () => {
+  // Load-bearing shape: mailbox UIDs don't start at 1 (retention prune /
+  // UIDVALIDITY bump). SEQ-axis counting on this mailbox would return 1
+  // for `UID FETCH 10051:*` (seq-clamp to maxSeq=9950 → both endpoints
+  // resolve to 9950 → 1). Cap gate would skip the clamp, and downstream
+  // `store.getMessages(10051, 19950)` would return all 9900 rows.
+  // Counting via UID intersection returns the correct 9900, cap fires,
+  // clamp runs, downstream fetches the first 50 UIDs only.
+  const pruned = Array.from({ length: 9950 }, (_, i) => 10001 + i);
+  const set = (ranges: SequenceSet["ranges"]): SequenceSet => ({
+    type: "sequence",
+    ranges,
+  });
+
+  it("counts real UIDs, not seq positions, on a pruned mailbox with a `n:*` range", () => {
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 10051, end: Number.MAX_SAFE_INTEGER }]), true)
+    ).toBe(9900);
+  });
+
+  it("counts 0 when the range is entirely below the mailbox's UIDs", () => {
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 1, end: 500 }]), true)
+    ).toBe(0);
+  });
+
+  it("counts 0 when the range is entirely above the mailbox's UIDs", () => {
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 50000, end: 60000 }]), true)
+    ).toBe(0);
+  });
+
+  it("counts the intersection when the range partially overlaps", () => {
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 9900, end: 10100 }]), true)
+    ).toBe(100);
+  });
+
+  it("`*:*` on empty mailbox counts 0 (never dereferences seqToUid[-1])", () => {
+    expect(
+      countSequenceSetMessages(
+        [],
+        set([{ start: Number.MAX_SAFE_INTEGER, end: Number.MAX_SAFE_INTEGER }]),
+        true
+      )
+    ).toBe(0);
+  });
+
+  it("counts a bare single-UID range (end=undefined)", () => {
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 10500 }]), true)
+    ).toBe(1);
+  });
+
+  it("counts multiple ranges by summing per-range intersections", () => {
+    expect(
+      countSequenceSetMessages(
+        pruned,
+        set([
+          { start: 10001, end: 10005 },  // 5 UIDs
+          { start: 15000, end: 15003 },  // 4 UIDs
+          { start: 50000, end: 60000 },  // 0 UIDs (both endpoints above max)
+        ]),
+        true
+      )
+    ).toBe(9);
+  });
+
+  it("returns 0 on empty sequence set", () => {
+    expect(countSequenceSetMessages(pruned, set([]), true)).toBe(0);
+  });
+
+  it("handles reversed ranges (RFC 3501 §9: `10:3` ≡ `3:10`)", () => {
+    // Both endpoints below the mailbox's UIDs → 0 either way; the point
+    // is that the counter doesn't return a negative or NaN when start > end.
+    expect(
+      countSequenceSetMessages(pruned, set([{ start: 10100, end: 10000 }]), true)
+    ).toBe(100);
   });
 });
 

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -6,6 +6,7 @@ import {
   resolveSeqRangeToUids,
   resolveUidRangeSentinel,
   countSequenceSetMessages,
+  clampSequenceSetToFirst,
   type SequenceState,
 } from "./sequence-resolver";
 import type { SequenceSet } from "./types";
@@ -260,4 +261,77 @@ describe("countSequenceSetMessages", () => {
     const set: SequenceSet = { ranges: [] };
     expect(countSequenceSetMessages(uids, set)).toBe(0);
   });
+});
+
+describe("clampSequenceSetToFirst", () => {
+  // 10-message mailbox for the shared cases below.
+  const uids = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
+
+  it("returns the original set unchanged when count is already at the limit", () => {
+    const set: SequenceSet = { ranges: [{ start: 1, end: 5 }] };
+    const result = clampSequenceSetToFirst(uids, set, 5);
+    expect(result.ranges).toEqual([{ start: 1, end: 5 }]);
+  });
+
+  it("returns the original set unchanged when count is below the limit", () => {
+    const set: SequenceSet = { ranges: [{ start: 1, end: 3 }] };
+    const result = clampSequenceSetToFirst(uids, set, 50);
+    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+  });
+
+  it("truncates a single range that exceeds the limit", () => {
+    const set: SequenceSet = { ranges: [{ start: 1, end: 10 }] };
+    const result = clampSequenceSetToFirst(uids, set, 3);
+    // First 3 messages: seq 1..3.
+    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+  });
+
+  it("truncates `1:*` (Number.MAX_SAFE_INTEGER sentinel) to the first N", () => {
+    const set: SequenceSet = {
+      ranges: [{ start: 1, end: Number.MAX_SAFE_INTEGER }],
+    };
+    const result = clampSequenceSetToFirst(uids, set, 4);
+    expect(result.ranges).toEqual([{ start: 1, end: 4 }]);
+  });
+
+  it("keeps whole ranges first, then partially takes the next", () => {
+    const set: SequenceSet = {
+      ranges: [
+        { start: 1, end: 2 },  // 2 msgs
+        { start: 5, end: 8 },  // 4 msgs
+        { start: 10 },         // 1 msg
+      ],
+    };
+    // limit=5: take {1,2}, then partial {5..7} (3 of 4), drop {10}.
+    const result = clampSequenceSetToFirst(uids, set, 5);
+    expect(result.ranges).toEqual([
+      { start: 1, end: 2 },
+      { start: 5, end: 7 },
+    ]);
+  });
+
+  it("keeps single-message ranges (end===undefined) as-is until the limit", () => {
+    const set: SequenceSet = {
+      ranges: [{ start: 3 }, { start: 5 }, { start: 7 }],
+    };
+    const result = clampSequenceSetToFirst(uids, set, 2);
+    expect(result.ranges).toEqual([{ start: 3 }, { start: 5 }]);
+  });
+
+  it("returns an empty ranges array when limit is 0", () => {
+    const set: SequenceSet = { ranges: [{ start: 1, end: 10 }] };
+    const result = clampSequenceSetToFirst(uids, set, 0);
+    expect(result.ranges).toEqual([]);
+  });
+
+  it("preserves the `type` discriminator (uid vs sequence)", () => {
+    const set: SequenceSet = {
+      type: "uid",
+      ranges: [{ start: 1, end: 10 }],
+    } as SequenceSet;
+    const result = clampSequenceSetToFirst(uids, set, 3);
+    expect((result as SequenceSet & { type?: string }).type).toBe("uid");
+    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+  });
+
 });

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -261,6 +261,18 @@ describe("countSequenceSetMessages — SEQ axis (isUidCommand=false)", () => {
     const set: SequenceSet = { ranges: [] };
     expect(countSequenceSetMessages(uids, set, false)).toBe(0);
   });
+
+  it("handles reversed ranges (`*:1` ≡ `1:*`) — counts whole mailbox, not 0", () => {
+    // Pre-fix returned 0 → cap gate skipped → downstream
+    // `convertSequenceSet` normalized to `1:*` and fetched every row,
+    // breaching the 50-body cap. Real cap-bypass DoS via a spec-legal
+    // `SEQ FETCH *:1`.
+    const set: SequenceSet = {
+      type: "sequence",
+      ranges: [{ start: Number.MAX_SAFE_INTEGER, end: 1 }],
+    };
+    expect(countSequenceSetMessages(uids, set, false)).toBe(uids.length);
+  });
 });
 
 describe("countSequenceSetMessages — UID axis (isUidCommand=true)", () => {
@@ -498,6 +510,34 @@ describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {
     for (let i = 0; i < 50; i++) {
       expect(result.ranges[i]).toEqual({ start: i * 2 + 1, end: i * 2 + 1 });
     }
+  });
+
+  it("R5 HIGH: `UID FETCH *:10051` on pruned mailbox — resolves `*`, normalizes reversed range, clamps to first N", () => {
+    // Pre-fix: `startUid = MAX_SAFE_INTEGER`, `endUid = 10051`.
+    // Predicate `uid >= MAX_SAFE_INTEGER` is never true → matched=[] →
+    // returns empty ranges → silent zero-fetch even though the counter
+    // now correctly reports 9900 requested UIDs. Post-fix resolves the
+    // `*` sentinel to maxUid, normalizes to `[10051..maxUid]`, and
+    // clamps to the first N.
+    const pruned = Array.from({ length: 9950 }, (_, i) => 10001 + i);
+    const result = clampSequenceSetToFirst(
+      pruned,
+      set([{ start: Number.MAX_SAFE_INTEGER, end: 10051 }]),
+      50,
+      true
+    );
+    expect(result.ranges).toEqual([{ start: 10051, end: 10100 }]);
+  });
+
+  it("R5 HIGH: `UID FETCH 19950:10051` (reversed) — normalized to `10051:19950`, clamps to first N", () => {
+    const pruned = Array.from({ length: 9950 }, (_, i) => 10001 + i);
+    const result = clampSequenceSetToFirst(
+      pruned,
+      set([{ start: 19950, end: 10051 }]),
+      50,
+      true
+    );
+    expect(result.ranges).toEqual([{ start: 10051, end: 10100 }]);
   });
 
   it("collapses contiguous matched UIDs into one range but keeps holes as separate ranges", () => {

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -346,7 +346,8 @@ describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {
   it("`UID 1:*` on a pruned mailbox emits a range of REAL UIDs, not seq positions", () => {
     // The R1 HIGH scenario: previously returned `{start:1, end:50}` and
     // silently matched zero rows. Now returns `{start:10001, end:10003}`
-    // for limit=3 — the actual first-3 UIDs.
+    // for limit=3 — the actual first-3 UIDs, and since they're contiguous
+    // the coalescer collapses them into a single range.
     const result = clampSequenceSetToFirst(
       uids,
       set([{ start: 1, end: Number.MAX_SAFE_INTEGER }]),
@@ -379,7 +380,12 @@ describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {
     expect(result.ranges).toEqual([]);
   });
 
-  it("walks multiple ranges in order, stopping at limit", () => {
+  it("walks multiple ranges in order, stopping at limit, and emits coalesced sub-ranges", () => {
+    // The R2 MED scenario: matched UIDs are non-contiguous, so a single
+    // enclosing range [10001..10006] would over-fetch (dense mailbox has
+    // real 10003/10004 in it, so `getMessages(10001, 10006)` would return
+    // 6 rows — 2 unrequested — breaching the cap by 50%). Coalescing
+    // preserves the request's shape post-clamp.
     const result = clampSequenceSetToFirst(
       uids,
       set([
@@ -389,10 +395,48 @@ describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {
       4,
       true
     );
-    // First 4 matched UIDs: 10001, 10002, 10005, 10006. Emitted as one
-    // enclosing range [10001, 10006]; 10003/10004 don't exist in the
-    // requested set, so downstream returns 4 rows.
-    expect(result.ranges).toEqual([{ start: 10001, end: 10006 }]);
+    expect(result.ranges).toEqual([
+      { start: 10001, end: 10002 },
+      { start: 10005, end: 10006 },
+    ]);
+  });
+
+  it("R2 adversarial: 100 discrete odd UIDs, cap=50 — coalesces to 50 single-UID ranges, no cap breach", () => {
+    // `UID FETCH 1,3,5,...,199 (BODY[])` — 100 discrete UIDs, all real.
+    // A single-enclosing-range clamp would emit [1..99] and downstream
+    // would fetch every UID in [1..99] that exists (up to 99 rows on a
+    // dense mailbox), breaching the body cap of 50 by ~2x. Coalescing
+    // emits exactly 50 single-UID ranges → downstream returns exactly 50.
+    const denseUids = Array.from({ length: 200 }, (_, i) => i + 1);
+    const requestedRanges = Array.from({ length: 100 }, (_, i) => ({
+      start: i * 2 + 1,
+      end: i * 2 + 1,
+    }));
+    const result = clampSequenceSetToFirst(denseUids, set(requestedRanges), 50, true);
+    expect(result.ranges).toHaveLength(50);
+    for (let i = 0; i < 50; i++) {
+      expect(result.ranges[i]).toEqual({ start: i * 2 + 1, end: i * 2 + 1 });
+    }
+  });
+
+  it("collapses contiguous matched UIDs into one range but keeps holes as separate ranges", () => {
+    // Mix: request touches 3 disjoint clusters, each contiguous internally.
+    const denseUids = Array.from({ length: 20 }, (_, i) => i + 1);
+    const result = clampSequenceSetToFirst(
+      denseUids,
+      set([
+        { start: 1, end: 3 },   // 3 UIDs → cluster 1
+        { start: 7, end: 9 },   // 3 UIDs → cluster 2
+        { start: 15, end: 17 }, // 3 UIDs → cluster 3
+      ]),
+      9,
+      true
+    );
+    expect(result.ranges).toEqual([
+      { start: 1, end: 3 },
+      { start: 7, end: 9 },
+      { start: 15, end: 17 },
+    ]);
   });
 
   it("single-UID range (end=undefined) treats end as start", () => {

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -263,75 +263,165 @@ describe("countSequenceSetMessages", () => {
   });
 });
 
-describe("clampSequenceSetToFirst", () => {
-  // 10-message mailbox for the shared cases below.
+describe("clampSequenceSetToFirst — SEQ axis (isUidCommand=false)", () => {
+  // 10-message mailbox; UIDs happen to be 101..110 (values don't matter
+  // for SEQ-axis — clamp counts by position, not by UID value).
   const uids = [101, 102, 103, 104, 105, 106, 107, 108, 109, 110];
+  const set = (ranges: SequenceSet["ranges"]): SequenceSet => ({
+    type: "sequence",
+    ranges,
+  });
 
   it("returns the original set unchanged when count is already at the limit", () => {
-    const set: SequenceSet = { ranges: [{ start: 1, end: 5 }] };
-    const result = clampSequenceSetToFirst(uids, set, 5);
-    expect(result.ranges).toEqual([{ start: 1, end: 5 }]);
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: 1, end: 5 }]), 5, false).ranges
+    ).toEqual([{ start: 1, end: 5 }]);
   });
 
   it("returns the original set unchanged when count is below the limit", () => {
-    const set: SequenceSet = { ranges: [{ start: 1, end: 3 }] };
-    const result = clampSequenceSetToFirst(uids, set, 50);
-    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: 1, end: 3 }]), 50, false).ranges
+    ).toEqual([{ start: 1, end: 3 }]);
   });
 
   it("truncates a single range that exceeds the limit", () => {
-    const set: SequenceSet = { ranges: [{ start: 1, end: 10 }] };
-    const result = clampSequenceSetToFirst(uids, set, 3);
-    // First 3 messages: seq 1..3.
-    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: 1, end: 10 }]), 3, false).ranges
+    ).toEqual([{ start: 1, end: 3 }]);
   });
 
   it("truncates `1:*` (Number.MAX_SAFE_INTEGER sentinel) to the first N", () => {
-    const set: SequenceSet = {
-      ranges: [{ start: 1, end: Number.MAX_SAFE_INTEGER }],
-    };
-    const result = clampSequenceSetToFirst(uids, set, 4);
-    expect(result.ranges).toEqual([{ start: 1, end: 4 }]);
+    expect(
+      clampSequenceSetToFirst(
+        uids,
+        set([{ start: 1, end: Number.MAX_SAFE_INTEGER }]),
+        4,
+        false
+      ).ranges
+    ).toEqual([{ start: 1, end: 4 }]);
   });
 
   it("keeps whole ranges first, then partially takes the next", () => {
-    const set: SequenceSet = {
-      ranges: [
-        { start: 1, end: 2 },  // 2 msgs
-        { start: 5, end: 8 },  // 4 msgs
-        { start: 10 },         // 1 msg
-      ],
-    };
     // limit=5: take {1,2}, then partial {5..7} (3 of 4), drop {10}.
-    const result = clampSequenceSetToFirst(uids, set, 5);
-    expect(result.ranges).toEqual([
-      { start: 1, end: 2 },
-      { start: 5, end: 7 },
-    ]);
+    expect(
+      clampSequenceSetToFirst(
+        uids,
+        set([{ start: 1, end: 2 }, { start: 5, end: 8 }, { start: 10 }]),
+        5,
+        false
+      ).ranges
+    ).toEqual([{ start: 1, end: 2 }, { start: 5, end: 7 }]);
   });
 
   it("keeps single-message ranges (end===undefined) as-is until the limit", () => {
-    const set: SequenceSet = {
-      ranges: [{ start: 3 }, { start: 5 }, { start: 7 }],
-    };
-    const result = clampSequenceSetToFirst(uids, set, 2);
-    expect(result.ranges).toEqual([{ start: 3 }, { start: 5 }]);
+    expect(
+      clampSequenceSetToFirst(
+        uids,
+        set([{ start: 3 }, { start: 5 }, { start: 7 }]),
+        2,
+        false
+      ).ranges
+    ).toEqual([{ start: 3 }, { start: 5 }]);
   });
 
   it("returns an empty ranges array when limit is 0", () => {
-    const set: SequenceSet = { ranges: [{ start: 1, end: 10 }] };
-    const result = clampSequenceSetToFirst(uids, set, 0);
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: 1, end: 10 }]), 0, false).ranges
+    ).toEqual([]);
+  });
+});
+
+describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {
+  // The load-bearing case: mailbox UIDs don't start at 1 (retention prune
+  // or UIDVALIDITY bump). SEQ-axis clamp would emit `{start:1, end:N}`
+  // which downstream `store.getMessages(uidStart=1, uidEnd=N)` resolves
+  // to zero rows — silent data loss. UID-axis clamp walks the actual UID
+  // list and emits a range enclosing the first N intersecting UIDs.
+  const uids = [10001, 10002, 10003, 10004, 10005, 10006, 10007, 10008, 10009, 10010];
+  const set = (ranges: SequenceSet["ranges"]): SequenceSet => ({
+    type: "sequence", // parser default even for UID commands
+    ranges,
+  });
+
+  it("`UID 1:*` on a pruned mailbox emits a range of REAL UIDs, not seq positions", () => {
+    // The R1 HIGH scenario: previously returned `{start:1, end:50}` and
+    // silently matched zero rows. Now returns `{start:10001, end:10003}`
+    // for limit=3 — the actual first-3 UIDs.
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([{ start: 1, end: Number.MAX_SAFE_INTEGER }]),
+      3,
+      true
+    );
+    expect(result.ranges).toEqual([{ start: 10001, end: 10003 }]);
+  });
+
+  it("takes only UIDs that intersect the requested range", () => {
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([{ start: 10005, end: 10008 }]),
+      2,
+      true
+    );
+    expect(result.ranges).toEqual([{ start: 10005, end: 10006 }]);
+  });
+
+  it("returns empty ranges when NO UIDs intersect the requested range", () => {
+    // Range 1..50 on a mailbox with UIDs 10001..10010 — nothing matches.
+    // Downstream `_fetchMessages` sees an empty ranges list and correctly
+    // returns 0 messages, not the whole mailbox.
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([{ start: 1, end: 50 }]),
+      3,
+      true
+    );
     expect(result.ranges).toEqual([]);
   });
 
-  it("preserves the `type` discriminator (uid vs sequence)", () => {
-    const set: SequenceSet = {
-      type: "uid",
-      ranges: [{ start: 1, end: 10 }],
-    } as SequenceSet;
-    const result = clampSequenceSetToFirst(uids, set, 3);
-    expect((result as SequenceSet & { type?: string }).type).toBe("uid");
-    expect(result.ranges).toEqual([{ start: 1, end: 3 }]);
+  it("walks multiple ranges in order, stopping at limit", () => {
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([
+        { start: 10001, end: 10002 }, // 2 UIDs
+        { start: 10005, end: 10008 }, // 4 UIDs
+      ]),
+      4,
+      true
+    );
+    // First 4 matched UIDs: 10001, 10002, 10005, 10006. Emitted as one
+    // enclosing range [10001, 10006]; 10003/10004 don't exist in the
+    // requested set, so downstream returns 4 rows.
+    expect(result.ranges).toEqual([{ start: 10001, end: 10006 }]);
   });
 
+  it("single-UID range (end=undefined) treats end as start", () => {
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([{ start: 10005 }]),
+      3,
+      true
+    );
+    expect(result.ranges).toEqual([{ start: 10005, end: 10005 }]);
+  });
+
+  it("empty mailbox returns empty ranges", () => {
+    const result = clampSequenceSetToFirst(
+      [],
+      set([{ start: 1, end: Number.MAX_SAFE_INTEGER }]),
+      50,
+      true
+    );
+    expect(result.ranges).toEqual([]);
+  });
+
+  it("limit=0 returns empty ranges", () => {
+    const result = clampSequenceSetToFirst(
+      uids,
+      set([{ start: 10001, end: 10010 }]),
+      0,
+      true
+    );
+    expect(result.ranges).toEqual([]);
+  });
 });

--- a/src/server/lib/imap/sequence-resolver.test.ts
+++ b/src/server/lib/imap/sequence-resolver.test.ts
@@ -422,6 +422,25 @@ describe("clampSequenceSetToFirst — SEQ axis (isUidCommand=false)", () => {
       clampSequenceSetToFirst(uids, set([{ start: 1, end: 10 }]), 0, false).ranges
     ).toEqual([]);
   });
+
+  it("R6 MED: `SEQ *:1` (reversed) — normalizes, does not silent-zero-fetch", () => {
+    // Made reachable by R5's SEQ-counter fix: pre-R5 the counter returned
+    // 0 for `*:1` so the cap gate skipped and downstream normalized to
+    // 1:* (spec-legal cap-bypass DoS). Post-R5 the counter correctly
+    // returns 10 → cap fires → clamp runs → without normalization here
+    // `effectiveStart=10 > effectiveEnd=1` → rangeCount=0 → empty ranges
+    // → silent zero-fetch. Fix mirrors the counter: `min`/`max` after
+    // seq-clamp. `*:1` should clamp to the first N seq positions.
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: Number.MAX_SAFE_INTEGER, end: 1 }]), 3, false).ranges
+    ).toEqual([{ start: 1, end: 3 }]);
+  });
+
+  it("R6 MED: `SEQ 10:3` (reversed) — normalizes to `3:10`, clamps to first N", () => {
+    expect(
+      clampSequenceSetToFirst(uids, set([{ start: 10, end: 3 }]), 4, false).ranges
+    ).toEqual([{ start: 3, end: 6 }]);
+  });
 });
 
 describe("clampSequenceSetToFirst — UID axis (isUidCommand=true)", () => {

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -123,9 +123,58 @@ export function resolveUidRangeSentinel(
 
 /**
  * Count messages covered by a sequence set (clamped to actual mailbox size).
- * Used for FETCH limit checks.
+ * Used for FETCH limit checks — feeds the `requestedCount > cap` gate in
+ * `fetchMessagesTyped`, so mis-counting = clamp skipped = cap bypassed.
+ *
+ * `isUidCommand` mirrors the split in `clampSequenceSetToFirst` above:
+ * the parser stamps every set with `type: "sequence"`, so the caller is
+ * the source of truth for axis. On the UID axis a seq-position-based
+ * count is wrong twice over: `UID FETCH 10051:*` on a pruned mailbox
+ * (UIDs 10001..19950) counts 1 (seq-clamp of 10051 → maxSeq → 1) even
+ * though the request covers 9900 real UIDs; downstream then over-fetches
+ * because the cap gate never fired. Instead, intersect each range with
+ * `seqToUid` (already monotonic per RFC 3501 §2.3.1.1) via binary search
+ * so each range is O(log N) rather than O(N).
  */
-export function countSequenceSetMessages(seqToUid: number[], sequenceSet: SequenceSet): number {
+export function countSequenceSetMessages(
+  seqToUid: number[],
+  sequenceSet: SequenceSet,
+  isUidCommand: boolean
+): number {
+  if (isUidCommand) {
+    if (seqToUid.length === 0) return 0;
+    const maxUid = seqToUid[seqToUid.length - 1];
+    let count = 0;
+    for (const range of sequenceSet.ranges) {
+      const rawStart = range.start;
+      const rawEnd = range.end ?? range.start;
+      // MAX_SAFE_INTEGER is the `*` sentinel — resolves to the highest UID.
+      const startUid = rawStart === Number.MAX_SAFE_INTEGER ? maxUid : rawStart;
+      const endUid = rawEnd === Number.MAX_SAFE_INTEGER ? maxUid : rawEnd;
+      const lo = Math.min(startUid, endUid);
+      const hi = Math.max(startUid, endUid);
+      // First index >= lo.
+      let left = 0;
+      let right = seqToUid.length;
+      while (left < right) {
+        const mid = (left + right) >>> 1;
+        if (seqToUid[mid] < lo) left = mid + 1;
+        else right = mid;
+      }
+      const startIdx = left;
+      // First index > hi.
+      left = startIdx;
+      right = seqToUid.length;
+      while (left < right) {
+        const mid = (left + right) >>> 1;
+        if (seqToUid[mid] <= hi) left = mid + 1;
+        else right = mid;
+      }
+      count += left - startIdx;
+    }
+    return count;
+  }
+
   const maxSeq = seqToUid.length;
   let count = 0;
   for (const range of sequenceSet.ranges) {

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -292,15 +292,25 @@ export function clampSequenceSetToFirst(
       remaining -= 1;
       continue;
     }
-    const effectiveStart = Math.min(range.start, maxSeq);
-    const effectiveEnd = Math.min(range.end, maxSeq);
-    const rangeCount = Math.max(0, effectiveEnd - effectiveStart + 1);
+    // Normalize reversed ranges (RFC 3501 §9: `*:1` ≡ `1:*`, `10:3` ≡
+    // `3:10`) via `min`/`max` after the seq-clamp — symmetric with the
+    // SEQ-axis counter and with `convertSequenceSet` in fetch-helpers.
+    // R5 fixed the counter's SEQ branch; without this the clamp still
+    // sees `effectiveStart > effectiveEnd`, computes rangeCount=0, skips
+    // the whole range, and emits an empty set — a silent zero-fetch that
+    // R5 made newly reachable (counter now correctly fires the cap gate
+    // for `*:1` where it used to skip).
+    const clampedStart = Math.min(range.start, maxSeq);
+    const clampedEnd = Math.min(range.end, maxSeq);
+    const lo = Math.min(clampedStart, clampedEnd);
+    const hi = Math.max(clampedStart, clampedEnd);
+    const rangeCount = Math.max(0, hi - lo + 1);
     if (rangeCount === 0) continue;
     if (rangeCount <= remaining) {
-      clamped.push(range);
+      clamped.push({ start: lo, end: hi });
       remaining -= rangeCount;
     } else {
-      clamped.push({ start: range.start, end: effectiveStart + remaining - 1 });
+      clamped.push({ start: lo, end: lo + remaining - 1 });
       remaining = 0;
     }
   }

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -181,9 +181,18 @@ export function countSequenceSetMessages(
     if (range.end === undefined) {
       count += 1;
     } else {
-      const effectiveEnd = Math.min(range.end, maxSeq);
-      const effectiveStart = Math.min(range.start, maxSeq);
-      count += Math.max(0, effectiveEnd - effectiveStart + 1);
+      // RFC 3501 §9: `10:3` ≡ `3:10`. Normalize AFTER the seq-clamp so
+      // `*:1` (parser: `{start: MAX_SAFE_INTEGER, end: 1}`) clamps to
+      // `{maxSeq, 1}` then swaps to `{1, maxSeq}` and counts the whole
+      // mailbox — matching what `convertSequenceSet` sends downstream.
+      // Pre-fix returned 0 (Math.max(0, 1 - maxSeq + 1) clamps to 0)
+      // so the cap gate skipped, and downstream fetched every row
+      // (cap-bypass DoS via a spec-legal `SEQ FETCH *:1`).
+      const clampedEnd = Math.min(range.end, maxSeq);
+      const clampedStart = Math.min(range.start, maxSeq);
+      const lo = Math.min(clampedStart, clampedEnd);
+      const hi = Math.max(clampedStart, clampedEnd);
+      count += Math.max(0, hi - lo + 1);
     }
   }
   return count;
@@ -233,12 +242,24 @@ export function clampSequenceSetToFirst(
   if (limit <= 0) return { ...sequenceSet, ranges: [] };
 
   if (isUidCommand) {
+    if (seqToUid.length === 0) return { ...sequenceSet, ranges: [] };
+    const maxUid = seqToUid[seqToUid.length - 1];
     const matched: number[] = [];
     outer: for (const range of sequenceSet.ranges) {
-      const startUid = range.start;
-      const endUid = range.end ?? range.start;
+      // Symmetric with `countSequenceSetMessages` and `resolveUidRangeSentinel`:
+      // resolve the `*` sentinel to the highest UID, then normalize
+      // reversed ranges (RFC 3501 §9: `10:3` ≡ `3:10`). Without this
+      // pair `UID FETCH *:10051` and `UID FETCH 19950:10051` never
+      // matched a UID and silently zero-fetched, even though the
+      // counter now correctly reports both as 9900-UID requests.
+      const rawStart = range.start;
+      const rawEnd = range.end ?? range.start;
+      const startUidResolved = rawStart === Number.MAX_SAFE_INTEGER ? maxUid : rawStart;
+      const endUidResolved = rawEnd === Number.MAX_SAFE_INTEGER ? maxUid : rawEnd;
+      const lo = Math.min(startUidResolved, endUidResolved);
+      const hi = Math.max(startUidResolved, endUidResolved);
       for (const uid of seqToUid) {
-        if (uid >= startUid && uid <= endUid) {
+        if (uid >= lo && uid <= hi) {
           matched.push(uid);
           if (matched.length >= limit) break outer;
         }

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -142,26 +142,60 @@ export function countSequenceSetMessages(seqToUid: number[], sequenceSet: Sequen
 
 /**
  * Take the first `limit` messages from a sequence set, dropping the rest.
- * Used when a FETCH request would exceed the server's per-command message cap
- * — instead of refusing the whole request with `NO [LIMIT]`, `fetchMessagesTyped`
- * shrinks the set to what it will actually process. RFC 3501 §6.4.5 lets the
- * server return a subset of the requested messages; clients then observe the
- * uncovered range and issue a follow-up FETCH for it, walking the mailbox in
- * cap-sized chunks. iOS Mail specifically treats `NO` as fatal ("Cannot Get
- * Mail" modal); returning a shortened `OK` avoids the modal entirely.
+ * Used when a FETCH request would exceed the server's per-command message
+ * cap — instead of refusing the whole request with `NO [LIMIT]`,
+ * `fetchMessagesTyped` shrinks the set to what it will actually process.
+ * RFC 3501 §6.4.5 lets the server return a subset of the requested
+ * messages; clients then observe the uncovered range and issue a
+ * follow-up FETCH for it, walking the mailbox in cap-sized chunks. iOS
+ * Mail specifically treats `NO` as fatal ("Cannot Get Mail" modal);
+ * returning a shortened `OK` avoids the modal entirely.
  *
- * Preserves range order and uses the same effective-max semantics as
- * `countSequenceSetMessages` above (so `1:*` and other max-sentinel ranges
- * clamp identically). For a UID-typed set the clamp still counts by seq
- * position — same known imprecision as the sibling counter, safe because
- * the goal is a bounded number of returned messages, not an exact one.
+ * `isUidCommand` distinguishes the two axes at the call site because the
+ * parser sets `sequenceSet.type = "sequence"` unconditionally — the
+ * actual UID vs seq discriminator is carried by `isUidCommand` from
+ * `fetchMessagesTyped` (see message-ops.ts). The two branches emit
+ * different shapes:
+ *
+ *  - SEQ-axis: ranges are seq positions. Walk them in order, keep whole
+ *    ones up to the limit, partially take the next, drop the rest.
+ *
+ *  - UID-axis: ranges are UID values, but UIDs are not necessarily 1..N —
+ *    a mailbox after retention pruning or a UIDVALIDITY bump may hold
+ *    e.g. UIDs 10001..11000. Clamping `1:*` to `{start:1, end:50}`
+ *    would resolve to zero rows downstream (silent data loss). Instead,
+ *    walk `seqToUid` in order (UIDs are monotonic per RFC 3501 §2.3.1.1),
+ *    keep the first `limit` that intersect the requested ranges, and
+ *    emit a single range enclosing them. Non-contiguous UIDs inside
+ *    that range simply match nothing downstream — correct.
  */
 export function clampSequenceSetToFirst(
   seqToUid: number[],
   sequenceSet: SequenceSet,
-  limit: number
+  limit: number,
+  isUidCommand: boolean
 ): SequenceSet {
   if (limit <= 0) return { ...sequenceSet, ranges: [] };
+
+  if (isUidCommand) {
+    const matched: number[] = [];
+    outer: for (const range of sequenceSet.ranges) {
+      const startUid = range.start;
+      const endUid = range.end ?? range.start;
+      for (const uid of seqToUid) {
+        if (uid >= startUid && uid <= endUid) {
+          matched.push(uid);
+          if (matched.length >= limit) break outer;
+        }
+      }
+    }
+    if (matched.length === 0) return { ...sequenceSet, ranges: [] };
+    return {
+      ...sequenceSet,
+      ranges: [{ start: matched[0], end: matched[matched.length - 1] }],
+    };
+  }
+
   const maxSeq = seqToUid.length;
   const clamped: SequenceRange[] = [];
   let remaining = limit;

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -166,8 +166,14 @@ export function countSequenceSetMessages(seqToUid: number[], sequenceSet: Sequen
  *    would resolve to zero rows downstream (silent data loss). Instead,
  *    walk `seqToUid` in order (UIDs are monotonic per RFC 3501 §2.3.1.1),
  *    keep the first `limit` that intersect the requested ranges, and
- *    emit a single range enclosing them. Non-contiguous UIDs inside
- *    that range simply match nothing downstream — correct.
+ *    emit coalesced sub-ranges of exactly those matched UIDs. A single
+ *    enclosing range [matched[0]..matched[last]] would over-fetch: on a
+ *    dense mailbox {10001..10010}, request `10001:10002,10005:10008`
+ *    limit=4 matches [10001,10002,10005,10006] but the enclosure
+ *    [10001..10006] would pull 10003/10004 too (breaching the cap by
+ *    50%) and drop the caller-requested 10007/10008. Coalescing yields
+ *    [{10001,10002},{10005,10006}] — downstream fetches exactly what
+ *    survived the clamp.
  */
 export function clampSequenceSetToFirst(
   seqToUid: number[],
@@ -190,10 +196,20 @@ export function clampSequenceSetToFirst(
       }
     }
     if (matched.length === 0) return { ...sequenceSet, ranges: [] };
-    return {
-      ...sequenceSet,
-      ranges: [{ start: matched[0], end: matched[matched.length - 1] }],
-    };
+    const coalesced: SequenceRange[] = [];
+    let start = matched[0];
+    let end = matched[0];
+    for (let i = 1; i < matched.length; i++) {
+      if (matched[i] === end + 1) {
+        end = matched[i];
+      } else {
+        coalesced.push({ start, end });
+        start = matched[i];
+        end = matched[i];
+      }
+    }
+    coalesced.push({ start, end });
+    return { ...sequenceSet, ranges: coalesced };
   }
 
   const maxSeq = seqToUid.length;

--- a/src/server/lib/imap/sequence-resolver.ts
+++ b/src/server/lib/imap/sequence-resolver.ts
@@ -6,7 +6,7 @@
  */
 
 import { Store } from "./store";
-import { SequenceSet } from "./types";
+import { SequenceSet, SequenceRange } from "./types";
 
 /**
  * Mutable sequence state held on ImapSession.
@@ -138,4 +138,51 @@ export function countSequenceSetMessages(seqToUid: number[], sequenceSet: Sequen
     }
   }
   return count;
+}
+
+/**
+ * Take the first `limit` messages from a sequence set, dropping the rest.
+ * Used when a FETCH request would exceed the server's per-command message cap
+ * — instead of refusing the whole request with `NO [LIMIT]`, `fetchMessagesTyped`
+ * shrinks the set to what it will actually process. RFC 3501 §6.4.5 lets the
+ * server return a subset of the requested messages; clients then observe the
+ * uncovered range and issue a follow-up FETCH for it, walking the mailbox in
+ * cap-sized chunks. iOS Mail specifically treats `NO` as fatal ("Cannot Get
+ * Mail" modal); returning a shortened `OK` avoids the modal entirely.
+ *
+ * Preserves range order and uses the same effective-max semantics as
+ * `countSequenceSetMessages` above (so `1:*` and other max-sentinel ranges
+ * clamp identically). For a UID-typed set the clamp still counts by seq
+ * position — same known imprecision as the sibling counter, safe because
+ * the goal is a bounded number of returned messages, not an exact one.
+ */
+export function clampSequenceSetToFirst(
+  seqToUid: number[],
+  sequenceSet: SequenceSet,
+  limit: number
+): SequenceSet {
+  if (limit <= 0) return { ...sequenceSet, ranges: [] };
+  const maxSeq = seqToUid.length;
+  const clamped: SequenceRange[] = [];
+  let remaining = limit;
+  for (const range of sequenceSet.ranges) {
+    if (remaining <= 0) break;
+    if (range.end === undefined) {
+      clamped.push(range);
+      remaining -= 1;
+      continue;
+    }
+    const effectiveStart = Math.min(range.start, maxSeq);
+    const effectiveEnd = Math.min(range.end, maxSeq);
+    const rangeCount = Math.max(0, effectiveEnd - effectiveStart + 1);
+    if (rangeCount === 0) continue;
+    if (rangeCount <= remaining) {
+      clamped.push(range);
+      remaining -= rangeCount;
+    } else {
+      clamped.push({ start: range.start, end: effectiveStart + remaining - 1 });
+      remaining = 0;
+    }
+  }
+  return { ...sequenceSet, ranges: clamped };
 }


### PR DESCRIPTION
## Summary

iOS Mail treats every tagged `NO` as fatal. When a FETCH exceeds the server's per-command message cap, the current handler returns `NO [LIMIT] FETCH too much data requested` and iOS shows a **"Cannot Get Mail"** modal:

> Server code `"LIMIT"`, server message `"FETCH too much data requested"`.

RFC 3501 §6.4.5 explicitly permits the server to return a subset of the requested messages. This PR replaces the hard refusal with a subset response — process the first `limit` UIDs, return `OK FETCH completed`. iOS observes the uncovered range and issues a follow-up FETCH for it, walking the mailbox in cap-sized chunks.

The cap itself is unchanged (still the OOM defense from prior work):

| Fetch shape | Cap |
|---|---|
| Flag-only (FLAGS/UID/RFC822.SIZE/INTERNALDATE) | ∞ |
| Header-only (adds BODY[HEADER] / HEADER_FIELDS) | 500 |
| Body (BODY[] / BODY[TEXT] / attachments) | 50 |

## What ships

- `clampSequenceSetToFirst` in `sequence-resolver.ts` — walks the sequenceSet ranges in order, keeps whole ones up to `limit`, partially takes the next, drops the rest. Preserves the `type` discriminator (`uid` vs `sequence`), uses the same effective-max semantics as `countSequenceSetMessages` so `1:*` and other `MAX_SAFE_INTEGER` sentinels clamp identically.
- `fetchMessagesTyped` in `message-ops.ts` — when `requestedCount > limit`, replaces the `NO [LIMIT]` early-return with an in-place sequenceSet clamp + an `info` log carrying `requestedCount`, `limit`, and the clamped ranges (so a client receiving a shorter response than it asked for is diagnosable from the log).

## Test plan

- [x] `tsc --noEmit` clean
- [x] `bun test src/server` — 1530 pass / 0 fail (+7 from the new sequence-resolver cases)
- [ ] Sandbox E2E: `UID FETCH 1:* (UID BODY[])` against a mailbox with >50 messages returns `OK FETCH completed` (with the first 50) instead of `NO [LIMIT]`; follow-up `UID FETCH 51:* (UID BODY[])` returns the next batch
- [ ] reviewoie
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)