### PR TITLE
feat(imap): optional wire-trace under IMAP_TRACE=1

### DIFF
--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -6,6 +6,7 @@ import { Socket } from "net";
 import { ImapSession } from "./session";
 import { ImapRequest } from "./types";
 import { parseCommand } from "./parsers";
+import { imapTrace } from "./trace";
 import { getBodyBudgetWaitMs, runInBodyBudgetContext } from "./body-budget";
 import { SOCKET_TIMEOUT_MS } from "./idle-manager";
 import { logger } from "server";
@@ -198,6 +199,7 @@ export class ImapRequestHandler {
               command: line.trim(),
               mailbox: session.selectedMailbox
             });
+            imapTrace("in", session.getSessionId(), line.trim());
 
             // Pace pipelined bursts. RFC 3501 §7 requires a tagged
             // completion for every command, so over-limit commands are

--- a/src/server/lib/imap/session.ts
+++ b/src/server/lib/imap/session.ts
@@ -23,6 +23,7 @@ import {
 import { getCapabilities } from "./capabilities";
 import { ImapRequestHandler } from "./handler";
 import { writeChunkedToSocket, writeStreamToSocket } from "./chunked-write";
+import { imapTrace } from "./trace";
 
 // Extracted module helpers
 import { handleAuthenticate, handleLogin } from "./auth";
@@ -122,6 +123,7 @@ export class ImapSession {
       // Only count after a successful call — a write that throws never
       // reached the wire.
       this.bytesWritten += Buffer.byteLength(data, "utf8");
+      imapTrace("out", this.sessionId, data);
       return ok;
     } catch (error) {
       logger.error("Error writing to socket", { component: "imap" }, error);

--- a/src/server/lib/imap/trace.test.ts
+++ b/src/server/lib/imap/trace.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { logger } from "server";
+
+describe("imapTrace", () => {
+  const originalTrace = process.env.IMAP_TRACE;
+  let infoSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    infoSpy = spyOn(logger, "info");
+  });
+  afterEach(() => {
+    infoSpy.mockRestore();
+    if (originalTrace === undefined) delete process.env.IMAP_TRACE;
+    else process.env.IMAP_TRACE = originalTrace;
+  });
+
+  it("is a no-op when IMAP_TRACE is not set", async () => {
+    delete process.env.IMAP_TRACE;
+    delete require.cache[require.resolve("./trace")];
+    const { imapTrace } = await import("./trace");
+    imapTrace("in", "session_abc", "A1 NOOP");
+    expect(infoSpy).not.toHaveBeenCalled();
+  });
+
+  it("emits one info per non-empty CRLF-split line when IMAP_TRACE=1", async () => {
+    process.env.IMAP_TRACE = "1";
+    delete require.cache[require.resolve("./trace")];
+    const { imapTrace } = await import("./trace");
+    imapTrace("out", "session_abc", "* 5 EXISTS\r\n* 5 RECENT\r\nA1 OK NOOP completed\r\n");
+    expect(infoSpy).toHaveBeenCalledTimes(3);
+    const lines = infoSpy.mock.calls.map((c) => (c[1] as { line: string }).line);
+    expect(lines).toEqual([
+      "* 5 EXISTS",
+      "* 5 RECENT",
+      "A1 OK NOOP completed",
+    ]);
+  });
+
+  it("clips lines longer than the cap and marks the overflow", async () => {
+    process.env.IMAP_TRACE = "1";
+    delete require.cache[require.resolve("./trace")];
+    const { imapTrace } = await import("./trace");
+    const long = "X".repeat(250);
+    imapTrace("out", "session_abc", long);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = (infoSpy.mock.calls[0][1] as { line: string }).line;
+    expect(line.length).toBeLessThan(long.length);
+    expect(line.endsWith("…[+50]")).toBe(true);
+  });
+});

--- a/src/server/lib/imap/trace.test.ts
+++ b/src/server/lib/imap/trace.test.ts
@@ -47,6 +47,24 @@ describe("imapTrace", () => {
     expect(line).not.toContain("hunter2");
   });
 
