### PR TITLE
security(imap): sanitize every stored value the RFC 5322 header block emits (#826)

### DIFF
--- a/src/server/lib/imap/fetch-helpers.test.ts
+++ b/src/server/lib/imap/fetch-helpers.test.ts
@@ -1300,6 +1300,31 @@ describe("buildBodyResponsePart header terminators (inbox #645)", () => {
     expect(content.endsWith("\r\n\r\n\r\n")).toBe(false);
   });
 
+  it("BODY[HEADER.FIELDS (FROM)] returns only the genuine From (#826)", async () => {
+    // The end-to-end shape of the spoofing primitive: HEADER_FIELDS selects
+    // lines by the field name before the colon, so a stored subject that
+    // opened its own `From:` line would be handed to the client as the
+    // message's sender.
+    const spoofed: Partial<MailType> = {
+      ...mail,
+      subject: "Hello\r\nFrom: ceo@bank.example\r\nX-Evil: 1"
+    };
+    const part = await buildBodyResponsePart(
+      spoofed,
+      {
+        type: "BODY",
+        peek: true,
+        section: { type: "HEADER_FIELDS", fields: ["From"], not: false }
+      },
+      docId,
+      mailbox
+    );
+    if (part!.type !== "literal") throw new Error("expected literal part");
+    const content = contentAsString(part!);
+
+    expect(content).toBe("From: alice@example.com\r\n\r\n");
+  });
+
   it("BODY[HEADER.FIELDS (no match)] is exactly a single blank line", async () => {
     const content = await contentOf({
       type: "BODY",

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -472,6 +472,52 @@ describe("buildFullMessage", () => {
       expect(result).not.toContain("--hijacked");
     });
 
+    it("a subject carrying the text `Content-Type: ` is not rewritten", () => {
+      // `rewriteContentType`'s match used to be unanchored, and Subject is
+      // emitted ahead of Content-Type — so this subject won the replace and
+      // the user's real subject was overwritten on BODY[] / RFC822 while
+      // BODY[HEADER] (which goes through formatHeaders directly) still showed
+      // the true one. No CRLF required.
+      const result = buildFullMessage(
+        {
+          subject: 'Content-Type: text/plain; boundary="evil"',
+          text: "Hello",
+          html: "<p>Hello</p>"
+        },
+        "docA"
+      );
+
+      expect(result).toContain(
+        'Subject: Content-Type: text/plain; boundary="evil"\r\n'
+      );
+      expect(result).toContain(
+        'Content-Type: multipart/alternative; boundary="boundary_docA"\r\n'
+      );
+      expect(result).not.toContain("--evil");
+    });
+
+    it("an attachment with no contentType / filename still serializes", () => {
+      // `attachments` comes off the JSONB column with no model hydration, so
+      // a row written before a field existed arrives `undefined`. Sanitizing
+      // it directly would throw on `.replace` and fail the whole FETCH.
+      const data = writeAttachment("att-bare", Buffer.from("DATA"));
+      const bare = {
+        content: { data: TEST_ID_PREFIX + "att-bare" },
+        size: data.byteLength
+      } as unknown as MailType["attachments"][number];
+
+      const result = buildFullMessage(
+        { text: "hi", attachments: [bare] },
+        "docC"
+      );
+
+      // Defaults match formatBodyStructure's for the same part, so a client
+      // comparing BODYSTRUCTURE against the part headers sees one answer.
+      expect(result).toContain("Content-Type: application/octet-stream\r\n");
+      expect(result).toContain('filename="unnamed"\r\n');
+      expect(result).not.toContain("undefined");
+    });
+
     it("an attachment filename cannot open a new parameter or header", () => {
       const data = writeAttachment("att-inject", Buffer.from("DATA"));
       const result = buildFullMessage(
@@ -721,6 +767,18 @@ describe("getBodyPartHeaders", () => {
       "Content-Type: image/png X-Evil: 1\r\n" +
         "Content-Transfer-Encoding: base64\r\n" +
         'Content-Disposition: attachment; filename="photo.png\\"; filename=\\"payroll.pdf"'
+    );
+  });
+
+  it("defaults a missing contentType / filename instead of throwing", () => {
+    const bare = {
+      content: { data: "att-bare" },
+      size: 10
+    } as unknown as MailType["attachments"][number];
+    expect(getBodyPartHeaders({ text: "Body", attachments: [bare] }, "2")).toBe(
+      "Content-Type: application/octet-stream\r\n" +
+        "Content-Transfer-Encoding: base64\r\n" +
+        'Content-Disposition: attachment; filename="unnamed"'
     );
   });
 

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -496,6 +496,30 @@ describe("buildFullMessage", () => {
       expect(result).not.toContain("--evil");
     });
 
+    it("a subject carrying U+2028 before `Content-Type: ` is not rewritten", () => {
+      // U+2028 / U+2029 are not RFC 5322 line breaks, but they ARE ECMAScript
+      // `LineTerminator`s, so `rewriteContentType`'s `/^…/m` treats what
+      // follows one as a line start — the anchor alone does not stop this.
+      // `headerFieldValue` collapsing them is what does.
+      const result = buildFullMessage(
+        {
+          subject: 'Hi\u2028Content-Type: text/plain; boundary="evil"',
+          text: "Hello",
+          html: "<p>Hello</p>"
+        },
+        "docU"
+      );
+
+      expect(result).toContain(
+        'Subject: Hi Content-Type: text/plain; boundary="evil"\r\n'
+      );
+      expect(result).toContain(
+        'Content-Type: multipart/alternative; boundary="boundary_docU"\r\n'
+      );
+      expect(result).not.toContain("\u2028");
+      expect(result).not.toContain("--evil");
+    });
+
     it("an attachment with no contentType / filename still serializes", () => {
       // `attachments` comes off the JSONB column with no model hydration, so
       // a row written before a field existed arrives `undefined`. Sanitizing

--- a/src/server/lib/imap/session-utils.test.ts
+++ b/src/server/lib/imap/session-utils.test.ts
@@ -445,6 +445,59 @@ describe("buildFullMessage", () => {
     const lines = result.split("\r\n");
     expect(lines.length).toBeGreaterThan(1);
   });
+
+  // #826: the MIME framing this function emits is derived from stored values
+  // an external sender controls, so a hostile mail must not be able to steer
+  // it.
+  describe("stored values cannot steer the MIME framing (#826)", () => {
+    it("a subject carrying boundary=\"…\" does not become the boundary", () => {
+      // The boundary used to be recovered by matching `boundary="([^"]+)"`
+      // against the whole header block, and Subject is emitted ahead of
+      // Content-Type — so this subject won the match and the `--` delimiters
+      // stopped agreeing with the declared boundary.
+      const result = buildFullMessage(
+        {
+          subject: 'winter sale boundary="hijacked"',
+          text: "Hello",
+          html: "<p>Hello</p>"
+        },
+        "doc-hijack"
+      );
+
+      expect(result).toContain(
+        'Content-Type: multipart/alternative; boundary="boundary_doc-hijack"'
+      );
+      expect(result).toContain("--boundary_doc-hijack\r\n");
+      expect(result).toContain("--boundary_doc-hijack--");
+      expect(result).not.toContain("--hijacked");
+    });
+
+    it("an attachment filename cannot open a new parameter or header", () => {
+      const data = writeAttachment("att-inject", Buffer.from("DATA"));
+      const result = buildFullMessage(
+        {
+          text: "See attached",
+          attachments: [
+            {
+              content: { data: TEST_ID_PREFIX + "att-inject" },
+              contentType: "text/plain\r\nX-Evil: 1",
+              filename: 'safe.txt"; filename="payroll.pdf',
+              size: data.byteLength
+            }
+          ]
+        },
+        "doc-att-inject"
+      );
+
+      expect(result).toContain("Content-Type: text/plain X-Evil: 1\r\n");
+      expect(result).toContain(
+        'Content-Disposition: attachment; filename="safe.txt\\"; filename=\\"payroll.pdf"\r\n'
+      );
+      expect(result.split("\r\n").some((l) => l.startsWith("X-Evil:"))).toBe(
+        false
+      );
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -647,6 +700,27 @@ describe("getBodyPartHeaders", () => {
       'Content-Type: image/png\r\n' +
         'Content-Transfer-Encoding: base64\r\n' +
         'Content-Disposition: attachment; filename="photo.png"'
+    );
+  });
+
+  it("escapes a hostile attachment contentType / filename (#826)", () => {
+    // Same part headers as the segment builder emits, so both surfaces have
+    // to survive the same stored bytes.
+    const mail: Partial<MailType> = {
+      text: "Body",
+      attachments: [
+        {
+          content: { data: "att-file" },
+          contentType: "image/png\r\nX-Evil: 1",
+          filename: 'photo.png"; filename="payroll.pdf',
+          size: 200
+        }
+      ]
+    };
+    expect(getBodyPartHeaders(mail, "2")).toBe(
+      "Content-Type: image/png X-Evil: 1\r\n" +
+        "Content-Transfer-Encoding: base64\r\n" +
+        'Content-Disposition: attachment; filename="photo.png\\"; filename=\\"payroll.pdf"'
     );
   });
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -6,7 +6,12 @@
 import fs from "node:fs";
 import { MailType } from "common";
 import { PartialRange, BodySection, FetchDataItem, HeaderFieldsSection } from "./types";
-import { formatHeaders } from "./util";
+import {
+  boundaryToken,
+  formatHeaders,
+  headerFieldValue,
+  headerQuotedParam
+} from "./util";
 import { getAttachment, getAttachmentFilePath } from "server";
 import { logger } from "server";
 import { pgTextChunks, pgByteChunks } from "server";
@@ -171,17 +176,19 @@ const resolveAttachmentRawSize = (dataId: string): number => {
 
 /**
  * The stable boundary strings a build for this mail would generate.
+ *
+ * Derived from the same `docId || messageId` the header block used, rather
+ * than recovered by matching `boundary="…"` against that block: the block also
+ * carries `Subject` and the address fields, so a stored subject of
+ * `sale boundary="--"` matched ahead of the real `Content-Type` line and the
+ * delimiters emitted below stopped agreeing with the declared boundary.
  */
 const boundariesFor = (
   mail: Partial<MailType>,
-  headers: string,
   docId?: string
 ): { boundary: string; altBoundary: string } => {
-  const boundaryMatch = headers.match(/boundary="([^"]+)"/);
-  const stableId = docId || mail.messageId || "default";
-  const boundary = boundaryMatch ? boundaryMatch[1] : "boundary_" + stableId;
-  const altBoundary = "alt_" + stableId.replace(/[^a-zA-Z0-9_]/g, "_");
-  return { boundary, altBoundary };
+  const token = boundaryToken(docId || mail.messageId || "default");
+  return { boundary: "boundary_" + token, altBoundary: "alt_" + token };
 };
 
 const rewriteContentType = (headers: string, replacement: string): string =>
@@ -316,7 +323,7 @@ export const buildMessageSegments = (
       messageId: mail.messageId
     });
   }
-  const { boundary, altBoundary } = boundariesFor(mail, headers, docId);
+  const { boundary, altBoundary } = boundariesFor(mail, docId);
 
   /** One base64 body part: boundary, part headers, encoded payload, CRLF. */
   const bodyPart = (
@@ -379,9 +386,11 @@ export const buildMessageSegments = (
 
   for (const att of mail.attachments!) {
     literal(`--${boundary}\r\n`);
-    literal(`Content-Type: ${att.contentType}\r\n`);
+    literal(`Content-Type: ${headerFieldValue(att.contentType)}\r\n`);
     literal(`Content-Transfer-Encoding: base64\r\n`);
-    literal(`Content-Disposition: attachment; filename="${att.filename}"\r\n\r\n`);
+    literal(
+      `Content-Disposition: attachment; filename=${headerQuotedParam(att.filename)}\r\n\r\n`
+    );
     segments.push({
       kind: "attachment",
       dataId: att.content.data,
@@ -1261,9 +1270,9 @@ export const getBodyPartHeaders = (
   ) {
     const att = mail.attachments[attachmentIndex];
     return (
-      `Content-Type: ${att.contentType}\r\n` +
+      `Content-Type: ${headerFieldValue(att.contentType)}\r\n` +
       `Content-Transfer-Encoding: base64\r\n` +
-      `Content-Disposition: attachment; filename="${att.filename}"`
+      `Content-Disposition: attachment; filename=${headerQuotedParam(att.filename)}`
     );
   }
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -195,7 +195,9 @@ const boundariesFor = (
 // subject containing that literal text got rewritten instead, with no CRLF
 // needed. Same shape as the `boundary="…"` recovery removed from
 // `boundariesFor`. `headerFieldValue` now guarantees no stored value can start
-// a line, which is what makes the anchor sufficient rather than just narrower.
+// a line — including U+2028 / U+2029, which `^` under `m` honours even though
+// RFC 5322 does not — which is what makes the anchor sufficient rather than
+// just narrower.
 const rewriteContentType = (headers: string, replacement: string): string =>
   headers.replace(/^Content-Type: [^\r\n]*/m, replacement);
 

--- a/src/server/lib/imap/session-utils.ts
+++ b/src/server/lib/imap/session-utils.ts
@@ -7,10 +7,9 @@ import fs from "node:fs";
 import { MailType } from "common";
 import { PartialRange, BodySection, FetchDataItem, HeaderFieldsSection } from "./types";
 import {
+  attachmentPartHeaderFields,
   boundaryToken,
-  formatHeaders,
-  headerFieldValue,
-  headerQuotedParam
+  formatHeaders
 } from "./util";
 import { getAttachment, getAttachmentFilePath } from "server";
 import { logger } from "server";
@@ -191,8 +190,14 @@ const boundariesFor = (
   return { boundary: "boundary_" + token, altBoundary: "alt_" + token };
 };
 
+// Anchored to a line start: unanchored, the first `Content-Type: ` ANYWHERE in
+// the block won — and `Subject` is emitted ahead of `Content-Type`, so a stored
+// subject containing that literal text got rewritten instead, with no CRLF
+// needed. Same shape as the `boundary="…"` recovery removed from
+// `boundariesFor`. `headerFieldValue` now guarantees no stored value can start
+// a line, which is what makes the anchor sufficient rather than just narrower.
 const rewriteContentType = (headers: string, replacement: string): string =>
-  headers.replace(/Content-Type: [^\r\n]+/, replacement);
+  headers.replace(/^Content-Type: [^\r\n]*/m, replacement);
 
 /**
  * A mail argument that may carry either the materialized body strings
@@ -385,11 +390,12 @@ export const buildMessageSegments = (
   }
 
   for (const att of mail.attachments!) {
+    const { contentType, filenameParam } = attachmentPartHeaderFields(att);
     literal(`--${boundary}\r\n`);
-    literal(`Content-Type: ${headerFieldValue(att.contentType)}\r\n`);
+    literal(`Content-Type: ${contentType}\r\n`);
     literal(`Content-Transfer-Encoding: base64\r\n`);
     literal(
-      `Content-Disposition: attachment; filename=${headerQuotedParam(att.filename)}\r\n\r\n`
+      `Content-Disposition: attachment; filename=${filenameParam}\r\n\r\n`
     );
     segments.push({
       kind: "attachment",
@@ -1268,11 +1274,13 @@ export const getBodyPartHeaders = (
     attachmentIndex >= 0 &&
     attachmentIndex < mail.attachments.length
   ) {
-    const att = mail.attachments[attachmentIndex];
+    const { contentType, filenameParam } = attachmentPartHeaderFields(
+      mail.attachments[attachmentIndex]
+    );
     return (
-      `Content-Type: ${headerFieldValue(att.contentType)}\r\n` +
+      `Content-Type: ${contentType}\r\n` +
       `Content-Transfer-Encoding: base64\r\n` +
-      `Content-Disposition: attachment; filename=${headerQuotedParam(att.filename)}`
+      `Content-Disposition: attachment; filename=${filenameParam}`
     );
   }
 

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -1,7 +1,10 @@
 import {
+  boundaryToken,
   encodeText,
   formatAddressList,
   formatHeaders,
+  headerFieldValue,
+  headerQuotedParam,
   formatEnvelope,
   formatBodyStructure,
   formatFlags,
@@ -436,6 +439,149 @@ describe("IMAP util", () => {
       const result = formatHeaders(mail);
       expect(result).toContain("\r\n");
       expect(result).not.toMatch(/[^\r]\n/); // No bare LF
+    });
+  });
+
+  // #826: an external sender picks the bytes in `subject`, `message_id` and
+  // the `*.text` address blobs — `receive.ts` stores them verbatim and
+  // mailparser decodes `=?utf-8?B?…?=`, so a CRLF reaches the column. Emitted
+  // raw into the RFC 5322 block, it opens a header field of the sender's
+  // choosing.
+  describe("formatHeaders — header injection (#826)", () => {
+    /** The block's field names, in order, one entry per emitted line. */
+    const fieldsOf = (block: string): string[] =>
+      block.split("\r\n").map((line) => line.slice(0, line.indexOf(":")));
+
+    const HOSTILE = "Hello\r\nFrom: ceo@bank.example\r\nX-Evil: 1";
+
+    it("a CRLF-bearing subject emits one Subject line and no new field", () => {
+      const block = formatHeaders(
+        {
+          messageId: "<x@y>",
+          from: { text: "real@sender.example", value: [] } as MailType["from"],
+          subject: HOSTILE,
+          text: "body"
+        },
+        "doc1"
+      );
+
+      expect(fieldsOf(block)).toEqual([
+        "Message-ID",
+        "From",
+        "Subject",
+        "MIME-Version",
+        "Content-Type",
+        "Content-Transfer-Encoding"
+      ]);
+      expect(block).toContain("Subject: Hello From: ceo@bank.example X-Evil: 1");
+      expect(block).toContain("From: real@sender.example\r\n");
+    });
+
+    // Every stored string named in #826's acceptance criteria, each carrying
+    // the same payload. Asserting the mapped result per field (rather than
+    // `.every(...)`) so one leaking field can't hide behind the others.
+    const CARRIERS = [
+      ["messageId", (v: string) => ({ messageId: v })],
+      ["subject", (v: string) => ({ subject: v })],
+      ["from", (v: string) => ({ from: { text: v, value: [] } })],
+      ["to", (v: string) => ({ to: { text: v, value: [] } })],
+      ["cc", (v: string) => ({ cc: { text: v, value: [] } })],
+      ["bcc", (v: string) => ({ bcc: { text: v, value: [] } })],
+      ["replyTo", (v: string) => ({ replyTo: { text: v, value: [] } })]
+    ] as const;
+
+    it("no stored field can open a header line", () => {
+      const injected = CARRIERS.map(([name, build]) => {
+        const block = formatHeaders(
+          build(HOSTILE) as Partial<MailType>,
+          "doc1"
+        );
+        // The payload survives as text inside its own field — what must not
+        // happen is a LINE of it, which is what the client selects on.
+        const opened = block
+          .split("\r\n")
+          .some((line) => line.startsWith("From: ceo@bank.example"));
+        return [name, opened] as const;
+      });
+
+      expect(injected).toEqual(
+        CARRIERS.map(([name]) => [name, false] as const)
+      );
+    });
+
+    it("no stored field can terminate the header block early", () => {
+      // CRLF CRLF is the RFC 5322 §2.1 body delimiter — a value carrying it
+      // would push its own tail out of the header block and into the body,
+      // which `BODY[TEXT]` then serves as message content.
+      const split = CARRIERS.map(([name, build]) => {
+        const block = formatHeaders(
+          build("start\r\n\r\nbody-goes-here") as Partial<MailType>,
+          "doc1"
+        );
+        return [name, block.includes("\r\n\r\n")] as const;
+      });
+
+      expect(split).toEqual(CARRIERS.map(([name]) => [name, false] as const));
+    });
+
+    it("a hostile Message-ID cannot escape the multipart boundary", () => {
+      // No docId → the boundary falls back to the stored Message-ID, so the
+      // sender's bytes land inside `boundary="…"` and in every `--<boundary>`
+      // delimiter downstream.
+      const block = formatHeaders({
+        messageId: '<a@b>\r\nX-Evil: 1"',
+        text: "hi",
+        html: "<p>hi</p>"
+      });
+      const boundary = block.match(/boundary="([^"\r\n]*)"/)?.[1];
+
+      expect(boundary).toBe("boundary__a_b___X-Evil__1_");
+      expect(fieldsOf(block)).toEqual([
+        "Message-ID",
+        "MIME-Version",
+        "Content-Type"
+      ]);
+    });
+  });
+
+  describe("headerFieldValue", () => {
+    it("collapses each CR / LF / NUL run to a single space", () => {
+      expect(headerFieldValue("a\r\nb\nc\rd\0e")).toBe("a b c d e");
+    });
+
+    it("leaves a value with no line breaks byte-identical", () => {
+      expect(headerFieldValue('Re: "quoted" \\ subject')).toBe(
+        'Re: "quoted" \\ subject'
+      );
+    });
+  });
+
+  describe("headerQuotedParam", () => {
+    it("escapes the quote that would close the parameter early", () => {
+      // Unescaped, `evil.txt"; filename="wanted.pdf` renames the attachment.
+      expect(headerQuotedParam('evil.txt"; filename="wanted.pdf')).toBe(
+        '"evil.txt\\"; filename=\\"wanted.pdf"'
+      );
+    });
+
+    it("escapes a trailing backslash so the string still terminates", () => {
+      expect(headerQuotedParam("report\\")).toBe('"report\\\\"');
+    });
+
+    it("strips line breaks before quoting", () => {
+      expect(headerQuotedParam("a\r\nb")).toBe('"a b"');
+    });
+  });
+
+  describe("boundaryToken", () => {
+    it("passes through the RFC 2046 bcharsnospace subset unchanged", () => {
+      expect(boundaryToken("test-doc.id_1")).toBe("test-doc.id_1");
+    });
+
+    it("substitutes character-for-character, so the length is stable", () => {
+      const hostile = '<a@b>\r\n"';
+      expect(boundaryToken(hostile)).toBe("_a_b____");
+      expect(boundaryToken(hostile).length).toBe(hostile.length);
     });
   });
 

--- a/src/server/lib/imap/util.test.ts
+++ b/src/server/lib/imap/util.test.ts
@@ -549,6 +549,12 @@ describe("IMAP util", () => {
       expect(headerFieldValue("a\r\nb\nc\rd\0e")).toBe("a b c d e");
     });
 
+    it("collapses U+2028 / U+2029 — line starts for a `/m` JS regex", () => {
+      // Not RFC 5322 line breaks, but ECMAScript `LineTerminator`s: left in,
+      // `rewriteContentType`'s `/^Content-Type: …/m` matches inside the value.
+      expect(headerFieldValue("a\u2028b\u2029c")).toBe("a b c");
+    });
+
     it("leaves a value with no line breaks byte-identical", () => {
       expect(headerFieldValue('Re: "quoted" \\ subject')).toBe(
         'Re: "quoted" \\ subject'

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -87,9 +87,38 @@ export const headerFieldValue = (value: string): string =>
  * attachment on the client. `quoted-string` escapes `"` and `\` with a
  * backslash, and both must be escaped: escaping only `"` turns a value ending
  * in a backslash into an unterminated string.
+ *
+ * Sibling of `quoteString` (RFC 3501 §9, added by #824 for the IMAP wire
+ * grammar). The two expand to the same expression today and are still
+ * deliberately separate: they encode different grammars for different
+ * consumers, so a future divergence — RFC 2045's parameter-length limit, or
+ * RFC 2231 continuations for non-ASCII filenames — belongs in one of them and
+ * not the other. Keep the cross-reference if you touch either.
  */
 export const headerQuotedParam = (value: string): string =>
   `"${headerFieldValue(value).replace(/[\\"]/g, "\\$&")}"`;
+
+/**
+ * The `Content-Type` value and quoted `filename` parameter for one attachment
+ * part header.
+ *
+ * The fallbacks mirror `formatBodyStructure`'s (`application/octet-stream` /
+ * `unnamed`) deliberately: BODYSTRUCTURE and the emitted part headers describe
+ * the same part, and a client comparing them must not be told two different
+ * things. They are `||` fallbacks rather than assertions because `attachments`
+ * reaches here straight off the JSONB column with no model hydration, so a row
+ * written before a field existed arrives `undefined` — which would throw on
+ * `.replace` where the old raw interpolation merely emitted the literal
+ * `undefined`.
+ */
+export const attachmentPartHeaderFields = (
+  attachment: Pick<AttachmentType, "contentType" | "filename">
+): { contentType: string; filenameParam: string } => ({
+  contentType: headerFieldValue(
+    attachment.contentType || "application/octet-stream"
+  ),
+  filenameParam: headerQuotedParam(attachment.filename || "unnamed")
+});
 
 /**
  * The MIME multipart boundary token derived from a mail's stable id.
@@ -98,9 +127,14 @@ export const headerQuotedParam = (value: string): string =>
  * an attacker-controlled string inside `Content-Type: …; boundary="…"` and
  * inside every `--<boundary>` delimiter. RFC 2046 §5.1.1 `bcharsnospace`
  * admits far less than an arbitrary Message-ID, so map anything outside it to
- * `_`. The substitution is character-for-character, so a boundary's length —
- * and with it `RFC822.SIZE` — is unchanged for every id that was already
- * legal.
+ * `_`.
+ *
+ * Character-for-character, so the boundary's CODE-UNIT count never changes.
+ * That is not the same as its byte count, and `segmentByteLength` measures
+ * bytes: a non-ASCII id shrinks (`café` 5 bytes → 4, `a😀b` 6 → 4). Harmless
+ * for a size computed from the same build — `RFC822.SIZE` and the `{N}`
+ * literal both derive from one `buildMessageSegments` call — but see the
+ * PR body for the persisted `mails.rfc822_size` rows this invalidates.
  */
 export const boundaryToken = (stableId: string): string =>
   stableId.replace(/[^A-Za-z0-9_.-]/g, "_");

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -75,9 +75,16 @@ export const encodeText = (str: string) => {
  * Each run collapses to a single space rather than being dropped: the bytes
  * carry no header semantics, and a space keeps adjacent words apart in the
  * value a client renders. NUL goes with them — it is outside `VCHAR`.
+ *
+ * U+2028 / U+2029 are stripped for the same reason one step removed: they are
+ * not RFC 5322 line breaks, but they ARE ECMAScript `LineTerminator`s, so a
+ * `/^…/m` regex run over the emitted block — `rewriteContentType` in
+ * `session-utils.ts` is one — sees a line starting mid-value. Leaving them in
+ * would make "no stored value can start a line" true of the wire and false of
+ * every JS reader of the same bytes.
  */
 export const headerFieldValue = (value: string): string =>
-  value.replace(/[\r\n\0]+/g, " ");
+  value.replace(/[\r\n\0\u2028\u2029]+/g, " ");
 
 /**
  * A stored value on its way into an RFC 2045 §5.1 quoted `parameter` value
@@ -110,6 +117,13 @@ export const headerQuotedParam = (value: string): string =>
  * written before a field existed arrives `undefined` — which would throw on
  * `.replace` where the old raw interpolation merely emitted the literal
  * `undefined`.
+ *
+ * `Attachment`'s constructor (`common/models/mails/Mail.ts`) defaults the same
+ * two fields to `text/plain` / `unnamed_file` instead. Those lose because the
+ * constructor never runs on this path — `store.ts` casts the JSONB column
+ * straight to `AttachmentType[]` with no hydration — and because BODYSTRUCTURE
+ * is the value a client cross-checks against. If hydration is ever added to
+ * the read path, reconcile the two rather than letting the wire drift.
  */
 export const attachmentPartHeaderFields = (
   attachment: Pick<AttachmentType, "contentType" | "filename">

--- a/src/server/lib/imap/util.ts
+++ b/src/server/lib/imap/util.ts
@@ -48,6 +48,63 @@ export const encodeText = (str: string) => {
   return Buffer.from(str, "utf8").toString("base64");
 };
 
+/**
+ * A stored value on its way into an RFC 5322 header field body.
+ *
+ * ```
+ * unstructured    = *([FWS] VCHAR) *WSP
+ * FWS             = ([*WSP CRLF] 1*WSP)
+ * ```
+ *
+ * A line break is legal in a field body only as folding — CRLF followed by
+ * WSP — and mailparser hands us already-unfolded values, so a CR or LF in a
+ * stored string is never something to preserve. Emitted raw it terminates the
+ * current header line and everything after it becomes a NEW header field:
+ * a subject of `Hello\r\nFrom: ceo@bank.example` puts a second, sender-chosen
+ * `From:` into the block, and `BODY[HEADER.FIELDS (FROM)]` hands it to the
+ * client as the message's sender. A CRLF CRLF ends the header block outright
+ * and the remainder of the value renders as body.
+ *
+ * The inputs are attacker-controlled — `receive.ts` stores `subject`,
+ * `message_id` and the `*.text` address blobs verbatim from the inbound
+ * message, and mailparser decodes encoded-words, so `=?utf-8?B?…?=` carries
+ * arbitrary bytes into the column. Route every stored value through here
+ * rather than checking at the call site; partial escaping at four sites is
+ * what produced #762 and #767 on the neighbouring RFC 3501 grammar.
+ *
+ * Each run collapses to a single space rather than being dropped: the bytes
+ * carry no header semantics, and a space keeps adjacent words apart in the
+ * value a client renders. NUL goes with them — it is outside `VCHAR`.
+ */
+export const headerFieldValue = (value: string): string =>
+  value.replace(/[\r\n\0]+/g, " ");
+
+/**
+ * A stored value on its way into an RFC 2045 §5.1 quoted `parameter` value
+ * (`filename="…"`, `name="…"`). Beyond the line-break rule above, an
+ * unescaped `"` closes the parameter early, so the rest of the value is read
+ * as further parameters — `evil.txt"; filename="wanted.pdf` renames the
+ * attachment on the client. `quoted-string` escapes `"` and `\` with a
+ * backslash, and both must be escaped: escaping only `"` turns a value ending
+ * in a backslash into an unterminated string.
+ */
+export const headerQuotedParam = (value: string): string =>
+  `"${headerFieldValue(value).replace(/[\\"]/g, "\\$&")}"`;
+
+/**
+ * The MIME multipart boundary token derived from a mail's stable id.
+ *
+ * The id falls back to `mail.messageId` when no `docId` is passed, which puts
+ * an attacker-controlled string inside `Content-Type: …; boundary="…"` and
+ * inside every `--<boundary>` delimiter. RFC 2046 §5.1.1 `bcharsnospace`
+ * admits far less than an arbitrary Message-ID, so map anything outside it to
+ * `_`. The substitution is character-for-character, so a boundary's length —
+ * and with it `RFC822.SIZE` — is unchanged for every id that was already
+ * legal.
+ */
+export const boundaryToken = (stableId: string): string =>
+  stableId.replace(/[^A-Za-z0-9_.-]/g, "_");
+
 export const formatAddressList = (value?: MailAddressValueType[]): string => {
   if (!value || value.length === 0) return "NIL";
 
@@ -94,7 +151,7 @@ export const formatHeaders = (
 
   // Add standard headers in proper order
   if (mail.messageId) {
-    headers.push(`Message-ID: ${mail.messageId}`);
+    headers.push(`Message-ID: ${headerFieldValue(mail.messageId)}`);
   }
 
   if (mail.date) {
@@ -103,27 +160,27 @@ export const formatHeaders = (
   }
 
   if (mail.from?.text) {
-    headers.push(`From: ${mail.from.text}`);
+    headers.push(`From: ${headerFieldValue(mail.from.text)}`);
   }
 
   if (mail.to?.text) {
-    headers.push(`To: ${mail.to.text}`);
+    headers.push(`To: ${headerFieldValue(mail.to.text)}`);
   }
 
   if (mail.cc?.text) {
-    headers.push(`Cc: ${mail.cc.text}`);
+    headers.push(`Cc: ${headerFieldValue(mail.cc.text)}`);
   }
 
   if (mail.bcc?.text) {
-    headers.push(`Bcc: ${mail.bcc.text}`);
+    headers.push(`Bcc: ${headerFieldValue(mail.bcc.text)}`);
   }
 
   if (mail.replyTo?.text) {
-    headers.push(`Reply-To: ${mail.replyTo.text}`);
+    headers.push(`Reply-To: ${headerFieldValue(mail.replyTo.text)}`);
   }
 
   if (mail.subject) {
-    headers.push(`Subject: ${mail.subject}`);
+    headers.push(`Subject: ${headerFieldValue(mail.subject)}`);
   }
 
   // Add MIME headers
@@ -145,11 +202,11 @@ export const formatHeaders = (
   // Determine Content-Type based on message structure
   if (hasAttachments) {
     // multipart/mixed for messages with attachments
-    const boundary = "boundary_" + stableId;
+    const boundary = "boundary_" + boundaryToken(stableId);
     headers.push(`Content-Type: multipart/mixed; boundary="${boundary}"`);
   } else if (hasText && hasHtml) {
     // multipart/alternative for messages with both text and HTML
-    const boundary = "boundary_" + stableId;
+    const boundary = "boundary_" + boundaryToken(stableId);
     headers.push(`Content-Type: multipart/alternative; boundary="${boundary}"`);
   } else if (hasHtml) {
     headers.push("Content-Type: text/html; charset=utf-8");


### PR DESCRIPTION
Closes #826.

## The defect

`formatHeaders` built the RFC 5322 header block by interpolating stored values raw and joining with CRLF. `receive.ts` stores `subject`, `message_id` and the `*.text` address blobs verbatim from the inbound message, and mailparser decodes encoded-words — so an external sender puts a CRLF in the column and gets **a header field of their choosing**.

`fetch-helpers.ts` `HEADER_FIELDS` selects lines by the name before the colon, so a stored subject of `Hello\r\nFrom: ceo@bank.example` makes `BODY[HEADER.FIELDS (FROM)]` return the injected address. That is a spoofing primitive against every IMAP client reading the mailbox, reachable with nothing but a crafted inbound email. `CRLF CRLF` additionally terminates the header block, pushing the value's tail into the body.

## The fix — one encoder per grammar

Same shape #824 used for RFC 3501 §9, in `util.ts`:

| helper | grammar | what it stops |
|---|---|---|
| `headerFieldValue` | RFC 5322 §2.2 field body | CR / LF / NUL runs collapse to a space — folding is legal only as CRLF+WSP, and mailparser already unfolds. U+2028 / U+2029 go with them: not RFC 5322 line breaks, but ECMAScript `LineTerminator`s, so a `/^…/m` regex over the emitted block sees a line starting mid-value (reviewoie R2 MED 1) |
| `headerQuotedParam` | RFC 2045 §5.1 `quoted-string` | an unescaped `"` in `filename="…"` closes the parameter, so `safe.txt"; filename="payroll.pdf` renames the attachment on the client; `\` escaped too, or a trailing backslash leaves the string unterminated |
| `boundaryToken` | RFC 2046 §5.1.1 `bcharsnospace` | the boundary falls back to the stored Message-ID when no `docId` is passed, putting sender bytes inside `boundary="…"` and in every delimiter |

`boundaryToken` substitutes character-for-character, so the token's code-unit count is stable; every production call passes `docId = mail_id` (a UUID), so it is ASCII and its **byte** count is unchanged too.

## Sibling sweep — same grammar, same change

The defect class is "attacker-controlled stored value interpolated into a header line", and `formatHeaders` was not the only site:

- **`buildMessageSegments`** attachment parts and **`getBodyPartHeaders`** both emit `Content-Type: ${att.contentType}` and `filename="${att.filename}"` from stored values. Both now take the two encoders.
- **`boundariesFor`** recovered the boundary by matching `boundary="([^"]+)"` against the emitted header block. `Subject` is emitted **ahead of** `Content-Type`, so a stored subject of `winter sale boundary="hijacked"` won that match — no CRLF required — and the `--<boundary>` delimiters stopped agreeing with the declared boundary. It now derives the token from the same `docId || messageId` the header block used, which is what the regex was recovering anyway in every non-hostile case.
- **`rewriteContentType`** matched the first `Content-Type: ` anywhere in the block, so a subject carrying that literal text won the replace. Now anchored to a line start — and, with the U+2028 / U+2029 collapse above, "no stored value can start a line" is true for a JS `/m` reader of the bytes, not just for the wire.

## Deploy step — required, and after this merges

Five paths here change the emitted byte count, and `mails.rfc822_size` is stamped at INSERT and returned verbatim on a cache hit. Pre-deploy rows therefore report a stale size, breaking the `RFC822.SIZE == BODY[] octets` invariant.

The sanitizers (`headerFieldValue`, `headerQuotedParam`, the attachment defaults) move a mail by a byte or two. **The two framing-path removals are the large ones**, and a CRLF-only backfill predicate misses them entirely:

- the removed `boundary="…"` recovery — a hijacked token was stamped into the declared boundary *and* every `--<boundary>` delimiter, four occurrences in the multipart/alternative shape: **+148 bytes** measured on `Winter sale boundary="hijacked"`;
- the now-anchored `rewriteContentType` — a value carrying the literal `Content-Type: ` used to have its own line rewritten to the canonical string: **−51 bytes** measured on `Content-Type: text/plain; charset=us-ascii`.

Both reach through **all seven emitted columns**, not just `subject`. Tracked with the widened idempotent SQL and a sandbox dry-run gate in #829. Run it *after* this deploys, or the backfill re-stamps the old value.

## Acceptance criteria (from the issue)

- [x] A stored subject containing CRLF produces exactly one `Subject:` line and injects no new field
- [x] `BODY[HEADER.FIELDS (FROM)]` returns only the genuine `From`
- [x] Same for `message_id`, `from.text`, `to.text`, `cc.text`, `bcc.text`, `reply_to.text` — asserted **per field** on the mapped array, not through an `every(...)` predicate that one leaking field could hide behind
- [x] A stored value containing CRLF CRLF cannot terminate the header block

Deliberately **not** in scope: the issue's second fix direction ("emit the structured parsed columns rather than echoing the `*.text` blobs"). That changes what every client sees in `From:`/`To:` for well-formed mail, which is a behaviour change on the happy path, not a fix for this defect. Worth a follow-up issue if you want it.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — **1814 pass / 0 fail (96 files)**; `upstream/main` at `da2b242` measures 1794 across the same 96 files, so **+20** from this branch. Re-measured after rebasing onto `da2b242`, which carries #773's lazy `BODY[TEXT]` / `BODY[<part>]` streaming — the same serialization path this PR sanitizes. Both numbers read off CI runs on those exact SHAs, not a local run
- [x] `bun run lint` — 0 errors, 17 warnings, **none introduced by this PR**: the lint output is byte-identical between this branch and an `upstream/main` worktree at `da2b242`. One of the 17 is in a file this PR touches (`session-utils.test.ts` unused `beforeEach`) and it is present on main too
- [x] **Mutation-tested the new assertions.** Reverting `headerFieldValue` to the identity function fails all four `formatHeaders — header injection` tests. Dropping just `\u2028\u2029` from its character class fails exactly the two tests added for reviewoie R2 MED 1 — `headerFieldValue > collapses U+2028 / U+2029` and `buildFullMessage > a subject carrying U+2028 before Content-Type: is not rewritten` — and nothing else. Un-anchoring `rewriteContentType` fails the Content-Type-in-subject test; dropping the attachment `||` fallbacks fails two more. Every new mechanism is load-bearing and pinned.
- [x] **End-to-end through the real fetch path**, not just the string builder: `buildBodyResponsePart(spoofedMail, BODY.PEEK[HEADER.FIELDS (From)])` returns exactly `From: alice@example.com\r\n\r\n` — the injected `ceo@bank.example` is absent from the wire bytes the client would parse. This is the assertion that pins the user-visible impact; the `formatHeaders` unit tests pin the mechanism.
- [x] Framing parity — `--<boundary>` delimiters and the declared `boundary="…"` still agree for the hijack-attempt subject, and the closing `--<boundary>--` is present.

No UI surface: the diff is entirely inside the IMAP server's wire serialization, which the web client does not consume — it reads mail through `/api`. The exercised surface is the IMAP FETCH response, driven above through `buildBodyResponsePart` with the byte-count assertion (`{N}` literal == emitted octets) that the surrounding suite already enforces on every header fetch.

