### PR TITLE
fix(writer): register the tiptap "update" listener once, skip no-op localStorage writes

### DIFF
--- a/src/client/Box/components/Writer/index.tsx
+++ b/src/client/Box/components/Writer/index.tsx
@@ -143,7 +143,19 @@ const Writer = () => {
 
   const editorRef = useRef(editor);
   editorRef.current = editor;
-  editorRef.current?.on("update", (e) => setInitialContent(e.editor.getHTML()));
+
+  // tiptap's `EventEmitter.on` appends without deduping and `emit` walks the
+  // whole array, so registering from the render body grows the callback list
+  // by one per render and never prunes it. Bind once per editor instance and
+  // unbind on teardown.
+  useEffect(() => {
+    if (!editor) return;
+    const onUpdate = () => setInitialContent(editor.getHTML());
+    editor.on("update", onUpdate);
+    return () => {
+      editor.off("update", onUpdate);
+    };
+  }, [editor, setInitialContent]);
 
   const setEditorContent = useCallback(
     (content: string) => {

--- a/src/client/Box/components/Writer/index.tsx
+++ b/src/client/Box/components/Writer/index.tsx
@@ -141,9 +141,6 @@ const Writer = () => {
     content: initialContent
   });
 
-  const editorRef = useRef(editor);
-  editorRef.current = editor;
-
   // tiptap's `EventEmitter.on` appends without deduping and `emit` walks the
   // whole array, so registering from the render body grows the callback list
   // by one per render and never prunes it. Bind once per editor instance and
@@ -159,10 +156,10 @@ const Writer = () => {
 
   const setEditorContent = useCallback(
     (content: string) => {
-      editorRef.current?.commands.setContent(content);
+      editor?.commands.setContent(content);
       setInitialContent(content);
     },
-    [setInitialContent]
+    [editor, setInitialContent]
   );
 
   useEffect(() => {

--- a/src/client/Box/components/Writer/writer-listener.test.ts
+++ b/src/client/Box/components/Writer/writer-listener.test.ts
@@ -166,17 +166,21 @@ describe("Writer tiptap update listener", () => {
 
     const editor = findEditor();
     expect(editor).not.toBeNull();
+    const whileMounted = editor!.callbacks.update.length;
 
-    await act(async () => {
-      editor!.commands.insertContent("hello");
-    });
-    expect(window.localStorage.getItem("initialContent")).toContain("hello");
+    try {
+      await act(async () => {
+        editor!.commands.insertContent("hello");
+      });
+      expect(window.localStorage.getItem("initialContent")).toContain("hello");
+    } finally {
+      await teardown();
+    }
 
     // tiptap registers its own internal `update` callbacks, so the absolute
     // count is not zero after teardown — what matters is that the component's
-    // one handler was removed by the effect cleanup.
-    const whileMounted = editor!.callbacks.update.length;
-    await teardown();
-    expect(editor!.callbacks.update.length).toBe(whileMounted - 1);
+    // handler is gone. Unmount also races tiptap's own `scheduleDestroy`, which
+    // replaces `callbacks` wholesale, so read the count defensively.
+    expect(editor!.callbacks.update?.length ?? 0).toBeLessThan(whileMounted);
   });
 });

--- a/src/client/Box/components/Writer/writer-listener.test.ts
+++ b/src/client/Box/components/Writer/writer-listener.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The compose editor must bind its tiptap `update` handler once per editor
+ * instance, not once per render (#768).
+ *
+ * `@tiptap/core`'s `EventEmitter.on` appends without deduping and `emit` walks
+ * the whole array, so a registration in the render body grows the callback list
+ * by one per render and never prunes it. Every accumulated handler re-serializes
+ * the document and issues a synchronous `localStorage.setItem`, which made an
+ * n-character mail cost O(n^2).
+ *
+ * These tests render the real `Writer` and read the live `Editor`'s callback
+ * list, so a regression is caught here rather than only by a manual E2E.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+beforeAll(() => {
+  GlobalRegistrator.register();
+  // React 18 only lets `act` flush work when this flag is set.
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+type TiptapEditor = {
+  callbacks: Record<string, unknown[]>;
+  getHTML: () => string;
+  commands: { insertContent: (content: string) => boolean; focus: () => boolean };
+};
+
+/**
+ * Reaches the live tiptap `Editor` from the rendered DOM. tiptap appends
+ * `view.dom` (`.ProseMirror`) imperatively, so that node carries no fiber —
+ * walk up to the nearest React-owned ancestor, then up the fiber chain to
+ * `EditorContent`, which holds `editor` in its props.
+ */
+const findEditor = (): TiptapEditor | null => {
+  let element: Element | null = document.querySelector(".ProseMirror");
+  while (element) {
+    const fiberKey = Object.keys(element).find((k) =>
+      k.startsWith("__reactFiber$")
+    );
+    if (fiberKey) {
+      let fiber = (element as unknown as Record<string, FiberLike>)[fiberKey];
+      for (let depth = 0; fiber && depth < 60; depth++) {
+        const editor = fiber.memoizedProps?.editor;
+        if (editor?.callbacks) return editor;
+        fiber = fiber.return as FiberLike;
+      }
+    }
+    element = element.parentElement;
+  }
+  return null;
+};
+
+interface FiberLike {
+  memoizedProps?: { editor?: TiptapEditor };
+  return?: unknown;
+}
+
+const mountWriter = async () => {
+  const { createElement, act } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+  const { QueryClient, QueryClientProvider } = await import("react-query");
+  const { Context } = await import("client");
+  const Writer = (await import("./index")).default;
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  // Minimum context `Writer` reads. `replyData` must be an object — the reply
+  // effect dereferences `replyData.id` on mount.
+  const contextValue = {
+    domainName: "example.com",
+    isWriterOpen: true,
+    setIsWriterOpen: () => {},
+    replyData: {},
+    setReplyData: () => {},
+  };
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  const render = async () =>
+    act(async () => {
+      root.render(
+        createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          createElement(
+            Context.Provider,
+            { value: contextValue as never },
+            createElement(Writer)
+          )
+        )
+      );
+    });
+
+  await render();
+
+  return {
+    act,
+    // Re-rendering the same element tree from the root is exactly what the old
+    // bare-statement registration reacted to.
+    rerender: render,
+    teardown: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+describe("Writer tiptap update listener", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("binds exactly one `update` handler and does not add one per render", async () => {
+    const { rerender, teardown } = await mountWriter();
+
+    try {
+      const editor = findEditor();
+      expect(editor).not.toBeNull();
+
+      const initial = editor!.callbacks.update.length;
+      for (let i = 0; i < 20; i++) await rerender();
+
+      // Before the fix this grew by one per render (20 renders -> +20).
+      expect(editor!.callbacks.update.length).toBe(initial);
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("keeps the handler count flat across document edits", async () => {
+    const { act, teardown } = await mountWriter();
+
+    try {
+      const editor = findEditor();
+      expect(editor).not.toBeNull();
+      const initial = editor!.callbacks.update.length;
+
+      for (let i = 0; i < 20; i++) {
+        await act(async () => {
+          editor!.commands.insertContent("a");
+        });
+      }
+
+      expect(editor!.callbacks.update.length).toBe(initial);
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("persists the document to localStorage on edit and unbinds on unmount", async () => {
+    const { act, teardown } = await mountWriter();
+
+    const editor = findEditor();
+    expect(editor).not.toBeNull();
+
+    await act(async () => {
+      editor!.commands.insertContent("hello");
+    });
+    expect(window.localStorage.getItem("initialContent")).toContain("hello");
+
+    // tiptap registers its own internal `update` callbacks, so the absolute
+    // count is not zero after teardown — what matters is that the component's
+    // one handler was removed by the effect cleanup.
+    const whileMounted = editor!.callbacks.update.length;
+    await teardown();
+    expect(editor!.callbacks.update.length).toBe(whileMounted - 1);
+  });
+});

--- a/src/client/Box/components/Writer/writer-listener.test.ts
+++ b/src/client/Box/components/Writer/writer-listener.test.ts
@@ -114,8 +114,15 @@ const mountWriter = async () => {
     // Re-rendering the same element tree from the root is exactly what the old
     // bare-statement registration reacted to.
     rerender: render,
-    teardown: async () => {
-      await act(async () => root.unmount());
+    // `probe` runs in the same synchronous turn as `root.unmount()`, before
+    // tiptap's `scheduleDestroy` (a `setTimeout(..., 1)`) can interleave and
+    // replace `callbacks` wholesale. Reading the callback list after `teardown`
+    // resolves would race that timer.
+    teardown: async (probe?: () => void) => {
+      await act(async () => {
+        root.unmount();
+        probe?.();
+      });
       container.remove();
     },
   };
@@ -166,6 +173,7 @@ describe("Writer tiptap update listener", () => {
 
     let editor!: TiptapEditor;
     let whileMounted!: number;
+    let afterUnmount: number | undefined;
 
     try {
       editor = findEditor()!;
@@ -177,16 +185,17 @@ describe("Writer tiptap update listener", () => {
       });
       expect(window.localStorage.getItem("initialContent")).toContain("hello");
     } finally {
-      await teardown();
+      // Read the count inside the unmount turn — see `teardown`. Capturing the
+      // array reference beforehand would not work either: `EventEmitter.off`
+      // filters into a new array rather than splicing in place.
+      await teardown(() => {
+        afterUnmount = editor.callbacks.update.length;
+      });
     }
 
     // tiptap registers its own internal `update` callbacks, so the absolute
     // count is not zero after teardown — what matters is that the component's
-    // handler is gone. Assert `callbacks.update` still exists rather than
-    // defaulting a missing one to 0: unmount races tiptap's `scheduleDestroy`,
-    // which replaces `callbacks` wholesale, and a default would make this pass
-    // whether or not the effect cleanup ever ran.
-    expect(editor.callbacks.update).toBeDefined();
-    expect(editor.callbacks.update.length).toBe(whileMounted - 1);
+    // handler is gone.
+    expect(afterUnmount).toBe(whileMounted - 1);
   });
 });

--- a/src/client/Box/components/Writer/writer-listener.test.ts
+++ b/src/client/Box/components/Writer/writer-listener.test.ts
@@ -164,13 +164,16 @@ describe("Writer tiptap update listener", () => {
   it("persists the document to localStorage on edit and unbinds on unmount", async () => {
     const { act, teardown } = await mountWriter();
 
-    const editor = findEditor();
-    expect(editor).not.toBeNull();
-    const whileMounted = editor!.callbacks.update.length;
+    let editor!: TiptapEditor;
+    let whileMounted!: number;
 
     try {
+      editor = findEditor()!;
+      expect(editor).not.toBeNull();
+      whileMounted = editor.callbacks.update.length;
+
       await act(async () => {
-        editor!.commands.insertContent("hello");
+        editor.commands.insertContent("hello");
       });
       expect(window.localStorage.getItem("initialContent")).toContain("hello");
     } finally {
@@ -179,8 +182,11 @@ describe("Writer tiptap update listener", () => {
 
     // tiptap registers its own internal `update` callbacks, so the absolute
     // count is not zero after teardown — what matters is that the component's
-    // handler is gone. Unmount also races tiptap's own `scheduleDestroy`, which
-    // replaces `callbacks` wholesale, so read the count defensively.
-    expect(editor!.callbacks.update?.length ?? 0).toBeLessThan(whileMounted);
+    // handler is gone. Assert `callbacks.update` still exists rather than
+    // defaulting a missing one to 0: unmount races tiptap's `scheduleDestroy`,
+    // which replaces `callbacks` wholesale, and a default would make this pass
+    // whether or not the effect cleanup ever ran.
+    expect(editor.callbacks.update).toBeDefined();
+    expect(editor.callbacks.update.length).toBe(whileMounted - 1);
   });
 });

--- a/src/client/lib/hooks.test.ts
+++ b/src/client/lib/hooks.test.ts
@@ -207,6 +207,34 @@ describe("useLocalStorage", () => {
     }
   });
 
+  it("contains a failing setItem — state still advances and nothing escapes to React", async () => {
+    // React re-throws an updater's error during the render phase, past the
+    // hook's outer try/catch, where the app-level ErrorBoundary would swap out
+    // the whole mail UI. A full-quota write must not cost the user their
+    // session, so the throw has to be caught inside the updater.
+    (window.localStorage as { setItem: (k: string, v: string) => void }).setItem =
+      () => {
+        throw new DOMException("quota", "QuotaExceededError");
+      };
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    let seen!: string;
+    const { act, teardown } = await render(() => {
+      const [value, setter] = useLocalStorage("draft", "");
+      setValue = setter;
+      seen = value;
+      return null;
+    });
+
+    try {
+      await act(async () => setValue("too big"));
+      expect(seen).toBe("too big");
+    } finally {
+      await teardown();
+    }
+  });
+
   it("supports the updater form and seeds state from an existing stored value", async () => {
     storage.store.set("count", "7");
     const { useLocalStorage } = await import("./hooks");

--- a/src/client/lib/hooks.test.ts
+++ b/src/client/lib/hooks.test.ts
@@ -133,6 +133,80 @@ describe("useLocalStorage", () => {
     }
   });
 
+  it("heals storage when `sanitize` rewrote the value on read, so state and storage diverge", async () => {
+    // `sanitize` normalizes at read time only — storage keeps the raw value.
+    // Comparing the incoming value against React state would treat the very
+    // first set as a no-op and strand the un-sanitized value in storage.
+    storage.store.set("category", '"Search"');
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    let seen!: string;
+    const { act, teardown } = await render(() => {
+      const [value, setter] = useLocalStorage("category", "AllMails", (v) =>
+        v === "Search" ? "AllMails" : v
+      );
+      setValue = setter;
+      seen = value;
+      return null;
+    });
+
+    try {
+      expect(seen).toBe("AllMails");
+      await act(async () => setValue("AllMails"));
+      expect(storage.writes).toEqual([["category", '"AllMails"']]);
+      expect(storage.store.get("category")).toBe('"AllMails"');
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("heals storage after it is cleared underneath a mounted component", async () => {
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    const { act, teardown } = await render(() => {
+      const [, setter] = useLocalStorage("draft", "");
+      setValue = setter;
+      return null;
+    });
+
+    try {
+      await act(async () => setValue("a"));
+      expect(storage.store.get("draft")).toBe('"a"');
+
+      // Another tab, or the app-version `localStorage.clear()`, wipes the key
+      // while this component stays mounted holding "a" in state.
+      storage.store.delete("draft");
+      await act(async () => setValue("a"));
+      expect(storage.store.get("draft")).toBe('"a"');
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("heals storage holding unparseable JSON that fell back to the initial value", async () => {
+    storage.store.set("draft", "{not json");
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    let seen!: string;
+    const { act, teardown } = await render(() => {
+      const [value, setter] = useLocalStorage("draft", "fallback");
+      setValue = setter;
+      seen = value;
+      return null;
+    });
+
+    try {
+      expect(seen).toBe("fallback");
+      await act(async () => setValue("fallback"));
+      expect(storage.store.get("draft")).toBe('"fallback"');
+    } finally {
+      await teardown();
+    }
+  });
+
   it("supports the updater form and seeds state from an existing stored value", async () => {
     storage.store.set("count", "7");
     const { useLocalStorage } = await import("./hooks");

--- a/src/client/lib/hooks.test.ts
+++ b/src/client/lib/hooks.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// `useLocalStorage` needs a real React render to exercise its state updater.
+// Register happy-dom for this file only (and tear it down after) so the rest of
+// the suite keeps running on the bare Bun runtime — same pattern as
+// `html.test.ts`.
+beforeAll(() => {
+  GlobalRegistrator.register();
+  // React 18 only lets `act` flush work when this flag is set.
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+afterAll(() => GlobalRegistrator.unregister());
+
+/**
+ * Shadows `window.localStorage` with a recording stand-in. happy-dom's real
+ * `localStorage` is a proxy whose method lookups don't honour a
+ * `Storage.prototype` patch, so a spy has to replace the object itself.
+ */
+const fakeLocalStorage = () => {
+  const store = new Map<string, string>();
+  const writes: [string, string][] = [];
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    writable: true,
+    value: {
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      setItem: (key: string, value: string) => {
+        writes.push([key, value]);
+        store.set(key, value);
+      },
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear()
+    }
+  });
+  return { writes, store };
+};
+
+const render = async (Probe: () => null) => {
+  const { createElement, act } = await import("react");
+  const { createRoot } = await import("react-dom/client");
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  await act(async () => {
+    root.render(createElement(Probe));
+  });
+
+  return {
+    act,
+    teardown: async () => {
+      await act(async () => root.unmount());
+      container.remove();
+    }
+  };
+};
+
+describe("useLocalStorage", () => {
+  let storage: ReturnType<typeof fakeLocalStorage>;
+  beforeEach(() => {
+    storage = fakeLocalStorage();
+  });
+
+  it("writes a changed value through to localStorage", async () => {
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    let seen!: string;
+    const { act, teardown } = await render(() => {
+      const [value, setter] = useLocalStorage("draft", "");
+      setValue = setter;
+      seen = value;
+      return null;
+    });
+
+    try {
+      await act(async () => setValue("a"));
+      expect(seen).toBe("a");
+      expect(storage.writes).toEqual([["draft", '"a"']]);
+      expect(storage.store.get("draft")).toBe('"a"');
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("skips the synchronous setItem when the value already stored is set again", async () => {
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: string) => void;
+    const { act, teardown } = await render(() => {
+      const [, setter] = useLocalStorage("draft", "");
+      setValue = setter;
+      return null;
+    });
+
+    try {
+      await act(async () => setValue("a"));
+      await act(async () => setValue("a"));
+      await act(async () => setValue("a"));
+      expect(storage.writes).toEqual([["draft", '"a"']]);
+
+      await act(async () => setValue("b"));
+      expect(storage.writes).toEqual([
+        ["draft", '"a"'],
+        ["draft", '"b"']
+      ]);
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("compares serialized values, so an equal object rebuilt per call writes once", async () => {
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: { id: string }) => void;
+    const { act, teardown } = await render(() => {
+      const [, setter] = useLocalStorage("meta", { id: "" });
+      setValue = setter;
+      return null;
+    });
+
+    try {
+      // Reference equality would let the second call through; the guard
+      // compares the serialized form, so only the first call writes.
+      await act(async () => setValue({ id: "x" }));
+      await act(async () => setValue({ id: "x" }));
+      expect(storage.writes).toEqual([["meta", '{"id":"x"}']]);
+    } finally {
+      await teardown();
+    }
+  });
+
+  it("supports the updater form and seeds state from an existing stored value", async () => {
+    storage.store.set("count", "7");
+    const { useLocalStorage } = await import("./hooks");
+
+    let setValue!: (value: (previous: number) => number) => void;
+    let seen!: number;
+    const { act, teardown } = await render(() => {
+      const [value, setter] = useLocalStorage("count", 0);
+      setValue = setter;
+      seen = value;
+      return null;
+    });
+
+    try {
+      expect(seen).toBe(7);
+      await act(async () => setValue((previous) => previous + 1));
+      expect(seen).toBe(8);
+      expect(storage.writes).toEqual([["count", "8"]]);
+    } finally {
+      await teardown();
+    }
+  });
+});

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -23,11 +23,16 @@ export const useLocalStorage = <T>(
           const valueToStore =
             value instanceof Function ? value(oldValue) : value;
           const serialized = JSON.stringify(valueToStore);
-          // `setItem` is synchronous and blocks the main thread, so a setter
-          // called with the value already stored is pure cost. Returning
-          // `oldValue` also lets React bail out of the re-render.
-          if (serialized === JSON.stringify(oldValue)) return oldValue;
-          window.localStorage.setItem(key, serialized);
+          // `setItem` is synchronous and blocks the main thread, so writing a
+          // value the key already holds is pure cost. Compare against storage
+          // rather than against `oldValue` — React state and storage do drift
+          // (another tab, a `clear()`, the `sanitize` above rewriting the value
+          // on read), and skipping on state equality would strand the stale
+          // stored value permanently. This still guarantees storage holds
+          // `valueToStore` once the setter returns.
+          if (serialized !== window.localStorage.getItem(key)) {
+            window.localStorage.setItem(key, serialized);
+          }
           return valueToStore;
         });
       } catch (error) {

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -22,16 +22,21 @@ export const useLocalStorage = <T>(
         setStoredValue((oldValue) => {
           const valueToStore =
             value instanceof Function ? value(oldValue) : value;
-          const serialized = JSON.stringify(valueToStore);
-          // `setItem` is synchronous and blocks the main thread, so writing a
-          // value the key already holds is pure cost. Compare against storage
-          // rather than against `oldValue` — React state and storage do drift
-          // (another tab, a `clear()`, the `sanitize` above rewriting the value
-          // on read), and skipping on state equality would strand the stale
-          // stored value permanently. This still guarantees storage holds
-          // `valueToStore` once the setter returns.
-          if (serialized !== window.localStorage.getItem(key)) {
-            window.localStorage.setItem(key, serialized);
+          // React re-throws an updater's error during the render phase, past
+          // the outer catch, where the ErrorBoundary would swap out the whole
+          // app. A full-quota `setItem` must not cost the user their session,
+          // so persistence failures are contained here and state still moves.
+          try {
+            const serialized = JSON.stringify(valueToStore);
+            // Compare against storage rather than against `oldValue`: the two
+            // drift (another tab, a `clear()`, the `sanitize` above rewriting
+            // the value on read), and skipping on state equality would strand
+            // the stale stored value permanently.
+            if (serialized !== window.localStorage.getItem(key)) {
+              window.localStorage.setItem(key, serialized);
+            }
+          } catch (error) {
+            console.error(error);
           }
           return valueToStore;
         });

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -18,31 +18,28 @@ export const useLocalStorage = <T>(
 
   const setValue = useCallback(
     (value: T | ((val: T) => T)) => {
-      try {
-        setStoredValue((oldValue) => {
-          const valueToStore =
-            value instanceof Function ? value(oldValue) : value;
-          // React re-throws an updater's error during the render phase, past
-          // the outer catch, where the ErrorBoundary would swap out the whole
-          // app. A full-quota `setItem` must not cost the user their session,
-          // so persistence failures are contained here and state still moves.
-          try {
-            const serialized = JSON.stringify(valueToStore);
-            // Compare against storage rather than against `oldValue`: the two
-            // drift (another tab, a `clear()`, the `sanitize` above rewriting
-            // the value on read), and skipping on state equality would strand
-            // the stale stored value permanently.
-            if (serialized !== window.localStorage.getItem(key)) {
-              window.localStorage.setItem(key, serialized);
-            }
-          } catch (error) {
-            console.error(error);
+      setStoredValue((oldValue) => {
+        const valueToStore =
+          value instanceof Function ? value(oldValue) : value;
+        // Contain persistence failures here, not around `setStoredValue`:
+        // React re-throws an updater's error during the render phase, so a
+        // catch out there never sees a full-quota `setItem` — it only sees
+        // React's own "Maximum update depth exceeded", which should crash
+        // loudly rather than wedge the app silently.
+        try {
+          const serialized = JSON.stringify(valueToStore);
+          // Compare against storage rather than against `oldValue`: the two
+          // drift (another tab, a `clear()`, the `sanitize` above rewriting
+          // the value on read), and skipping on state equality would strand
+          // the stale stored value permanently.
+          if (serialized !== window.localStorage.getItem(key)) {
+            window.localStorage.setItem(key, serialized);
           }
-          return valueToStore;
-        });
-      } catch (error) {
-        console.error(error);
-      }
+        } catch (error) {
+          console.error(error);
+        }
+        return valueToStore;
+      });
     },
     [key, setStoredValue]
   );

--- a/src/client/lib/hooks.ts
+++ b/src/client/lib/hooks.ts
@@ -22,7 +22,12 @@ export const useLocalStorage = <T>(
         setStoredValue((oldValue) => {
           const valueToStore =
             value instanceof Function ? value(oldValue) : value;
-          window.localStorage.setItem(key, JSON.stringify(valueToStore));
+          const serialized = JSON.stringify(valueToStore);
+          // `setItem` is synchronous and blocks the main thread, so a setter
+          // called with the value already stored is pure cost. Returning
+          // `oldValue` also lets React bail out of the re-render.
+          if (serialized === JSON.stringify(oldValue)) return oldValue;
+          window.localStorage.setItem(key, serialized);
           return valueToStore;
         });
       } catch (error) {


### PR DESCRIPTION
Closes #768

## Problem

`Writer` registered its tiptap `update` handler from a bare statement in the component body:

```ts
editorRef.current?.on("update", (e) => setInitialContent(e.editor.getHTML()));
```

`@tiptap/core`'s `EventEmitter.on` appends without deduping, `emit` walks the whole array, and nothing ever called `off`. So the callback list grew by one **per render** and was never pruned. Each accumulated handler re-serialized the entire ProseMirror document and issued a synchronous `localStorage.setItem`, so one keystroke fanned out into `listeners` full-document serializations plus `listeners` blocking storage writes — and `listeners` itself grew one-per-keystroke. Writing an n-character mail cost O(n²).

It was not typing-specific: any re-render of `Writer` added a listener, and closing the composer only toggles a CSS class, so the count survived until a full page reload.

## Fix

1. **`Writer`** — bind once per editor instance inside an effect, unbind on teardown. `setInitialContent` is a stable `useCallback`, so the effect does not re-fire per render.
2. **`useLocalStorage`** — skip `setItem` when the serialized value matches **what the key already holds**. Comparing against React state instead would have been wrong: state and storage drift (a second tab, the app-version `localStorage.clear()`, the hook's own read-time `sanitize`), and skipping on state equality would strand the stale stored value permanently. Comparing against storage keeps the setter's real guarantee — after it returns, the key holds the value.

3. **`useLocalStorage`** — catch a failing `setItem` **inside** the state updater. React re-throws an updater's error during the render phase, past the hook's outer `try/catch`, so a `QuotaExceededError` reached the app-level `ErrorBoundary` and swapped out the whole mail UI. `initialContent` holds unbounded draft HTML written on every keystroke, so crossing the origin quota mid-compose was reachable. Pre-existing on `main`, but this PR rewrites exactly that write, so it is fixed here rather than deferred.

Together, 2 and 3 remove a class of redundant blocking writes across every caller (the composer's 8 keys, plus `App`'s and `Accounts`' persisted UI state), not just the one this bug surfaced.

`editorRef` is gone as the issue proposed: with the listener bound in an effect, its only remaining reader was `setEditorContent`, which closes over `editor` directly. `useEditor` (deps `[]`) returns a stable instance — probed as 0 identity changes across 20 re-renders and 20 edits — so the reply effect that depends on `setEditorContent` cannot churn.

Left alone deliberately: the dead `editorKey` state noted at the bottom of the issue is separate cleanup, and the pre-existing unused `useEffect` import in `hooks.ts` is unrelated to this scope.

## Test plan

### Unit

**New `src/client/Box/components/Writer/writer-listener.test.ts`** — renders the real `Writer` (happy-dom + `QueryClientProvider` + `Context.Provider`) and reads the live tiptap `Editor` off the React fiber. Three cases: the handler count stays flat across 20 forced re-renders, flat across 20 document edits, and the effect cleanup unbinds on unmount. Moving the registration back into the render body turns **all three red** (43 listeners vs 2).

**New `src/client/lib/hooks.test.ts`** — 8 cases pinning `useLocalStorage`: a changed value writes through; the same value set repeatedly writes once; a fresh object that serializes equal writes once (reference equality would let it through); storage heals in each of the three state/storage divergence cases (`sanitize` rewrote on read, storage cleared underneath a mounted component, storage holding unparseable JSON); a failing `setItem` is contained and state still advances; and the updater form works with state seeded from an existing stored value.

Regression checks, each run: reverting the storage comparison back to the state comparison turns **3 of 8 red**; removing the inner `try/catch` turns the quota case red; reverting the listener registration turns **all 3** Writer cases red.

Full suite: **1805 pass / 0 fail** across 98 files — CI run 31940574618 at the rebased head `907f4d2`, `bun test --coverage`. `bun run typecheck` clean. `eslint` reports no new findings on the touched files (one pre-existing unused-`useEffect` import in `hooks.ts`).

### E2E — production build, real UI clicks, 390x844

`bun run build-client`, served by the app server. Driven with Playwright: real login form, real header **"Compose new mail"** affordance (`aria-label`), real `keyboard.type` into the editor — no `page.goto` shortcut, no direct state poking. `Storage.prototype.setItem` wrapped to count writes; listener count read off the live tiptap `Editor` via its React fiber. Same harness run against `upstream/main` and against this branch on the same machine, back to back.

| docLen | ms/char before | ms/char after | listeners before | listeners after | cumulative setItem before | after | cumulative MB written before | after |
|---|---|---|---|---|---|---|---|---|
| 100 | 6.2 | 3.3 | 106 | 2 | 5,450 | 100 | 0.4 | 0.0 |
| 400 | 31.2 | 2.8 | 406 | 2 | 81,800 | 400 | 21.4 | 0.1 |
| 800 | 103.1 | 3.0 | 807 | 2 | 323,683 | 800 | 167.1 | 0.3 |
| 1200 | 208.6 | 2.6 | 1,209 | 2 | 726,064 | 1,200 | 559.6 | 0.7 |
| 1400 | **274.4** | **2.9** | **1,410** | **2** | **987,649** | **1,400** | **886.9** | **0.9** |

The baseline reproduces the issue's measured numbers (1,410 listeners / 987k `setItem` / 886.9 MB at 1400 chars). After the fix the listener count is **flat at 2** for the whole run, `setItem` is **exactly one per character**, and per-character cost is flat at ~2.6-3.3 ms with no upward trend — a ~95x improvement at 1400 characters, and unbounded as the mail gets longer.

### Behavior preserved (the point of the listener)

- Draft persists while typing: `localStorage.initialContent` holds the full draft at the end of both runs.
- Draft survives a reload: after `page.reload()`, the composer re-renders the full draft — identical before and after the fix.
- `page.on("pageerror")` and console-error watches: **0 page errors, 0 console errors** across the full fixed run.
- **Eraser flow** (the path that lost `editorRef`): typed a full draft — sender, recipient, subject, body — clicked the real eraser icon; the editor and all persisted keys cleared, 0 page errors, 0 console errors.

### Note on the harness

The first attempt ran the server with `NODE_ENV=production`, which flips `secure: true` on the session cookie (`src/server/lib/http/index.ts:47`) and silently logged the browser out on reload over plain HTTP. Re-run without it; the client bundle is still the production vite build, which is what the issue measured.

## Sibling audit

Grepped `src/client` for every other listener registration on a long-lived emitter. `Writer` line 146 was the only `.on(` in the client. Of the `addEventListener` sites, all but two pair with a `removeEventListener`; the two that do not (`MailBody.tsx:178`, `MailBody.tsx:240`) attach to nodes inside a freshly-created iframe document that dies with the document, so they cannot accumulate. No sibling fix needed.


