### PR TITLE
fix(imap): serialize per-session command execution — prevents FETCH response interleaving on large-body pipelined bursts

### DIFF
--- a/src/server/lib/imap/handler-serial-drain.test.ts
+++ b/src/server/lib/imap/handler-serial-drain.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Per-session command-drain serialization test.
+ *
+ * Node emits `data` events synchronously per TCP segment. Before this
+ * fix, the `socket.on("data", async …)` handler was itself async — so
+ * pipelined commands that arrived in separate segments would spawn
+ * concurrent async processing loops. Each loop mutated the shared
+ * `buffer` AND awaited `handleRequest` in parallel, and inside a
+ * long-running FETCH the concurrent handler's synchronous `write()`
+ * would inject headers into the previous response's still-streaming
+ * literal — corrupting the wire stream and desyncing the client.
+ *
+ * The fix serializes: the `data` event is now synchronous (buffer
+ * append only), then a single `drainCommands` loop pumps one command
+ * at a time under a `draining` guard. RFC 3501 permits serial
+ * execution.
+ *
+ * These tests pin the invariants:
+ *  1) Every command in a burst still gets a tagged completion (no drops).
+ *  2) The number of `OK` responses matches the number of commands sent
+ *     across N separate data events (the drain doesn't wedge under
+ *     re-entrance).
+ *  3) The order of tagged completions matches the order commands were
+ *     sent (no interleaving).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { EventEmitter } from "events";
+import "../push";
+import { ImapRequestHandler } from "./handler";
+
+function makeMockSocket() {
+  const socket = new EventEmitter() as EventEmitter & {
+    writes: string[];
+    writable: boolean;
+    destroyed: boolean;
+    write: (data: string) => boolean;
+    setTimeout: () => void;
+    destroy: () => void;
+    end: () => void;
+  };
+  socket.writes = [];
+  socket.writable = true;
+  socket.destroyed = false;
+  socket.write = (data: string) => {
+    socket.writes.push(data);
+    return true;
+  };
+  socket.setTimeout = () => {};
+  socket.destroy = () => {
+    socket.destroyed = true;
+  };
+  socket.end = () => {};
+  return socket;
+}
+
+const waitFor = async (predicate: () => boolean, timeoutMs: number) => {
+  const start = Date.now();
+  while (!predicate() && Date.now() - start < timeoutMs) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+};
+
+describe("IMAP handler per-session drain serialization", () => {
+  it("emits every tagged completion across N separate data events (drain re-entrance safe)", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+
+    // 25 commands, each in its own `data` event. Under the pre-fix
+    // async handler this would spawn 25 concurrent processing loops
+    // racing on the shared buffer; under the fix each fires drainCommands
+    // which self-serializes via the `draining` guard.
+    const n = 25;
+    for (let i = 1; i <= n; i++) {
+      socket.emit("data", Buffer.from(`t${i} NOOP\r\n`));
+    }
+
+    await waitFor(
+      () => socket.writes.filter((w) => w.includes("OK NOOP completed")).length >= n,
+      2000
+    );
+
+    const oks = socket.writes.filter((w) => w.includes("OK NOOP completed"));
+    expect(oks.length).toBe(n);
+  });
+
+  it("preserves command order across pipelined + separate-segment inputs", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+
+    // Interleave shapes the client actually produces: burst-of-3 pipelined
+    // in one segment, then two more one-per-segment, then a burst of 5.
+    socket.emit("data", Buffer.from("a1 NOOP\r\na2 NOOP\r\na3 NOOP\r\n"));
+    socket.emit("data", Buffer.from("a4 NOOP\r\n"));
+    socket.emit("data", Buffer.from("a5 NOOP\r\n"));
+    socket.emit(
+      "data",
+      Buffer.from("a6 NOOP\r\na7 NOOP\r\na8 NOOP\r\na9 NOOP\r\na10 NOOP\r\n")
+    );
+
+    await waitFor(
+      () => socket.writes.filter((w) => w.includes("OK NOOP completed")).length >= 10,
+      2000
+    );
+
+    // Extract the tag from each OK response and confirm strict ascending
+    // order — no interleaving, no reordering across the drain boundary.
+    const tagOrder = socket.writes
+      .map((w) => /^(a\d+) OK NOOP completed/.exec(w)?.[1])
+      .filter((t): t is string => Boolean(t));
+    expect(tagOrder).toEqual([
+      "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9", "a10",
+    ]);
+  });
+
+  it("recovers a partial line split across two data events", async () => {
+    const handler = new ImapRequestHandler();
+    const socket = makeMockSocket();
+    handler.setSocket(socket as never);
+
+    // Command arrives across three TCP segments — the drain must wait for
+    // \r\n before dispatching, but the drain re-entrance from each segment
+    // must not process partial input as a broken command.
+    socket.emit("data", Buffer.from("b1 NO"));
+    socket.emit("data", Buffer.from("OP"));
+    socket.emit("data", Buffer.from("\r\n"));
+
+    await waitFor(
+      () => socket.writes.some((w) => w.includes("b1 OK NOOP completed")),
+      1000
+    );
+
+    const oks = socket.writes.filter((w) => w.includes("b1 OK NOOP completed"));
+    expect(oks.length).toBe(1);
+    const bads = socket.writes.filter((w) => /^b1 BAD/.test(w));
+    expect(bads.length).toBe(0);
+  });
+});

