### PR TITLE
fix(imap): quote BODYSTRUCTURE strings per RFC 3501 §9 (unsticks iOS Mail retry loop)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -991,9 +991,10 @@ describe("buildFetchResponsePart BODYSTRUCTURE cached-column short-circuit (#740
     expect(part!.type).toBe("simple");
     if (part!.type === "simple") {
       // Single text part shape — no HTML, no attachments.
-      // Format: (TEXT PLAIN ("CHARSET" "UTF-8") NIL NIL BASE64 <size> <lines>)
-      expect(part!.content).toContain('"TEXT" "PLAIN"'.replace(/"/g, ""));
-      expect(part!.content).toContain("BASE64 44 42");
+      // Format: ("TEXT" "PLAIN" ("CHARSET" "UTF-8") NIL NIL "BASE64" <size> <lines>)
+      // Type/subtype/encoding must be quoted strings (RFC 3501 §9).
+      expect(part!.content).toContain('"TEXT" "PLAIN"');
+      expect(part!.content).toContain('"BASE64" 44 42');
     }
   });
 
@@ -1015,8 +1016,8 @@ describe("buildFetchResponsePart BODYSTRUCTURE cached-column short-circuit (#740
     if (part!.type === "simple") {
       // Both parts + the alternative wrapper. Both must derive from cache
       // (no strings on mail — would `NaN` or 0 on materialized fallback).
-      expect(part!.content).toContain("BASE64 8 2");
-      expect(part!.content).toContain("BASE64 20 5");
+      expect(part!.content).toContain('"BASE64" 8 2');
+      expect(part!.content).toContain('"BASE64" 20 5');
       expect(part!.content).toContain('"alternative"');
     }
   });

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -440,35 +440,43 @@ describe("IMAP util", () => {
   });
 
   describe("formatBodyStructure", () => {
-    it("should format text-only body structure", () => {
-      const mail: Partial<MailType> = {
-        text: "Hello, World!"
-      };
+    // RFC 3501 §9: media-type + media-subtype + body-fld-enc are `string`
+    // (quoted or literal). Bare atoms crash strict client parsers (Apple Mail
+    // iOS ≥ 26 aborts and retry-loops); assertions below pin the QUOTED form
+    // byte-for-byte so a regression to the bare-atom shape fails the suite.
+    it("quotes TEXT/PLAIN and BASE64 per RFC 3501 §9 (text-only)", () => {
+      const mail: Partial<MailType> = { text: "Hello, World!" };
       const result = formatBodyStructure(mail);
-      expect(result).toContain("TEXT");
-      expect(result).toContain("PLAIN");
-      expect(result).toContain("BASE64");
+      // The byte-perfect pin below carries the full-shape regression; here
+      // just assert the three tokens land in their quoted form so a partial
+      // regression on any one is caught in isolation.
+      expect(result).toContain('"TEXT"');
+      expect(result).toContain('"PLAIN"');
+      expect(result).toContain('"BASE64"');
     });
 
-    it("should format HTML-only body structure", () => {
-      const mail: Partial<MailType> = {
-        html: "<p>Hello, World!</p>"
-      };
+    it("quotes TEXT/HTML per RFC 3501 §9 (html-only)", () => {
+      const mail: Partial<MailType> = { html: "<p>Hello, World!</p>" };
       const result = formatBodyStructure(mail);
-      expect(result).toContain("TEXT");
-      expect(result).toContain("HTML");
+      expect(result).toContain('"TEXT"');
+      expect(result).toContain('"HTML"');
     });
 
-    it("should format multipart/alternative for text+HTML", () => {
+    it("emits multipart/alternative with NO space between sibling parts (RFC 3501 §9)", () => {
       const mail: Partial<MailType> = {
         text: "Hello",
         html: "<p>Hello</p>"
       };
       const result = formatBodyStructure(mail);
       expect(result).toContain('"alternative"');
+      // ABNF: body-type-mpart = 1*body SP media-subtype — siblings concatenate
+      // with no separator; the single SP is the sentinel before media-subtype.
+      // Correct: `)(` between siblings, ` "alternative"` before subtype.
+      expect(result).toMatch(/\)\("TEXT" "HTML"/);
+      expect(result).not.toMatch(/\) \("TEXT" "HTML"/);
     });
 
-    it("should format multipart/mixed for attachments", () => {
+    it("emits multipart/mixed with NO space between sibling parts", () => {
       const mail: Partial<MailType> = {
         text: "Hello",
         attachments: [
@@ -484,6 +492,9 @@ describe("IMAP util", () => {
       expect(result).toContain('"mixed"');
       expect(result).toContain('"application"');
       expect(result).toContain('"pdf"');
+      // Text part → attachment part concatenate with no space.
+      expect(result).toMatch(/\)\("application"/);
+      expect(result).not.toMatch(/\) \("application"/);
     });
 
     it("should include attachment filename in disposition", () => {
@@ -503,11 +514,48 @@ describe("IMAP util", () => {
       expect(result).toContain('"FILENAME" "document.pdf"');
     });
 
-    it("should default to empty text part", () => {
+    it("should default to empty text part with quoted TEXT/PLAIN", () => {
       const mail: Partial<MailType> = {};
       const result = formatBodyStructure(mail);
-      expect(result).toContain("TEXT");
-      expect(result).toContain("PLAIN");
+      expect(result).toContain('"TEXT"');
+      expect(result).toContain('"PLAIN"');
+    });
+
+    // Byte-for-byte pin — regression against the exact prod shape that
+    // Apple Mail iOS 26 stuck on. Covers all three violations at once:
+    // (a) quoted TEXT/PLAIN/HTML, (b) quoted BASE64, (c) no space between
+    // sibling parts inside the outer multipart wrapper.
+    it("full byte-perfect shape for text+html+2 attachments (the iOS regression case)", () => {
+      const mail: Partial<MailType> = {
+        text_octets: 27060,
+        html_octets: 11138020,
+        text_line_count: 522,
+        html_line_count: 230,
+        attachments: [
+          {
+            content: { data: "att1" },
+            filename: "1000025304.jpg",
+            size: 6162016,
+            contentType: "image/jpeg"
+          },
+          {
+            content: { data: "att2" },
+            filename: "1000025344.jpg",
+            size: 81495,
+            contentType: "image/jpeg"
+          }
+        ]
+      };
+      const expected =
+        '((' +
+          '("TEXT" "PLAIN" ("CHARSET" "UTF-8") NIL NIL "BASE64" 36080 522)' +
+          '("TEXT" "HTML" ("CHARSET" "UTF-8") NIL NIL "BASE64" 14850696 230)' +
+          ' "alternative" NIL NIL NIL NIL' +
+        ')' +
+        '("image" "jpeg" ("NAME" "1000025304.jpg") NIL NIL "BASE64" 8216024 NIL ("ATTACHMENT" ("FILENAME" "1000025304.jpg")) NIL NIL)' +
+        '("image" "jpeg" ("NAME" "1000025344.jpg") NIL NIL "BASE64" 108660 NIL ("ATTACHMENT" ("FILENAME" "1000025344.jpg")) NIL NIL)' +
+        ' "mixed" NIL NIL NIL NIL)';
+      expect(formatBodyStructure(mail)).toBe(expected);
     });
 
     // #740: BODYSTRUCTURE's `size` + `lines` derive from the persisted
@@ -523,7 +571,7 @@ describe("IMAP util", () => {
         html_line_count: 0,
       });
       // ceil(30/3)*4 = 40 octets base64, three lines.
-      expect(cached).toContain("BASE64 40 3");
+      expect(cached).toContain('"BASE64" 40 3');
       // No HTML → single text part, not multipart.
       expect(cached).not.toContain("alternative");
     });
@@ -583,7 +631,7 @@ describe("IMAP util", () => {
         // The attachment part itself now ends at the size field (BASE64 <size>).
         const attachmentSize = Math.ceil(1024 / 3) * 4;
         expect(nonExt).toContain(`"application" "pdf"`);
-        expect(nonExt).toContain(`BASE64 ${attachmentSize})`);
+        expect(nonExt).toContain(`"BASE64" ${attachmentSize})`);
       });
     });
   });

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -230,13 +230,17 @@ export const formatBodyStructure = (
       ? lineCount
       : (content ?? "").split(/\r?\n/).length;
 
+    // RFC 3501 §9: media-type and media-subtype are `string` (quoted or
+    // literal), body-fld-enc is a quoted string too. Bare atoms like
+    // `TEXT PLAIN BASE64` break strict client parsers (Apple Mail on iOS
+    // ≥ 26 aborts the session mid-response and reconnects).
     const parts = [
-      "TEXT",
-      subtype.toUpperCase(),
+      `"TEXT"`,
+      `"${subtype.toUpperCase()}"`,
       `("CHARSET" "UTF-8")`,
       "NIL",
       "NIL",
-      "BASE64",
+      `"BASE64"`,
       size.toString(),
       lines.toString()
     ];
@@ -268,7 +272,7 @@ export const formatBodyStructure = (
         : "NIL",
       "NIL", // body ID
       "NIL", // body description
-      "BASE64", // encoding
+      `"BASE64"`, // encoding — quoted string per RFC 3501 §9 body-fld-enc
       size.toString()
     ];
 
@@ -312,9 +316,13 @@ export const formatBodyStructure = (
     return htmlPart();
   }
 
+  // RFC 3501 §9: `body-type-mpart = 1*body SP media-subtype [SP …]`. Sibling
+  // parts CONCATENATE — no separator. The single SP is the sentinel telling
+  // the parser "parts done, subtype next." Emitting `(partA) (partB)` breaks
+  // parsers that use SP-after-`)` as the parts-done delimiter (Apple Mail).
   // Case 3: Text and HTML (multipart/alternative)
   if (hasText && hasHtml && !hasAttachments) {
-    return `(${textPart()} ${htmlPart()} ${multipartTail("alternative")})`;
+    return `(${textPart()}${htmlPart()} ${multipartTail("alternative")})`;
   }
 
   // Case 4: Content with attachments (multipart/mixed)
@@ -323,7 +331,7 @@ export const formatBodyStructure = (
 
     // If we have both text and HTML, create a multipart/alternative first
     if (hasText && hasHtml) {
-      const alternativePart = `(${textPart()} ${htmlPart()} ${multipartTail(
+      const alternativePart = `(${textPart()}${htmlPart()} ${multipartTail(
         "alternative"
       )})`;
       bodyParts.push(alternativePart);
@@ -338,7 +346,7 @@ export const formatBodyStructure = (
       bodyParts.push(buildAttachmentPart(attachment));
     });
 
-    return `(${bodyParts.join(" ")} ${multipartTail("mixed")})`;
+    return `(${bodyParts.join("")} ${multipartTail("mixed")})`;
   }
 
   // Default case: empty text part (no lazy inputs either, so the


### PR DESCRIPTION
## The bug (finally)

`formatBodyStructure` in `src/server/lib/imap/util.ts` emits IMAP BODYSTRUCTURE with three RFC 3501 §9 grammar violations. Apple Mail on iOS ≥ 26 has a strict recursive-descent parser that aborts the session mid-response when it hits an unquoted atom where the ABNF requires a `string` — iOS drops the TCP connection, opens a fresh session, re-issues the FETCH, loops forever. Small mails avoid this (iOS fetches whole; never asks for BODYSTRUCTURE). Large mails plan the fetch via BODYSTRUCTURE first, so they always hit the loop.

The 19MB "Re: San Jose tattoo inquiry" thread (10 UIDs including 12381) was the smoking-gun cluster we chased through PRs 793 / 772 / 798.

## The three violations (all in `formatBodyStructure`)

| # | Wrong | Right | RFC ref |
|---|---|---|---|
| a | Bare `TEXT PLAIN` / `TEXT HTML` atoms on text parts | Quoted: `"TEXT" "PLAIN"` / `"TEXT" "HTML"` | §9 `media-type = string`, `media-subtype = string` |
| b | Bare `BASE64` atom on every part | Quoted: `"BASE64"` | §9 `body-fld-enc = (DQUOTE ... DQUOTE) / string` |
| c | Space between sibling parts inside multipart: `(part1) (part2) "MIXED"` | Concatenate siblings: `(part1)(part2) "MIXED"` | §9 `body-type-mpart = 1*body SP media-subtype` — parts have no separator; the SP is the sentinel |

Attachment parts already quoted `"image" "jpeg"` — the text-part code path was the outlier. `bodyParts.join(" ")` in the multipart wrapper was the third defect.

## Before vs after (UID 12381 captured against no-scramble sandbox)

Before:
```
(((TEXT PLAIN ("CHARSET" "UTF-8") NIL NIL BASE64 27060 522) (TEXT HTML ("CHARSET" "UTF-8") NIL NIL BASE64 11138020 230) "alternative" NIL NIL NIL NIL) ("image" "jpeg" ("NAME" "1000025304.jpg") NIL NIL BASE64 8216024 NIL ("ATTACHMENT" ("FILENAME" "1000025304.jpg")) NIL NIL) …)
```

After:
```
((("TEXT" "PLAIN" ("CHARSET" "UTF-8") NIL NIL "BASE64" 27060 522)("TEXT" "HTML" ("CHARSET" "UTF-8") NIL NIL "BASE64" 11138020 230) "alternative" NIL NIL NIL NIL)("image" "jpeg" ("NAME" "1000025304.jpg") NIL NIL "BASE64" 8216024 NIL ("ATTACHMENT" ("FILENAME" "1000025304.jpg")) NIL NIL)("image" "jpeg" ("NAME" "1000025344.jpg") NIL NIL "BASE64" 108660 NIL ("ATTACHMENT" ("FILENAME" "1000025344.jpg")) NIL NIL) "mixed" NIL NIL NIL NIL)
```

## Why existing tests didn't catch it

Six `formatBodyStructure` tests in `util.test.ts` used loose `.toContain("TEXT")` / `.toContain("BASE64")` assertions — those match the substring whether or not the token is quoted, so the broken shape shipped. Two tests in `fetch-helpers.test.ts` pinned `BASE64 <n> <n>` unquoted.

This PR:
- Rewrote the 6 util tests to assert `.toContain('"TEXT"')` / `.toContain('"BASE64"')` and added a byte-perfect pin covering the 12381 exact shape (text+html+2 attachments) — any regression on any of the three violations fails.
- Updated the 2 fetch-helpers tests to the quoted form.

## Motivation trail

- Prior rfc822_size drift theory refuted by in-container diagnostic — sizes byte-perfect (see earlier investigation).
- 793 (FETCH LIMIT clamp), 798 (offset-aware partial), 804 (IMAP wire trace) were all correct fixes for real bugs — none of them THIS bug.
- 804's IMAP_TRACE=1 was load-bearing: it captured the exact FETCH command iOS was looping on (`UID RFC822.SIZE BODYSTRUCTURE`), which is what pointed at BODYSTRUCTURE parseability rather than SIZE / partial / whole-body.

## Test plan
- [x] Full `bun test src/server` — 1578/1578 pass (from 1576 baseline; 2 new tests added).
- [x] Sandbox (no-scramble, port 31804) raw-socket verify:
  - `UID FETCH 12381 (UID RFC822.SIZE BODYSTRUCTURE)` returns the quoted shape shown above.
  - `UID FETCH 12428 (UID RFC822.SIZE BODYSTRUCTURE)` returns quoted alternative shape (baseline case).
  - `A3 OK FETCH completed` on both — server-side behavior unchanged.
- [ ] iOS Mail regression on the actual sandbox — needs Hoie to point his iPhone at the sandbox and see the loop stop. (Iff possible; the sandbox is on `claoie.tplinkdns.com:31804` plain IMAP, no TLS — iOS may refuse without STARTTLS. Alternative: merge to prod, watch trace for the loop to stop.)