### PR TITLE
fix(mails): stop reporting a DB fault as "not found or no permission"

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -15,6 +15,18 @@ export const callWithDelay = <T>(callback: () => Promise<T>, delay: number) => {
   return new Promise((res) => setTimeout(() => res(callback()), delay));
 };
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Screen an id before it reaches a query against a `uuid` column. Postgres
+ * answers a malformed uuid with a 22P02 error rather than an empty result, so
+ * an id that could never have matched anything has to be rejected up front —
+ * otherwise a stale bookmark or an old client's cached id becomes a 500 and an
+ * alarm page instead of a plain not-found (#747).
+ */
+export const isUuid = (value: unknown): value is string =>
+  typeof value === "string" && UUID_PATTERN.test(value);
+
 export const getRandomId = () => {
   // Use Web Crypto API (available in both browser and Node.js 19+)
   const bytes = new Uint8Array(4);

--- a/src/server/lib/http/routes/mails/delete.ts
+++ b/src/server/lib/http/routes/mails/delete.ts
@@ -1,3 +1,4 @@
+import { isUuid } from "common";
 import { getMailBody, deleteMail } from "server";
 import { Route } from "../route";
 
@@ -10,6 +11,17 @@ export const deleteMailRoute = new Route<MailDeleteResponse>(
     const user = req.session.user!;
 
     const mailId = req.params.id;
+
+    // A malformed uuid raises 22P02 in Postgres rather than matching no row,
+    // and the repository no longer swallows that — screen it here so a bad id
+    // stays a plain rejection instead of a 500 (#747).
+    if (!isUuid(mailId)) {
+      return {
+        status: "failed",
+        message: "Invalid request. You may not manipulate other users' email"
+      };
+    }
+
     const data = await getMailBody(user.id, mailId);
 
     if (!data) {
@@ -19,6 +31,11 @@ export const deleteMailRoute = new Route<MailDeleteResponse>(
       };
     }
 
+    // Deliberately not gated on the return value. A DB fault now throws, so
+    // `false` here means only that the row disappeared between the check above
+    // and the delete — a concurrent delete that reached the same end state the
+    // caller asked for. Reporting that as a failure would be a lie in the
+    // other direction.
     await deleteMail(user.id, mailId);
     return { status: "success" };
   }

--- a/src/server/lib/http/routes/mails/get-body.ts
+++ b/src/server/lib/http/routes/mails/get-body.ts
@@ -1,4 +1,4 @@
-import { MailBodyDataType } from "common";
+import { MailBodyDataType, isUuid } from "common";
 import { getMailBody } from "server";
 import { Route } from "../route";
 
@@ -9,6 +9,12 @@ export const getBodyRoute = new Route<BodyGetResponse>(
   "/body/:id",
   async (req) => {
     const user = req.session.user!;
+
+    // `mail_id` is a uuid column: a malformed id raises 22P02 rather than
+    // matching nothing, and since the repository no longer swallows that it
+    // would answer 500 and page the alarm channel. An id of the wrong shape is
+    // a client error, so screen it here and keep the plain not-found (#747).
+    if (!isUuid(req.params.id)) return { status: "failed", message: "No email is found." };
 
     const mail = await getMailBody(user.id, req.params.id);
     if (!mail) return { status: "failed", message: "No email is found." };

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -13,7 +13,9 @@ const mockGetMailHeaders = mock(async () => []);
 const mockGetMailHeadersDelta = mock(async () => ({ as_of: "", headers: [], expunged_ids: [] }));
 const mockGetAccounts = mock(async () => ({ received: [], sent: [] }));
 const mockGetMailBody = mock(async () => null as unknown);
-const mockDeleteMail = mock(async () => {});
+// Matches the real `deleteMail(): Promise<boolean>` — a stub resolving
+// `undefined` could never surface the true/false distinction the route reads.
+const mockDeleteMail = mock(async () => true);
 // `markRead` / `markSaved` report the outcome as a boolean — false means the
 // row did not match, and a DB fault throws instead (#747). Mock the real
 // signature so a route that ignores the result cannot pass.
@@ -103,6 +105,13 @@ mock.module("server/lib/spam/classifier", () => ({
 // ── Helper factories ──────────────────────────────────────────────────────────
 
 const makeUser = (username = "alice", id = "u1") => ({ id, username });
+
+// `mails.mail_id` is `UUID PRIMARY KEY DEFAULT gen_random_uuid()`, and the
+// routes now shape-check it before querying (#747), so fixtures have to use
+// ids that could actually exist.
+const MAIL_ID = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+const MISSING_ID = "9c8b7a65-4d3e-42f1-8a09-1b2c3d4e5f60";
+const OTHER_ID = "5e4d3c2b-1a09-4f8e-b7d6-c5b4a3928170";
 
 const makeReq = (overrides: Record<string, unknown> = {}) =>
   ({
@@ -341,7 +350,7 @@ describe("getBodyRoute", () => {
     const fakeMail = { id: "m1", html: "<p>Hello</p>" };
     mockGetMailBody.mockResolvedValueOnce(fakeMail);
 
-    const req = makeReq({ params: { id: "m1" } });
+    const req = makeReq({ params: { id: MAIL_ID } });
     const res = makeRes();
 
     const result = await getBodyRoute.callback(req, res, noopStream);
@@ -354,7 +363,7 @@ describe("getBodyRoute", () => {
 
     mockGetMailBody.mockResolvedValueOnce(null);
 
-    const req = makeReq({ params: { id: "missing" } });
+    const req = makeReq({ params: { id: MISSING_ID } });
     const res = makeRes();
 
     const result = await getBodyRoute.callback(req, res, noopStream);
@@ -376,12 +385,12 @@ describe("deleteMailRoute", () => {
 
     mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
 
-    const req = makeReq({ method: "DELETE", params: { id: "m1" } });
+    const req = makeReq({ method: "DELETE", params: { id: MAIL_ID } });
     const res = makeRes();
 
     const result = await deleteMailRoute.callback(req, res, noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
-    expect(mockDeleteMail).toHaveBeenCalledWith("u1", "m1");
+    expect(mockDeleteMail).toHaveBeenCalledWith("u1", MAIL_ID);
   });
 
   it("returns failed when mail not found (or belongs to another user)", async () => {
@@ -389,7 +398,7 @@ describe("deleteMailRoute", () => {
 
     mockGetMailBody.mockResolvedValueOnce(null);
 
-    const req = makeReq({ method: "DELETE", params: { id: "other-m" } });
+    const req = makeReq({ method: "DELETE", params: { id: OTHER_ID } });
     const res = makeRes();
 
     const result = await deleteMailRoute.callback(req, res, noopStream);
@@ -415,13 +424,13 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1", read: true },
+      body: { mail_id: MAIL_ID, read: true },
     });
     const res = makeRes();
 
     const result = await postMarkMailRoute.callback(req, res, noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
-    expect(mockMarkRead).toHaveBeenCalledWith("u1", "m1");
+    expect(mockMarkRead).toHaveBeenCalledWith("u1", MAIL_ID);
   });
 
   it("marks mail as saved when save=true", async () => {
@@ -431,13 +440,13 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1", save: true },
+      body: { mail_id: MAIL_ID, save: true },
     });
     const res = makeRes();
 
     const result = await postMarkMailRoute.callback(req, res, noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
-    expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", true);
+    expect(mockMarkSaved).toHaveBeenCalledWith("u1", MAIL_ID, true);
   });
 
   it("marks mail as unsaved when save=false", async () => {
@@ -447,13 +456,13 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1", save: false },
+      body: { mail_id: MAIL_ID, save: false },
     });
     const res = makeRes();
 
     const result = await postMarkMailRoute.callback(req, res, noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
-    expect(mockMarkSaved).toHaveBeenCalledWith("u1", "m1", false);
+    expect(mockMarkSaved).toHaveBeenCalledWith("u1", MAIL_ID, false);
   });
 
   it("returns failed when mail not found", async () => {
@@ -463,7 +472,7 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "bad-id", read: true },
+      body: { mail_id: MISSING_ID, read: true },
     });
     const res = makeRes();
 
@@ -537,7 +546,7 @@ describe("postMarkMailRoute", () => {
     mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
     mockMarkRead.mockResolvedValueOnce(false);
 
-    const req = makeReq({ method: "POST", body: { mail_id: "m1", read: true } });
+    const req = makeReq({ method: "POST", body: { mail_id: MAIL_ID, read: true } });
     const result = await postMarkMailRoute.callback(req, makeRes(), noopStream);
 
     expect((result as ApiResponse<unknown>).status).toBe("failed");
@@ -551,7 +560,7 @@ describe("postMarkMailRoute", () => {
     mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
     mockMarkSaved.mockResolvedValueOnce(false);
 
-    const req = makeReq({ method: "POST", body: { mail_id: "m1", save: true } });
+    const req = makeReq({ method: "POST", body: { mail_id: MAIL_ID, save: true } });
     const result = await postMarkMailRoute.callback(req, makeRes(), noopStream);
 
     expect((result as ApiResponse<unknown>).status).toBe("failed");
@@ -562,7 +571,7 @@ describe("postMarkMailRoute", () => {
 
     mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
 
-    const req = makeReq({ method: "POST", body: { mail_id: "m1" } });
+    const req = makeReq({ method: "POST", body: { mail_id: MAIL_ID } });
     const result = await postMarkMailRoute.callback(req, makeRes(), noopStream);
 
     expect((result as ApiResponse<unknown>).status).toBe("success");
@@ -577,7 +586,7 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1" },
+      body: { mail_id: MAIL_ID },
     });
     const res = makeRes();
 
@@ -592,7 +601,7 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1", read: true },
+      body: { mail_id: MAIL_ID, read: true },
     });
 
     await postMarkMailRoute.callback(req, makeRes(), noopStream);
@@ -612,14 +621,14 @@ describe("postMarkMailRoute", () => {
 
     const req = makeReq({
       method: "POST",
-      body: { mail_id: "m1", read: true },
+      body: { mail_id: MAIL_ID, read: true },
     });
 
     const result = await postMarkMailRoute.callback(req, makeRes(), noopStream);
 
     // markRead still ran — the badge-decrement rejection is logged, not propagated.
     expect((result as ApiResponse<unknown>).status).toBe("success");
-    expect(mockMarkRead).toHaveBeenCalledWith("u1", "m1");
+    expect(mockMarkRead).toHaveBeenCalledWith("u1", MAIL_ID);
 
     // Give the .catch(logger.error) microtask a chance to run.
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
@@ -866,7 +875,7 @@ describe("postMarkSpamMailRoute", () => {
 
   it("rejects when is_spam is not boolean", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
-    const req = makeReq({ body: { mail_id: "m1", is_spam: "yes" } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: "yes" } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("failed");
     expect((result as ApiResponse<unknown>).message).toMatch(/boolean/i);
@@ -876,13 +885,13 @@ describe("postMarkSpamMailRoute", () => {
   it("returns failed when mail not found or no permission (cross-user gate)", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce({ found: false, changed: false });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("failed");
     expect((result as ApiResponse<unknown>).message).toMatch(/not found/i);
     // markSpam was reached with the session user_id — the ownership gate is at
     // the repo layer; assert it was passed.
-    expect(mockMarkSpam).toHaveBeenCalledWith("u1", "m1", true);
+    expect(mockMarkSpam).toHaveBeenCalledWith("u1", MAIL_ID, true);
     expect(mockGetMailById).not.toHaveBeenCalled();
     expect(mockTrainWithEmail).not.toHaveBeenCalled();
   });
@@ -896,13 +905,13 @@ describe("postMarkSpamMailRoute", () => {
       html: "<p>Click here</p>",
       from_address: [{ address: "spammer@evil.example" }],
     });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
     // Wait for the fire-and-forget training pipeline.
     await new Promise<void>((resolve) => setTimeout(resolve, 0));
-    expect(mockGetMailById).toHaveBeenCalledWith("u1", "m1");
+    expect(mockGetMailById).toHaveBeenCalledWith("u1", MAIL_ID);
     expect(mockTrainWithEmail).toHaveBeenCalledTimes(1);
     expect(mockTrainWithEmail).toHaveBeenCalledWith(
       "u1",
@@ -923,7 +932,7 @@ describe("postMarkSpamMailRoute", () => {
       html: "<p>Updates</p>",
       from_address: [{ address: "news@legit.example" }],
     });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: false } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: false } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -938,7 +947,7 @@ describe("postMarkSpamMailRoute", () => {
   it("returns success but skips training when re-marking with the same value (#491)", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce({ found: true, changed: false });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -951,7 +960,7 @@ describe("postMarkSpamMailRoute", () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockResolvedValueOnce({ found: true, changed: true });
     mockGetMailById.mockResolvedValueOnce(null);
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -970,7 +979,7 @@ describe("postMarkSpamMailRoute", () => {
       from_address: [{ address: "a@b.example" }],
     });
     mockTrainWithEmail.mockRejectedValueOnce(new Error("classifier offline"));
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -988,7 +997,7 @@ describe("postMarkSpamMailRoute", () => {
       html: "<p>y</p>",
       from_address: null,
     });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -1010,7 +1019,7 @@ describe("postMarkSpamMailRoute", () => {
       html: "<p>y</p>",
       from_address: [],
     });
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     const result = await postMarkSpamMailRoute.callback(req, makeRes(), noopStream);
     expect((result as ApiResponse<unknown>).status).toBe("success");
 
@@ -1089,7 +1098,7 @@ describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
   it("post-spam-mark propagates instead of answering not-found", async () => {
     const { postMarkSpamMailRoute } = await import("./post-spam-mark");
     mockMarkSpam.mockRejectedValueOnce(new Error("connection terminated"));
-    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, is_spam: true } });
     await expect(
       postMarkSpamMailRoute.callback(req, makeRes(), noopStream)
     ).rejects.toThrow("connection terminated");
@@ -1099,7 +1108,7 @@ describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
     const { postMarkMailRoute } = await import("./post-mark");
     mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
     mockMarkRead.mockRejectedValueOnce(new Error("connection terminated"));
-    const req = makeReq({ body: { mail_id: "m1", read: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, read: true } });
     await expect(
       postMarkMailRoute.callback(req, makeRes(), noopStream)
     ).rejects.toThrow("connection terminated");
@@ -1109,7 +1118,7 @@ describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
     const { postMarkMailRoute } = await import("./post-mark");
     mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
     mockMarkSaved.mockRejectedValueOnce(new Error("connection terminated"));
-    const req = makeReq({ body: { mail_id: "m1", save: true } });
+    const req = makeReq({ body: { mail_id: MAIL_ID, save: true } });
     await expect(
       postMarkMailRoute.callback(req, makeRes(), noopStream)
     ).rejects.toThrow("connection terminated");
@@ -1118,7 +1127,7 @@ describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
   it("get-body propagates instead of answering no-email-is-found", async () => {
     const { getBodyRoute } = await import("./get-body");
     mockGetMailBody.mockRejectedValueOnce(new Error("connection terminated"));
-    const req = makeReq({ params: { id: "m1" } });
+    const req = makeReq({ params: { id: MAIL_ID } });
     await expect(
       getBodyRoute.callback(req, makeRes(), noopStream)
     ).rejects.toThrow("connection terminated");
@@ -1128,9 +1137,78 @@ describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
     const { deleteMailRoute } = await import("./delete");
     mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
     mockDeleteMail.mockRejectedValueOnce(new Error("connection terminated"));
-    const req = makeReq({ params: { id: "m1" } });
+    const req = makeReq({ params: { id: MAIL_ID } });
     await expect(
       deleteMailRoute.callback(req, makeRes(), noopStream)
     ).rejects.toThrow("connection terminated");
+  });
+});
+
+// ── malformed mail_id stays a rejection, not a 500 (#747) ────────────────────
+
+describe("mail routes reject a malformed mail_id before it reaches Postgres (#747)", () => {
+  // `mails.mail_id` is a uuid column, so Postgres answers a malformed value
+  // with a 22P02 error rather than an empty result. Once the repository stopped
+  // swallowing errors, an id of the wrong shape — a stale bookmark, an old
+  // client's cached id — would have become a 500 plus an alarm page. These pin
+  // that the shape check happens first and the repository is never called.
+  const BAD_IDS = ["not-a-uuid", "", "123", "'; DROP TABLE mails; --"];
+
+  beforeEach(() => {
+    mockGetMailBody.mockClear();
+    mockDeleteMail.mockClear();
+    mockMarkSpam.mockClear();
+    mockMarkRead.mockClear();
+  });
+
+  it.each(BAD_IDS)("get-body rejects %p without querying", async (id) => {
+    const { getBodyRoute } = await import("./get-body");
+    const result = await getBodyRoute.callback(makeReq({ params: { id } }), makeRes(), noopStream);
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect(mockGetMailBody).not.toHaveBeenCalled();
+  });
+
+  it.each(BAD_IDS)("delete rejects %p without querying", async (id) => {
+    const { deleteMailRoute } = await import("./delete");
+    const result = await deleteMailRoute.callback(
+      makeReq({ params: { id } }),
+      makeRes(),
+      noopStream
+    );
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect(mockGetMailBody).not.toHaveBeenCalled();
+    expect(mockDeleteMail).not.toHaveBeenCalled();
+  });
+
+  it.each(BAD_IDS)("post-mark rejects %p without querying", async (id) => {
+    const { postMarkMailRoute } = await import("./post-mark");
+    const result = await postMarkMailRoute.callback(
+      makeReq({ body: { mail_id: id, read: true } }),
+      makeRes(),
+      noopStream
+    );
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect(mockGetMailBody).not.toHaveBeenCalled();
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it.each(BAD_IDS)("post-spam-mark rejects %p without querying", async (id) => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    const result = await postMarkSpamMailRoute.callback(
+      makeReq({ body: { mail_id: id, is_spam: true } }),
+      makeRes(),
+      noopStream
+    );
+    expect((result as ApiResponse<unknown>).status).toBe("failed");
+    expect(mockMarkSpam).not.toHaveBeenCalled();
+  });
+
+  it("a well-formed uuid still reaches the repository", async () => {
+    const { getBodyRoute } = await import("./get-body");
+    mockGetMailBody.mockResolvedValueOnce({ id: "m1" });
+    const id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    const result = await getBodyRoute.callback(makeReq({ params: { id } }), makeRes(), noopStream);
+    expect(mockGetMailBody).toHaveBeenCalledWith("u1", id);
+    expect((result as ApiResponse<unknown>).status).toBe("success");
   });
 });

--- a/src/server/lib/http/routes/mails/mails.test.ts
+++ b/src/server/lib/http/routes/mails/mails.test.ts
@@ -14,9 +14,9 @@ const mockGetMailHeadersDelta = mock(async () => ({ as_of: "", headers: [], expu
 const mockGetAccounts = mock(async () => ({ received: [], sent: [] }));
 const mockGetMailBody = mock(async () => null as unknown);
 const mockDeleteMail = mock(async () => {});
-// `markRead` / `markSaved` report the outcome as a boolean — the repositories
-// catch their own errors and return false. Mock the real signature so a route
-// that ignores the result cannot pass.
+// `markRead` / `markSaved` report the outcome as a boolean — false means the
+// row did not match, and a DB fault throws instead (#747). Mock the real
+// signature so a route that ignores the result cannot pass.
 const mockMarkRead = mock(async () => true);
 const mockMarkSaved = mock(async () => true);
 const mockDecrementBadgeCount = mock(async () => {});
@@ -1065,5 +1065,72 @@ describe("getAttachmentRoute", () => {
     const req = makeReq({ params: { id: "att1" } });
     const result = await getAttachmentRoute.callback(req, makeRes(), noopStream);
     expect(result).toBe(fakeBuffer);
+  });
+});
+
+// ── DB fault is not reported as not-found (#747) ─────────────────────────────
+
+describe("mail routes: a DB fault reaches the route boundary (#747)", () => {
+  // The mail repository used to catch its own errors and return the same
+  // falsy value it returns for a genuinely missing row. A transient DB fault
+  // therefore reached the user as "not found or you don't have permission" —
+  // an authorization verdict on a mail the user owns. The repository now lets
+  // the error propagate, so `Route.handler` logs it, fires the alarm and
+  // answers 500. These assert the callback rejects rather than resolving to a
+  // not-found body.
+  beforeEach(() => {
+    mockMarkSpam.mockClear();
+    mockMarkRead.mockClear();
+    mockMarkSaved.mockClear();
+    mockGetMailBody.mockClear();
+    mockDeleteMail.mockClear();
+  });
+
+  it("post-spam-mark propagates instead of answering not-found", async () => {
+    const { postMarkSpamMailRoute } = await import("./post-spam-mark");
+    mockMarkSpam.mockRejectedValueOnce(new Error("connection terminated"));
+    const req = makeReq({ body: { mail_id: "m1", is_spam: true } });
+    await expect(
+      postMarkSpamMailRoute.callback(req, makeRes(), noopStream)
+    ).rejects.toThrow("connection terminated");
+  });
+
+  it("post-mark read propagates instead of answering failed-to-mark", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+    mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
+    mockMarkRead.mockRejectedValueOnce(new Error("connection terminated"));
+    const req = makeReq({ body: { mail_id: "m1", read: true } });
+    await expect(
+      postMarkMailRoute.callback(req, makeRes(), noopStream)
+    ).rejects.toThrow("connection terminated");
+  });
+
+  it("post-mark save propagates instead of answering failed-to-update", async () => {
+    const { postMarkMailRoute } = await import("./post-mark");
+    mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
+    mockMarkSaved.mockRejectedValueOnce(new Error("connection terminated"));
+    const req = makeReq({ body: { mail_id: "m1", save: true } });
+    await expect(
+      postMarkMailRoute.callback(req, makeRes(), noopStream)
+    ).rejects.toThrow("connection terminated");
+  });
+
+  it("get-body propagates instead of answering no-email-is-found", async () => {
+    const { getBodyRoute } = await import("./get-body");
+    mockGetMailBody.mockRejectedValueOnce(new Error("connection terminated"));
+    const req = makeReq({ params: { id: "m1" } });
+    await expect(
+      getBodyRoute.callback(req, makeRes(), noopStream)
+    ).rejects.toThrow("connection terminated");
+  });
+
+  it("delete propagates instead of answering success for a delete that never landed", async () => {
+    const { deleteMailRoute } = await import("./delete");
+    mockGetMailBody.mockResolvedValueOnce({ text: "t", html: "h" });
+    mockDeleteMail.mockRejectedValueOnce(new Error("connection terminated"));
+    const req = makeReq({ params: { id: "m1" } });
+    await expect(
+      deleteMailRoute.callback(req, makeRes(), noopStream)
+    ).rejects.toThrow("connection terminated");
   });
 });

--- a/src/server/lib/http/routes/mails/post-mark.ts
+++ b/src/server/lib/http/routes/mails/post-mark.ts
@@ -1,3 +1,4 @@
+import { isUuid } from "common";
 import {
   push,
   getMailBody,
@@ -28,8 +29,11 @@ export const postMarkMailRoute = new Route<MarkMailPostResponse>(
 
     const { mail_id, read, save } = body as Record<string, unknown>;
 
-    if (typeof mail_id !== "string" || !mail_id) {
-      return { status: "failed", message: "mail_id must be a non-empty string" };
+    // Shape-check rather than just non-empty: `mail_id` is a uuid column, so a
+    // malformed value raises 22P02 instead of matching no row, and the
+    // repository no longer swallows that (#747).
+    if (!isUuid(mail_id)) {
+      return { status: "failed", message: "mail_id must be a valid id" };
     }
 
     const mail = await getMailBody(user.id, mail_id);

--- a/src/server/lib/http/routes/mails/post-mark.ts
+++ b/src/server/lib/http/routes/mails/post-mark.ts
@@ -41,10 +41,11 @@ export const postMarkMailRoute = new Route<MarkMailPostResponse>(
       };
     }
 
-    // The repositories catch their own errors and report the outcome as a
-    // boolean, so an unreported failure here would answer success for a write
-    // that never landed — and, for `read`, would have already decremented the
-    // badge for a mail that stayed unread.
+    // A DB fault now propagates to the route boundary (500), so a `false` here
+    // means the row genuinely stopped matching between the check above and the
+    // write — report it rather than answering success for a write that never
+    // landed, or, for `read`, decrementing the badge for a mail that stayed
+    // unread.
     if (read === true) {
       if (!(await markRead(user.id, mail_id))) {
         return { status: "failed", message: "Failed to mark the mail read" };

--- a/src/server/lib/http/routes/mails/post-spam-mark.ts
+++ b/src/server/lib/http/routes/mails/post-spam-mark.ts
@@ -1,3 +1,4 @@
+import { isUuid } from "common";
 import { markSpam } from "server";
 import { getMailById } from "server/lib/postgres/repositories/mails";
 import { trainWithEmail } from "server/lib/spam/classifier";
@@ -31,6 +32,16 @@ export const postMarkSpamMailRoute = new Route<SpamMarkPostResponse>(
 
     if (typeof is_spam !== "boolean") {
       return { status: "failed", message: "is_spam must be a boolean" };
+    }
+
+    // `mail_id` reaches a uuid column unchecked here. A malformed value raises
+    // 22P02 rather than matching no row, and the repository no longer swallows
+    // that, so screen the shape before the query (#747).
+    if (!isUuid(mail_id)) {
+      return {
+        status: "failed",
+        message: "Mail not found or you don't have permission"
+      };
     }
 
     const { found, changed } = await markSpam(user.id, mail_id, is_spam);

--- a/src/server/lib/postgres/repositories/mails/core.ts
+++ b/src/server/lib/postgres/repositories/mails/core.ts
@@ -416,12 +416,7 @@ export const getMailById = async (
   user_id: string,
   mail_id: string
 ): Promise<MailModel | null> => {
-  try {
-    return await mailsTable.queryOne({ [MAIL_ID]: mail_id, [USER_ID]: user_id });
-  } catch (error) {
-    logger.error("Failed to get mail by ID", {}, error);
-    return null;
-  }
+  return mailsTable.queryOne({ [MAIL_ID]: mail_id, [USER_ID]: user_id });
 };
 
 /**
@@ -516,17 +511,12 @@ export const markMailRead = async (
   user_id: string,
   mail_id: string
 ): Promise<boolean> => {
-  try {
-    const rows = await mailsTable.updateWhere(
-      { [MAIL_ID]: mail_id, [USER_ID]: user_id },
-      { read: true, updated: DB_NOW },
-      [MAIL_ID]
-    );
-    return rows.length > 0;
-  } catch (error) {
-    logger.error("Failed to mark mail as read", {}, error);
-    return false;
-  }
+  const rows = await mailsTable.updateWhere(
+    { [MAIL_ID]: mail_id, [USER_ID]: user_id },
+    { read: true, updated: DB_NOW },
+    [MAIL_ID]
+  );
+  return rows.length > 0;
 };
 
 export const markMailSaved = async (
@@ -534,41 +524,31 @@ export const markMailSaved = async (
   mail_id: string,
   saved: boolean
 ): Promise<boolean> => {
-  try {
-    const rows = await mailsTable.updateWhere(
-      { [MAIL_ID]: mail_id, [USER_ID]: user_id },
-      { saved, updated: DB_NOW },
-      [MAIL_ID]
-    );
-    if (rows.length === 0) return false;
-    // Mirror the flag into the `Starred` pivot so the IMAP utility view
-    // agrees with the web client (#725). If skipped, a "Save" from the web
-    // sets `mails.saved = true` and the `Starred` mailbox stays empty for
-    // that message — the two surfaces diverge on the same row. The IMAP
-    // STORE path syncs the pivot in `storeFlagsTyped`; this is the HTTP
-    // sibling. `syncMailboxPivot` is idempotent so a repeat mark is safe.
-    await syncMailboxPivot(user_id, "Starred", mail_id, saved);
-    return true;
-  } catch (error) {
-    logger.error("Failed to mark mail as saved", {}, error);
-    return false;
-  }
+  const rows = await mailsTable.updateWhere(
+    { [MAIL_ID]: mail_id, [USER_ID]: user_id },
+    { saved, updated: DB_NOW },
+    [MAIL_ID]
+  );
+  if (rows.length === 0) return false;
+  // Mirror the flag into the `Starred` pivot so the IMAP utility view
+  // agrees with the web client (#725). If skipped, a "Save" from the web
+  // sets `mails.saved = true` and the `Starred` mailbox stays empty for
+  // that message — the two surfaces diverge on the same row. The IMAP
+  // STORE path syncs the pivot in `storeFlagsTyped`; this is the HTTP
+  // sibling. `syncMailboxPivot` is idempotent so a repeat mark is safe.
+  await syncMailboxPivot(user_id, "Starred", mail_id, saved);
+  return true;
 };
 
 export const deleteMail = async (
   user_id: string,
   mail_id: string
 ): Promise<boolean> => {
-  try {
-    const count = await mailsTable.deleteWhere({
-      [MAIL_ID]: mail_id,
-      [USER_ID]: user_id
-    });
-    return count > 0;
-  } catch (error) {
-    logger.error("Failed to delete mail", {}, error);
-    return false;
-  }
+  const count = await mailsTable.deleteWhere({
+    [MAIL_ID]: mail_id,
+    [USER_ID]: user_id
+  });
+  return count > 0;
 };
 
 /**
@@ -580,6 +560,8 @@ export const deleteMail = async (
  *
  * Distinguishing "no change" from "not found" lets the caller skip classifier
  * training on idempotent re-marks while still surfacing real auth failures.
+ * A DB fault is neither: it propagates so the route boundary answers 500
+ * rather than telling the owner of an existing mail it is not theirs (#747).
  *
  * The flip moves the mail in or out of IMAP's INBOX (see `isInboxTree`), so
  * it advances the mod-sequence the way every other membership change does. That
@@ -597,21 +579,16 @@ export const markMailSpam = async (
   mail_id: string,
   is_spam: boolean
 ): Promise<{ found: boolean; changed: boolean }> => {
-  try {
-    const result = await pool.query(
-      `UPDATE mails SET is_spam = $1, updated = NOW(), modseq = $4
-         WHERE mail_id = $2 AND user_id = $3 AND is_spam IS DISTINCT FROM $1
-         RETURNING mail_id`,
-      [is_spam, mail_id, user_id, await getNextModseq(user_id)]
-    );
-    if ((result.rowCount ?? 0) > 0) return { found: true, changed: true };
-    const exists = await pool.query(
-      `SELECT 1 FROM mails WHERE mail_id = $1 AND user_id = $2 LIMIT 1`,
-      [mail_id, user_id]
-    );
-    return { found: (exists.rowCount ?? 0) > 0, changed: false };
-  } catch (error) {
-    logger.error("Failed to mark mail as spam", {}, error);
-    return { found: false, changed: false };
-  }
+  const result = await pool.query(
+    `UPDATE mails SET is_spam = $1, updated = NOW(), modseq = $4
+       WHERE mail_id = $2 AND user_id = $3 AND is_spam IS DISTINCT FROM $1
+       RETURNING mail_id`,
+    [is_spam, mail_id, user_id, await getNextModseq(user_id)]
+  );
+  if ((result.rowCount ?? 0) > 0) return { found: true, changed: true };
+  const exists = await pool.query(
+    `SELECT 1 FROM mails WHERE mail_id = $1 AND user_id = $2 LIMIT 1`,
+    [mail_id, user_id]
+  );
+  return { found: (exists.rowCount ?? 0) > 0, changed: false };
 };

--- a/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
+++ b/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
@@ -40,3 +40,22 @@ describe("core.ts does not report a DB fault as not-found (#747)", () => {
     expect(body).not.toContain("catch");
   });
 });
+
+describe("http.ts getMailHeaders does not render an empty mailbox on a DB fault", () => {
+  // This one swallowed into `return []`, which is the same lie with the widest
+  // blast radius in the family: GET /api/mails answered 200 with an empty list,
+  // so a DB fault presented as "you have no mail" rather than as an error.
+  let source: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    source = await fs.readFile(path.join(import.meta.dir, "http.ts"), "utf8");
+  });
+
+  it("swallows no error", () => {
+    const body = source.match(/export const getMailHeaders = async \([\s\S]*?\n};/)?.[0];
+    expect(body).toBeDefined();
+    expect(body).not.toContain("catch");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
+++ b/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
@@ -1,8 +1,13 @@
 /**
- * Source-level guards for decisions in `core.ts` that every consumer mocks
- * away. The repository is stubbed at the barrel in each route/service test, so
- * these read the file and pin the shape at the source — the same technique the
- * mod-sequence guards in `imap.test.ts` use.
+ * Source-level guards for error propagation in the mail repository (#747).
+ *
+ * Every consumer mocks these functions away — the repository is stubbed at the
+ * barrel in each route/service test — so no behavioral test can observe whether
+ * they swallow a DB fault. These read the source and pin the shape, the same
+ * technique the mod-sequence guards in `imap.test.ts` use.
+ *
+ * Named for the invariant rather than the file, so it does not collide with the
+ * unrelated `core-decisions.test.ts` (pivot-gating logic, #725).
  */
 import { describe, it, expect, beforeAll } from "bun:test";
 

--- a/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
+++ b/src/server/lib/postgres/repositories/mails/error-propagation.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Source-level guards for decisions in `core.ts` that every consumer mocks
+ * away. The repository is stubbed at the barrel in each route/service test, so
+ * these read the file and pin the shape at the source — the same technique the
+ * mod-sequence guards in `imap.test.ts` use.
+ */
+import { describe, it, expect, beforeAll } from "bun:test";
+
+describe("core.ts does not report a DB fault as not-found (#747)", () => {
+  // Each of these used to wrap its query in `try { … } catch { return <falsy> }`,
+  // where <falsy> is the exact value that also means "no row matched". A
+  // transient DB fault therefore reached the user as "not found or you don't
+  // have permission" (post-spam-mark), "No email is found." (get-body) or a
+  // plain success for a delete that never landed. Letting the error propagate
+  // routes it to `Route.handler`, which logs, alarms and answers 500 — the
+  // same call `saveMail` already makes ("silent-drop is worse than loud
+  // failure").
+  const fns = [
+    "getMailById",
+    "markMailRead",
+    "markMailSaved",
+    "deleteMail",
+    "markMailSpam",
+  ];
+
+  let source: string;
+
+  beforeAll(async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    source = await fs.readFile(path.join(import.meta.dir, "core.ts"), "utf8");
+  });
+
+  it.each(fns)("%s swallows no error", (name) => {
+    const body = source.match(
+      new RegExp(`export const ${name} = async \\([\\s\\S]*?\\n};`)
+    )?.[0];
+    // A missed match would make every assertion below vacuous.
+    expect(body).toBeDefined();
+    expect(body).not.toContain("catch");
+  });
+});

--- a/src/server/lib/postgres/repositories/mails/http.ts
+++ b/src/server/lib/postgres/repositories/mails/http.ts
@@ -95,71 +95,66 @@ export const getMailHeaders = async (
   address: string,
   options: GetMailHeadersOptions
 ): Promise<MailHeaderResult[]> => {
-  try {
-    const addressJson = JSON.stringify([{ address }]);
-    const addressCondition = buildHeaderAddressCondition(options);
-    // Select only columns needed for mail headers — excludes html/text/attachments
-    // to avoid loading full email bodies into memory for every concurrent request.
-    const headerColumns = [
-      MAIL_ID, USER_ID, SUBJECT, DATE,
-      FROM_ADDRESS, FROM_TEXT,
-      TO_ADDRESS, TO_TEXT,
-      CC_ADDRESS, CC_TEXT,
-      BCC_ADDRESS, BCC_TEXT,
-      READ, SAVED, SENT, IS_SPAM, INSIGHT,
-    ].join(", ");
-    let sql = `
-      SELECT ${headerColumns} FROM mails 
-      WHERE user_id = $1 
-        AND ${addressCondition}
-        AND expunged = FALSE
-        AND draft = FALSE
-    `;
-    const values: ParamValue[] = [user_id, addressJson];
-    let paramIdx = 3;
+  const addressJson = JSON.stringify([{ address }]);
+  const addressCondition = buildHeaderAddressCondition(options);
+  // Select only columns needed for mail headers — excludes html/text/attachments
+  // to avoid loading full email bodies into memory for every concurrent request.
+  const headerColumns = [
+    MAIL_ID, USER_ID, SUBJECT, DATE,
+    FROM_ADDRESS, FROM_TEXT,
+    TO_ADDRESS, TO_TEXT,
+    CC_ADDRESS, CC_TEXT,
+    BCC_ADDRESS, BCC_TEXT,
+    READ, SAVED, SENT, IS_SPAM, INSIGHT,
+  ].join(", ");
+  let sql = `
+    SELECT ${headerColumns} FROM mails 
+    WHERE user_id = $1 
+      AND ${addressCondition}
+      AND expunged = FALSE
+      AND draft = FALSE
+  `;
+  const values: ParamValue[] = [user_id, addressJson];
+  let paramIdx = 3;
 
-    if (options.new) {
-      sql += ` AND read = FALSE`;
-    } else if (options.saved) {
-      sql += ` AND saved = TRUE`;
-    }
-
-    if (options.spam) {
-      // Spam mail is always received, never sent — matches the (sent = FALSE)
-      // guard the standalone spam query carried before spam became per-account.
-      sql += ` AND is_spam = TRUE AND sent = FALSE`;
-    } else {
-      // Every non-spam view (New / All / Saved / Sent) is the complement of the
-      // spam folder: a mail flagged spam — whether auto-classified on receipt or
-      // marked by the user via /spam/mark — belongs only in the spam folder, not
-      // here. Without this the "Mark as spam" action is cosmetic: the row would
-      // reappear on the next refetch because the inbox query still returned it.
-      sql += ` AND is_spam = FALSE`;
-    }
-
-    if (options.since !== undefined) {
-      sql += ` AND updated > $${paramIdx++}`;
-      values.push(options.since);
-    }
-
-    sql += ` ORDER BY date DESC`;
-
-    if (options.size !== undefined) {
-      sql += ` LIMIT $${paramIdx++}`;
-      values.push(options.size);
-    }
-
-    if (options.from !== undefined) {
-      sql += ` OFFSET $${paramIdx}`;
-      values.push(options.from);
-    }
-
-    const result = await pool.query(sql, values);
-    return result.rows as MailHeaderResult[];
-  } catch (error) {
-    logger.error("Failed to get mail headers", {}, error);
-    return [];
+  if (options.new) {
+    sql += ` AND read = FALSE`;
+  } else if (options.saved) {
+    sql += ` AND saved = TRUE`;
   }
+
+  if (options.spam) {
+    // Spam mail is always received, never sent — matches the (sent = FALSE)
+    // guard the standalone spam query carried before spam became per-account.
+    sql += ` AND is_spam = TRUE AND sent = FALSE`;
+  } else {
+    // Every non-spam view (New / All / Saved / Sent) is the complement of the
+    // spam folder: a mail flagged spam — whether auto-classified on receipt or
+    // marked by the user via /spam/mark — belongs only in the spam folder, not
+    // here. Without this the "Mark as spam" action is cosmetic: the row would
+    // reappear on the next refetch because the inbox query still returned it.
+    sql += ` AND is_spam = FALSE`;
+  }
+
+  if (options.since !== undefined) {
+    sql += ` AND updated > $${paramIdx++}`;
+    values.push(options.since);
+  }
+
+  sql += ` ORDER BY date DESC`;
+
+  if (options.size !== undefined) {
+    sql += ` LIMIT $${paramIdx++}`;
+    values.push(options.size);
+  }
+
+  if (options.from !== undefined) {
+    sql += ` OFFSET $${paramIdx}`;
+    values.push(options.from);
+  }
+
+  const result = await pool.query(sql, values);
+  return result.rows as MailHeaderResult[];
 };
 
 export interface MailHeadersDeltaResult {


### PR DESCRIPTION
Closes #747

## The defect

Five functions in `src/server/lib/postgres/repositories/mails/core.ts` wrapped their query in a `catch` that returned **the same falsy value they return for a genuinely missing row**. "The DB is broken" and "that mail does not exist" were the same value, so the routes above turned an infrastructure fault into an authorization verdict on a mail the user owns:

| function | what the user saw on a DB fault |
|---|---|
| `markMailSpam` | `Mail not found or you don't have permission` |
| `getMailById` | `No email is found.` (`GET /api/mails/body/:id`) |
| `markMailRead` | `Failed to mark the mail read` |
| `markMailSaved` | `Failed to update the saved flag` |
| `deleteMail` | plain `success` — for a delete that never landed |
| `getMailHeaders` | **an empty mailbox** — `GET /api/mails` answered 200 with `[]` |

Issue #747 named `markMailSpam` (where PR 740 widened the blast radius by putting `getNextModseq` inside the same `try`). The other five are the sibling audit: same shape, same user-visible lie. `getMailHeaders` lives one file over in `http.ts` and was folded in on review — presenting a DB fault as "you have no mail" is the widest-blast-radius member of the family.

## The fix

Delete the swallow. A DB fault now propagates to `Route.handler`, which already logs, fires the alarm, and answers 500. `found: false` / `false` once again means only "no row matched".

This is not a new convention — `saveMail` in the same file already made this exact call:

> Throw rather than return undefined so the SMTP-receive / IMAP-write caller replies 5xx / NO and the sender or client retries — silent-drop is worse than loud failure

The removed `logger.error` calls were also duplicating what `Route.handler` logs.

### Screening the id first

Removing the swallow had a consequence worth stating plainly, because it was a regression this PR introduced and reviewoie caught it:

`mails.mail_id` is `UUID PRIMARY KEY`, so Postgres answers a **malformed** id with a 22P02 error rather than an empty result. While the repository swallowed errors, a stale bookmark or an old client's cached id produced a clean not-found. With the swallow gone it would have produced a 500 — plus a Discord alarm page — reachable by any authenticated user on four routes, none of which validated the id shape (a repo-wide grep for a UUID validator returned 0 hits). The 500 body would also have carried the raw Postgres error text, since the Dockerfile builds without `NODE_ENV` and Bun folds `route.ts`'s production guard away at build time (that fold is #766 / PR 789, still open).

So this PR adds `isUuid` to `common/util.ts` and screens the id in `get-body`, `delete`, `post-mark` and `post-spam-mark`. Each keeps its own existing not-found message, so **a malformed id behaves exactly as it did before this PR** and only a genuine infrastructure fault reaches the 500 path. An id of the wrong shape is a client error and was always being answered as one — it just wasn't being checked.

### Caller audit

Every caller of the five functions was checked before changing the contract:

- **`post-mark.ts`** pre-checks existence with `getMailBody`, so a `false` there now means the row stopped matching between check and write — it still reports that, and its comment (which documented the old swallow) is corrected.
- **`delete.ts`** ignored the return value entirely, so a DB fault answered success. That half is fixed: the fault now throws. It still answers success when `deleteMail` returns `false`, and that is deliberate — with faults throwing, `false` means only that the row vanished between the check and the delete, i.e. a concurrent delete reached the end state the caller asked for. There is now a comment saying so.
- **`message-ops.ts:258`** (IMAP `FETCH` marking `\Seen`) is the one non-HTTP caller. It is already inside a per-message `try/catch` that logs and continues, so a throw stays contained to that one message and cannot take down the session.
- `spam.ts` / `update.ts` are pass-throughs; their existing tests already assert they propagate rejections.

## Test plan

**New — `error-propagation.test.ts` (source-level guard, 6 tests).** The repository is barrel-mocked in every route/service test, so no existing test can observe `core.ts`'s own error handling. This reads the source and pins that none of the five functions contains a `catch`, using the same technique as the mod-sequence guards in `imap.test.ts`.

Mutation-tested rather than assumed: with `core.ts` stashed back to its pre-fix state, **all 5 guards fail**; restored, all 5 pass. The `expect(body).toBeDefined()` line guards against a regex miss making the assertions vacuous.

**New — 5 route-level tests in `mails.test.ts`.** Assert that a rejecting mutator propagates out of each route callback instead of resolving to a not-found body: `post-spam-mark`, `post-mark` (read), `post-mark` (save), `get-body`, `delete`. These pin the *routes* — they mock the repository, so they are the complement to the source guard above, not a substitute for it.

**New — 17 route tests for the malformed-id path.** Each of the four routes is driven with `not-a-uuid`, `""`, `123` and a SQL-injection-shaped string, asserting it is rejected *and* that the repository was never called; plus one test that a well-formed uuid still reaches the repository. Mutation-tested: deleting the guard from `get-body.ts` turns exactly those 4 get-body cases red, restored to green.

Existing fixtures were updated from `"m1"`-style ids to real uuids, since the routes now shape-check — the old fixtures could not have existed in the database.

**Full suite:** `bun test` — **1822 pass, 0 fail** across 97 files. Baseline on `upstream/main` (da2b242), measured in the same clean worktree: **1794 pass across 96 files**. So this PR adds **28 tests** — 6 source-guard + 5 propagation + 17 malformed-id. (Re-measured after the 2026-08-16 rebase onto da2b242; the previous figures, 1793 / 1765, were taken against the older 0edf95c base.)
**Typecheck:** `bun run tsc --noEmit` — clean.
**Lint:** 0 errors, and the same 17 pre-existing warnings as before this PR — `eslint .` output is byte-identical between the base and this branch, so none is in a changed file.

## Not in scope

`saveMail`'s catch is untouched — it already logs and rethrows, which is the behavior this PR extends to its siblings.

**Twelve** swallow-into-a-falsy-value sites survive in this directory, tracked in **#832**: four in `http.ts` (`searchMails`, `getAccountStats`, `searchAccountStats`, `getUnreadNotifications`), one in `counters.ts` (`getHighestModseq`, returning a fabricated `1` that a CONDSTORE client reads as "nothing changed"), and seven in `imap.ts` — including `countMessages`, which returns `{total: 0, unread: 0, maxUid: 0}` and so reports `EXISTS 0 / UNSEEN 0` for a populated mailbox on the IMAP SELECT path. Filed rather than folded in because the IMAP ones need their own session-handling check before a throw is safe there.

(For the record, `counters.ts`'s `deleteMailboxUid` and `writeMailboxUid` also catch, but they **rethrow** after logging — they are already correct and are not part of that sweep.)

`getMailHeadersDelta` is deliberately left as-is: its catch echoes the caller's `since` cursor back so the client cursor cannot advance past rows it never received. That one is correct.

## Filename note

The source guard is `error-propagation.test.ts`, not `core-decisions.test.ts`. PR 830 has since merged and owns `repositories/mails/core-decisions.test.ts` (unrelated pivot-gating tests for #725). This branch is now rebased onto that merge and creates its guard file directly under the `error-propagation.test.ts` name, so 830's file is untouched. The name states the invariant rather than the file it reads.

## Diff-reading note

The `getMailHeaders` hunk in `http.ts` looks large because removing the `try` de-indents 60 lines. `git diff -w` on that file shows the real change: the `try {` line and the 4-line `catch` block, nothing else.


