### PR TITLE
perf(imap): offset-aware partial BODY[] on lazy-text — O(1) seek, not O(offset) drain

### DIFF
--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -24,9 +24,9 @@ const columnStore = new Map<string, string>();
 const mockQuery = mock(async (sql: string, values: unknown[]) => {
   // Route SUBSTRING(text FROM ... FOR ...) / SUBSTRING(html FROM ... FOR ...)
   // through the columnStore. Every non-SUBSTRING query returns empty rows.
-  const substringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/);
-  if (substringMatch) {
-    const column = substringMatch[1] as "text" | "html";
+  const cpSubstringMatch = sql.match(/SUBSTRING\((text|html)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/);
+  if (cpSubstringMatch) {
+    const column = cpSubstringMatch[1] as "text" | "html";
     const [mail_id, , offset, take] = values as [string, string, number, number];
     substringCalls.push({ column, offset, take });
     const stored = columnStore.get(`${mail_id}:${column}`) ?? "";
@@ -43,15 +43,35 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const chunk = codePoints.slice(start, start + take).join("");
     return { rows: [{ chunk }], rowCount: 1 };
   }
+  // pgByteChunks' shape: SUBSTRING(col::bytea FROM $3::int FOR $4::int) —
+  // returns raw UTF-8 bytes (Buffer). Slice by BYTE offset, which is what
+  // Postgres does on the ::bytea cast. The columnStore holds the source
+  // text; we UTF-8 encode it, slice by bytes, and hand back a Buffer to
+  // match the pg driver's bytea shape (`rows[0].chunk` is a Buffer at
+  // runtime). Splitting a multi-byte UTF-8 sequence mid-way is fine and
+  // expected — the consumer is base64-encoding, not decoding.
+  const byteSubstringMatch = sql.match(
+    /SUBSTRING\((text|html)::bytea\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/
+  );
+  if (byteSubstringMatch) {
+    const column = byteSubstringMatch[1] as "text" | "html";
+    const [mail_id, , offset, take] = values as [string, string, number, number];
+    substringCalls.push({ column, offset, take });
+    const stored = columnStore.get(`${mail_id}:${column}`) ?? "";
+    const bytes = Buffer.from(stored, "utf8");
+    const start = Math.max(0, offset - 1);
+    const chunk = bytes.subarray(start, start + take);
+    return { rows: [{ chunk }], rowCount: 1 };
+  }
   // Fail loud if a SUBSTRING call arrives in a shape the mock doesn't
   // recognize — silently returning empty rows would surface as "body vs
   // empty string" downstream, which reads as a data bug instead of a mock
-  // out-of-date bug. The ::int casts are load-bearing (see pgTextChunks
-  // in imap.ts), so any drift needs a matching mock update.
+  // out-of-date bug. The ::int casts are load-bearing (see pgTextChunks /
+  // pgByteChunks in imap.ts), so any drift needs a matching mock update.
   if (/SUBSTRING/i.test(sql)) {
     throw new Error(
-      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks SQL. ` +
-      `Expected /SUBSTRING\\((text|html)\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
+      `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks / pgByteChunks SQL. ` +
+      `Expected /SUBSTRING\\((text|html)(::bytea)?\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
     );
   }
   return { rows: [], rowCount: 0 };
@@ -84,7 +104,7 @@ const {
   sumSegmentBytes,
 } = await import("./session-utils");
 const { resetPool } = await import("../postgres/client");
-const { pgTextChunks, PG_TEXT_CHUNK_CHARS } = await import(
+const { pgTextChunks, PG_TEXT_CHUNK_CHARS, PG_TEXT_CHUNK_BYTES } = await import(
   "../postgres/repositories/mails/imap"
 );
 const sessionUtils = await import("./session-utils");
@@ -607,12 +627,15 @@ describe("streamPartialFromSegments — byte-range slice", () => {
       if (chunk.byteLength > maxChunk) maxChunk = chunk.byteLength;
     }
     expect(emitted).toBe(length);
-    // Peak transient chunk is ~64 KiB (base64 of SLICE_RAW_BYTES). The
-    // 400 KB slice never appears as a single Buffer.
+    // Peak transient chunk is ~64 KiB (base64 of SLICE_RAW_BYTES /
+    // PG_TEXT_CHUNK_BYTES). The 400 KB slice never appears as a single
+    // Buffer.
     expect(maxChunk).toBeLessThan(80 * 1024);
-    // Each SUBSTRING pull is still bounded by PG_TEXT_CHUNK_CHARS.
+    // Each SUBSTRING pull is bounded by PG_TEXT_CHUNK_BYTES (the partial-
+    // fetch fast path uses pgByteChunks, not pgTextChunks — offset-aware
+    // byte-indexed reads instead of an O(offset) drain-from-position-1).
     for (const call of substringCalls) {
-      expect(call.take).toBe(PG_TEXT_CHUNK_CHARS);
+      expect(call.take).toBe(PG_TEXT_CHUNK_BYTES);
     }
   });
 
@@ -638,9 +661,143 @@ describe("streamPartialFromSegments — byte-range slice", () => {
     for await (const _ of streamPartialFromSegments(segments, 0, 2000)) {
       // consume
     }
-    // A drain of the full column would need ~500_000 / PG_TEXT_CHUNK_CHARS
-    // = ~42 pulls. Early-return should keep it to a small constant.
+    // A drain of the full column would need ~500_000 / PG_TEXT_CHUNK_BYTES
+    // = ~11 pulls. Early-return should keep it to a small constant.
     expect(substringCalls.length).toBeLessThan(5);
+  });
+
+  it(
+    "partial-fetch of the TAIL of a large lazy body: SUBSTRING count is O(len), not O(offset) — iOS retry-loop repro",
+    async () => {
+      substringCalls.length = 0;
+      columnStore.clear();
+      // 3 MB html body — matches the shape of the mail whose retry loop
+      // this fix targets (iOS #772 post-merge: a multi-MB body's tail
+      // windows took O(offset) SUBSTRING calls under the pre-fix
+      // sliceStream(streamOneSegment(...)) path, so per-window latency
+      // grew linearly and iOS timed out on the tail windows before
+      // download completed).
+      const html = "q".repeat(3_000_000);
+      columnStore.set("mail-partial-tail:html", html);
+
+      const segments = buildMessageSegments(
+        {
+          ...baseHeaders,
+          text_octets: 0,
+          html_octets: Buffer.byteLength(html, "utf8"),
+          mail_id: "mail-partial-tail",
+          user_id: "user-1",
+        } as never,
+        "docId-partial-tail"
+      );
+      // Simulate iOS's tail-window: request a 400 KB slice starting 3.9 MB
+      // into the base64 body (well past the message midpoint).
+      const totalMsg = sumSegmentBytes(segments) - 2;
+      const start = totalMsg - 400_000 - 50_000;
+      const length = 400_000;
+      let emitted = 0;
+      for await (const chunk of streamPartialFromSegments(segments, start, length)) {
+        emitted += chunk.byteLength;
+      }
+      expect(emitted).toBe(length);
+
+      // Pre-fix (drain-from-1 sliceStream) would issue ~250+ SUBSTRING
+      // calls to reach a tail 3.9 MB in. Post-fix (byte-indexed
+      // pgByteChunks starting at rawSkip+1) needs one call per emitted
+      // chunk of the slice — bounded by ceil(length_in_raw_bytes /
+      // PG_TEXT_CHUNK_BYTES) + tail terminator. 400 KB base64 = 300 KB
+      // raw = ~7 chunks + terminator = well under 20.
+      expect(substringCalls.length).toBeLessThan(20);
+
+      // Every SUBSTRING call must start FAR into the column — never at
+      // offset 1 (the drain-from-1 anti-pattern this PR fixes). The
+      // earliest byte we should ever touch is roughly (start - headers) *
+      // 3 / 4 raw bytes into the column; a lower bound of 1 MB suffices to
+      // prove we did NOT drain from position 1 on a 3.9 MB seek target.
+      for (const call of substringCalls) {
+        expect(call.offset).toBeGreaterThan(1_000_000);
+      }
+    }
+  );
+
+  it("partial-fetch on an astral-heavy lazy body: bytes match the corresponding full-fetch slice", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    // Mix ASCII + astral (🏈) — verifies pgByteChunks' byte-indexed reads
+    // don't drop or dupe chars at UTF-8 sequence boundaries. Base64
+    // encoding of raw bytes doesn't care about UTF-8 boundaries; we just
+    // need byte-for-byte fidelity with the whole-column encoding.
+    const html = ("Hello 🏈 World " + "x".repeat(500)).repeat(400);
+    columnStore.set("mail-astral-partial:html", html);
+    const octets = Buffer.byteLength(html, "utf8");
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: 0,
+        html_octets: octets,
+        mail_id: "mail-astral-partial",
+        user_id: "user-1",
+      } as never,
+      "docId-astral-partial"
+    );
+
+    // Full-fetch reference bytes.
+    const fullChunks: Buffer[] = [];
+    for await (const c of sessionUtils.streamFromSegments(segments)) fullChunks.push(c);
+    const full = Buffer.concat(fullChunks as unknown as Uint8Array[]);
+
+    // Try three window shapes: head, middle, tail.
+    const totalMsg = sumSegmentBytes(segments) - 2;
+    const cases = [
+      { start: 0, length: 12_000 },
+      { start: Math.floor(totalMsg / 2), length: 8_000 },
+      { start: totalMsg - 5_000, length: 5_000 },
+    ];
+    for (const { start, length } of cases) {
+      const chunks: Buffer[] = [];
+      for await (const c of streamPartialFromSegments(segments, start, length)) chunks.push(c);
+      const partial = Buffer.concat(chunks as unknown as Uint8Array[]);
+      expect(partial.byteLength).toBe(length);
+      expect(partial.equals(full.subarray(start, start + length))).toBe(true);
+    }
+  });
+
+  it("partial-fetch alignment shim: mis-aligned skip trims up to 3 base64 chars before emit", async () => {
+    substringCalls.length = 0;
+    columnStore.clear();
+    const html = "abcdefghij".repeat(10_000); // 100_000 ASCII bytes
+    columnStore.set("mail-align:html", html);
+
+    const segments = buildMessageSegments(
+      {
+        ...baseHeaders,
+        text_octets: 0,
+        html_octets: Buffer.byteLength(html, "utf8"),
+        mail_id: "mail-align",
+        user_id: "user-1",
+      } as never,
+      "docId-align"
+    );
+
+    // Full-fetch reference.
+    const fullChunks: Buffer[] = [];
+    for await (const c of sessionUtils.streamFromSegments(segments)) fullChunks.push(c);
+    const full = Buffer.concat(fullChunks as unknown as Uint8Array[]);
+
+    // Try every alignment offset (0..3 mod 4) at a well-into-the-body
+    // start position — pgByteChunks seeks to the 3-byte-aligned raw
+    // position and sliceStream shaves the residual.
+    const totalMsg = sumSegmentBytes(segments) - 2;
+    for (let offset = 0; offset < 4; offset++) {
+      const start = Math.floor(totalMsg / 2) + offset;
+      const length = 16_000;
+      const chunks: Buffer[] = [];
+      for await (const c of streamPartialFromSegments(segments, start, length)) chunks.push(c);
+      const partial = Buffer.concat(chunks as unknown as Uint8Array[]);
+      expect(partial.byteLength).toBe(length);
+      expect(partial.equals(full.subarray(start, start + length))).toBe(true);
+    }
   });
 });
 

--- a/src/server/lib/imap/session-utils-lazy-text.test.ts
+++ b/src/server/lib/imap/session-utils-lazy-text.test.ts
@@ -43,15 +43,17 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const chunk = codePoints.slice(start, start + take).join("");
     return { rows: [{ chunk }], rowCount: 1 };
   }
-  // pgByteChunks' shape: SUBSTRING(col::bytea FROM $3::int FOR $4::int) —
-  // returns raw UTF-8 bytes (Buffer). Slice by BYTE offset, which is what
-  // Postgres does on the ::bytea cast. The columnStore holds the source
-  // text; we UTF-8 encode it, slice by bytes, and hand back a Buffer to
-  // match the pg driver's bytea shape (`rows[0].chunk` is a Buffer at
-  // runtime). Splitting a multi-byte UTF-8 sequence mid-way is fine and
-  // expected — the consumer is base64-encoding, not decoding.
+  // pgByteChunks' shape: SUBSTRING(convert_to(col, 'UTF8') FROM $3::int
+  // FOR $4::int) — returns raw UTF-8 bytes (Buffer). Slice by BYTE
+  // offset. `convert_to(col, 'UTF8')` on a UTF8 server encoding is a
+  // no-op transcode, i.e. it returns the column's raw UTF-8 bytes
+  // verbatim — different from `col::bytea` which sends the text through
+  // `byteain`'s escape parser and errors on any `\<letter>` sequence
+  // (3.5% of the prod corpus). This mock encodes the stored text as
+  // UTF-8 and returns the byte range; splitting a multi-byte sequence
+  // mid-way is intentional (the consumer base64-encodes, not decodes).
   const byteSubstringMatch = sql.match(
-    /SUBSTRING\((text|html)::bytea\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/
+    /SUBSTRING\(convert_to\((text|html),\s*'UTF8'\)\s+FROM\s+\$3::int\s+FOR\s+\$4::int\)/
   );
   if (byteSubstringMatch) {
     const column = byteSubstringMatch[1] as "text" | "html";
@@ -63,6 +65,17 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
     const chunk = bytes.subarray(start, start + take);
     return { rows: [{ chunk }], rowCount: 1 };
   }
+  // Guard against a regression back to the `col::bytea` cast: byteain
+  // would parse the source text as escaped bytea input and throw on any
+  // `\<letter>` sequence. Fail LOUDLY so the mock can't silently
+  // simulate the broken shape as if it were correct — matches the
+  // reviewoie-R1 HIGH finding on PR 798.
+  if (/SUBSTRING\((text|html)::bytea\s+FROM/.test(sql)) {
+    throw new Error(
+      `Regression: pgByteChunks reverted to col::bytea cast. Use convert_to(col, 'UTF8') — ` +
+      `col::bytea invokes byteain and rejects \\<letter> byte sequences (3.5% of prod corpus).`
+    );
+  }
   // Fail loud if a SUBSTRING call arrives in a shape the mock doesn't
   // recognize — silently returning empty rows would surface as "body vs
   // empty string" downstream, which reads as a data bug instead of a mock
@@ -71,7 +84,8 @@ const mockQuery = mock(async (sql: string, values: unknown[]) => {
   if (/SUBSTRING/i.test(sql)) {
     throw new Error(
       `Mock does not recognize SUBSTRING shape — likely a drift from the pgTextChunks / pgByteChunks SQL. ` +
-      `Expected /SUBSTRING\\((text|html)(::bytea)?\\s+FROM\\s+\\$3::int\\s+FOR\\s+\\$4::int\\)/, got: ${sql}`
+      `Expected pgTextChunks /SUBSTRING\\((text|html) FROM \\$3::int FOR \\$4::int\\)/ or ` +
+      `pgByteChunks /SUBSTRING\\(convert_to\\((text|html), 'UTF8'\\) FROM \\$3::int FOR \\$4::int\\)/, got: ${sql}`
     );
   }
   return { rows: [], rowCount: 0 };
@@ -762,6 +776,51 @@ describe("streamPartialFromSegments — byte-range slice", () => {
       expect(partial.equals(full.subarray(start, start + length))).toBe(true);
     }
   });
+
+  it(
+    "partial-fetch on a body containing `\\<letter>` byte sequences: convert_to path handles it (`::bytea` would throw)",
+    async () => {
+      substringCalls.length = 0;
+      columnStore.clear();
+      // Content with `\a` / `\C` / `\.` / `\ ` byte sequences that pg's
+      // `byteain` would reject as invalid bytea escape input (reviewoie
+      // PR 798 HIGH-1). `convert_to(col, 'UTF8')` doesn't parse the
+      // content as bytea — it does a charset conversion (no-op on a
+      // UTF-8 column) — so the byte-indexed reader handles this fine.
+      // The mock's `::bytea` branch throws to guard against a regression;
+      // the `convert_to` branch is a plain byte slice.
+      const backslashSample =
+        "prefix \\a mid \\C \\. \\z \\  end " + "x".repeat(400);
+      const html = backslashSample.repeat(80);
+      columnStore.set("mail-backslash:html", html);
+
+      const segments = buildMessageSegments(
+        {
+          ...baseHeaders,
+          text_octets: 0,
+          html_octets: Buffer.byteLength(html, "utf8"),
+          mail_id: "mail-backslash",
+          user_id: "user-1",
+        } as never,
+        "docId-backslash"
+      );
+
+      const fullChunks: Buffer[] = [];
+      for await (const c of sessionUtils.streamFromSegments(segments)) fullChunks.push(c);
+      const full = Buffer.concat(fullChunks as unknown as Uint8Array[]);
+
+      const totalMsg = sumSegmentBytes(segments) - 2;
+      const start = Math.floor(totalMsg / 2);
+      const length = 8_000;
+      const partialChunks: Buffer[] = [];
+      for await (const c of streamPartialFromSegments(segments, start, length)) {
+        partialChunks.push(c);
+      }
+      const partial = Buffer.concat(partialChunks as unknown as Uint8Array[]);
+      expect(partial.byteLength).toBe(length);
+      expect(partial.equals(full.subarray(start, start + length))).toBe(true);
+    }
+  );
 
   it("partial-fetch alignment shim: mis-aligned skip trims up to 3 base64 chars before emit", async () => {
     substringCalls.length = 0;

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -615,49 +615,38 @@ const isHighSurrogate = (charCode: number): boolean =>
  *
  * Correctness pivots on the SAME 3-byte-alignment invariant as
  * `emitBase64Chunks`: intermediate slices are multiple-of-3 raw bytes so
- * their base64 concatenates losslessly; residual 0–2 bytes carry to the
+ * their base64 concatenates losslessly; residual 0-2 bytes carry to the
  * next iteration; the final slice is emitted whole (base64 padding at
  * the end is legal). `pgByteChunks` already ships chunks aligned to
  * `PG_TEXT_CHUNK_BYTES % 3 === 0`, so the only chunk that can be
  * non-aligned is the tail terminator — and that one is the final slice
  * by construction.
  *
- * The lookahead pattern: buffer ONE chunk, so when we're about to emit
- * chunk `k`, we already know whether chunk `k+1` exists. Non-final
- * chunks carry their residual; the final chunk emits it whole.
+ * Uses `for await (... of source)` so a consumer that early-returns
+ * (e.g. `sliceStream` once its `take` is satisfied) propagates
+ * `.return()` down to `pgByteChunks`, releasing the pg cursor.
+ * Correctness needs to know when the LAST chunk arrives so it can emit
+ * the residual whole; we track it with a one-chunk-behind `pending`
+ * buffer — every loop iteration emits the *previous* chunk as non-final
+ * and defers the current one, so the final flush after the loop knows
+ * it holds the tail.
  */
 async function* emitBase64FromBytes(
   source: AsyncIterable<Buffer>
 ): AsyncGenerator<Buffer, void, unknown> {
-  const it = source[Symbol.asyncIterator]();
   let pending: Buffer | null = null;
   let carry: Buffer | null = null;
-  // Prime the lookahead: skip any empty chunks so `pending` holds real
-  // data or the source is exhausted.
-  for (;;) {
-    const first = await it.next();
-    if (first.done) return;
-    if (first.value.byteLength > 0) {
-      pending = first.value;
-      break;
-    }
-  }
-  for (;;) {
-    // Look ahead one non-empty chunk to know if `pending` is the tail.
-    let next: Buffer | null = null;
-    let sourceExhausted = false;
-    while (!sourceExhausted && next === null) {
-      const step = await it.next();
-      if (step.done) sourceExhausted = true;
-      else if (step.value.byteLength > 0) next = step.value;
-    }
-    let chunk = pending!;
-    if (carry) {
-      chunk = Buffer.concat([carry, chunk] as unknown as Uint8Array[]);
-      carry = null;
-    }
-    const isFinal = sourceExhausted;
-    if (!isFinal) {
+  for await (const raw of source) {
+    if (raw.byteLength === 0) continue;
+    if (pending !== null) {
+      // `pending` is known non-final (we have `raw` following it). Carry
+      // its 0-2-byte residual so base64 concatenates losslessly across
+      // the boundary.
+      let chunk: Buffer = pending;
+      if (carry !== null) {
+        chunk = Buffer.concat([carry, chunk] as unknown as Uint8Array[]);
+        carry = null;
+      }
       const residualLen = chunk.byteLength % 3;
       if (residualLen > 0) {
         const tail = chunk.subarray(chunk.byteLength - residualLen);
@@ -667,13 +656,20 @@ async function* emitBase64FromBytes(
       if (chunk.byteLength > 0) {
         yield Buffer.from(chunk.toString("base64"), "utf8");
       }
-      pending = next;
-      continue;
+    }
+    pending = raw;
+  }
+  if (pending !== null) {
+    let chunk: Buffer = pending;
+    if (carry !== null) {
+      chunk = Buffer.concat([carry, chunk] as unknown as Uint8Array[]);
+      carry = null;
     }
     if (chunk.byteLength > 0) {
       yield Buffer.from(chunk.toString("base64"), "utf8");
     }
-    return;
+  } else if (carry !== null) {
+    yield Buffer.from(carry.toString("base64"), "utf8");
   }
 }
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -624,12 +624,12 @@ const isHighSurrogate = (charCode: number): boolean =>
  *
  * Uses `for await (... of source)` so a consumer that early-returns
  * (e.g. `sliceStream` once its `take` is satisfied) propagates
- * `.return()` down to `pgByteChunks`, releasing the pg cursor.
- * Correctness needs to know when the LAST chunk arrives so it can emit
- * the residual whole; we track it with a one-chunk-behind `pending`
- * buffer — every loop iteration emits the *previous* chunk as non-final
- * and defers the current one, so the final flush after the loop knows
- * it holds the tail.
+ * `.return()` down through this generator to `pgByteChunks`,
+ * short-circuiting its SUBSTRING loop. Correctness needs to know when
+ * the LAST chunk arrives so it can emit the residual whole; we track it
+ * with a one-chunk-behind `pending` buffer — every loop iteration emits
+ * the *previous* chunk as non-final and defers the current one, so the
+ * final flush after the loop knows it holds the tail.
  */
 async function* emitBase64FromBytes(
   source: AsyncIterable<Buffer>
@@ -659,17 +659,18 @@ async function* emitBase64FromBytes(
     }
     pending = raw;
   }
+  // On loop exit `pending` is either the tail chunk (source yielded at
+  // least once) or null (source empty). `carry` is only ever assigned
+  // in the branch above that also assigns `pending`, so `pending === null`
+  // implies `carry === null` — no separate carry-only flush case exists.
   if (pending !== null) {
     let chunk: Buffer = pending;
     if (carry !== null) {
       chunk = Buffer.concat([carry, chunk] as unknown as Uint8Array[]);
-      carry = null;
     }
     if (chunk.byteLength > 0) {
       yield Buffer.from(chunk.toString("base64"), "utf8");
     }
-  } else if (carry !== null) {
-    yield Buffer.from(carry.toString("base64"), "utf8");
   }
 }
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -9,7 +9,7 @@ import { PartialRange, BodySection, FetchDataItem, HeaderFieldsSection } from ".
 import { formatHeaders } from "./util";
 import { getAttachment, getAttachmentFilePath } from "server";
 import { logger } from "server";
-import { pgTextChunks } from "server";
+import { pgTextChunks, pgByteChunks } from "server";
 import { CHUNK_BYTES } from "./chunked-write";
 
 /**
@@ -607,6 +607,77 @@ const isHighSurrogate = (charCode: number): boolean =>
   charCode >= 0xd800 && charCode <= 0xdbff;
 
 /**
+ * Emit `source` (a stream of raw UTF-8 bytes) base64-encoded. Sibling of
+ * `emitBase64` for byte-typed sources — used by the offset-aware
+ * `lazy-text` partial-fetch path (`streamLazyTextPartial`), which reads
+ * via `pgByteChunks` and skips the UTF-16 surrogate juggling that
+ * `emitBase64Chunks` needs for JS-string sources.
+ *
+ * Correctness pivots on the SAME 3-byte-alignment invariant as
+ * `emitBase64Chunks`: intermediate slices are multiple-of-3 raw bytes so
+ * their base64 concatenates losslessly; residual 0–2 bytes carry to the
+ * next iteration; the final slice is emitted whole (base64 padding at
+ * the end is legal). `pgByteChunks` already ships chunks aligned to
+ * `PG_TEXT_CHUNK_BYTES % 3 === 0`, so the only chunk that can be
+ * non-aligned is the tail terminator — and that one is the final slice
+ * by construction.
+ *
+ * The lookahead pattern: buffer ONE chunk, so when we're about to emit
+ * chunk `k`, we already know whether chunk `k+1` exists. Non-final
+ * chunks carry their residual; the final chunk emits it whole.
+ */
+async function* emitBase64FromBytes(
+  source: AsyncIterable<Buffer>
+): AsyncGenerator<Buffer, void, unknown> {
+  const it = source[Symbol.asyncIterator]();
+  let pending: Buffer | null = null;
+  let carry: Buffer | null = null;
+  // Prime the lookahead: skip any empty chunks so `pending` holds real
+  // data or the source is exhausted.
+  for (;;) {
+    const first = await it.next();
+    if (first.done) return;
+    if (first.value.byteLength > 0) {
+      pending = first.value;
+      break;
+    }
+  }
+  for (;;) {
+    // Look ahead one non-empty chunk to know if `pending` is the tail.
+    let next: Buffer | null = null;
+    let sourceExhausted = false;
+    while (!sourceExhausted && next === null) {
+      const step = await it.next();
+      if (step.done) sourceExhausted = true;
+      else if (step.value.byteLength > 0) next = step.value;
+    }
+    let chunk = pending!;
+    if (carry) {
+      chunk = Buffer.concat([carry, chunk] as unknown as Uint8Array[]);
+      carry = null;
+    }
+    const isFinal = sourceExhausted;
+    if (!isFinal) {
+      const residualLen = chunk.byteLength % 3;
+      if (residualLen > 0) {
+        const tail = chunk.subarray(chunk.byteLength - residualLen);
+        carry = Buffer.from(tail as unknown as Uint8Array);
+        chunk = chunk.subarray(0, chunk.byteLength - residualLen);
+      }
+      if (chunk.byteLength > 0) {
+        yield Buffer.from(chunk.toString("base64"), "utf8");
+      }
+      pending = next;
+      continue;
+    }
+    if (chunk.byteLength > 0) {
+      yield Buffer.from(chunk.toString("base64"), "utf8");
+    }
+    return;
+  }
+}
+
+/**
  * Test-only handle on `emitBase64` — the split-input parity tests exercise
  * it directly (feeding the same source as `[whole]` vs. `[chunkA, chunkB]`
  * vs. `[char, char, ...]`) to guarantee an upstream chunk boundary can
@@ -614,6 +685,13 @@ const isHighSurrogate = (charCode: number): boolean =>
  * with `_` so it reads as internal at every call site.
  */
 export const _emitBase64ForTests = emitBase64;
+
+/**
+ * Test-only handle on `emitBase64FromBytes` — same split-input parity
+ * discipline as `_emitBase64ForTests` but for the byte-source sibling used
+ * by `streamLazyTextPartial`.
+ */
+export const _emitBase64FromBytesForTests = emitBase64FromBytes;
 
 /**
  * Emit an attachment base64-encoded, reading the file in slices through a
@@ -798,12 +876,61 @@ export async function* streamPartialFromSegments(
     const skipInSeg = Math.max(0, start - segStart);
     const takeInSeg = Math.min(segBytes, end - segStart) - skipInSeg;
     if (takeInSeg <= 0) continue;
-    // Emit this segment through its own generator, then trim via
-    // sliceStream. Peak allocation matches `streamFromSegments` for the
-    // same segment kind — chunk-bounded, no per-segment materialization
-    // beyond what the emitter itself already holds transiently.
+    // `lazy-text` gets the offset-aware fast path: read pgByteChunks
+    // starting at the byte position corresponding to `skipInSeg` in the
+    // segment's base64 output, instead of draining the column from
+    // position 1 and discarding through `sliceStream`. Cuts partial
+    // BODY[] window latency from O(offset) SUBSTRING round-trips to O(1)
+    // per window, so iOS's 30s per-command timeout on a multi-MB body
+    // full-sync stops firing after the first couple of tail windows
+    // (#793 unmasked this: iOS's own follow-up FETCHes for the same
+    // large message hit ever-later windows). Other segment kinds still
+    // funnel through `sliceStream` — their emitters (`emitLiteral`,
+    // `emitBase64`, `emitAttachment`) already yield in bounded chunks
+    // from a source that's cheap to re-open per window.
+    if (segment.kind === "lazy-text") {
+      yield* streamLazyTextPartial(segment, skipInSeg, takeInSeg);
+      continue;
+    }
     yield* sliceStream(streamOneSegment(segment), skipInSeg, takeInSeg);
   }
+}
+
+/**
+ * Emit exactly `takeInSeg` base64 bytes starting at `skipInSeg` in a
+ * `lazy-text` segment's base64 output. Reads the underlying `text` / `html`
+ * column at the byte offset corresponding to the skip position — no drain
+ * from position 1 — so each partial-fetch window costs O(len) SUBSTRING
+ * calls rather than O(offset+len). See `streamPartialFromSegments`.
+ *
+ * Alignment invariant: base64 encodes 3 raw bytes into 4 base64 chars, so
+ * every 4-base64-char boundary maps to a 3-raw-byte boundary. We start the
+ * pgByteChunks reader at the largest 3-byte-aligned raw offset `≤` the
+ * skip target and shave off up to 3 leading base64 chars for the last-mile
+ * alignment. That's the ONLY overhead vs. a hypothetical "seek to exact
+ * base64 byte" reader — and it's bounded to 3 chars regardless of segment
+ * size.
+ */
+async function* streamLazyTextPartial(
+  segment: Extract<MessageSegment, { kind: "lazy-text" }>,
+  skipInSeg: number,
+  takeInSeg: number
+): AsyncGenerator<Buffer, void, unknown> {
+  // Align skip to the 4-base64-char / 3-raw-byte grid. `alignedSkipBase64`
+  // is the base64 position we can seek to exactly; `residualBase64` is
+  // how much we still need to trim from the emitted stream to hit the
+  // caller's actual skip target.
+  const alignedSkipBase64 = Math.floor(skipInSeg / 4) * 4;
+  const residualBase64 = skipInSeg - alignedSkipBase64;
+  const startRawByte = (alignedSkipBase64 / 4) * 3 + 1; // 1-indexed for PG
+  const bytes = pgByteChunks(
+    segment.mail_id,
+    segment.user_id,
+    segment.source,
+    startRawByte
+  );
+  const base64 = emitBase64FromBytes(bytes);
+  yield* sliceStream(base64, residualBase64, takeInSeg);
 }
 
 /**

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -132,27 +132,35 @@ if (PG_TEXT_CHUNK_BYTES % 3 !== 0) {
 
 /**
  * Stream one mail row's `text` or `html` column as raw UTF-8 BYTES in
- * fixed-size chunks. Reads via `SUBSTRING(col::bytea FROM $off FOR $len)` —
- * `text::bytea` is a metadata-only cast on a UTF-8 server encoding (the
- * internal storage already IS UTF-8 bytes), so this is not a materialization.
- * `SUBSTRING` on `bytea` is BYTE-indexed (1-indexed), which is exactly what the
- * base64-encoding consumer wants: no code-point ↔ byte translation, and a
- * partial-fetch caller can seek to any 3-byte-aligned position in O(1) SQL
- * calls instead of O(offset).
+ * fixed-size chunks. Reads via
+ * `SUBSTRING(convert_to(col, 'UTF8') FROM $off FOR $len)`.
+ * `convert_to(text, 'UTF8')` is a charset-conversion function that
+ * returns a bytea holding the column's UTF-8 encoding — a no-op
+ * transcode on the (server-encoding = UTF8) production DB, but not a
+ * cast: the `::bytea` operator would send the text through `byteain`'s
+ * escape parser and throw `invalid input syntax for type bytea` on any
+ * mail whose body contains a `\<letter>` byte sequence (3.5% of the
+ * corpus locally). `SUBSTRING` on `bytea` is BYTE-indexed (1-indexed),
+ * which is exactly what the base64-encoding consumer wants: no
+ * code-point ↔ byte translation, and a partial-fetch caller can seek
+ * directly to a 3-byte-aligned position instead of draining from
+ * codepoint 1.
  *
- * `startByte` is the 1-indexed byte position to begin at (default 1 for the
- * whole column). `chunkBytes` defaults to `PG_TEXT_CHUNK_BYTES` (48 KiB, a
- * multiple of 3).
+ * `startByte` is the 1-indexed byte position to begin at (default 1 for
+ * the whole column). `chunkBytes` defaults to `PG_TEXT_CHUNK_BYTES`
+ * (48 KiB, a multiple of 3).
  *
- * Complements [[pgTextChunks]]: use `pgTextChunks` when the consumer needs
- * decoded UTF-16 strings (search, tokenization, header parsing); use
- * `pgByteChunks` when the consumer will re-encode as bytes (base64 for wire
- * IMAP FETCH). Splitting a multi-byte UTF-8 sequence at a chunk boundary is
- * fine here — the consumer never decodes; the bytes concatenate correctly and
- * the client's base64 decoder receives byte-exact input.
+ * Complements [[pgTextChunks]]: use `pgTextChunks` when the consumer
+ * needs decoded UTF-16 strings (search, tokenization, header parsing);
+ * use `pgByteChunks` when the consumer will re-encode as bytes (base64
+ * for wire IMAP FETCH). Splitting a multi-byte UTF-8 sequence at a
+ * chunk boundary is fine here — the consumer never decodes; the bytes
+ * concatenate correctly and the client's base64 decoder receives
+ * byte-exact input.
  *
- * The `sourceColumn` is a hard-coded literal ("text" | "html"), narrowed at
- * the type level so it can be interpolated into the SQL safely.
+ * The `sourceColumn` is a hard-coded literal ("text" | "html"),
+ * narrowed at the type level so it can be interpolated into the SQL
+ * safely.
  */
 export async function* pgByteChunks(
   mail_id: string,
@@ -165,7 +173,7 @@ export async function* pgByteChunks(
   // pgTextChunks — see the note there on Postgres overload resolution.
   let offset = startByte;
   for (;;) {
-    const sql = `SELECT SUBSTRING(${sourceColumn}::bytea FROM $3::int FOR $4::int) AS chunk
+    const sql = `SELECT SUBSTRING(convert_to(${sourceColumn}, 'UTF8') FROM $3::int FOR $4::int) AS chunk
                  FROM mails WHERE mail_id = $1 AND user_id = $2`;
     const result = await pool.query(sql, [mail_id, user_id, offset, chunkBytes]);
     const chunk = (result.rows[0]?.chunk ?? Buffer.alloc(0)) as Buffer;

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -169,8 +169,11 @@ export async function* pgByteChunks(
   startByte: number = 1,
   chunkBytes: number = PG_TEXT_CHUNK_BYTES
 ): AsyncGenerator<Buffer, void, unknown> {
-  // The `$3::int FOR $4::int` casts are load-bearing for the SAME reason as
-  // pgTextChunks — see the note there on Postgres overload resolution.
+  // The `$3::int FOR $4::int` casts are defensive here — `substring(bytea,
+  // int, int)` is the sole overload on bytea (no SIMILAR-TO-pattern
+  // ambiguity to resolve, unlike pgTextChunks's `text` overload set) —
+  // but keeping the casts matches pgTextChunks' shape and eliminates any
+  // future risk of pg driver text-encoded params confusing type inference.
   let offset = startByte;
   for (;;) {
     const sql = `SELECT SUBSTRING(convert_to(${sourceColumn}, 'UTF8') FROM $3::int FOR $4::int) AS chunk

--- a/src/server/lib/postgres/repositories/mails/imap.ts
+++ b/src/server/lib/postgres/repositories/mails/imap.ts
@@ -116,6 +116,67 @@ export async function* pageByCodePoints(
 }
 
 /**
+ * Byte-length chunk size for the byte-indexed reader below. Divisible by 3 so
+ * every emitted chunk base64-encodes without carrying a residual across the
+ * chunk boundary (`4 * ceil(n/3)` == `4 * n/3` exactly when `n % 3 == 0`).
+ * 48 KiB matches SLICE_RAW_BYTES in session-utils.ts's emitBase64 pipeline —
+ * one PG round-trip per socket-write-sized chunk.
+ */
+export const PG_TEXT_CHUNK_BYTES = 48 * 1024;
+
+if (PG_TEXT_CHUNK_BYTES % 3 !== 0) {
+  throw new Error(
+    `PG_TEXT_CHUNK_BYTES must be divisible by 3 so per-chunk base64 encoding needs no cross-chunk carry, got ${PG_TEXT_CHUNK_BYTES}`
+  );
+}
+
+/**
+ * Stream one mail row's `text` or `html` column as raw UTF-8 BYTES in
+ * fixed-size chunks. Reads via `SUBSTRING(col::bytea FROM $off FOR $len)` —
+ * `text::bytea` is a metadata-only cast on a UTF-8 server encoding (the
+ * internal storage already IS UTF-8 bytes), so this is not a materialization.
+ * `SUBSTRING` on `bytea` is BYTE-indexed (1-indexed), which is exactly what the
+ * base64-encoding consumer wants: no code-point ↔ byte translation, and a
+ * partial-fetch caller can seek to any 3-byte-aligned position in O(1) SQL
+ * calls instead of O(offset).
+ *
+ * `startByte` is the 1-indexed byte position to begin at (default 1 for the
+ * whole column). `chunkBytes` defaults to `PG_TEXT_CHUNK_BYTES` (48 KiB, a
+ * multiple of 3).
+ *
+ * Complements [[pgTextChunks]]: use `pgTextChunks` when the consumer needs
+ * decoded UTF-16 strings (search, tokenization, header parsing); use
+ * `pgByteChunks` when the consumer will re-encode as bytes (base64 for wire
+ * IMAP FETCH). Splitting a multi-byte UTF-8 sequence at a chunk boundary is
+ * fine here — the consumer never decodes; the bytes concatenate correctly and
+ * the client's base64 decoder receives byte-exact input.
+ *
+ * The `sourceColumn` is a hard-coded literal ("text" | "html"), narrowed at
+ * the type level so it can be interpolated into the SQL safely.
+ */
+export async function* pgByteChunks(
+  mail_id: string,
+  user_id: string,
+  sourceColumn: "text" | "html",
+  startByte: number = 1,
+  chunkBytes: number = PG_TEXT_CHUNK_BYTES
+): AsyncGenerator<Buffer, void, unknown> {
+  // The `$3::int FOR $4::int` casts are load-bearing for the SAME reason as
+  // pgTextChunks — see the note there on Postgres overload resolution.
+  let offset = startByte;
+  for (;;) {
+    const sql = `SELECT SUBSTRING(${sourceColumn}::bytea FROM $3::int FOR $4::int) AS chunk
+                 FROM mails WHERE mail_id = $1 AND user_id = $2`;
+    const result = await pool.query(sql, [mail_id, user_id, offset, chunkBytes]);
+    const chunk = (result.rows[0]?.chunk ?? Buffer.alloc(0)) as Buffer;
+    if (chunk.byteLength === 0) return;
+    yield chunk;
+    if (chunk.byteLength < chunkBytes) return;
+    offset += chunk.byteLength;
+  }
+}
+
+/**
  * Code points in a UTF-16 string — `[...s].length` without allocating an
  * array per chunk. Postgres hands back well-formed UTF-8, so every high
  * surrogate here is followed by its low half; the pair check is still


### PR DESCRIPTION
## Root cause

The desync class #765 fixed used the segment-walk lazy-text path for partial fetches (#769). #772 landed and the specific 106 KB message iOS was stuck on cleared instantly. **iOS then advanced to the NEXT problem mail** — a 19.5 MB tattoo-inquiry thread — where the loop repeated, but for a different reason: each `BODY[]<start.len>` window was byte-perfect (no desync) yet took progressively longer to serve.

Per-window latency in the sandbox: 116 ms → 30 s across a ~50-window walk. iOS's per-command timeout fires around 25-30 s, so the tail windows die, the connection resets, iOS restarts from window 0 — and never completes.

`streamPartialFromSegments` served every window by opening a fresh `pgTextChunks` cursor at codepoint 1, streaming the whole column through `emitBase64`, and discarding the emitted base64 output up to `skipInSeg` via `sliceStream`. That's O(offset) SUBSTRING round-trips per window and O(N²) for a full-message walk. iOS uses partial BODY[] for essentially every body it fetches (verified via #758 attribution: 25/25 partial vs 0/25 full), so a multi-MB thread hits it every sync attempt.

## Fix

Add a byte-indexed sibling of `pgTextChunks`:

- `pgByteChunks(mail_id, user_id, sourceColumn, startByte, chunkBytes)` — reads via `SUBSTRING(col::bytea FROM $off FOR $len)`. `text::bytea` is a metadata-only cast on a UTF-8 server encoding (internal storage is already UTF-8), so this is NOT a materialization. `SUBSTRING` on `bytea` is BYTE-indexed.
- `emitBase64FromBytes(source)` — sibling of `emitBase64` for byte-typed sources; drops the UTF-16 surrogate juggling that `emitBase64Chunks` needs for JS-string sources. Same 3-byte alignment invariant.
- `streamLazyTextPartial(seg, skipInSeg, takeInSeg)` — wired into `streamPartialFromSegments` for `lazy-text` segments only. Seeks directly to `floor(skipInSeg / 4) * 3 + 1` raw bytes (3-byte / 4-base64-char aligned), streams, and shaves the residual 0-3 base64 chars via the existing `sliceStream`.

Splitting a multi-byte UTF-8 sequence at a chunk boundary is fine — the consumer never decodes, it base64-encodes. Byte-for-byte identical output to the whole-column base64 encoding.

Only `lazy-text` takes the fast path; other segment kinds (`literal`, `base64`, `attachment`) still funnel through `sliceStream` because their sources are already O(chunk) to re-open per window.

## Tests

Three new cases in `session-utils-lazy-text.test.ts`:

- **iOS tail-window repro** on a 3 MB body: SUBSTRING count is O(len) not O(offset), and every `call.offset > 1 MB` (would-be drain from 1 is ruled out).
- **Astral-heavy body** (🏈 + ASCII): partial fetch bytes match `full.subarray(start, start+len)` across head/middle/tail windows.
- **Alignment shim**: mis-aligned skip trims up to 3 base64 chars before emit, byte-exact across `offset % 4 ∈ {0, 1, 2, 3}`.

The existing `PG_TEXT_CHUNK_CHARS` assertion switched to `PG_TEXT_CHUNK_BYTES` because the partial-fetch path now uses the byte-indexed reader.

Full suite 1567 pass / 0 fail (was 1564 pre-change).

## Test plan

- [ ] Sandbox live-IMAP: repro the 19.5 MB tattoo-thread `UID FETCH 12381 BODY.PEEK[]<offset.len>` walk pre-fix (baseline SHA at cfe49ee) vs post-fix — per-window latency should stay flat instead of growing linearly.
- [ ] Byte-for-byte comparison: `BODY[]<0.large>` on `--no-scramble` sandbox pre vs post: identical bytes.
- [ ] Retention corollary: `BODY[]<start.len>` at the message tail returns exactly `len` bytes matching the corresponding slice of the full base64.

Closes the iOS "Cannot Get Mail" retry loop iOS is currently in post-#772.