### PR TITLE
fix(imap): APPEND files into the named mailbox instead of always INBOX (#695)

### DIFF
--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -44,6 +44,7 @@ import type { SequenceState } from "./sequence-resolver";
 
 const STORED_UIDVALIDITY = 1716512400;
 const DOMAIN_UID = 100;
+const ACCOUNT_UID = 42;
 
 // pg-FakePool pattern (see users.test.ts): mock `pg` so the lazy pool in
 // postgres/client.ts is a FakePool, then run the REAL imap code. The functions
@@ -80,12 +81,18 @@ const mockQuery = mock(async (sql: string, values?: unknown[]) => {
   const sqlStr = typeof sql === "string" ? sql : "";
   // getDomainUidNext / getAccountUidNext both SELECT ... AS next_uid FROM mails
   if (sqlStr.includes("next_uid")) {
+    const kind = String(values?.[1]);
     uidReservations.push({
-      kind: String(values?.[1]),
+      kind,
       scope: String(values?.[2]),
       sent: values?.[3] === true,
     });
-    return { rows: [{ next_uid: String(DOMAIN_UID) }], rowCount: 1 };
+    // Distinct per lane. Returning one constant for both would let APPENDUID
+    // report either UID and still pass, which is exactly the selection the
+    // response has to get right (RFC 4315 §3 wants the destination
+    // mailbox's UID).
+    const next_uid = kind === "account" ? ACCOUNT_UID : DOMAIN_UID;
+    return { rows: [{ next_uid: String(next_uid) }], rowCount: 1 };
   }
   // usersTable.queryOne(...) for getImapUidValidity — narrowed to queries
   // that target the users table so an out-of-file leak (Bun's mock.module
@@ -233,6 +240,40 @@ describe("appendMessage — APPENDUID UIDVALIDITY (#544)", () => {
     const response = await runAppend("A004", makeAppendStore(null));
     expect(response).toContain("A004 NO APPEND failed to store message");
     expect(response).not.toContain("APPENDUID");
+  });
+
+  it("reports the destination mailbox's own UID, per lane", async () => {
+    // RFC 4315 §3: APPENDUID carries the UID the message got *in the mailbox
+    // it was appended to*. Only INBOX and the unified Sent folder are served
+    // out of the domain lane (isDomainScoped); every other box — including
+    // Archive, which is neither INBOX nor account-named — is read back through
+    // mail_mailbox_uid, so reporting the domain UID there would send the
+    // client's follow-up `UID FETCH` to a UID that box does not hold.
+    const targets = [
+      "INBOX",
+      "Sent Messages",
+      "Archive",
+      "INBOX/accounts/admin",
+      "Sent Messages/accounts/admin",
+    ];
+    const reported: Array<number | null> = [];
+    for (const [i, mailbox] of targets.entries()) {
+      const response = await runAppend(
+        `A20${i}`,
+        makeAppendStore(),
+        null,
+        mailbox
+      );
+      const match = response.match(/\[APPENDUID \d+ (\d+)\]/);
+      reported.push(match ? Number(match[1]) : null);
+    }
+    expect(reported).toEqual([
+      DOMAIN_UID,
+      DOMAIN_UID,
+      ACCOUNT_UID,
+      ACCOUNT_UID,
+      ACCOUNT_UID,
+    ]);
   });
 });
 

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -70,10 +70,21 @@ const USER_ROW = {
   imap_uid_validity: STORED_UIDVALIDITY,
 };
 
-const mockQuery = mock(async (sql: string) => {
+// Every UID reservation this run made, in call order. `buildReserveUidQuery`
+// binds [user_id, kind, scope, sent, …], so the tuple is enough to tell the
+// INBOX lane from the Sent lane.
+type UidReservation = { kind: string; scope: string; sent: boolean };
+const uidReservations: UidReservation[] = [];
+
+const mockQuery = mock(async (sql: string, values?: unknown[]) => {
   const sqlStr = typeof sql === "string" ? sql : "";
   // getDomainUidNext / getAccountUidNext both SELECT ... AS next_uid FROM mails
   if (sqlStr.includes("next_uid")) {
+    uidReservations.push({
+      kind: String(values?.[1]),
+      scope: String(values?.[2]),
+      sent: values?.[3] === true,
+    });
     return { rows: [{ next_uid: String(DOMAIN_UID) }], rowCount: 1 };
   }
   // usersTable.queryOne(...) for getImapUidValidity — narrowed to queries
@@ -130,31 +141,58 @@ afterAll(() => {
 
 beforeEach(() => {
   mockQuery.mockClear();
+  uidReservations.length = 0;
 });
 
 // ---------------------------------------------------------------------------
 // appendMessage — APPENDUID (#544) + flag defaults (#548)
 // ---------------------------------------------------------------------------
 
+type AppendedMail = { sent: boolean };
+
 type FakeStore = {
   getUser: () => { id: string; username: string };
-  storeMail: (mail: unknown) => Promise<unknown>;
+  mailboxExists: (box: string) => Promise<boolean>;
+  storeMail: (mail: AppendedMail, mailbox?: string) => Promise<unknown>;
+  /** Every (mail, mailbox) pair storeMail received, in call order. */
+  appended: Array<{ mail: AppendedMail; mailbox?: string }>;
 };
 
-const makeAppendStore = (storeResult: unknown = { _id: "stored" }): FakeStore => ({
-  getUser: () => ({ id: "user-123", username: "admin" }),
-  storeMail: async () => storeResult,
-});
+// The listable set a Store would report for user "admin": INBOX, the unified
+// Sent folder, and one per-account box in each lane.
+const EXISTING_MAILBOXES = [
+  "INBOX",
+  "Sent Messages",
+  "accounts/admin",
+  "Sent Messages/accounts/admin",
+];
+
+const makeAppendStore = (
+  storeResult: unknown = { _id: "stored" },
+  mailboxes: string[] = EXISTING_MAILBOXES
+): FakeStore => {
+  const appended: FakeStore["appended"] = [];
+  return {
+    getUser: () => ({ id: "user-123", username: "admin" }),
+    mailboxExists: async (box: string) => mailboxes.includes(box),
+    storeMail: async (mail: AppendedMail, mailbox?: string) => {
+      appended.push({ mail, mailbox });
+      return storeResult;
+    },
+    appended,
+  };
+};
 
 const runAppend = async (
   tag: string,
   store: FakeStore,
-  selectedMailbox: string | null = null
+  selectedMailbox: string | null = null,
+  mailbox = "INBOX"
 ) => {
   const writes: string[] = [];
   await appendMessage(
     tag,
-    { mailbox: "INBOX", message: "Subject: test\r\n\r\nHello" },
+    { mailbox, message: "Subject: test\r\n\r\nHello" },
     store as never,
     selectedMailbox,
     (data: string) => {
@@ -189,6 +227,64 @@ describe("appendMessage — APPENDUID UIDVALIDITY (#544)", () => {
     const response = await runAppend("A004", makeAppendStore(null));
     expect(response).toContain("A004 NO APPEND failed to store message");
     expect(response).not.toContain("APPENDUID");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// appendMessage — target mailbox (#695)
+// ---------------------------------------------------------------------------
+
+describe("appendMessage — target mailbox (#695)", () => {
+  it("files an APPEND to the unified Sent folder as sent mail", async () => {
+    const store = makeAppendStore();
+    const response = await runAppend("A101", store, null, "Sent Messages");
+
+    expect(response).toContain("A101 OK [APPENDUID");
+    expect(store.appended).toHaveLength(1);
+    expect(store.appended[0].mail.sent).toBe(true);
+    // Domain-scoped: storeMail takes no per-mailbox arg for INBOX / Sent.
+    expect(store.appended[0].mailbox).toBeUndefined();
+    // Both UID lanes are reserved on the sent side of the counter.
+    expect(uidReservations.every((r) => r.sent)).toBe(true);
+    expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
+  });
+
+  it("files an APPEND to INBOX as received mail", async () => {
+    const store = makeAppendStore();
+    const response = await runAppend("A102", store, null, "INBOX");
+
+    expect(response).toContain("A102 OK [APPENDUID");
+    expect(store.appended[0].mail.sent).toBe(false);
+    expect(uidReservations.every((r) => r.sent)).toBe(false);
+  });
+
+  it("files an APPEND to a per-account Sent box as sent mail scoped to that box", async () => {
+    const store = makeAppendStore();
+    await runAppend("A103", store, null, "Sent Messages/accounts/admin");
+
+    expect(store.appended[0].mail.sent).toBe(true);
+    // Account-scoped: the box path reaches the mail_mailbox_uid dual-write.
+    expect(store.appended[0].mailbox).toBe("Sent Messages/accounts/admin");
+    expect(uidReservations.every((r) => r.sent)).toBe(true);
+  });
+
+  it("answers NO [TRYCREATE] for a mailbox that does not exist and stores nothing", async () => {
+    const store = makeAppendStore();
+    const response = await runAppend("A104", store, null, "ZzNoSuchMailbox");
+
+    expect(response).toBe("A104 NO [TRYCREATE] Mailbox does not exist\r\n");
+    expect(response).not.toContain("APPENDUID");
+    expect(store.appended).toHaveLength(0);
+    // Nothing is reserved for a rejected APPEND — no UID burned.
+    expect(uidReservations).toHaveLength(0);
+  });
+
+  it("still accepts a lowercase inbox target (RFC 3501 §5.1)", async () => {
+    const store = makeAppendStore();
+    const response = await runAppend("A105", store, null, "inbox");
+
+    expect(response).toContain("A105 OK [APPENDUID");
+    expect(store.appended[0].mail.sent).toBe(false);
   });
 });
 
@@ -448,6 +544,7 @@ async function appendAndCapture(flags?: string[]): Promise<MailType> {
   let captured: MailType | undefined;
   const store = {
     getUser: () => ({ id: 1, username: "admin" }),
+    mailboxExists: async () => true,
     storeMail: async (mail: MailType) => {
       captured = mail;
       return true;

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -159,11 +159,13 @@ type FakeStore = {
 };
 
 // The listable set a Store would report for user "admin": INBOX, the unified
-// Sent folder, and one per-account box in each lane.
+// Sent folder, and one per-account box in each lane. The received per-account
+// path is `INBOX/accounts/<local>` (ACCOUNTS_FOLDER in util.ts), not
+// `accounts/<local>` — `accountToBox` builds it from that prefix.
 const EXISTING_MAILBOXES = [
   "INBOX",
   "Sent Messages",
-  "accounts/admin",
+  "INBOX/accounts/admin",
   "Sent Messages/accounts/admin",
 ];
 
@@ -266,6 +268,24 @@ describe("appendMessage — target mailbox (#695)", () => {
     // Account-scoped: the box path reaches the mail_mailbox_uid dual-write.
     expect(store.appended[0].mailbox).toBe("Sent Messages/accounts/admin");
     expect(uidReservations.every((r) => r.sent)).toBe(true);
+    // Domain reservation is unscoped; the account one is keyed on the box's
+    // address. The domain half varies with EMAIL_DOMAIN, so pin the local part.
+    expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
+    expect(uidReservations[1].scope.split("@")[0]).toBe("admin");
+  });
+
+  it("files an APPEND to a per-account received box as received mail scoped to that box", async () => {
+    const store = makeAppendStore();
+    await runAppend("A106", store, null, "INBOX/accounts/admin");
+
+    // The received lane is the mirror of A103 — without this the suite would
+    // pass a regression that made `sent` unconditionally true for every
+    // account-scoped target.
+    expect(store.appended[0].mail.sent).toBe(false);
+    expect(store.appended[0].mailbox).toBe("INBOX/accounts/admin");
+    expect(uidReservations.every((r) => r.sent)).toBe(false);
+    expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
+    expect(uidReservations[1].scope.split("@")[0]).toBe("admin");
   });
 
   it("answers NO [TRYCREATE] for a mailbox that does not exist and stores nothing", async () => {

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -128,6 +128,9 @@ const {
   cloneMailToDestination,
 } = await import("./message-ops");
 const { resetPool } = await import("../postgres/client");
+// Dynamic, like the imports above: a hoisted `import … from "server"` would
+// pull the barrel (and postgres/client) before the pg double is registered.
+const { getUserDomain } = await import("server");
 
 beforeAll(() => {
   mock.module("pg", pgMock);
@@ -167,6 +170,7 @@ const EXISTING_MAILBOXES = [
   "Sent Messages",
   "INBOX/accounts/admin",
   "Sent Messages/accounts/admin",
+  "Archive",
 ];
 
 const makeAppendStore = (
@@ -246,9 +250,11 @@ describe("appendMessage — target mailbox (#695)", () => {
     expect(store.appended[0].mail.sent).toBe(true);
     // Domain-scoped: storeMail takes no per-mailbox arg for INBOX / Sent.
     expect(store.appended[0].mailbox).toBeUndefined();
-    // Both UID lanes are reserved on the sent side of the counter.
-    expect(uidReservations.every((r) => r.sent)).toBe(true);
+    // Both UID lanes are reserved on the sent side of the counter. Pinned
+    // per-reservation: `every(r => r.sent) === false` would be satisfied by
+    // the domain half alone and would miss an inverted account lane.
     expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
+    expect(uidReservations.map((r) => r.sent)).toEqual([true, true]);
   });
 
   it("files an APPEND to INBOX as received mail", async () => {
@@ -257,7 +263,7 @@ describe("appendMessage — target mailbox (#695)", () => {
 
     expect(response).toContain("A102 OK [APPENDUID");
     expect(store.appended[0].mail.sent).toBe(false);
-    expect(uidReservations.every((r) => r.sent)).toBe(false);
+    expect(uidReservations.map((r) => r.sent)).toEqual([false, false]);
   });
 
   it("files an APPEND to a per-account Sent box as sent mail scoped to that box", async () => {
@@ -267,11 +273,11 @@ describe("appendMessage — target mailbox (#695)", () => {
     expect(store.appended[0].mail.sent).toBe(true);
     // Account-scoped: the box path reaches the mail_mailbox_uid dual-write.
     expect(store.appended[0].mailbox).toBe("Sent Messages/accounts/admin");
-    expect(uidReservations.every((r) => r.sent)).toBe(true);
     // Domain reservation is unscoped; the account one is keyed on the box's
-    // address. The domain half varies with EMAIL_DOMAIN, so pin the local part.
+    // address, which `getUserDomain` derives from the username.
     expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
-    expect(uidReservations[1].scope.split("@")[0]).toBe("admin");
+    expect(uidReservations.map((r) => r.sent)).toEqual([true, true]);
+    expect(uidReservations[1].scope).toBe(`admin@${getUserDomain("admin")}`);
   });
 
   it("files an APPEND to a per-account received box as received mail scoped to that box", async () => {
@@ -283,9 +289,23 @@ describe("appendMessage — target mailbox (#695)", () => {
     // account-scoped target.
     expect(store.appended[0].mail.sent).toBe(false);
     expect(store.appended[0].mailbox).toBe("INBOX/accounts/admin");
-    expect(uidReservations.every((r) => r.sent)).toBe(false);
     expect(uidReservations.map((r) => r.kind)).toEqual(["domain", "account"]);
-    expect(uidReservations[1].scope.split("@")[0]).toBe("admin");
+    expect(uidReservations.map((r) => r.sent)).toEqual([false, false]);
+    expect(uidReservations[1].scope).toBe(`admin@${getUserDomain("admin")}`);
+  });
+
+  it("files an APPEND to a user-created box as received mail scoped to that box", async () => {
+    const store = makeAppendStore();
+    await runAppend("A107", store, null, "Archive");
+
+    // A user-created box is neither sent nor domain-scoped, so it takes the
+    // received lane and the box path. Note this does NOT remove the message
+    // from INBOX: INBOX's read path filters on `sent` with no mailbox join,
+    // so a received-lane message is in both views. Same for COPY/MOVE.
+    expect(store.appended[0].mail.sent).toBe(false);
+    expect(store.appended[0].mailbox).toBe("Archive");
+    expect(uidReservations.map((r) => r.sent)).toEqual([false, false]);
+    expect(uidReservations[1].scope).toBe(`Archive@${getUserDomain("admin")}`);
   });
 
   it("answers NO [TRYCREATE] for a mailbox that does not exist and stores nothing", async () => {

--- a/src/server/lib/imap/message-ops.test.ts
+++ b/src/server/lib/imap/message-ops.test.ts
@@ -289,8 +289,11 @@ describe("appendMessage — target mailbox (#695)", () => {
     expect(response).toContain("A101 OK [APPENDUID");
     expect(store.appended).toHaveLength(1);
     expect(store.appended[0].mail.sent).toBe(true);
-    // Domain-scoped: storeMail takes no per-mailbox arg for INBOX / Sent.
-    expect(store.appended[0].mailbox).toBeUndefined();
+    // appendMessage hands storeMail the canonical target box; storeMail is
+    // what drops it for a domain-scoped destination when it builds the
+    // mapping row (`!isDomainScoped(destination) ? destination : undefined`).
+    // Asserting `undefined` here would pin the wrong layer.
+    expect(store.appended[0].mailbox).toBe("Sent Messages");
     // Both UID lanes are reserved on the sent side of the counter. Pinned
     // per-reservation: `every(r => r.sent) === false` would be satisfied by
     // the domain half alone and would miss an inverted account lane.

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -1163,9 +1163,7 @@ export async function appendMessage(
     // (false), skipping onAppended (the sequence-mapping rebuild) and
     // leaving the next seq-numbered FETCH for the appended message
     // returning wrong/missing data.
-    const targetMailbox = isInbox(appendRequest.mailbox)
-      ? "INBOX"
-      : appendRequest.mailbox;
+    const targetMailbox = canonicalMailbox(appendRequest.mailbox);
 
     // RFC 3501 §6.3.11: the target must exist. The server MUST NOT create
     // it, and answers NO [TRYCREATE] so the client can CREATE and retry.
@@ -1223,14 +1221,6 @@ export async function appendMessage(
     }
 
     const user = store.getUser();
-    // RFC 3501 §5.1: INBOX is case-insensitive. SELECT canonicalizes
-    // selectedMailbox to "INBOX"; APPEND must canonicalize the target to
-    // match — otherwise a SELECT inbox + APPEND inbox sequence reads
-    // `selectedMailbox === appendRequest.mailbox` as `"INBOX" === "inbox"`
-    // (false), skipping onAppended (the sequence-mapping rebuild) and
-    // leaving the next seq-numbered FETCH for the appended message
-    // returning wrong/missing data.
-    const targetMailbox = canonicalMailbox(appendRequest.mailbox);
     const account = boxToAccount(user.username, targetMailbox);
     // `sent` is what separates the two domain-scoped views — INBOX and the
     // unified Sent folder share `uid_domain` and are told apart by this

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -1156,6 +1156,25 @@ export async function appendMessage(
   onAppended: () => Promise<void>
 ): Promise<void> {
   try {
+    // RFC 3501 §5.1: INBOX is case-insensitive. SELECT canonicalizes
+    // selectedMailbox to "INBOX"; APPEND must canonicalize the target to
+    // match — otherwise a SELECT inbox + APPEND inbox sequence reads
+    // `selectedMailbox === appendRequest.mailbox` as `"INBOX" === "inbox"`
+    // (false), skipping onAppended (the sequence-mapping rebuild) and
+    // leaving the next seq-numbered FETCH for the appended message
+    // returning wrong/missing data.
+    const targetMailbox = isInbox(appendRequest.mailbox)
+      ? "INBOX"
+      : appendRequest.mailbox;
+
+    // RFC 3501 §6.3.11: the target must exist. The server MUST NOT create
+    // it, and answers NO [TRYCREATE] so the client can CREATE and retry.
+    // Gated before parsing so a rejected APPEND doesn't walk the literal.
+    if (!(await store.mailboxExists(targetMailbox))) {
+      write(`${tag} NO [TRYCREATE] Mailbox does not exist\r\n`);
+      return;
+    }
+
     const messageLines = appendRequest.message.split("\r\n");
     let headerEndIndex = messageLines.findIndex((line) => line === "");
     if (headerEndIndex === -1) headerEndIndex = messageLines.length;
@@ -1210,14 +1229,22 @@ export async function appendMessage(
     // returning wrong/missing data.
     const targetMailbox = canonicalMailbox(appendRequest.mailbox);
     const account = boxToAccount(user.username, targetMailbox);
-    const domainUid = await getDomainUidNext(user.id);
+    // `sent` is what separates the two domain-scoped views — INBOX and the
+    // unified Sent folder share `uid_domain` and are told apart by this
+    // column alone — so it has to reach both the stored row and the UID
+    // counters, which key their per-user sequences on (user, sent). Same
+    // shape as COPY/MOVE above.
+    const targetIsSent = isSentBox(targetMailbox);
+    mail.sent = targetIsSent;
+    const domainUid = await getDomainUidNext(user.id, targetIsSent);
     // Same split as COPY/MOVE: a mapped-utility target (`Starred`/`Trash`)
-    // reserves from the per-mailbox counter (no `sent` axis), everything
-    // else from the per-account counter. `mail.sent` on an APPENDed row is
-    // false — the counter axis matches.
+    // reserves from the per-mailbox counter, which has no `sent` axis —
+    // those boxes are not domain-scoped, so the pair (user, mailbox) is the
+    // whole key. Everything else reserves from the per-account counter,
+    // which does key on `sent`.
     const accountUid = isMappedUtilityFolder(targetMailbox)
       ? await getMailboxUidNext(user.id, targetMailbox)
-      : await getAccountUidNext(user.id, account);
+      : await getAccountUidNext(user.id, account, targetIsSent);
     mail.uid.domain = domainUid;
     mail.uid.account = accountUid;
 

--- a/src/server/lib/imap/message-ops.ts
+++ b/src/server/lib/imap/message-ops.ts
@@ -1169,7 +1169,10 @@ export async function appendMessage(
 
     // RFC 3501 §6.3.11: the target must exist. The server MUST NOT create
     // it, and answers NO [TRYCREATE] so the client can CREATE and retry.
-    // Gated before parsing so a rejected APPEND doesn't walk the literal.
+    // Gated ahead of the RFC822 parse so a rejected APPEND neither walks
+    // the message nor burns a UID off the counters. (Framing is unaffected
+    // either way — `handler.ts` has already consumed the whole literal off
+    // the socket before this function is entered.)
     if (!(await store.mailboxExists(targetMailbox))) {
       write(`${tag} NO [TRYCREATE] Mailbox does not exist\r\n`);
       return;


### PR DESCRIPTION
Closes #695

## Problem

`appendMessage` discarded the target mailbox entirely:

- It never set `mail.sent`, and `Mail` defaults it to `false`.
- It reserved both UIDs on the received side of the counter (`getDomainUidNext(user.id)` / `getAccountUidNext(user.id, account)` — the `sent` arg defaults to `false`).
- It had no existence gate.

INBOX is defined as the mail carrying a received-lane domain UID, so every APPEND surfaced in INBOX no matter which mailbox the client named. A client that saves its outgoing copy via APPEND (Thunderbird "Place a copy in… Sent", mutt, many others) put the user's own sent mail into their inbox, and it never appeared in Sent. A bogus target was answered `OK [APPENDUID …]` and swallowed into INBOX instead of the RFC-required `NO [TRYCREATE]`.

## Fix

Resolve the target the same way COPY/MOVE already do — the machinery existed, APPEND was the only write path skipping it:

1. Canonicalize the target through main's `canonicalMailbox` (which also fixes the spelling of the server-defined utility folders), hoisted to the top of the function so the existence gate below compares against a LIST name.
2. Gate on `store.mailboxExists(targetMailbox)` → `NO [TRYCREATE] Mailbox does not exist` (RFC 3501 §6.3.11: the server MUST return an error and MUST NOT auto-create). Placed ahead of the RFC822 parse so a rejected APPEND neither parses the message nor burns a UID off the counters. (Protocol framing is unaffected either way — `handler.ts` consumes the whole `{N}` literal before `parseCommand` runs, so `appendMessage` is only ever entered with the literal already read.)
3. Derive `targetIsSent` from `isSentBox` and thread it into `mail.sent` **and** the UID reservations that have a `sent` axis — the per-domain lane always, and the per-account lane for everything except a mapped-utility target (`Starred`/`Trash`), which reserves from `getMailboxUidNext` keyed on `(user, mailbox)` alone. That split is main's, unchanged; this PR only adds the `sent` argument on the lanes that take one.

Out of scope, left on #695 as the documented follow-up: the ignored APPEND date-time argument (INTERNALDATE is still derived from the `Date:` header).

## Test plan

### Unit — full `bun test` → 1802 pass / 0 fail (CI, head `82f6bcb`)

7 new cases in `message-ops.test.ts` under "appendMessage — target mailbox (695)", plus one in the existing `#544` describe that pins which UID space `APPENDUID` reports per lane (the mock used to return one constant for both reservations, so either lane satisfied it; `Archive` is the case that matters — neither INBOX nor account-named, read back through `mail_mailbox_uid`, so it must report the account UID). The existing `#544` / `#548` append fixtures gained a `mailboxExists` stub. The suite now captures the `(mail, mailbox)` pairs handed to `storeMail` and the `(kind, scope, sent)` tuple of every UID reservation, so the lane is asserted directly, not inferred:

- APPEND to the unified Sent folder → `mail.sent === true`, the canonical box name passed through to `storeMail` (which drops a domain-scoped destination itself when it builds the mapping row), both reservations on the sent lane
- APPEND to INBOX → `mail.sent === false`, both reservations on the received lane
- APPEND to `Sent Messages/accounts/admin` → `sent === true` + the box path reaches the `mail_mailbox_uid` dual-write
- APPEND to `INBOX/accounts/admin` (the received per-account lane) → the mirror image: `sent === false`, same box path, both reservations on the received lane
- APPEND to a nonexistent box → exactly `NO [TRYCREATE] Mailbox does not exist`, `storeMail` never called, zero UID reservations
- APPEND to a user-created box (`Archive`) → received lane + the box path (this one also documents that the message stays visible in INBOX — see the parity note below)
- APPEND to lowercase `inbox` → still accepted (RFC 3501 §5.1)

Each lane assertion pins *every* reservation (`map(r => r.sent)` against an exact array), not `every(...)` — the latter is satisfied by the domain half alone and lets an inverted account lane through. Mutation check: forcing the account reservation onto the sent lane fails 3 tests; before the assertions were tightened it failed 0.

The account-scoped assertions pin the reservation scope against `getUserDomain("admin")` rather than a literal address, so the domain-derivation rule is covered without the assertion depending on `EMAIL_DOMAIN` (verified green with it unset and with `example.test`). The import is dynamic, after the pg double is registered.

`bun run typecheck` clean. `bun run lint` — 0 errors (18 pre-existing warnings, none in the touched files).

### E2E — real IMAP protocol, before vs after

Server-side IMAP has no client surface, so this was driven over a raw socket against a throwaway Postgres DB (`inbox_e2e_695`), never the real local `inbox` DB. Two servers on separate DBs and ports, seeded identically with one sent row so the Sent folder is listable: `upstream/main` (3bdc350) as baseline, this branch as the fix. Same driver script, same command sequence, both asserted at the protocol level AND at the row level via `psql`.

| Command | `upstream/main` | this branch |
|---|---|---|
| `APPEND ZzNoSuchMailbox12345` | `OK [APPENDUID …]` | `NO [TRYCREATE] Mailbox does not exist` |
| → `SELECT INBOX` + `SEARCH SUBJECT ZzAppendNonexist` | `* SEARCH 1` (in INBOX) | `* SEARCH` (empty — nothing stored) |
| `APPEND "Sent Messages"` | `OK [APPENDUID …]` | `OK [APPENDUID …]` |
| → `SELECT INBOX` + `SEARCH SUBJECT ZzAppendToSent` | `* SEARCH 4` (in INBOX) | `* SEARCH` (empty) |
| → `SELECT "Sent Messages"` + same SEARCH | `* SEARCH` (empty) | `* SEARCH 2` (in Sent) |
| `APPEND INBOX` | in INBOX | in INBOX (unchanged) |
| `APPEND inbox` (lowercase) | in INBOX | in INBOX (unchanged) |

Row-level truth, `select subject, sent, uid_domain from mails`:

```
=== upstream/main ===          === this branch ===
ZzAppendNonexist  | f | 1      ZzAppendToInbox | f | 1
ZzSeedSent        | t | 1      ZzSeedSent      | t | 1
ZzAppendToInbox   | f | 2      ZzAppendLower   | f | 2
ZzAppendLower     | f | 3      ZzAppendToSent  | t | 2
ZzAppendToSent    | f | 4
```

Baseline: every appended message lands `sent=f` on one monotonic received-lane sequence, including the one addressed to Sent and the one addressed to a mailbox that does not exist. Fixed: the Sent append is `sent=t` and draws from the sent lane's own sequence (independent of the received lane — both legitimately reach 2), and the nonexistent-target message is absent entirely.

### E2E round 2 — cases raised in review

Same harness, fresh throwaway DB (`inbox_e2e_695b`), driven over the protocol and confirmed against `mails` ⋈ `mail_mailbox_uid`:

| case | result |
|---|---|
| `CREATE Archive` then `APPEND Archive` in the same session | `OK [APPENDUID …]` — the new gate has no stale-miss window |
| 3 back-to-back APPENDs to `Archive` | per-mailbox UIDs 1, 2, 3; `UIDNEXT` tracks to 4; no collision with the domain lane |
| `APPEND "INBOX/accounts/admin"` (received per-account lane) | filed there (`SELECT` + `SEARCH` find it), absent from Sent, `mail_mailbox_uid` row `INBOX/accounts/admin` uid 1 |
| `APPEND Archive` → `SELECT INBOX` | **also** found in INBOX — see the parity note |

### Parity note — user-created boxes

For the Sent lane the title holds exactly: an APPEND to a Sent target no longer appears in INBOX. For a **user-created** box (`Archive`) the message is filed into that box *and* remains visible in INBOX, because INBOX's read path filters on `sent` with no `mail_mailbox_uid` join. That is pre-existing and identical for COPY and MOVE (`newMail.sent = destIsSent` with no INBOX suppression), so this PR doesn't change it — it's now pinned by a test and stated here rather than left implied.

### Behavior note

`mailboxExists` reports the unified Sent folder only once the user has at least one sent mail, so on an account that has never sent anything, `APPEND "Sent Messages"` answers `NO [TRYCREATE]`. The exposure is narrow: inbox runs its own SMTP submission server whose `onDataOutgoing` awaits `sendMail` (which writes `sent: true`) before ACKing, so in the ordinary send-then-APPEND-the-copy flow the sent row already exists and the folder is listable. Only a client pairing inbox's IMAP with third-party SMTP, before any send, reaches it — and for that user the folder was never in LIST either. `NO [TRYCREATE]` is the response clients are built to handle.

Sandbox: not spun — this is an IMAP protocol change with no web-client surface; the E2E above drives the actual affected protocol.

## Review

reviewoie rounds 1 and 2 raised nine findings. Six are addressed here (the gate comment's literal-framing claim was wrong; the test fixture named a mailbox path the server cannot emit; the received per-account lane had no coverage; the lane assertions used `every(...)`, which a lane inversion passed; the scope assertion depended on `EMAIL_DOMAIN`; user-created boxes were the one listable class with no case). Round 2's HIGH was a genuine hole — the assertion did not pin what this body claimed it did. Two are cross-cutting and filed separately rather than folded in, because both are properties of `Store.mailboxExists` shared by the COPY / MOVE / SELECT / STATUS / RENAME gates:

- #800 — APPEND/COPY/MOVE accept the `\Noselect` accounts parent folders as a destination.
- #801 — `mailboxExists` builds the whole listable set (two full-table JSONB aggregates) per check, which APPEND pays per message.

Neither gates this fix; #801 notes that the existence check is required for the RFC-mandated `NO [TRYCREATE]`, so the cost is inherent to the gate rather than to this change. Full reasoning in the PR comment thread.

## Rebase history

### Onto `da2b242` (current base)

Rebased again onto today's main, picking up 773 (lazy `BODY[TEXT]` streaming)
and 685 (IDB-seeded header revalidation). Clean — no conflicts. Current head
`82f6bcb`, CI green on all three checks (secrets-scan, test, build), full
`bun test` 1802 pass / 0 fail.

Note on the two E2E sections above: they were driven at the pre-utility-folder
base (`3bdc350`) and have not been re-run since main landed 725's
`Starred`/`Trash`/`Drafts`/`Junk` work. The lane behaviour they demonstrate is
now carried by the unit cases, including the mapped-utility split.

### Onto `0bf9a32` (pick up 835)

The rebase collided in `appendMessage`, resolved in `82f6bcb`: `targetMailbox`
was declared twice (this branch's inline `isInbox(...) ? "INBOX" : …` vs main's
`canonicalMailbox(...)` — kept main's, since the `mailboxExists` gate right
below depends on the utility folders being canonicalized too); the account UID
lane now goes through main's mapped-utility split while keeping this branch's
`sent` argument on the lanes that have that axis; and the Sent-folder test's
"no mailbox argument" assertion was pinning the wrong layer once main moved
that decision inside `storeMail`, so it now asserts the canonical box is passed
through.

Picking up 835 is what cleared the two CI failures this branch had been
carrying: `users.test.ts` failed 12 cases on Linux because
this file's own pg double answered *every* unmatched SELECT with a truthy
`USER_ROW`, and Bun's `mock.module` is process-global. That is a pre-existing
main bug (the same 12 failures hit PRs 836 and 828 on unrelated branches), not
a defect in this change — the branch was green locally on macOS throughout.

Both rebase conflicts were in `message-ops.test.ts`, in the same `mockQuery`
helper, and were resolved as a union: 835's hardening is preserved verbatim
(the `sqlStr` normalization, the `next_uid` guard, the `/from\s+users\b/i`
narrowing, and the empty-by-default return) and this PR's per-lane
`uidReservations` tracking sits inside the `next_uid` branch on top of it.

At that base: `bun run typecheck` clean, `bun run lint` 0 errors (18
pre-existing warnings), full `bun test` 1775 pass / 0 fail, CI green.