+  it("drops LITERAL+ continuation lines on inbound (no <tag> <VERB> prefix)", async () => {
+    process.env.IMAP_TRACE = "1";
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    // A hypothetical LITERAL+ client sends `A1 LOGIN {5+}\r\nadmin {8+}\r\npassword\r\n`.
+    // The handler CRLF-splits with no literal-continuation state, so `admin {8+}`
+    // and `password` reach imapTrace as their own inbound lines. Neither matches
+    // <tag> <VERB> — both must be dropped before they land in the journal.
+    imapTrace("in", "session_abc", "A1 LOGIN {5+}\r\nadmin {8+}\r\npassword");
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = (infoSpy.mock.calls[0][1] as { line: string }).line;
+    expect(line).toBe("A1 LOGIN [REDACTED]");
+    const anyCallHasPassword = infoSpy.mock.calls.some((c) =>
+      JSON.stringify(c).includes("password")
+    );
+    expect(anyCallHasPassword).toBe(false);
+  });
+
   it("redacts AUTHENTICATE initial response on inbound (RFC 4959)", async () => {
     process.env.IMAP_TRACE = "1";
     const { imapTrace } = await importTrace();

--- a/src/server/lib/imap/trace.test.ts
+++ b/src/server/lib/imap/trace.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { logger } from "server";
 
+const importTrace = async () => {
+  delete require.cache[require.resolve("./trace")];
+  return await import("./trace");
+};
+
 describe("imapTrace", () => {
   const originalTrace = process.env.IMAP_TRACE;
   let infoSpy: ReturnType<typeof spyOn>;
@@ -16,35 +21,101 @@ describe("imapTrace", () => {
 
   it("is a no-op when IMAP_TRACE is not set", async () => {
     delete process.env.IMAP_TRACE;
-    delete require.cache[require.resolve("./trace")];
-    const { imapTrace } = await import("./trace");
+    const { imapTrace } = await importTrace();
     imapTrace("in", "session_abc", "A1 NOOP");
     expect(infoSpy).not.toHaveBeenCalled();
   });
 
-  it("emits one info per non-empty CRLF-split line when IMAP_TRACE=1", async () => {
+  it("emits one info per non-empty CRLF-split inbound line when IMAP_TRACE=1", async () => {
     process.env.IMAP_TRACE = "1";
-    delete require.cache[require.resolve("./trace")];
-    const { imapTrace } = await import("./trace");
-    imapTrace("out", "session_abc", "* 5 EXISTS\r\n* 5 RECENT\r\nA1 OK NOOP completed\r\n");
-    expect(infoSpy).toHaveBeenCalledTimes(3);
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear(); // ignore the load-time enable-notice
+    imapTrace("in", "session_abc", "A1 NOOP\r\nA2 CAPABILITY\r\n");
+    expect(infoSpy).toHaveBeenCalledTimes(2);
     const lines = infoSpy.mock.calls.map((c) => (c[1] as { line: string }).line);
-    expect(lines).toEqual([
-      "* 5 EXISTS",
-      "* 5 RECENT",
-      "A1 OK NOOP completed",
-    ]);
+    expect(lines).toEqual(["A1 NOOP", "A2 CAPABILITY"]);
+  });
+
+  it("redacts LOGIN password on inbound", async () => {
+    process.env.IMAP_TRACE = "1";
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    imapTrace("in", "session_abc", 'A1 LOGIN "admin" "hunter2"');
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = (infoSpy.mock.calls[0][1] as { line: string }).line;
+    expect(line).toBe("A1 LOGIN [REDACTED]");
+    expect(line).not.toContain("hunter2");
+  });
+
+  it("redacts AUTHENTICATE initial response on inbound (RFC 4959)", async () => {
+    process.env.IMAP_TRACE = "1";
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    imapTrace("in", "session_abc", "A2 AUTHENTICATE PLAIN AGFkbWluAGh1bnRlcjI=");
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = (infoSpy.mock.calls[0][1] as { line: string }).line;
+    expect(line).toBe("A2 AUTHENTICATE PLAIN [REDACTED]");
+    expect(line).not.toContain("AGFkbWlu");
+  });
+
+  it("emits outbound framing lines that match the allowlist", async () => {
+    process.env.IMAP_TRACE = "1";
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    imapTrace(
+      "out",
+      "session_abc",
+      [
+        "* OK IMAP4rev1 Service Ready",
+        "* CAPABILITY IMAP4rev1 LITERAL+",
+        "* 12 EXISTS",
+        "* 0 RECENT",
+        "* BYE Server logging out",
+        "+ go ahead",
+        "A1 OK LOGIN completed",
+        "A2 NO Not authenticated.",
+        "A3 BAD Invalid syntax",
+      ].join("\r\n")
+    );
+    expect(infoSpy).toHaveBeenCalledTimes(9);
+  });
+
+  it("drops untagged FETCH data + literal payload + ENVELOPE content", async () => {
+    process.env.IMAP_TRACE = "1";
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    imapTrace(
+      "out",
+      "session_abc",
+      [
+        "* 5 FETCH (UID 100 RFC822.SIZE 19222751 FLAGS (\\Seen))",
+        "Subject: Attorney client privileged — do not disclose",
+        "From: someone@example.com",
+        'ENVELOPE ("Wed" "hello" ((NIL NIL "alice" "ex.com")) …)',
+        ")",
+      ].join("\r\n")
+    );
+    expect(infoSpy).not.toHaveBeenCalled();
   });
 
   it("clips lines longer than the cap and marks the overflow", async () => {
     process.env.IMAP_TRACE = "1";
-    delete require.cache[require.resolve("./trace")];
-    const { imapTrace } = await import("./trace");
-    const long = "X".repeat(250);
-    imapTrace("out", "session_abc", long);
+    const { imapTrace } = await importTrace();
+    infoSpy.mockClear();
+    const filler = "X".repeat(600);
+    imapTrace("in", "session_abc", `A1 SELECT ${filler}`);
     expect(infoSpy).toHaveBeenCalledTimes(1);
     const line = (infoSpy.mock.calls[0][1] as { line: string }).line;
-    expect(line.length).toBeLessThan(long.length);
-    expect(line.endsWith("…[+50]")).toBe(true);
+    expect(line.length).toBeLessThan(600 + "A1 SELECT ".length);
+    expect(line).toMatch(/…\[\+\d+\]$/);
+  });
+
+  it("emits a one-time enable notice at module load when IMAP_TRACE=1", async () => {
+    process.env.IMAP_TRACE = "1";
+    await importTrace();
+    const enableCall = infoSpy.mock.calls.find(
+      (c) => (c[0] as string).includes("IMAP wire trace ENABLED")
+    );
+    expect(enableCall).toBeDefined();
   });
 });

--- a/src/server/lib/imap/trace.ts
+++ b/src/server/lib/imap/trace.ts
@@ -3,6 +3,14 @@ import { logger } from "server";
 const TRACE_ON = process.env.IMAP_TRACE === "1";
 const LINE_CAP = 512;
 
+// Inbound allow-shape. The handler CRLF-splits the socket buffer line-by-line
+// with no LITERAL continuation state, so `LOGIN {5+}\r\nadmin {8+}\r\npassword`
+// would emit two follow-up lines whose content is a secret but whose text
+// doesn't match the LOGIN/AUTHENTICATE prefix `redactCredentials` looks for.
+// Requiring `<tag> <VERB>` at the start drops every non-command line —
+// literal-continuation payload, junk, empty — before any redaction runs.
+const INBOUND_COMMAND = /^[A-Za-z0-9]+\s+[A-Z]+\b/;
+
 // LOGIN carries the plaintext password as the last quoted arg; AUTHENTICATE
 // carries the SASL initial response (RFC 4959) — base64-decoded, PLAIN yields
 // `\0user\0password`. Both must be scrubbed before the line lands in the
@@ -42,6 +50,7 @@ export const imapTrace = (
   if (!TRACE_ON) return;
   for (const raw of data.split("\r\n")) {
     if (!raw) continue;
+    if (direction === "in" && !INBOUND_COMMAND.test(raw)) continue;
     if (direction === "out" && !OUTBOUND_FRAMING.test(raw)) continue;
     const sanitized = direction === "in" ? redactCredentials(raw) : raw;
     logger.info(`IMAP wire ${direction}`, {

--- a/src/server/lib/imap/trace.ts
+++ b/src/server/lib/imap/trace.ts
@@ -1,0 +1,25 @@
+import { logger } from "server";
+
+const TRACE_ON = process.env.IMAP_TRACE === "1";
+const LINE_CAP = 200;
+
+const clip = (s: string): string =>
+  s.length <= LINE_CAP ? s : `${s.slice(0, LINE_CAP)}…[+${s.length - LINE_CAP}]`;
+
+export const imapTrace = (
+  direction: "in" | "out",
+  sessionId: string,
+  data: string
+): void => {
+  if (!TRACE_ON) return;
+  for (const raw of data.split("\r\n")) {
+    if (!raw) continue;
+    logger.info(`IMAP wire ${direction}`, {
+      component: "imap.trace",
+      sessionId,
+      line: clip(raw),
+    });
+  }
+};
+
+export const isImapTraceOn = (): boolean => TRACE_ON;

--- a/src/server/lib/imap/trace.ts
+++ b/src/server/lib/imap/trace.ts
@@ -1,7 +1,35 @@
 import { logger } from "server";
 
 const TRACE_ON = process.env.IMAP_TRACE === "1";
-const LINE_CAP = 200;
+const LINE_CAP = 512;
+
+// LOGIN carries the plaintext password as the last quoted arg; AUTHENTICATE
+// carries the SASL initial response (RFC 4959) — base64-decoded, PLAIN yields
+// `\0user\0password`. Both must be scrubbed before the line lands in the
+// journal.
+const redactCredentials = (line: string): string =>
+  line
+    .replace(/^(\S+\s+LOGIN\s+).*$/i, "$1[REDACTED]")
+    .replace(/^(\S+\s+AUTHENTICATE\s+\S+)\s+.*$/i, "$1 [REDACTED]");
+
+// Outbound allowlist. The plain `write()` path also carries FETCH response
+// atoms — HEADER.FIELDS literal payload, ENVELOPE strings, BODY[HEADER] data —
+// which contain real mail headers (Subject/From/To/Message-ID). Tracing every
+// outbound write() would spill that into the journal on any FETCH burst.
+//
+// This regex keeps only IMAP framing and status lines the diagnostic actually
+// needs — tag completions (OK/NO/BAD), untagged server status (`* OK …`,
+// `* CAPABILITY`, `* BYE`), sequence updates without a data tuple (EXISTS /
+// RECENT / EXPUNGE), and the `+` continuation prompt. Anything else outbound
+// is dropped silently.
+const OUTBOUND_FRAMING = new RegExp(
+  [
+    /^\+ /.source, // continuation ("+ go ahead", "+ idling")
+    /^\* (?:OK|BAD|NO|BYE|CAPABILITY|ENABLED|PREAUTH)\b/.source,
+    /^\* \d+ (?:EXISTS|RECENT|EXPUNGE)\s*$/.source,
+    /^[A-Za-z0-9]+ (?:OK|BAD|NO) /.source,
+  ].join("|")
+);
 
 const clip = (s: string): string =>
   s.length <= LINE_CAP ? s : `${s.slice(0, LINE_CAP)}…[+${s.length - LINE_CAP}]`;
@@ -14,12 +42,18 @@ export const imapTrace = (
   if (!TRACE_ON) return;
   for (const raw of data.split("\r\n")) {
     if (!raw) continue;
+    if (direction === "out" && !OUTBOUND_FRAMING.test(raw)) continue;
+    const sanitized = direction === "in" ? redactCredentials(raw) : raw;
     logger.info(`IMAP wire ${direction}`, {
       component: "imap.trace",
       sessionId,
-      line: clip(raw),
+      line: clip(sanitized),
     });
   }
 };
 
-export const isImapTraceOn = (): boolean => TRACE_ON;
+if (TRACE_ON) {
+  logger.info("IMAP wire trace ENABLED via IMAP_TRACE=1", {
+    component: "imap.trace",
+  });
+}


### PR DESCRIPTION
## Summary
- New file `src/server/lib/imap/trace.ts` — `imapTrace(direction, sessionId, data)`; short-circuit no-op when `IMAP_TRACE` env var is not `"1"`. When enabled, emits a one-time `IMAP wire trace ENABLED` info log at module load, then one `logger.info` per non-empty CRLF-split line under `component: "imap.trace"`, clipped at 512 chars.
- **Inbound:** every parsed command line traced. `LOGIN "user" "pass"` and `AUTHENTICATE PLAIN <initial-response>` are redacted to `<tag> LOGIN [REDACTED]` / `<tag> AUTHENTICATE PLAIN [REDACTED]` before the line lands in the journal.
- **Outbound:** allowlist — only lines matching IMAP framing patterns are traced (tag completions `OK/BAD/NO`, `+` continuation, `* OK/BAD/NO/BYE/CAPABILITY/ENABLED/PREAUTH`, `* <n> EXISTS/RECENT/EXPUNGE`). Everything else is dropped, so untagged `* <n> FETCH (...)` opener lines, LITERAL header payload (`write(string)` at fetch-helpers.ts:928), and ENVELOPE atoms (:938) don't leak header content — Subject/From/To/Message-ID stay out of journald on FETCH bursts.
- Streaming body chunks (`writeChunked` / `writeStream`) already bypass the trace by construction. The APPEND literal path also doesn't call trace — inbound raw mail bytes never reach the log.

## Motivation

iOS Mail is retry-looping on UID 12381 (19,490,973 bytes). Prior theory — `rfc822_size` drift between stored value and current serializer — was refuted out-of-band: an in-container diagnostic recomputed `computeFullMessageSize()` for the 7 target UIDs and every stored value matched byte-perfect. RFC822.SIZE isn't lying, so the retry loop must be on a different shape (framing, partial-offset math, an unexpected SEARCH/STATUS, IDLE-related). Existing debug log for received commands never fires in prod (default LOG_LEVEL=info) and covers only inbound; ad-hoc `docker exec … tcpdump` would need TLS session keys. This adds a scoped flip-on/flip-off trace to see the actual conversation.

## Usage

Prod (temporary window during a retry burst):
```
# Set IMAP_TRACE=1 in the container env (docker-compose override or `docker exec -e`)
# and restart the process. On startup you'll see one:
#   IMAP wire trace ENABLED via IMAP_TRACE=1
# Then per-command entries; grep with:
docker logs hoie-inbox-1 --since 2m 2>&1 | grep 'imap.trace'
```

Zero runtime cost when unset (single-boolean short-circuit at the top of `imapTrace`).

## Test plan
- [x] Unit: 8 tests in `trace.test.ts` — no-op default, per-line info emit, LOGIN redaction, AUTHENTICATE redaction, outbound allowlist accepts framing, outbound allowlist drops FETCH literal / ENVELOPE / raw header content, cap-and-clip, load-time enable notice.
- [x] Full `bun test src/server` — 1576/1576 pass.
- [x] E2E (raw-socket TLS-off on sandbox pr-804): drove LOGIN → SELECT INBOX → UID FETCH 12300 (UID FLAGS INTERNALDATE RFC822.SIZE ENVELOPE BODY.PEEK[HEADER.FIELDS (SUBJECT FROM TO MESSAGE-ID)]) → LOGOUT. Confirmed:
  - `IMAP wire in` fires for each command, LOGIN line reads `A1 LOGIN [REDACTED]`.
  - `IMAP wire out` fires for banner, EXISTS/RECENT, tag completions.
  - `Subject:`/`From:`/`To:`/`Message-ID:` grep across the trace log: **zero hits** (the FETCH did surface a real mail row's HEADER.FIELDS to the client; only its framing landed in the trace).
- [x] Load-time notice observed: `IMAP wire trace ENABLED via IMAP_TRACE=1` on startup.

## Reviewoie R1
Findings addressed in commit 540e907 — response comment on the review thread.