### PR TITLE
fix(postgres): buildUpsert conflict clause covers only the columns the INSERT wrote (#745)

### DIFF
--- a/src/server/lib/postgres/database.test.ts
+++ b/src/server/lib/postgres/database.test.ts
@@ -170,6 +170,62 @@ describe("buildUpsert — empty SET degradation", () => {
   });
 });
 
+describe("buildUpsert — conflict clause covers only the columns the INSERT wrote", () => {
+  it("drops a column whose value is undefined", () => {
+    const { sql } = buildUpsert(
+      "mailboxes",
+      "mailbox_id",
+      { mailbox_id: "m1", name: "a", parent_id: undefined },
+      { updateColumns: ["mailbox_id", "name", "parent_id"], stampUpdated: false }
+    );
+    expect(insertColumns(sql)).toEqual(["mailbox_id", "name"]);
+    expect(setColumns(sql)).toEqual(["name"]);
+  });
+
+  it("drops a column absent from data entirely", () => {
+    const { sql } = buildUpsert(
+      "mailboxes",
+      "mailbox_id",
+      { mailbox_id: "m1", name: "a" },
+      { updateColumns: ["name", "parent_id"], stampUpdated: false }
+    );
+    expect(setColumns(sql)).toEqual(["name"]);
+  });
+
+  it("still stamps updated when every requested column was dropped", () => {
+    const { sql } = buildUpsert(
+      "users",
+      "user_id",
+      { user_id: "u1", username: undefined },
+      { updateColumns: ["username"] }
+    );
+    expect(setColumns(sql)).toEqual(["updated"]);
+  });
+
+  it("degrades to the conflict-key no-op when nothing is left to write", () => {
+    const { sql } = buildUpsert(
+      "mailboxes",
+      "mailbox_id",
+      { mailbox_id: "m1", name: undefined },
+      { updateColumns: ["name"], stampUpdated: false, returning: ["*"] }
+    );
+    expect(setColumns(sql)).toEqual(["mailbox_id"]);
+    expect(sql).toContain("RETURNING *");
+    expect(sql).not.toContain("DO NOTHING");
+  });
+});
+
+describe("Table.upsert — undefined column reaches neither INSERT nor conflict SET", () => {
+  it("does not null a stored password when the caller omits one", async () => {
+    // `writeUser` builds `{ username, password: hashedPassword }` and leaves
+    // password undefined when no password is supplied.
+    await usersTable.upsert({ user_id: "u1", username: "alice", password: undefined });
+    const sql = lastSql();
+    expect(insertColumns(sql)).toEqual(["updated", "user_id", "username"]);
+    expect(setColumns(sql)).toEqual(["username", "updated"]);
+  });
+});
+
 describe("every registered table, through the real Table methods", () => {
   it("registers at least the known tables", () => {
     // Guards against an empty import silently passing the sweeps below.

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -37,6 +37,7 @@ export interface UpdateOptions extends StampUpdatedOption {
 }
 
 export interface UpsertOptions extends StampUpdatedOption {
+  /** Columns to carry onto the conflict path; those the INSERT omitted are dropped. */
   updateColumns?: string[];
   returning?: string[];
 }
@@ -213,11 +214,13 @@ export function buildUpsert(
 
   const { columns, placeholders } = autoColumns(stampUpdated);
   const values: ParamValue[] = [];
+  const insertedColumns = new Set<string>();
   let paramIndex = 1;
 
   for (const [key, value] of Object.entries(data)) {
     if (isUndefined(value)) continue;
     columns.push(key);
+    insertedColumns.add(key);
     placeholders.push(`$${paramIndex}`);
     values.push(prepareParamValue(value as ParamValue));
     paramIndex++;
@@ -226,14 +229,18 @@ export function buildUpsert(
   let sql = `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${placeholders.join(", ")})`;
 
   if (updateColumns.length > 0) {
+    // `EXCLUDED.col` for a column the INSERT omitted is that column's DEFAULT,
+    // so assigning it overwrites the stored value with NULL. Only columns this
+    // statement actually wrote can be carried onto the conflict path.
     const updateClauses = updateColumns
-      .filter((col) => col !== primaryKey)
+      .filter((col) => col !== primaryKey && insertedColumns.has(col))
       .map((col) => `${col} = EXCLUDED.${col}`);
     if (stampUpdated) updateClauses.push("updated = CURRENT_TIMESTAMP");
-    // Every requested column was the conflict key and there is no `updated` to
-    // stamp, so nothing is left to write. An empty SET list is a syntax error;
-    // re-assigning the conflict key is the no-op that keeps `DO UPDATE` — and
-    // therefore `RETURNING` — so the caller still gets the conflicting row.
+    // Every requested column was the conflict key or absent from the INSERT,
+    // and there is no `updated` to stamp, so nothing is left to write. An empty
+    // SET list is a syntax error; re-assigning the conflict key is the no-op
+    // that keeps `DO UPDATE` — and therefore `RETURNING` — so the caller still
+    // gets the conflicting row.
     if (updateClauses.length === 0) {
       updateClauses.push(`${primaryKey} = EXCLUDED.${primaryKey}`);
     }

--- a/src/server/lib/postgres/database.ts
+++ b/src/server/lib/postgres/database.ts
@@ -230,8 +230,9 @@ export function buildUpsert(
 
   if (updateColumns.length > 0) {
     // `EXCLUDED.col` for a column the INSERT omitted is that column's DEFAULT,
-    // so assigning it overwrites the stored value with NULL. Only columns this
-    // statement actually wrote can be carried onto the conflict path.
+    // so assigning it overwrites the stored value with that default — NULL where
+    // none is declared, otherwise a silent reset to the default. Only columns
+    // this statement actually wrote can be carried onto the conflict path.
     const updateClauses = updateColumns
       .filter((col) => col !== primaryKey && insertedColumns.has(col))
       .map((col) => `${col} = EXCLUDED.${col}`);


### PR DESCRIPTION
Closes #745.

## The defect

`buildUpsert` (`database.ts`) composes the INSERT column list by skipping `undefined` values, but it carried **every** requested `updateColumns` entry onto the conflict path:

```
upsert({ mailbox_id: "m1", name: "a", parent_id: undefined })
-> INSERT (mailbox_id, name) ...
   ON CONFLICT DO UPDATE SET name = EXCLUDED.name, parent_id = EXCLUDED.parent_id
```

`EXCLUDED.parent_id` for a column the INSERT omitted is that column's **DEFAULT**, so an existing `parent_id` was overwritten by an upsert that never mentioned it — NULL where no default is declared, and on a `NOT NULL DEFAULT` column a silent reset to the default rather than an error. `Table.upsert` derives `updateColumns` from `Object.keys(data)` with no `undefined` filter, so any caller passing an explicit `undefined` hits this.

## The fix

Filter `updateColumns` against the set of columns the statement actually wrote. One boundary enforces it, so both the derived (`Table.upsert`) and the explicit (`options.updateColumns`) paths are covered — an explicit `updateColumns: ["parent_id"]` alongside `parent_id: undefined` had the same defect and a caller-side filter would have missed it.

The empty-SET degradation already in the function covers the new way the SET list can end up empty (every requested column dropped), so `DO UPDATE` — and therefore `RETURNING` — is preserved rather than degrading to `DO NOTHING`.

## Sibling audit

Per the axis-mixing-at-a-helper-boundary rule, every sibling that takes the same `data` object was checked for the same disagreement:

| Helper | Filters `undefined`? |
|---|---|
| `buildInsert` | yes — INSERT loop, no conflict clause |
| `buildUpdate` | yes — SET list |
| `buildUpsert` | INSERT loop yes, **conflict clause no** ← this PR |
| `Table.updateWhere` | yes — both filters and data |
| `Table.deleteWhere` | yes — filters |

`buildUpsert`'s conflict clause was the lone gap. The hand-written upserts in `mails/counters.ts` and `spam_training.ts` use fixed column lists and are unaffected.

## Live callers

There are exactly three `Table.upsert` call sites (`grep '\.upsert(' src/`):

- **`writeUser`** (`users.ts:22`) builds `{ username, password: hashedPassword }` and leaves `password` undefined when no password is supplied — so the shape that destroys a stored password hash is one caller away. Its only current caller (`initializeAdminUser`) always passes a password, which is why this never fired in production.
- **`updateSession`** (`sessions.ts:74`) passes cookie fields express routinely leaves undefined. Those columns were already NULL, so sessions were unaffected either way (confirmed below). The `NOT NULL` session columns behave identically pre- and post-fix: Postgres validates the proposed INSERT tuple before conflict arbitration, so an undefined `session_user_id` fails the same way on both sides — the fix neither introduces nor masks that failure.
- **`mailgun-events.ts:160`** passes `updateColumns: []`, taking the `DO NOTHING` branch before the new filter is reached. No behavior change.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors (18 pre-existing warnings, none in the touched files)
- [x] `bun run build` — clean
- [x] `bun test src/server` — **1586 pass / 0 fail** (full suite, not a subdir, per the process-global `mock.module` hazard)
- [x] **5 new tests, all mutation-verified.** Reverting the one-line filter turns all 5 red (14 pass / 5 fail); with the fix, 19 pass. Four drive the pure exported `buildUpsert` with no pool; one drives `Table.upsert` through the existing FakePool seam on the real `writeUser` shape.
- [x] **Real-Postgres round-trip, paired against the pre-fix logic** (throwaway `inbox_e2e_745`, dropped after): insert a user row with a password hash, then upsert the same primary key with `password: undefined`, exactly as `writeUser` composes it.
  - pre-fix: `username` updated, **`password` = null** — the stored hash destroyed
  - with fix: `username` updated to the new value, **`password` preserved** — the conflict path still writes what the caller passed and only that
- [x] **UI E2E**, real server built from this branch on the throwaway DB, Playwright at 390x844:
  - `/` sign-in screen → filled the real username/password inputs and clicked the form's submit button (no `page.goto` of an authed URL, no direct API post) → signed in, `@hoie.kim` inbox renders. Screenshots `/tmp/pr-745-signin.png`, `/tmp/pr-745-loggedin.png` (eye-checked).
  - This exercises the other live upsert caller: express-session writes and touches the session row through `sessionsTable.upsert`, i.e. the conflict path, on every request.
  - Reload → still signed in, session read back from the row the upsert wrote, authed `GET /api/mails/accounts` = 200. Screenshot `/tmp/pr-745-reload.png`.
  - `page.on("pageerror")` + console-error watches: **0 errors**.
  - Post-run DB assertions: the session row's written columns all survived the conflict path (`session_user_id` / `session_username` / `session_email` / `cookie_http_only` / `cookie_path` all non-null), `cookie_domain` still NULL because express never supplies it — identical pre- and post-fix. Admin's password hash intact after boot + login.
- [x] Leak gate (`check-text-leaks.sh`) exit 0 on the commit message, the staged diff's added lines, and this body.

## Follow-up filed

reviewoie surfaced a second, pre-existing latent trap inside the same function and it is deliberately **not** folded in (rule 2 — scope): `autoColumns` appends `updated` unconditionally and is never reconciled with an `updated` key present in `data`, so the INSERT column list can carry it twice and Postgres rejects the statement. Filed as #813, with the same shape noted for `buildInsert`.