--- a/src/server/lib/imap/handler.ts
+++ b/src/server/lib/imap/handler.ts
@@ -116,20 +116,29 @@ export class ImapRequestHandler {
 
     // pendingSaslTag is stored on this (class property) so session can set it
 
-    socket.on("data", async (data) => {
+    // Per-session serial drain guard. Node emits `data` events without
+    // awaiting the async handler, so before this guard existed each TCP
+    // segment spawned its own async loop reading and mutating the shared
+    // `buffer` — and, worse, calling `handleRequest`/`session.write` in
+    // parallel. Pipelined FETCHes on one session (iOS Mail issues N
+    // `UID FETCH (BODY.PEEK[]<off.393216>)` slices in a burst for a
+    // multi-MB body) would interleave: `writeFetchResponse` writes a
+    // literal-length header `{N}\r\n`, `await writeStream(...)`, then `)`.
+    // Under WAN backpressure the `await` yields, and the concurrent
+    // handler's synchronous `write()` for the next FETCH injects its own
+    // `* n FETCH (…` header into the middle of the still-streaming
+    // literal — iOS's parser desyncs and drops the session ("Cannot Get
+    // Mail" modal). RFC 3501 explicitly permits serial command execution
+    // on a single connection, so we serialize.
+    let draining = false;
+    const drainCommands = async (): Promise<void> => {
+      if (draining) return;
+      draining = true;
       try {
-        buffer += data.toString();
-
-        // Process complete lines
-        let lineEnd;
         while (true) {
           // If accumulating literal data for APPEND, consume raw bytes first
           if (pendingAppendLine !== null) {
-            if (buffer.length < literalBytesNeeded) {
-              // Wait for more data
-              break;
-            }
-            // We have enough bytes — reconstruct the full APPEND input and parse
+            if (buffer.length < literalBytesNeeded) return;
             const literalData = buffer.substring(0, literalBytesNeeded);
             buffer = buffer.substring(literalBytesNeeded);
             // Skip optional \r\n after literal
@@ -161,8 +170,8 @@ export class ImapRequestHandler {
             continue;
           }
 
-          lineEnd = buffer.indexOf("\r\n");
-          if (lineEnd === -1) break;
+          const lineEnd = buffer.indexOf("\r\n");
+          if (lineEnd === -1) return;
 
           const line = buffer.substring(0, lineEnd);
           buffer = buffer.substring(lineEnd + 2);
@@ -180,84 +189,84 @@ export class ImapRequestHandler {
             continue;
           }
 
-          if (line.trim()) {
-            // The only valid client input during IDLE is "DONE". This line
-            // buffer already reassembles split TCP chunks and pipelined input,
-            // so handle DONE here: terminate IDLE and fall through so any
-            // command pipelined after DONE (e.g. "DONE\r\nA4 NOOP\r\n") is
-            // processed on the next loop iteration. Non-DONE input during IDLE
-            // is ignored per RFC 2177.
-            if (session.isInIdleMode()) {
-              if (line.trim().toUpperCase() === "DONE") {
-                session.endIdle();
+          if (!line.trim()) continue;
+
+          // The only valid client input during IDLE is "DONE". This line
+          // buffer already reassembles split TCP chunks and pipelined input,
+          // so handle DONE here: terminate IDLE and fall through so any
+          // command pipelined after DONE (e.g. "DONE\r\nA4 NOOP\r\n") is
+          // processed on the next loop iteration. Non-DONE input during IDLE
+          // is ignored per RFC 2177.
+          if (session.isInIdleMode()) {
+            if (line.trim().toUpperCase() === "DONE") {
+              session.endIdle();
+            }
+            continue;
+          }
+
+          logger.debug("IMAP command received", {
+            component: "imap",
+            command: line.trim(),
+            mailbox: session.selectedMailbox
+          });
+          imapTrace("in", session.getSessionId(), line.trim());
+
+          // Pace pipelined bursts. RFC 3501 §7 requires a tagged
+          // completion for every command, so over-limit commands are
+          // delayed, never skipped — clients pipeline heavily during
+          // folder sync (iOS Mail sends STATUS for every mailbox in one
+          // burst after LIST).
+          await session.waitForCommandSlot();
+
+          // Detect APPEND command with a literal size indicator {N} or {N+}
+          // e.g. "a001 APPEND INBOX (\Seen) {512}"
+          // When found, switch to literal accumulation mode instead of parsing now.
+          const literalMatch = /\{(\d+)(\+?)\}\s*$/.exec(line.trim());
+          if (literalMatch) {
+            const upperLine = line.trim().toUpperCase();
+            // Only intercept APPEND literals here; other commands with literals
+            // (e.g. LOGIN with quoted strings) don't need this treatment.
+            const parts = upperLine.split(/\s+/);
+            const commandWord = parts[1] || parts[0];
+            if (commandWord === "APPEND") {
+              pendingAppendLine = line.trim();
+              literalBytesNeeded = parseInt(literalMatch[1], 10);
+              // Synchronizing literals {N} (without +) require a continuation
+              // response before the client will send the literal data.
+              // Non-synchronizing literals {N+} (LITERAL+) do not.
+              const isSynchronizing = !literalMatch[2];
+              if (isSynchronizing) {
+                session.write("+ go ahead\r\n");
               }
               continue;
             }
+          }
 
-            logger.debug("IMAP command received", {
-              component: "imap",
-              command: line.trim(),
-              mailbox: session.selectedMailbox
-            });
-            imapTrace("in", session.getSessionId(), line.trim());
+          try {
+            // Parse the command using the typed parser
+            const parseResult = parseCommand(line.trim());
 
-            // Pace pipelined bursts. RFC 3501 §7 requires a tagged
-            // completion for every command, so over-limit commands are
-            // delayed, never skipped — clients pipeline heavily during
-            // folder sync (iOS Mail sends STATUS for every mailbox in one
-            // burst after LIST).
-            await session.waitForCommandSlot();
-
-            // Detect APPEND command with a literal size indicator {N} or {N+}
-            // e.g. "a001 APPEND INBOX (\Seen) {512}"
-            // When found, switch to literal accumulation mode instead of parsing now.
-            const literalMatch = /\{(\d+)(\+?)\}\s*$/.exec(line.trim());
-            if (literalMatch) {
-              const upperLine = line.trim().toUpperCase();
-              // Only intercept APPEND literals here; other commands with literals
-              // (e.g. LOGIN with quoted strings) don't need this treatment.
-              const parts = upperLine.split(/\s+/);
-              const commandWord = parts[1] || parts[0];
-              if (commandWord === "APPEND") {
-                pendingAppendLine = line.trim();
-                literalBytesNeeded = parseInt(literalMatch[1], 10);
-                // Synchronizing literals {N} (without +) require a continuation
-                // response before the client will send the literal data.
-                // Non-synchronizing literals {N+} (LITERAL+) do not.
-                const isSynchronizing = !literalMatch[2];
-                if (isSynchronizing) {
-                  session.write("+ go ahead\r\n");
-                }
-                continue;
-              }
-            }
-
-            try {
-              // Parse the command using the typed parser
-              const parseResult = parseCommand(line.trim());
-
-              if (parseResult.success && parseResult.value) {
-                const { tag, request } = parseResult.value;
-                await this.handleRequest(tag, request);
-              } else {
-                // If parsing failed, send error response only if socket is writable
-                logger.debug("Parse failed", {
-                  component: "imap.parser",
-                  input: line.trim(),
-                  error: parseResult.error
-                });
-                const parts = line.trim().split(" ");
-                const tag = parts[0] || "BAD";
-                const errorMsg = parseResult.error || "Invalid command syntax";
-                session.write(`${tag} BAD ${errorMsg}\r\n`);
-              }
-            } catch (error) {
-              logger.error("Error processing command", { component: "imap" }, error);
-              // Only send error response if socket is still writable
+            if (parseResult.success && parseResult.value) {
+              const { tag, request } = parseResult.value;
+              await this.handleRequest(tag, request);
+            } else {
+              // If parsing failed, send error response only if socket is writable
+              logger.debug("Parse failed", {
+                component: "imap.parser",
+                input: line.trim(),
+                error: parseResult.error
+              });
               const parts = line.trim().split(" ");
               const tag = parts[0] || "BAD";
-              session.write(`${tag} BAD Internal server error\r\n`);
+              const errorMsg = parseResult.error || "Invalid command syntax";
+              session.write(`${tag} BAD ${errorMsg}\r\n`);
             }
+          } catch (error) {
+            logger.error("Error processing command", { component: "imap" }, error);
+            // Only send error response if socket is still writable
+            const parts = line.trim().split(" ");
+            const tag = parts[0] || "BAD";
+            session.write(`${tag} BAD Internal server error\r\n`);
           }
         }
       } catch (error) {
@@ -265,7 +274,30 @@ export class ImapRequestHandler {
         if (!socket.destroyed) {
           socket.destroy();
         }
+      } finally {
+        draining = false;
       }
+    };
+
+    socket.on("data", (data) => {
+      // Sync-only: append to the shared buffer, then wake the drain.
+      // The `data` event fires synchronously per TCP segment; any await
+      // here would let a second segment race the buffer append. Keep this
+      // handler synchronous — all async work belongs inside `drainCommands`
+      // which owns the `draining` guard.
+      try {
+        buffer += data.toString();
+      } catch (error) {
+        logger.error("Error appending data to buffer", { component: "imap" }, error);
+        if (!socket.destroyed) socket.destroy();
+        return;
+      }
+      // Fire-and-forget: `drainCommands` self-serializes via `draining`.
+      // Errors inside are already logged; catch here just to prevent an
+      // unhandled-rejection.
+      void drainCommands().catch((error) => {
+        logger.error("Unhandled drain error", { component: "imap" }, error);
+      });
     });
 
     socket.on("close", () => {
@@ -306,17 +338,17 @@ export class ImapRequestHandler {
     // duration, so a memory spike can be attributed to a specific command
     // rather than only to a coarse metrics-poll window. Sampled from
     // `session.bytesWritten` (session-scoped counter) rather than wrapping
-    // `session.write` — the wrap approach was racy under Node's data-event
-    // concurrency (the handler is an async function but the socket emits
-    // `data` events without awaiting), which could restore an orphan
-    // `originalWrite` from a nested handler and permanently break the wrap
-    // for the rest of the socket's lifetime. The delta is not a mutex —
-    // overlapping commands on the same session over-attribute to whichever
-    // completed first — but no orphan-restore risk.
+    // `session.write` — the wrap approach was racy under the pre-serialized
+    // data-event handler and could restore an orphan `originalWrite` from a
+    // nested handler and permanently break the wrap for the rest of the
+    // socket's lifetime. Commands are now serialized per session (see the
+    // `drainCommands` note above), so cross-command interleaving on the
+    // same session is gone; the counter approach stays because it also
+    // avoids the wrap-restore hazard.
     //
     // RSS is process-wide, not session-scoped: under multi-socket load two
-    // concurrent commands both see the same rssDelta. `remote` in the log
-    // lets triage disambiguate.
+    // concurrent commands (on DIFFERENT sessions) both see the same
+    // rssDelta. `remote` in the log lets triage disambiguate.
     const session = this.session;
     const startedAt = performance.now();
     const memBefore = process.memoryUsage();


### PR DESCRIPTION
## The bug

The `socket.on("data", async …)` handler at `handler.ts:119` is itself async and mutates a shared `buffer` while awaiting. Node emits `data` events synchronously per TCP segment; nothing serialized them. Each new segment spawned its own async processing loop, so pipelined commands from a single session ran concurrently AND both processing loops shared the `buffer` variable.

`writeFetchResponse` (`fetch-helpers.ts:915-942`) emits `* n FETCH (…) {N}\r\n` header, then `await writeStream(...)`, then `)`. Under WAN backpressure on a 384 KB slice the `await` yields. During the yield, the concurrent handler's synchronous `write()` for the NEXT pipelined command injects its own `* n FETCH (…` header into the middle of the previous response's still-streaming literal. The client's IMAP parser desyncs on the malformed literal (expected N bytes, got N + injected header text), drops the connection, retries, and never advances past the offending mail — Apple Mail iOS shows "Cannot Get Mail. The mail server 'mail.hoie.kim' is not responding."

**Trigger:** Apple Mail iOS pipelines 8-16 `UID FETCH … (UID BODY.PEEK[]<off.393216>)` slices per multi-MB body during initial INBOX sync. Small mails complete in one event-loop turn (no yield, no interleave); large mails yield. The 19.5 MB `Re: San Jose tattoo inquiry` cluster was the smoking-gun trigger; it's what iOS chokes on.

**Prod fingerprint (journald):** an `IMAP command completed` line with `responseBytes` = its own literal size + ~50 (the injected next command's header). Zero WARN/ERROR/BAD/NO because the tiny post-corruption writes fell below the debug threshold — the "hang" was a logging artifact.

**Why it wasn't hit before:** iOS never got past `BODYSTRUCTURE` on those mails until #806 fixed the RFC 3501 §9 quoting violations. #806 unmasked this next-layer bug.

## The fix (`handler.ts`)

- `socket.on("data", …)` is now **synchronous**: append to the shared `buffer`, then fire-and-forget `drainCommands()`.
- New `drainCommands()` owns all async work. Self-serializes via a `draining` boolean — re-entrant `data` events see `draining=true` and return; the currently-running drain re-checks `buffer.indexOf("\r\n")` each iteration and picks up newly-appended input.
- One command completes (through its `await handleRequest`) before the next one starts parsing. RFC 3501 explicitly permits serial execution on a single connection; no client-visible change other than the interleave going away.
- Also closes a latent shared-`buffer` read/write race between concurrent data callbacks (pre-fix, one callback's `buffer.substring(...)` could straddle another's `buffer += data.toString()`).
- Updated the diagnostic comment at `handleRequest` (lines 305-315): the concurrency it described no longer exists on a single session. Cross-session concurrency (RSS is process-wide across all sockets) is unchanged.

## E2E verification (sandbox `pr-804`, no-scramble prod-DB clone, port 31804)

Fable's `repro_interleave.py`: send four `UID FETCH 12381 (UID BODY.PEEK[]<off.393216>)` slices as separate TCP segments 30 ms apart with a slow reader that forces backpressure.

**Before:** 2 violations — `* n FETCH (…)` header embedded inside the previous literal + missing `)` closer.

**After:** 0 violations. All 4 literals emit at exactly 393216 bytes each, followed by `)\r\n` + a tagged `OK FETCH completed`, in strict `M20 → M21 → M22 → M23` order:
```
FETCH<0>       lit=393216 closeOK=True  |  M20 OK FETCH completed
FETCH<393216>  lit=393216 closeOK=True  |  M21 OK FETCH completed
FETCH<786432>  lit=393216 closeOK=True  |  M22 OK FETCH completed
FETCH<1179648> lit=393216 closeOK=True  |  M23 OK FETCH completed
```

## Tests (`handler-serial-drain.test.ts`, 3 new)

- 25 commands across 25 separate `data` events all get tagged completions (drain re-entrance safe under high segment rate).
- Mixed pipelined + separate-segment inputs preserve strict tag ordering across 10 commands `a1..a10`.
- A NOOP split across 3 TCP segments still parses as one clean command (partial-line handling in the drain).

Full `bun test src/server`: **1581/1581 pass** (1578 baseline + 3 new).

## Test plan
- [x] Unit: 3 new drain-serial tests pass.
- [x] Full `bun test src/server` — 1581/1581 pass.
- [x] Sandbox E2E — 4-slice pipelined `UID FETCH BODY.PEEK[]` interleave repro passes (0 violations).
- [ ] Prod verification: after merge + recompose, watch trace during next iOS sync — INBOX FETCH sequence on 12381 body slices should complete cleanly and iOS should catch up to UIDs 12473-12475 (currently stuck at 12472 = the pre-#806 last-good sync).

## Motivation trail

1. `#793` FETCH LIMIT clamp — real fix, not this bug.
2. `#798` offset-aware partial BODY[] — real fix, not this bug.
3. `#804` IMAP wire trace (`IMAP_TRACE=1`) — enabled this diagnosis.
4. `#806` BODYSTRUCTURE RFC 3501 §9 quoting — unmasked this bug.
5. This PR — the actual mechanism iOS was choking on.